### PR TITLE
fix : Add error state to PRMetrics, StreakTracker, and TopRepos

### DIFF
--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -12,13 +12,21 @@ interface PRData {
 export default function PRMetrics() {
   const [metrics, setMetrics] = useState<PRData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchMetrics = () => {
+    setLoading(true);
+    setError(null);
+
     fetch("/api/metrics/prs")
       .then((r) => r.json())
       .then((data: PRData) => setMetrics(data))
-      .catch(() => {})
+      .catch(() => setError("We couldn't load your PR analytics right now. Please try again in a moment."))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchMetrics();
   }, []);
 
   const stats = metrics
@@ -38,6 +46,17 @@ export default function PRMetrics() {
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="h-20 rounded-lg bg-[var(--card-muted)] p-4 animate-pulse" />
           ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchMetrics}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
         </div>
       ) : (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -12,13 +12,21 @@ interface StreakData {
 export default function StreakTracker() {
   const [data, setData] = useState<StreakData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchStreak = () => {
+    setLoading(true);
+    setError(null);
+
     fetch("/api/metrics/streak")
       .then((r) => r.json())
       .then((d: StreakData) => setData(d))
-      .catch(() => {})
+      .catch(() => setError("We couldn't load your streak data right now. Please try again in a moment."))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchStreak();
   }, []);
 
   if (loading) {
@@ -29,6 +37,24 @@ export default function StreakTracker() {
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="h-20 rounded-lg bg-[var(--card-muted)] animate-pulse" />
           ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Commit Streaks</h2>
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchStreak}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
         </div>
       </div>
     );

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -11,15 +11,21 @@ interface Repo {
 export default function TopRepos() {
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [days, setDays] = useState(30);
 
-  useEffect(() => {
+  const fetchRepos = () => {
     setLoading(true);
+    setError(null);
     fetch(`/api/metrics/repos?days=${days}`)
       .then((r) => r.json())
       .then((d: { repos: Repo[] }) => setRepos(d.repos ?? []))
-      .catch(() => {})
+      .catch(() => setError("We couldn't load your top repositories right now. Please try again in a moment."))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchRepos();
   }, [days]);
 
   const maxCommits = repos[0]?.commits ?? 1;
@@ -38,12 +44,24 @@ export default function TopRepos() {
           <option value={90}>Last 90d</option>
         </select>
       </div>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
 
       {loading ? (
         <div className="space-y-3">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="h-10 rounded bg-[var(--card-muted)] animate-pulse" />
           ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchRepos}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
         </div>
       ) : repos.length === 0 ? (
         <p className="text-sm text-[var(--muted-foreground)]">No commits in the last {days} days.</p>

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -44,8 +44,6 @@ export default function TopRepos() {
           <option value={90}>Last 90d</option>
         </select>
       </div>
-      {error && <p className="text-red-400 text-sm">{error}</p>}
-
       {loading ? (
         <div className="space-y-3">
           {[1, 2, 3, 4].map((i) => (


### PR DESCRIPTION
## Summary

This PR enhances the UX of the PR Metrics, Streak Tracker, and Top Repositories cards when their API requests fail. Instead of failing silently or leaving the cards blank, each component now maintains an error state and displays a clear red error message within the card.

Closes #40

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup

## Changes Made

Added error state to PRMetrics, StreakTracker, and TopRepos  
Set a friendly error message in each fetch .catch() block  
Displayed text-red-400 error text when data loading fails  
Kept existing loading and success UI unchanged

## How to Test

Steps for the reviewer to verify this works:

1. Just replace the api  url with a wrong url , you will get the error


## Screenshots (if UI change)
<img width="1843" height="990" alt="Screenshot 2026-05-15 133134" src="https://github.com/user-attachments/assets/d8c50bf1-315b-4049-8875-bc314456c924" />
<img width="1843" height="990" alt="Screenshot 2026-05-15 133134" src="https://github.com/user-attachments/assets/6430a969-a0dd-4824-ac45-3633c9e747a1" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
