### PR TITLE
feat/sign-out

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,14 +1,13 @@
 import ContributionGraph from "@/components/ContributionGraph";
 import PRMetrics from "@/components/PRMetrics";
 import GoalTracker from "@/components/GoalTracker";
+import DashboardHeader from "@/components/DashboardHeader";
+
 
 export default function DashboardPage() {
   return (
     <div className="min-h-screen bg-slate-900 p-8">
-      <header className="mb-8">
-        <h1 className="text-3xl font-bold text-white">Dashboard</h1>
-        <p className="text-slate-400 mt-1">Your coding activity at a glance</p>
-      </header>
+      <DashboardHeader />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import SignOutButton from "@/components/SignOutButton";
+
+
+export default function DashboardHeader() {
+    return (
+        <header className="flex items-center justify-between p-4 mb-8">
+            <div>
+                <h1 className="text-3xl font-bold text-white">Dashboard</h1>
+                <p className="text-slate-400 mt-1">Your coding activity at a glance</p>
+            </div>
+
+            <SignOutButton />
+
+        </header>
+    );
+}

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import { signOut } from "next-auth/react"
+
+export default function DashboardPage() {
+    return (
+        <button 
+            onClick={() => signOut({ callbackUrl: "/" })}
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded ">
+            Sign-out
+        </button>
+    );
+}


### PR DESCRIPTION
## Summary

Created Sign-out component to sign users out using NextAuth signOut() and redirecting to home via callbackUrl.

Refactored dashboard header to its own component to allow for "use client" without affecting the server-side rendering of the rest of the dashboard.

Closes #12 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Created ``src\components\SignOutButton.tsx``
- Created ``src\components\DashboardHeader.tsx``
- Added SignOutButton to Dashboard Header

## How to Test

Steps for the reviewer to verify this works:

1. Login with GitHub at http://localhost:3000/
2. Sign out at the top right 
3. Navigate manually to http://localhost:3000/dashboard and the values will appear blank or undefinedh

## Screenshots (if UI change)

<img width="1907" height="622" alt="PR Screenshot issue 12" src="https://github.com/user-attachments/assets/69eec06e-1b7d-4f80-b5d0-e3eb57ecdcff" />

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
