### PR TITLE
Feat: add goal completion toast

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,12 +14,10 @@ export default async function HomePage() {
     <main className="min-h-screen flex flex-col items-center justify-center px-4">
       <div className="max-w-2xl text-center">
         <h1 className="text-5xl font-bold mb-4 text-white">DevTrack</h1>
-
         <p className="text-xl text-slate-400 mb-8">
           Open-source developer productivity dashboard. Track coding habits,
           visualize GitHub contributions, and hit your goals.
         </p>
-
         <div className="flex gap-4 justify-center">
           <Link
             href="/api/auth/signin/github?callbackUrl=/dashboard"
@@ -27,7 +25,6 @@ export default async function HomePage() {
           >
             Sign in with GitHub
           </Link>
-
           <a
             href="https://github.com/Priyanshu-byte-coder/devtrack"
             target="_blank"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
-
+import GoalTracker from "@/components/GoalTracker";
 export default function HomePage() {
   return (
     <main className="min-h-screen flex flex-col items-center justify-center px-4">
+      <GoalTracker />
       <div className="max-w-2xl text-center">
         <h1 className="text-5xl font-bold mb-4 text-white">DevTrack</h1>
         <p className="text-xl text-slate-400 mb-8">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,7 @@
 import Link from "next/link";
-import GoalTracker from "@/components/GoalTracker";
 export default function HomePage() {
   return (
     <main className="min-h-screen flex flex-col items-center justify-center px-4">
-      <GoalTracker />
       <div className="max-w-2xl text-center">
         <h1 className="text-5xl font-bold mb-4 text-white">DevTrack</h1>
         <p className="text-xl text-slate-400 mb-8">

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Toast from "./Toast";
 
 interface Goal {
   id: string;
@@ -13,18 +14,36 @@ export default function GoalTracker() {
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
 
+  const [toastMessage, setToastMessage] = useState("");
+  const [notifiedGoals, setNotifiedGoals] = useState<string[]>([]);
+
   useEffect(() => {
     fetch("/api/goals")
       .then((r) => r.json())
-      .then((data: { goals: Goal[] }) => setGoals(data.goals ?? []))
-      .catch(() => {})
+      .then((data: { goals: Goal[] }) => {
+        setGoals(data.goals ?? []);
+      })
+      .catch(() => { })
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    goals.forEach((goal) => {
+      const isComplete = goal.current >= goal.target;
+      const alreadyNotified = notifiedGoals.includes(goal.id);
+
+      if (isComplete && !alreadyNotified) {
+        setToastMessage(`🎉 Goal complete: ${goal.label}!`);
+        setNotifiedGoals((prev) => [...prev, goal.id]);
+      }
+    });
+  }, [goals, notifiedGoals]);
 
   if (loading) {
     return (
       <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
         <div className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse" />
+
         {[1, 2, 3].map((i) => (
           <div key={i} className="mb-4">
             <div className="mb-2 h-3 rounded bg-[var(--card-muted)] animate-pulse" />
@@ -36,35 +55,55 @@ export default function GoalTracker() {
   }
 
   return (
-    <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Weekly Goals</h2>
-      {goals.length === 0 ? (
-        <p className="text-sm text-[var(--muted-foreground)]">
-          No goals yet. Create one via the API or future UI.
-        </p>
-      ) : (
-        <ul className="space-y-4">
-          {goals.map((goal) => {
-            const pct = Math.min((goal.current / goal.target) * 100, 100);
-            return (
-              <li key={goal.id}>
-                <div className="flex justify-between text-sm mb-1">
-                  <span className="text-[var(--card-foreground)]">{goal.label}</span>
-                  <span className="text-[var(--muted-foreground)]">
-                    {goal.current}/{goal.target}
-                  </span>
-                </div>
-                <div className="h-2 overflow-hidden rounded-full bg-[var(--control)]">
-                  <div
-                    className="h-full rounded-full bg-[var(--accent)] transition-all"
-                    style={{ width: `${pct}%` }}
-                  />
-                </div>
-              </li>
-            );
-          })}
-        </ul>
+    <>
+      {toastMessage && (
+        <Toast
+          message={toastMessage}
+          onClose={() => setToastMessage("")}
+        />
       )}
-    </div>
+
+      <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
+          Weekly Goals
+        </h2>
+
+        {goals.length === 0 ? (
+          <p className="text-sm text-[var(--muted-foreground)]">
+            No goals yet. Create one via the API or future UI.
+          </p>
+        ) : (
+          <ul className="space-y-4">
+            {goals.map((goal) => {
+              const pct = Math.min(
+                (goal.current / goal.target) * 100,
+                100
+              );
+
+              return (
+                <li key={goal.id}>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span className="text-[var(--card-foreground)]">
+                      {goal.label}
+                    </span>
+
+                    <span className="text-[var(--muted-foreground)]">
+                      {goal.current}/{goal.target}
+                    </span>
+                  </div>
+
+                  <div className="h-2 overflow-hidden rounded-full bg-[var(--control)]">
+                    <div
+                      className="h-full rounded-full bg-[var(--accent)] transition-all"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </>
   );
 }

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -13,12 +13,10 @@ interface Goal {
 export default function GoalTracker() {
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
-
   const [label, setLabel] = useState("");
   const [target, setTarget] = useState(7);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
-
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
@@ -37,59 +35,6 @@ export default function GoalTracker() {
       .finally(() => setLoading(false));
   }, [loadGoals]);
 
-  async function handleCreate(e: React.FormEvent) {
-    e.preventDefault();
-
-    setCreating(true);
-    setCreateError(null);
-
-    try {
-      const response = await fetch("/api/goals", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ label, target }),
-      });
-
-      if (!response.ok) {
-        throw new Error();
-      }
-    } catch {
-      setCreateError("Failed to create goal. Please try again.");
-      setCreating(false);
-      return;
-    }
-
-    setLabel("");
-    setTarget(7);
-
-    await loadGoals().catch(() => { });
-
-    setCreating(false);
-  }
-
-  async function handleDelete(id: string) {
-    const previousGoals = goals;
-
-    setGoals((prev) => prev.filter((g) => g.id !== id));
-
-    setConfirmingId(null);
-    setDeletingId(id);
-
-    try {
-      const response = await fetch(`/api/goals/${id}`, {
-        method: "DELETE",
-      });
-
-      if (!response.ok) {
-        setGoals(previousGoals);
-      }
-    } catch {
-      setGoals(previousGoals);
-    } finally {
-      setDeletingId(null);
-    }
-  }
-
   useEffect(() => {
     goals.forEach((goal) => {
       const isComplete = goal.current >= goal.target;
@@ -102,10 +47,62 @@ export default function GoalTracker() {
     });
   }, [goals, notifiedGoals]);
 
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setCreating(true);
+    setCreateError(null);
+
+    try {
+      const response = await fetch("/api/goals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label, target }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to create goal");
+      }
+    } catch {
+      setCreateError("Failed to create goal. Please try again.");
+      setCreating(false);
+      return;
+    }
+
+    setLabel("");
+    setTarget(7);
+    await loadGoals().catch(() => { });
+    setCreating(false);
+  }
+
+  async function handleDelete(id: string) {
+    const previousGoals = goals;
+    setGoals((prev) => prev.filter((g) => g.id !== id));
+    setConfirmingId(null);
+    setDeletingId(id);
+
+    try {
+      const res = await fetch(`/api/goals/${id}`, { method: "DELETE" });
+
+      if (!res.ok) {
+        setGoals(previousGoals);
+      }
+    } catch {
+      setGoals(previousGoals);
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
   if (loading) {
     return (
       <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
         <div className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse" />
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="mb-4">
+            <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse mb-2" />
+            <div className="h-2 bg-[var(--card-muted)] rounded animate-pulse" />
+          </div>
+        ))}
       </div>
     );
   }
@@ -131,39 +128,45 @@ export default function GoalTracker() {
         ) : (
           <ul className="space-y-4">
             {goals.map((goal) => {
-              const pct = Math.min(
-                (goal.current / goal.target) * 100,
-                100
-              );
-
+              const pct = Math.min((goal.current / goal.target) * 100, 100);
               const isConfirming = confirmingId === goal.id;
               const isDeleting = deletingId === goal.id;
 
               return (
                 <li key={goal.id}>
                   <div className="flex justify-between items-center text-sm mb-1">
-                    <span>{goal.label}</span>
+                    <span className="text-[var(--card-foreground)]">
+                      {goal.label}
+                    </span>
 
                     <div className="flex items-center gap-2">
-                      <span>
+                      <span className="text-[var(--muted-foreground)]">
                         {goal.current}/{goal.target}
                       </span>
 
                       {isConfirming ? (
                         <span className="flex items-center gap-1 text-xs">
-                          <span>Delete?</span>
+                          <span className="text-[var(--muted-foreground)]">
+                            Delete?
+                          </span>
 
                           <button
                             onClick={() => handleDelete(goal.id)}
                             disabled={isDeleting}
+                            className="text-red-400 hover:text-red-300 font-semibold transition-colors disabled:opacity-50"
+                            aria-label={`Confirm delete goal: ${goal.label}`}
                           >
                             Yes
                           </button>
 
-                          <span>/</span>
+                          <span className="text-[var(--muted-foreground)]">
+                            /
+                          </span>
 
                           <button
                             onClick={() => setConfirmingId(null)}
+                            className="text-[var(--muted-foreground)] hover:text-[var(--card-foreground)] transition-colors"
+                            aria-label="Cancel delete"
                           >
                             No
                           </button>
@@ -172,9 +175,23 @@ export default function GoalTracker() {
                         <button
                           onClick={() => setConfirmingId(goal.id)}
                           disabled={isDeleting}
+                          className="text-[var(--muted-foreground)] hover:text-red-400 transition-colors disabled:opacity-50"
                           aria-label={`Delete goal: ${goal.label}`}
+                          title="Delete goal"
                         >
-                          🗑️
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                            className="w-4 h-4"
+                            aria-hidden="true"
+                          >
+                            <path
+                              fillRule="evenodd"
+                              d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
                         </button>
                       )}
                     </div>
@@ -196,32 +213,64 @@ export default function GoalTracker() {
           onSubmit={handleCreate}
           className="mt-6 space-y-3 border-t border-[var(--border)] pt-4"
         >
-          <input
-            type="text"
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            placeholder="Commit every day"
-            required
-            disabled={creating}
-          />
+          <div>
+            <label
+              htmlFor="goal-label"
+              className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]"
+            >
+              Goal label
+            </label>
 
-          <input
-            type="number"
-            min={1}
-            value={target}
-            onChange={(e) => setTarget(Number(e.target.value))}
-            disabled={creating}
-          />
+            <input
+              id="goal-label"
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Commit every day"
+              required
+              disabled={creating}
+              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)]"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="goal-target"
+              className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]"
+            >
+              Weekly target
+            </label>
+
+            <input
+              id="goal-target"
+              type="number"
+              min={1}
+              value={target}
+              onChange={(e) => setTarget(Number(e.target.value))}
+              disabled={creating}
+              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)]"
+            />
+          </div>
 
           <button
             type="submit"
             disabled={creating || !label.trim()}
+            className="inline-flex items-center gap-2 rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {creating ? "Creating..." : "Add goal"}
+            {creating ? (
+              <>
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                Creating...
+              </>
+            ) : (
+              "Add goal"
+            )}
           </button>
 
           {createError && (
-            <p>{createError}</p>
+            <p className="text-sm text-red-500">
+              {createError}
+            </p>
           )}
         </form>
       </div>

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,28 +1,31 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface ToastProps {
     message: string;
     onClose: () => void;
 }
 
-export default function Toast({ message, onClose }: ToastProps) {
+export default function Toast({
+    message,
+    onClose,
+}: ToastProps) {
+    const onCloseRef = useRef(onClose);
+
     useEffect(() => {
         const timer = setTimeout(() => {
-            onClose();
+            onCloseRef.current();
         }, 3000);
 
         return () => clearTimeout(timer);
-    }, [onClose]);
+    }, []);
 
     return (
-        <div className="fixed inset-0 flex justify-center items-start pt-6 pointer-events-none z-50">
-            <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-5 py-3 shadow-lg animate-bounce">
-                <p className="text-sm font-medium text-[var(--card-foreground)]">
-                    {message}
-                </p>
-            </div>
+        <div className="fixed top-6 left-1/2 -translate-x-1/2 z-50 rounded-lg border border-[var(--border)] bg-[var(--card)] px-4 py-3 shadow-lg">
+            <p className="text-sm font-medium text-[var(--card-foreground)]">
+                {message}
+            </p>
         </div>
     );
 }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface ToastProps {
+    message: string;
+    onClose: () => void;
+}
+
+export default function Toast({ message, onClose }: ToastProps) {
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            onClose();
+        }, 3000);
+
+        return () => clearTimeout(timer);
+    }, [onClose]);
+
+    return (
+        <div className="fixed inset-0 flex justify-center items-start pt-6 pointer-events-none z-50">
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-5 py-3 shadow-lg animate-bounce">
+                <p className="text-sm font-medium text-[var(--card-foreground)]">
+                    {message}
+                </p>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Implemented in-app goal completion toast notifications for the weekly goal tracker.

Closes #65

## Type of Change

* [ ] Bug fix
* [✅] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Added a reusable `Toast` component for in-app notifications
* Triggered toast when a goal reaches 100% completion
* Prevented duplicate notifications using local state tracking
* Added animation and theme-compatible styling

## How to Test

Steps for the reviewer to verify this works:

1. Run `npm install` and `npm run dev`
2. Navigate to the dashboard or render `GoalTracker`
3. Ensure a goal has `current >= target`
4. Verify a celebration toast appears
5. Refresh/re-render and verify the same goal does not trigger duplicate notifications

## Screenshots (if UI change)
<img width="1108" height="830" alt="WhatsApp Image 2026-05-15 at 1 55 56 PM" src="https://github.com/user-attachments/assets/c4c2aad5-2e25-445b-88af-931e58fa1eaf" />

Added UI screenshot of toast notification after goal completion.

## Checklist

* [✅] Linked issue in summary
* [✅] `npm run lint` passes locally
* [✅] No TypeScript errors (`npm run type-check`)
* [✅] Self-reviewed the diff
* [✅] Added/updated tests if applicable
