### PR TITLE
feat : added add goal form

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface Goal {
   id: string;
@@ -12,14 +12,44 @@ interface Goal {
 export default function GoalTracker() {
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
+  const [label, setLabel] = useState("");
+  const [target, setTarget] = useState(7);
+  const [creating, setCreating] = useState(false);
+
+  const loadGoals = useCallback(async () => {
+    const response = await fetch("/api/goals");
+    const data: { goals: Goal[] } = await response.json();
+    setGoals(data.goals ?? []);
+  }, []);
 
   useEffect(() => {
-    fetch("/api/goals")
-      .then((r) => r.json())
-      .then((data: { goals: Goal[] }) => setGoals(data.goals ?? []))
+    loadGoals()
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, []);
+  }, [loadGoals]);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setCreating(true);
+
+    try {
+      const response = await fetch("/api/goals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label, target }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to create goal");
+      }
+
+      setLabel("");
+      setTarget(7);
+      await loadGoals();
+    } finally {
+      setCreating(false);
+    }
+  }
 
   if (loading) {
     return (
@@ -65,6 +95,51 @@ export default function GoalTracker() {
           })}
         </ul>
       )}
+      <form onSubmit={handleCreate} className="mt-6 space-y-3 border-t border-[var(--border)] pt-4">
+        <div>
+          <label htmlFor="goal-label" className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+            Goal label
+          </label>
+          <input
+            id="goal-label"
+            type="text"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            placeholder="Commit every day"
+            required
+            disabled={creating}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)]"
+          />
+        </div>
+        <div>
+          <label htmlFor="goal-target" className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+            Weekly target
+          </label>
+          <input
+            id="goal-target"
+            type="number"
+            min={1}
+            value={target}
+            onChange={(event) => setTarget(Number(event.target.value))}
+            disabled={creating}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)]"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={creating || !label.trim()}
+          className="inline-flex items-center gap-2 rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {creating ? (
+            <>
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+              Creating...
+            </>
+          ) : (
+            "Add goal"
+          )}
+        </button>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Added an inline weekly goal creation form to the GoalTracker widget on the dashboard, allowing users to set goals without manually using the API. The form takes a goal label and weekly target, sends them directly to /api/goals, displays a loading spinner while saving, and updates the goals list right after a successful save so the empty state refreshes instantly.

Closes #13 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made



Steps for the reviewer to verify this works:

1.changed a single file GoalTracker.tsx, Updated the dashboard GoalTracker widget so users can create a new weekly goal directly in the UI. The component now includes a form for the goal label and weekly target .

## How to Test

just use the form visible in the goal widget and it will add new goals directlt

## Screenshots (if UI change)
[

https://github.com/user-attachments/assets/24657472-b060-4af2-b54c-467acc97dd16

]

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
