### PR TITLE
feat: add bar/line toggle to contribution graph

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 import {
   BarChart,
   Bar,
+  LineChart,
+  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -16,21 +18,20 @@ interface DayData {
   commits: number;
 }
 
-const RANGES = [
-  { label: "7d", days: 7 },
-  { label: "14d", days: 14 },
-  { label: "30d", days: 30 },
-  { label: "90d", days: 90 },
+type ViewMode = "bar" | "line";
+
+const charts: { key: ViewMode; label: string }[] = [
+  { key: "bar", label: "Bar" },
+  { key: "line", label: "Line" },
 ];
 
 export default function ContributionGraph() {
   const [data, setData] = useState<DayData[]>([]);
   const [loading, setLoading] = useState(true);
-  const [days, setDays] = useState(30);
+  const [chartType, setChartType] = useState<ViewMode>("bar");
 
   useEffect(() => {
-    setLoading(true);
-    fetch(`/api/metrics/contributions?days=${days}`)
+    fetch("/api/metrics/contributions?days=30")
       .then((r) => r.json())
       .then((res: { data: Record<string, number> }) => {
         const sorted = Object.entries(res.data ?? {})
@@ -40,48 +41,77 @@ export default function ContributionGraph() {
       })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [days]);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="bg-slate-800 rounded-xl p-6">
+        <div className="h-5 w-48 bg-slate-700 rounded animate-pulse mb-4" />
+        <div className="h-[200px] bg-slate-700 rounded animate-pulse" />
+      </div>
+    );
+  }
 
   return (
     <div className="bg-slate-800 rounded-xl p-6">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-white font-semibold text-lg">Commit Activity</h2>
-        <div className="flex gap-1 bg-slate-700 rounded-lg p-1">
-          {RANGES.map((r) => (
-            <button
-              key={r.days}
-              onClick={() => setDays(r.days)}
-              className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
-                days === r.days
-                  ? "bg-indigo-500 text-white"
-                  : "text-slate-400 hover:text-slate-200"
-              }`}
-            >
-              {r.label}
-            </button>
-          ))}
-        </div>
+        <h2 className="text-white font-semibold text-lg">
+          Commit Activity (Last 30 Days)
+        </h2>
+
+        {/* ChartType Toggle Buttons */}
+     {data.length > 0 && (<div className="flex gap-2 text-sm">
+     {charts.map((v) => (
+    <button
+      key={v.key}
+      onClick={() => setChartType(v.key)}
+      className={`px-3 py-1 rounded transition-colors duration-200 ${
+        chartType === v.key
+          ? "bg-indigo-500 text-white"
+          : "bg-slate-700 text-slate-300"
+         }`}
+       >
+        {v.label}
+      </button>
+     ))}
+    </div>)}
       </div>
 
-      {loading ? (
-        <div className="h-[200px] bg-slate-700 rounded animate-pulse" />
-      ) : data.length === 0 ? (
-        <p className="text-slate-400 text-sm h-[200px] flex items-center">
-          No commits in the last {days} days.
+      {data.length === 0 ? (
+        <p className="text-slate-400 text-sm">
+          No commits in the last 30 days.
         </p>
       ) : (
         <ResponsiveContainer width="100%" height={200}>
-          <BarChart data={data}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
-            <XAxis dataKey="day" hide />
-            <YAxis stroke="#94a3b8" allowDecimals={false} />
-            <Tooltip
-              contentStyle={{ background: "#1e293b", border: "none", borderRadius: "8px" }}
-              labelStyle={{ color: "#f8fafc", fontSize: "12px" }}
-              cursor={{ fill: "#334155" }}
-            />
-            <Bar dataKey="commits" fill="#6366f1" radius={[4, 4, 0, 0]} />
-          </BarChart>
+          {chartType === "bar" ? (
+            <BarChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+              <XAxis dataKey="day" hide />
+              <YAxis stroke="#94a3b8" />
+              <Tooltip
+                contentStyle={{ background: "#1e293b", border: "none" }}
+                labelStyle={{ color: "#f8fafc" }}
+              />
+              <Bar dataKey="commits" fill="#6366f1" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          ) : (
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+              <XAxis dataKey="day" hide />
+              <YAxis stroke="#94a3b8" />
+              <Tooltip
+                contentStyle={{ background: "#1e293b", border: "none" }}
+                labelStyle={{ color: "#f8fafc" }}
+              />
+              <Line
+                type="monotone"
+                dataKey="commits"
+                stroke="#6366f1"
+                strokeWidth={2}
+                dot={false}
+              />
+            </LineChart>
+          )}
         </ResponsiveContainer>
       )}
     </div>

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -20,6 +20,13 @@ interface DayData {
 
 type ViewMode = "bar" | "line";
 
+const RANGES = [
+  { label: "7d", days: 7 },
+  { label: "14d", days: 14 },
+  { label: "30d", days: 30 },
+  { label: "90d", days: 90 },
+];
+
 const charts: { key: ViewMode; label: string }[] = [
   { key: "bar", label: "Bar" },
   { key: "line", label: "Line" },
@@ -28,58 +35,75 @@ const charts: { key: ViewMode; label: string }[] = [
 export default function ContributionGraph() {
   const [data, setData] = useState<DayData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [days, setDays] = useState(30);
   const [chartType, setChartType] = useState<ViewMode>("bar");
 
   useEffect(() => {
-    fetch("/api/metrics/contributions?days=30")
+    setLoading(true);
+    fetch(`/api/metrics/contributions?days=${days}`)
       .then((r) => r.json())
       .then((res: { data: Record<string, number> }) => {
         const sorted = Object.entries(res.data ?? {})
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([day, commits]) => ({ day, commits }));
+
         setData(sorted);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="bg-slate-800 rounded-xl p-6">
-        <div className="h-5 w-48 bg-slate-700 rounded animate-pulse mb-4" />
-        <div className="h-[200px] bg-slate-700 rounded animate-pulse" />
-      </div>
-    );
-  }
+  }, [days]);
 
   return (
     <div className="bg-slate-800 rounded-xl p-6">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-white font-semibold text-lg">
-          Commit Activity (Last 30 Days)
+          Commit Activity
         </h2>
 
-        {/* ChartType Toggle Buttons */}
-     {data.length > 0 && (<div className="flex gap-2 text-sm">
-     {charts.map((v) => (
-    <button
-      key={v.key}
-      onClick={() => setChartType(v.key)}
-      className={`px-3 py-1 rounded transition-colors duration-200 ${
-        chartType === v.key
-          ? "bg-indigo-500 text-white"
-          : "bg-slate-700 text-slate-300"
-         }`}
-       >
-        {v.label}
-      </button>
-     ))}
-    </div>)}
+        <div className="flex items-center gap-3">
+    
+          <div className="flex gap-1 bg-slate-700 rounded-lg p-1">
+            {RANGES.map((r) => (
+              <button
+                key={r.days}
+                onClick={() => setDays(r.days)}
+                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
+                  days === r.days
+                    ? "bg-indigo-500 text-white"
+                    : "text-slate-400 hover:text-slate-200"
+                }`}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Chart Toggle Buttons */}
+          {data.length > 0 && (
+            <div className="flex gap-1 bg-slate-700 rounded-lg p-1 text-sm">
+              {charts.map((chart) => (
+                <button
+                  key={chart.key}
+                  onClick={() => setChartType(chart.key)}
+                  className={`px-3 py-1 rounded-md transition-colors duration-200 ${
+                    chartType === chart.key
+                      ? "bg-indigo-500 text-white"
+                      : "text-slate-400 hover:text-slate-200"
+                  }`}
+                >
+                  {chart.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
-      {data.length === 0 ? (
-        <p className="text-slate-400 text-sm">
-          No commits in the last 30 days.
+      {loading ? (
+        <div className="h-[200px] bg-slate-700 rounded animate-pulse" />
+      ) : data.length === 0 ? (
+        <p className="text-slate-400 text-sm h-[200px] flex items-center">
+          No commits in the last {days} days.
         </p>
       ) : (
         <ResponsiveContainer width="100%" height={200}>
@@ -87,21 +111,41 @@ export default function ContributionGraph() {
             <BarChart data={data}>
               <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
               <XAxis dataKey="day" hide />
-              <YAxis stroke="#94a3b8" />
+              <YAxis stroke="#94a3b8" allowDecimals={false} />
               <Tooltip
-                contentStyle={{ background: "#1e293b", border: "none" }}
-                labelStyle={{ color: "#f8fafc" }}
+                contentStyle={{
+                  background: "#1e293b",
+                  border: "none",
+                  borderRadius: "8px",
+                }}
+                labelStyle={{
+                  color: "#f8fafc",
+                  fontSize: "12px",
+                }}
+                cursor={{ fill: "#334155" }}
               />
-              <Bar dataKey="commits" fill="#6366f1" radius={[4, 4, 0, 0]} />
+              <Bar
+                dataKey="commits"
+                fill="#6366f1"
+                radius={[4, 4, 0, 0]}
+              />
             </BarChart>
           ) : (
             <LineChart data={data}>
               <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
               <XAxis dataKey="day" hide />
-              <YAxis stroke="#94a3b8" />
+              <YAxis stroke="#94a3b8" allowDecimals={false} />
               <Tooltip
-                contentStyle={{ background: "#1e293b", border: "none" }}
-                labelStyle={{ color: "#f8fafc" }}
+                contentStyle={{
+                  background: "#1e293b",
+                  border: "none",
+                  borderRadius: "8px",
+                }}
+                labelStyle={{
+                  color: "#f8fafc",
+                  fontSize: "12px",
+                }}
+                cursor={{ fill: "#334155" }}
               />
               <Line
                 type="monotone"


### PR DESCRIPTION
## Summary

Adds a toggle to switch between BarChart and LineChart in the ContributionGraph component.
Users can now switch visualization modes to better analyze commit activity trends over time.

Closes #17

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added `chartType` state (`bar | line`)
- Implemented toggle buttons for switching chart views
- Added conditional rendering for BarChart and LineChart (Recharts)
- Refactored chart UI to data-driven button mapping
- Improved empty state handling for no commit data

## How to Test

Steps for the reviewer to verify this works:
1. Open the dashboard page containing the ContributionGraph
2. Ensure there is commit data loaded
3. Click on "Bar" and "Line" toggle buttons
4. Verify chart switches between BarChart and LineChart correctly
5. Confirm empty state still displays when no data exists

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
