### PR TITLE
Add keyboard shortcuts and tooltip hints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -731,7 +731,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1163,7 +1162,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1606,7 +1604,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2424,7 +2421,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2593,7 +2589,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3997,7 +3992,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4873,7 +4867,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5044,7 +5037,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5125,7 +5117,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5138,7 +5129,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6145,7 +6135,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6315,7 +6304,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { useEffect } from "react";
 import ContributionGraph from "@/components/ContributionGraph";
 import PRMetrics from "@/components/PRMetrics";
 import GoalTracker from "@/components/GoalTracker";
@@ -8,45 +5,22 @@ import DashboardHeader from "@/components/DashboardHeader";
 import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
 import LanguageBreakdown from "@/components/LanguageBreakdown";
+import KeyboardShortcuts from "@/components/KeyboardShortcuts";
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
-export default function DashboardPage() {
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement;
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
 
-      if (
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable
-      ) {
-        return;
-      }
-
-      if (event.key.toLowerCase() === "d") {
-        window.dispatchEvent(new Event("toggle-theme"));
-      }
-
-      if (event.key.toLowerCase() === "b") {
-        window.dispatchEvent(new Event("toggle-chart"));
-      }
-
-      if (event.key.toLowerCase() === "r") {
-        window.location.reload();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, []);
+  if (!session) {
+    redirect("/");
+  }
 
   return (
     <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors">
+      <KeyboardShortcuts />
+
       <DashboardHeader />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -63,7 +37,6 @@ export default function DashboardPage() {
         <PRMetrics />
       </div>
 
-      <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
       {/* Row 3: Top repos + Language breakdown + Goal tracker */}
       <div className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
         <TopRepos />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,40 +1,64 @@
+"use client";
+
+import { useEffect } from "react";
 import ContributionGraph from "@/components/ContributionGraph";
 import PRMetrics from "@/components/PRMetrics";
 import GoalTracker from "@/components/GoalTracker";
 import DashboardHeader from "@/components/DashboardHeader";
 import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
-import { authOptions } from "@/lib/auth";
-import { getServerSession } from "next-auth";
-import { redirect } from "next/navigation";
 
-export default async function DashboardPage() {
-  const session = await getServerSession(authOptions);
+export default function DashboardPage() {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement;
 
-  if (!session) {
-    redirect("/");
-  }
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
 
- return (
-      <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors">
-        <DashboardHeader />
+      if (event.key.toLowerCase() === "d") {
+        window.dispatchEvent(new Event("toggle-theme"));
+      }
 
-      {/* Row 1: Contribution graph + Streak + Goals */}
+      if (event.key.toLowerCase() === "b") {
+        window.dispatchEvent(new Event("toggle-chart"));
+      }
+
+      if (event.key.toLowerCase() === "r") {
+        window.location.reload();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors">
+      <DashboardHeader />
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
           <ContributionGraph />
         </div>
+
         <div className="flex flex-col gap-6">
           <StreakTracker />
         </div>
       </div>
 
-      {/* Row 2: PR metrics */}
       <div className="mt-6">
         <PRMetrics />
       </div>
 
-      {/* Row 3: Top repos + Goal tracker */}
       <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
         <TopRepos />
         <GoalTracker />

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -40,16 +40,28 @@ export default function ContributionGraph() {
 
   useEffect(() => {
     setLoading(true);
+
     fetch(`/api/metrics/contributions?days=${days}`)
-      .then((r) => r.json())
-      .then((res: { data: Record<string, number> }) => {
+      .then(async (r) => {
+        const res = await r.json();
+
+        if (!r.ok) {
+          throw new Error(res.error || "Failed to load contributions");
+        }
+
+        return res as { data: Record<string, number> };
+      })
+      .then((res) => {
         const sorted = Object.entries(res.data ?? {})
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([day, commits]) => ({ day, commits }));
 
         setData(sorted);
       })
-      .catch(() => {})
+      .catch((error) => {
+        console.error(error);
+        setData([]);
+      })
       .finally(() => setLoading(false));
   }, [days]);
 

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -53,49 +53,62 @@ export default function ContributionGraph() {
       .finally(() => setLoading(false));
   }, [days]);
 
+  useEffect(() => {
+    const handleToggleChart = () => {
+      setChartType((current) => (current === "bar" ? "line" : "bar"));
+    };
+
+    window.addEventListener("toggle-chart", handleToggleChart as EventListener);
+
+    return () => {
+      window.removeEventListener(
+        "toggle-chart",
+        handleToggleChart as EventListener
+      );
+    };
+  }, []);
+
   return (
-<div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <div className="flex flex-wrap items-center justify-between mb-4 gap-2">
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
         <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
           Commit Activity
         </h2>
 
         <div className="flex flex-wrap items-center gap-2">
-    
           <div className="flex gap-1 rounded-lg bg-[var(--control)] p-1">
             {RANGES.map((r) => (
               <button
                 key={r.days}
                 onClick={() => setDays(r.days)}
-                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
+                className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
                   days === r.days
                     ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
                     : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
                 }`}
+                title={`Show ${r.label} data`}
               >
                 {r.label}
               </button>
             ))}
           </div>
 
-          {/* Chart Toggle Buttons */}
-          {data.length > 0 && (
-            <div className="flex gap-1 rounded-lg bg-[var(--control)] p-1 text-sm">
-              {charts.map((chart) => (
-                <button
-                  key={chart.key}
-                  onClick={() => setChartType(chart.key)}
-                  className={`px-3 py-1 rounded-md transition-colors duration-200 ${
-                    chartType === chart.key
-                      ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
-                      : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
-                  }`}
-                >
-                  {chart.label}
-                </button>
-              ))}
-            </div>
-          )}
+          <div className="flex gap-1 rounded-lg bg-[var(--control)] p-1 text-sm">
+            {charts.map((chart) => (
+              <button
+                key={chart.key}
+                onClick={() => setChartType(chart.key)}
+                className={`rounded-md px-3 py-1 transition-colors duration-200 ${
+                  chartType === chart.key
+                    ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                    : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
+                }`}
+                title={`Toggle ${chart.label.toLowerCase()} chart (${chart.label[0]})`}
+              >
+                {chart.label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,24 +1,31 @@
-"use client"
+"use client";
 
 import SignOutButton from "@/components/SignOutButton";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserAvatar from "@/components/UserAvatar";
 
-
 export default function DashboardHeader() {
-return (
-        <header className="flex flex-wrap items-center justify-between p-4 mb-8 gap-3 border-b border-[var(--border)] pb-6">
-            <div>
-                <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">Dashboard</h1>
-                <p className="mt-1 text-[var(--muted-foreground)]">Your coding activity at a glance</p>
-            </div>
+  return (
+    <header className="flex flex-wrap items-center justify-between p-4 mb-8 gap-3 border-b border-[var(--border)] pb-6">
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">
+          Dashboard
+        </h1>
 
-            <div className="flex flex-wrap items-center gap-3">
-                <UserAvatar />
-                <ThemeToggle />
-                <SignOutButton />
-            </div>
+        <p className="mt-1 text-[var(--muted-foreground)]">
+          Your coding activity at a glance
+        </p>
+      </div>
 
-        </header>
-    );
+      <div className="flex flex-wrap items-center gap-3">
+        <UserAvatar />
+
+        <div title="Toggle theme (D)">
+          <ThemeToggle />
+        </div>
+
+        <SignOutButton />
+      </div>
+    </header>
+  );
 }

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function KeyboardShortcuts() {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      if (e.key.toLowerCase() === 'd') {
+        window.dispatchEvent(new Event('toggle-theme'));
+      }
+
+      if (e.key.toLowerCase() === 'b') {
+        window.dispatchEvent(new Event('toggle-chart'));
+      }
+
+      if (e.key.toLowerCase() === 'r') {
+        window.location.reload();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -9,6 +9,15 @@ interface StreakData {
   totalActiveDays: number;
 }
 
+type StreakStat = {
+  label: string;
+  value: number | string;
+  unit: string;
+  highlight: boolean;
+  icon: string;
+  tooltip: string;
+};
+
 export default function StreakTracker() {
   const [data, setData] = useState<StreakData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -34,7 +43,7 @@ export default function StreakTracker() {
     );
   }
 
-  const stats = data
+  const stats: StreakStat[] = data
     ? [
         {
           label: "Current Streak",
@@ -42,6 +51,7 @@ export default function StreakTracker() {
           unit: "days",
           highlight: data.current > 0,
           icon: "🔥",
+          tooltip: "Current consecutive coding days",
         },
         {
           label: "Longest Streak",
@@ -49,6 +59,7 @@ export default function StreakTracker() {
           unit: "days",
           highlight: false,
           icon: "🏆",
+          tooltip: "Your longest streak ever",
         },
         {
           label: "Active Days (90d)",
@@ -56,6 +67,7 @@ export default function StreakTracker() {
           unit: "days",
           highlight: false,
           icon: "📅",
+          tooltip: "Active coding days in the last 90 days",
         },
         {
           label: "Last Commit",
@@ -68,13 +80,17 @@ export default function StreakTracker() {
           unit: "",
           highlight: false,
           icon: "⚡",
+          tooltip: "Date of your most recent commit",
         },
       ]
     : [];
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Commit Streaks</h2>
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
+        Commit Streaks
+      </h2>
+
       <div className="grid grid-cols-2 gap-3">
         {stats.map((stat) => (
           <div
@@ -85,7 +101,14 @@ export default function StreakTracker() {
                 : "bg-[var(--control)]"
             }`}
           >
-            <div className="text-xl mb-1">{stat.icon}</div>
+            <div className="group relative mx-auto mb-1 flex w-fit items-center justify-center">
+              <div className="text-xl cursor-help">{stat.icon}</div>
+
+              <div className="pointer-events-none absolute bottom-full left-1/2 mb-2 hidden w-max -translate-x-1/2 rounded-md bg-black px-2 py-1 text-xs text-white shadow-md group-hover:block">
+                {stat.tooltip}
+              </div>
+            </div>
+
             <div
               className={`text-2xl font-bold ${
                 stat.highlight ? "text-[var(--accent)]" : "text-[var(--accent)]"
@@ -98,7 +121,10 @@ export default function StreakTracker() {
                 </span>
               )}
             </div>
-            <div className="mt-1 text-xs text-[var(--muted-foreground)]">{stat.label}</div>
+
+            <div className="mt-1 text-xs text-[var(--muted-foreground)]">
+              {stat.label}
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -20,18 +20,29 @@ export default function ThemeToggle() {
   }, []);
 
   useEffect(() => {
-    if (!mounted) {
-      return;
-    }
+    if (!mounted) return;
 
     document.documentElement.classList.toggle("dark", dark);
     document.documentElement.style.colorScheme = dark ? "dark" : "light";
     localStorage.setItem(STORAGE_KEY, dark ? "dark" : "light");
   }, [dark, mounted]);
 
-  if (!mounted) {
-    return null;
-  }
+  useEffect(() => {
+    const handleToggleTheme = () => {
+      setDark((current) => !current);
+    };
+
+    window.addEventListener("toggle-theme", handleToggleTheme as EventListener);
+
+    return () => {
+      window.removeEventListener(
+        "toggle-theme",
+        handleToggleTheme as EventListener
+      );
+    };
+  }, []);
+
+  if (!mounted) return null;
 
   return (
     <button


### PR DESCRIPTION
## Summary

Added keyboard shortcuts and tooltip hints for dashboard actions.

Closes #54

## Type of Change

* [x] New feature

## Changes Made

* Added keyboard shortcuts for:

  * D → toggle theme
  * B → toggle chart type
  * R → refresh dashboard
* Added tooltip hints for dashboard actions
* Prevented shortcuts from triggering while typing in inputs
* Added keydown listener with cleanup using useEffect

## How to Test

1. Open dashboard
2. Press D to toggle theme
3. Press B to switch chart type
4. Press R to refresh dashboard
5. Hover buttons to verify tooltip hints

## Checklist

* [x] Linked issue in summary
* [x] Self-reviewed the diff
