### PR TITLE
[BUG] GitHub session does not persist across browser restarts

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,9 @@ import { type NextAuthOptions } from "next-auth";
 import GitHubProvider from "next-auth/providers/github";
 import { supabaseAdmin } from "./supabase";
 
+const SESSION_MAX_AGE = 30 * 24 * 60 * 60;
+const useSecureCookies = process.env.NODE_ENV === "production";
+
 export const authOptions: NextAuthOptions = {
   providers: [
     GitHubProvider({
@@ -12,6 +15,28 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
+  session: {
+    strategy: "jwt",
+    maxAge: SESSION_MAX_AGE,
+    // updateAge: SESSION_UPDATE_AGE,
+  },
+  jwt: {
+    maxAge: SESSION_MAX_AGE,
+  },
+  cookies: {
+    sessionToken: {
+      name: useSecureCookies
+        ? "__Secure-next-auth.session-token"
+        : "next-auth.session-token",
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: useSecureCookies,
+        maxAge: SESSION_MAX_AGE,
+      },
+    },
+  },
   callbacks: {
     async signIn({ account, profile }) {
       if (account?.provider === "github" && profile) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import GitHubProvider from "next-auth/providers/github";
 import { supabaseAdmin } from "./supabase";
 
 const SESSION_MAX_AGE = 30 * 24 * 60 * 60;
+const SESSION_UPDATE_AGE = 24 * 60 * 60;
 const useSecureCookies = process.env.NODE_ENV === "production";
 
 export const authOptions: NextAuthOptions = {
@@ -18,7 +19,7 @@ export const authOptions: NextAuthOptions = {
   session: {
     strategy: "jwt",
     maxAge: SESSION_MAX_AGE,
-    // updateAge: SESSION_UPDATE_AGE,
+    updateAge: SESSION_UPDATE_AGE,
   },
   jwt: {
     maxAge: SESSION_MAX_AGE,


### PR DESCRIPTION
## Summary

Fixes GitHub authentication sessions not persisting across browser restarts.

Previously, users were required to re-authenticate with GitHub every time the browser/tab was reopened because session persistence settings and cookie configuration were not explicitly defined.

Closes #71 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added explicit JWT-based session strategy
- Configured persistent session expiration using maxAge
- Added updateAge for periodic session refresh
- Added JWT expiration configuration
- Configured persistent session token cookies
- Added production-safe secure cookie handling
- Added environment-aware cookie naming:
    - __Secure-next-auth.session-token in production
    - next-auth.session-token in development

## How to Test

Steps for the reviewer to verify this works:

1. Open the DevTrack application
2. Sign in using GitHub OAuth
3. Access the dashboard successfully
4. Close the browser tab or browser window
5. Reopen the application
6. Observe that the app redirects to dashboard, instead of prompting user to sign-in again

## Screenshots (if UI change)

> None

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
```
> devtrack@0.2.0 lint
> next lint

=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=4.7.4 <5.5.0

YOUR TYPESCRIPT VERSION: 5.9.3

Please only submit bug reports when using the officially supported version.

=============
✔ No ESLint warnings or errors
```
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
