### PR TITLE
feat(dashboard): show signed-in GitHub user

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import("next").NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import SignOutButton from "@/components/SignOutButton";
+import UserAvatar from "@/components/UserAvatar";
 
 
 export default function DashboardHeader() {
@@ -11,7 +12,10 @@ export default function DashboardHeader() {
                 <p className="text-slate-400 mt-1">Your coding activity at a glance</p>
             </div>
 
-            <SignOutButton />
+            <div className="flex items-center gap-3">
+                <UserAvatar />
+                <SignOutButton />
+            </div>
 
         </header>
     );

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Image from "next/image";
+import { useSession } from "next-auth/react";
+import { useState } from "react";
+
+function getInitial(name?: string | null) {
+  return name?.trim().charAt(0).toUpperCase() || "?";
+}
+
+export default function UserAvatar() {
+  const { data: session } = useSession();
+  const [imageFailed, setImageFailed] = useState(false);
+
+  const name = session?.user?.name ?? session?.githubLogin ?? "GitHub user";
+  const image = session?.user?.image;
+  const showImage = image && !imageFailed;
+
+  return (
+    <div className="flex items-center gap-3 rounded-full border border-slate-700 bg-slate-800/80 px-3 py-2">
+      <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-slate-700 text-sm font-semibold text-white">
+        {showImage ? (
+          <Image
+            src={image}
+            alt={`${name} avatar`}
+            width={32}
+            height={32}
+            className="h-8 w-8 rounded-full object-cover"
+            onError={() => setImageFailed(true)}
+          />
+        ) : (
+          <span aria-hidden="true">{getInitial(name)}</span>
+        )}
+      </div>
+      <span className="max-w-32 truncate text-sm font-medium text-slate-100">
+        {name}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
﻿## Summary
- add a client `UserAvatar` component using NextAuth session data
- show the GitHub avatar and username in the dashboard header
- fall back to a placeholder initial if the avatar cannot load
- allow GitHub avatar images in Next.js image config

Fixes #2.

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run build` with dummy Supabase/NextAuth env values from `.env.example`
- `git diff --check`
