### PR TITLE
fix(dashboard): redirect signed-out users

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,9 +2,17 @@ import ContributionGraph from "@/components/ContributionGraph";
 import PRMetrics from "@/components/PRMetrics";
 import GoalTracker from "@/components/GoalTracker";
 import DashboardHeader from "@/components/DashboardHeader";
+import { authOptions } from "@/lib/auth";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
 
-export default function DashboardPage() {
+  if (!session) {
+    redirect("/");
+  }
+
   return (
     <div className="min-h-screen bg-slate-900 p-8">
       <DashboardHeader />


### PR DESCRIPTION
﻿## Summary
- add a server-side NextAuth session check to `/dashboard`
- redirect signed-out users to `/` before dashboard content renders

Fixes #19.

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run build` with dummy Supabase/NextAuth env values from `.env.example`
- `git diff --check`
