### PR TITLE
feat: add copy dashboard URL button to header

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -13,6 +13,7 @@ export default function DashboardHeader() {
 
     const [isPublic, setIsPublic] = useState<boolean | null>(null);
     const [copied, setCopied] = useState(false);
+    const [copyError, setCopyError] = useState(false);
 
     useEffect(() => {
         if (!session) {
@@ -48,9 +49,13 @@ export default function DashboardHeader() {
             setTimeout(() => {
                 setCopied(false);
             }, 2000);
-        } catch (error) {
-            console.error(error);
-            alert("Copy failed");
+
+        } catch {
+            setCopyError(true);
+
+            setTimeout(() => {
+                setCopyError(false);
+            }, 2000);
         }
     };
 
@@ -90,7 +95,7 @@ export default function DashboardHeader() {
                         aria-label="Copy dashboard link"
                         className="px-3 py-2 rounded-md border border-[var(--border)]"
                     >
-                        {copied ? "Copied!" : "📋"}
+                        {copied ? "✓ Copied!" : copyError ? "Failed" : "📋"}
                     </button>
 
                     <ThemeToggle />

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
@@ -9,65 +9,96 @@ import UserAvatar from "@/components/UserAvatar";
 import KeyboardShortcuts from "@/components/KeyboardShortcuts";
 
 export default function DashboardHeader() {
-  const { data: session } = useSession();
-  const [isPublic, setIsPublic] = useState<boolean | null>(null);
+    const { data: session } = useSession();
 
-  useEffect(() => {
-    if (!session) {
-      setIsPublic(null);
-      return;
-    }
+    const [isPublic, setIsPublic] = useState<boolean | null>(null);
+    const [copied, setCopied] = useState(false);
 
-    async function loadSettings() {
-      try {
-        const res = await fetch("/api/user/settings");
-        if (res.ok) {
-          const data = await res.json();
-          setIsPublic(data.is_public === true);
-        } else {
-          setIsPublic(false);
+    useEffect(() => {
+        if (!session) {
+            setIsPublic(null);
+            return;
         }
-      } catch (error) {
-        console.error("Failed to load settings:", error);
-        setIsPublic(false);
-      }
-    }
 
-    loadSettings();
-  }, [session]);
+        async function loadSettings() {
+            try {
+                const res = await fetch("/api/user/settings");
 
-  return (
-    <header className="mb-8 border-b border-[var(--border)] p-4 pb-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">
-            Dashboard
-          </h1>
-          <p className="mt-1 text-[var(--muted-foreground)]">
-            Your coding activity at a glance
-          </p>
-        </div>
+                if (res.ok) {
+                    const data = await res.json();
+                    setIsPublic(data.is_public === true);
+                } else {
+                    setIsPublic(false);
+                }
+            } catch (error) {
+                console.error("Failed to load settings:", error);
+                setIsPublic(false);
+            }
+        }
 
-        <div className="flex flex-wrap items-center gap-3">
-          {isPublic === true && session?.githubLogin && (
-            <a
-              href={`/u/${session.githubLogin}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--control)] text-[var(--card-foreground)] text-sm font-medium hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] transition-colors"
-              title="View your public profile"
-            >
-              Share Profile
-            </a>
-          )}
-          <KeyboardShortcuts />
-          <UserAvatar />
-          <ThemeToggle />
-          <SignOutButton />
-        </div>
-      </div>
+        loadSettings();
+    }, [session]);
 
-      <AccountToggle />
-    </header>
-  );
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(window.location.href);
+
+            setCopied(true);
+
+            setTimeout(() => {
+                setCopied(false);
+            }, 2000);
+        } catch (error) {
+            console.error(error);
+            alert("Copy failed");
+        }
+    };
+
+    return (
+        <header className="mb-8 border-b border-[var(--border)] p-4 pb-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">
+                        Dashboard
+                    </h1>
+
+                    <p className="mt-1 text-[var(--muted-foreground)]">
+                        Your coding activity at a glance
+                    </p>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3">
+                    {isPublic === true && session?.githubLogin && (
+                        <a
+                            href={`/u/${session.githubLogin}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--control)] text-[var(--card-foreground)] text-sm font-medium hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] transition-colors"
+                            title="View your public profile"
+                        >
+                            Share Profile
+                        </a>
+                    )}
+
+                    <KeyboardShortcuts />
+
+                    <UserAvatar />
+
+                    <button
+                        type="button"
+                        onClick={handleCopy}
+                        aria-label="Copy dashboard link"
+                        className="px-3 py-2 rounded-md border border-[var(--border)]"
+                    >
+                        {copied ? "Copied!" : "📋"}
+                    </button>
+
+                    <ThemeToggle />
+                    <SignOutButton />
+                </div>
+            </div>
+
+            <AccountToggle />
+        </header>
+    );
 }

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -9,101 +9,100 @@ import UserAvatar from "@/components/UserAvatar";
 import KeyboardShortcuts from "@/components/KeyboardShortcuts";
 
 export default function DashboardHeader() {
-    const { data: session } = useSession();
+  const { data: session } = useSession();
 
-    const [isPublic, setIsPublic] = useState<boolean | null>(null);
-    const [copied, setCopied] = useState(false);
-    const [copyError, setCopyError] = useState(false);
+  const [isPublic, setIsPublic] = useState<boolean | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
 
-    useEffect(() => {
-        if (!session) {
-            setIsPublic(null);
-            return;
+  useEffect(() => {
+    if (!session) {
+      setIsPublic(null);
+      return;
+    }
+
+    async function loadSettings() {
+      try {
+        const res = await fetch("/api/user/settings");
+
+        if (res.ok) {
+          const data = await res.json();
+          setIsPublic(data.is_public === true);
+        } else {
+          setIsPublic(false);
         }
+      } catch (error) {
+        console.error("Failed to load settings:", error);
+        setIsPublic(false);
+      }
+    }
 
-        async function loadSettings() {
-            try {
-                const res = await fetch("/api/user/settings");
+    loadSettings();
+  }, [session]);
 
-                if (res.ok) {
-                    const data = await res.json();
-                    setIsPublic(data.is_public === true);
-                } else {
-                    setIsPublic(false);
-                }
-            } catch (error) {
-                console.error("Failed to load settings:", error);
-                setIsPublic(false);
-            }
-        }
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
 
-        loadSettings();
-    }, [session]);
+      setCopied(true);
 
-    const handleCopy = async () => {
-        try {
-            await navigator.clipboard.writeText(window.location.href);
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch {
+      setCopyError(true);
 
-            setCopied(true);
+      setTimeout(() => {
+        setCopyError(false);
+      }, 2000);
+    }
+  };
 
-            setTimeout(() => {
-                setCopied(false);
-            }, 2000);
+  return (
+    <header className="mb-8 border-b border-[var(--border)] p-4 pb-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">
+            Dashboard
+          </h1>
 
-        } catch {
-            setCopyError(true);
+          <p className="mt-1 text-[var(--muted-foreground)]">
+            Your coding activity at a glance
+          </p>
+        </div>
 
-            setTimeout(() => {
-                setCopyError(false);
-            }, 2000);
-        }
-    };
+        <div className="flex flex-wrap items-center gap-3">
+          {isPublic === true && session?.githubLogin && (
+            <a
+              href={`/u/${session.githubLogin}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--control)] text-[var(--card-foreground)] text-sm font-medium hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] transition-colors"
+              title="View your public profile"
+            >
+              Share Profile
+            </a>
+          )}
 
-    return (
-        <header className="mb-8 border-b border-[var(--border)] p-4 pb-6">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                    <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">
-                        Dashboard
-                    </h1>
+          <KeyboardShortcuts />
 
-                    <p className="mt-1 text-[var(--muted-foreground)]">
-                        Your coding activity at a glance
-                    </p>
-                </div>
+          <UserAvatar />
 
-                <div className="flex flex-wrap items-center gap-3">
-                    {isPublic === true && session?.githubLogin && (
-                        <a
-                            href={`/u/${session.githubLogin}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--control)] text-[var(--card-foreground)] text-sm font-medium hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] transition-colors"
-                            title="View your public profile"
-                        >
-                            Share Profile
-                        </a>
-                    )}
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label="Copy dashboard link"
+            className="px-3 py-2 rounded-md border border-[var(--border)]"
+          >
+            {copied ? "✓ Copied!" : copyError ? "Failed" : "📋"}
+          </button>
 
-                    <KeyboardShortcuts />
+          <ThemeToggle />
+          <SignOutButton />
+        </div>
+      </div>
 
-                    <UserAvatar />
-
-                    <button
-                        type="button"
-                        onClick={handleCopy}
-                        aria-label="Copy dashboard link"
-                        className="px-3 py-2 rounded-md border border-[var(--border)]"
-                    >
-                        {copied ? "✓ Copied!" : copyError ? "Failed" : "📋"}
-                    </button>
-
-                    <ThemeToggle />
-                    <SignOutButton />
-                </div>
-            </div>
-
-            <AccountToggle />
-        </header>
-    );
+      <AccountToggle />
+    </header>
+  );
 }


### PR DESCRIPTION
## Summary

This PR adds a copy dashboard URL button to the dashboard header, making it easier for users to quickly share their dashboard link. On clicking the button, the current dashboard URL gets copied and the user sees a short "Copied!" confirmation.

Closes #52

## Type of Change
* [ ] Bug fix
* [✅] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Added a copy button in `DashboardHeader.tsx`
* Copied the current page URL using the Clipboard API
* Added a temporary "Copied!" feedback for better user experience
* Added accessibility support with `aria-label`
* Verified it works properly in both light and dark mode

## How to Test

1. Run the project locally using `npm run dev`
2. Open the dashboard page
3. Click the copy button in the header
4. Confirm that "Copied!" appears for a few seconds
5. Paste anywhere to verify the dashboard URL was copied

## Screenshots (if UI change)
<img width="1423" height="87" alt="Screenshot 2026-05-15 at 12 26 47 PM" src="https://github.com/user-attachments/assets/1e552587-0096-4a63-a273-4cad397913af" />

<img width="476" height="107" alt="Screenshot 2026-05-15 at 12 27 41 PM" src="https://github.com/user-attachments/assets/e636199e-f364-4e24-aae5-ee35f74d86b4" />

<img width="1411" height="80" alt="Screenshot 2026-05-15 at 12 28 17 PM" src="https://github.com/user-attachments/assets/284c2335-eebf-4317-aee8-5ef86f8a3d91" />


Tested locally.

## Checklist
* [✅] Linked issue in summary
* [✅] Self-reviewed the changes
* [✅] Tested locally
