### PR TITLE
feat: add sign out button to dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,14 +1,20 @@
 import ContributionGraph from "@/components/ContributionGraph";
 import PRMetrics from "@/components/PRMetrics";
 import GoalTracker from "@/components/GoalTracker";
+import SignOutButton from "@/components/SignOutButton";
 
 export default function DashboardPage() {
   return (
     <div className="min-h-screen bg-slate-900 p-8">
-      <header className="mb-8">
-        <h1 className="text-3xl font-bold text-white">Dashboard</h1>
-        <p className="text-slate-400 mt-1">Your coding activity at a glance</p>
-      </header>
+    <header className="mb-8">
+     <div className="flex items-start justify-between">
+      <div>
+       <h1 className="text-3xl font-bold text-white">Dashboard</h1>
+       <p className="text-slate-400 mt-1"> Your coding activity at a glance </p>
+       </div>
+       <SignOutButton />
+     </div>
+   </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -1,0 +1,9 @@
+'use client'
+import { signOut } from "next-auth/react";
+
+
+export default function SignOutButton () {
+    return (<button onClick={() => signOut({ callbackUrl: "/" })}>
+  Sign Out
+</button>)
+}


### PR DESCRIPTION
## Summary

Add a sign-out button to the dashboard header that allows authenticated users to safely log out and redirects them to the landing page.

Closes #12

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added SignOutButton client component
- Integrated next-auth/react signOut() function
- Placed sign-out button in dashboard header (top-right area)
- Ensured redirect to landing page after sign-out (callbackUrl: "/")
- Maintained existing UI layout and styling consistency

## How to Test

Steps for the reviewer to verify this works:
1. Start the app and log in
2. Navigate to the dashboard page
3. Click the “Sign Out” button in the top-right corner
4. Verify that the user is redirected to the landing page /
5. Confirm that the session is cleared (user is logged out)

## Screenshots (if UI change)
Before: 
<img width="983" height="849" alt="Screenshot 2026-05-11 180028" src="https://github.com/user-attachments/assets/6a892696-b7f6-4f99-b8c7-501e810baf8c" />

After: 
<img width="974" height="751" alt="Screenshot 2026-05-11 175953" src="https://github.com/user-attachments/assets/aa26b468-9033-4730-9b53-d4b9cc564eeb" />

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
