### PR TITLE
feat(goals): add delete button to individual goals in GoalTracker (#98)

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,5 +1,9 @@
 name: Welcome first-time contributors
 
+permissions:
+  pull-requests: write
+  issues: write
+
 on:
   pull_request_target:
     types: [opened]

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,2 @@
+[.ShellClassInfo]
+LocalizedResourceName=@devtrack,0

--- a/package-lock.json
+++ b/package-lock.json
@@ -731,6 +731,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1162,6 +1163,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1604,6 +1606,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2421,6 +2424,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2589,6 +2593,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3992,6 +3997,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4867,6 +4873,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5037,6 +5044,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5117,6 +5125,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5129,6 +5138,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6135,6 +6145,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6304,6 +6315,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -1,0 +1,36 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.githubId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: user } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", session.githubId)
+    .single();
+
+  if (!user) return Response.json({ error: "User not found" }, { status: 404 });
+
+  // Only delete if the goal belongs to the authenticated user
+  const { error } = await supabaseAdmin
+    .from("goals")
+    .delete()
+    .eq("id", params.id)
+    .eq("user_id", user.id);
+
+  if (error) {
+    return Response.json({ error: "Failed to delete goal" }, { status: 500 });
+  }
+
+  return Response.json({ success: true }, { status: 200 });
+}

--- a/src/app/api/metrics/languages/route.ts
+++ b/src/app/api/metrics/languages/route.ts
@@ -1,0 +1,75 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_API = "https://api.github.com";
+
+interface RepoItem {
+  repository: { full_name: string };
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const headers = {
+    Authorization: `Bearer ${session.accessToken}`,
+    Accept: "application/vnd.github+json",
+  };
+
+  // Fetch recent commits to discover the user's active repos (same approach as repos route)
+  const since = new Date();
+  since.setDate(since.getDate() - 90);
+  const sinceStr = since.toISOString().slice(0, 10);
+
+  const searchRes = await fetch(
+    `${GITHUB_API}/search/commits?q=author:${session.githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
+    { headers, cache: "no-store" }
+  );
+
+  if (!searchRes.ok) {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+
+  const data = (await searchRes.json()) as { items: RepoItem[] };
+
+  // Deduplicate repo names
+  const repoNames = Array.from(new Set(data.items.map((i) => i.repository.full_name)));
+
+  // Fetch language breakdown for each repo
+  const langTotals: Record<string, number> = {};
+
+  await Promise.all(
+    repoNames.map(async (repoName) => {
+      try {
+        const res = await fetch(`${GITHUB_API}/repos/${repoName}/languages`, {
+          headers,
+          cache: "no-store",
+        });
+        if (!res.ok) return;
+        const langs = (await res.json()) as Record<string, number>;
+        for (const [lang, bytes] of Object.entries(langs)) {
+          langTotals[lang] = (langTotals[lang] ?? 0) + bytes;
+        }
+      } catch {
+        // Skip repos that fail
+      }
+    })
+  );
+
+  const totalBytes = Object.values(langTotals).reduce((s, b) => s + b, 0);
+
+  const languages = Object.entries(langTotals)
+    .map(([name, bytes]) => ({
+      name,
+      bytes,
+      percentage: totalBytes > 0 ? Math.round((bytes / totalBytes) * 1000) / 10 : 0,
+    }))
+    .sort((a, b) => b.percentage - a.percentage)
+    .slice(0, 6);
+
+  return Response.json({ languages });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,7 +16,7 @@ export default async function DashboardPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-900 p-8">
+  <div className="min-h-screen bg-slate-900 p-4 md:p-8">
       <DashboardHeader />
 
       {/* Row 1: Contribution graph + Streak + Goals */}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import GoalTracker from "@/components/GoalTracker";
 import DashboardHeader from "@/components/DashboardHeader";
 import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
+import LanguageBreakdown from "@/components/LanguageBreakdown";
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
@@ -15,9 +16,9 @@ export default async function DashboardPage() {
     redirect("/");
   }
 
-  return (
-  <div className="min-h-screen bg-slate-900 p-4 md:p-8">
-      <DashboardHeader />
+ return (
+      <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors">
+        <DashboardHeader />
 
       {/* Row 1: Contribution graph + Streak + Goals */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -34,9 +35,10 @@ export default async function DashboardPage() {
         <PRMetrics />
       </div>
 
-      {/* Row 3: Top repos + Goal tracker */}
-      <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Row 3: Top repos + Language breakdown + Goal tracker */}
+      <div className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
         <TopRepos />
+        <LanguageBreakdown />
         <GoalTracker />
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,11 +3,43 @@
 @tailwind utilities;
 
 :root {
+  color-scheme: light;
+  --background: #f8fafc;
+  --foreground: #0f172a;
+  --muted-foreground: #475569;
+  --card: #ffffff;
+  --card-foreground: #0f172a;
+  --card-muted: #e2e8f0;
+  --border: #cbd5e1;
+  --accent: #6366f1;
+  --accent-soft: rgba(99, 102, 241, 0.15);
+  --accent-foreground: #ffffff;
+  --control: #e2e8f0;
+  --control-hover: #cbd5e1;
+  --tooltip: #ffffff;
+  --tooltip-foreground: #0f172a;
+}
+
+.dark {
+  color-scheme: dark;
   --background: #0f172a;
   --foreground: #f8fafc;
+  --muted-foreground: #94a3b8;
+  --card: #1e293b;
+  --card-foreground: #f8fafc;
+  --card-muted: #334155;
+  --border: #334155;
+  --accent: #818cf8;
+  --accent-soft: rgba(99, 102, 241, 0.2);
+  --accent-foreground: #ffffff;
+  --control: #334155;
+  --control-hover: #475569;
+  --tooltip: #1e293b;
+  --tooltip-foreground: #f8fafc;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
+  transition: background-color 200ms ease, color 200ms ease;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body className={inter.className}>
         <Providers>{children}</Providers>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,15 @@
 import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
 
-export default function HomePage() {
+export default async function HomePage() {
+  const session = await getServerSession(authOptions);
+
+  if (session) {
+    redirect("/dashboard");
+  }
+
   return (
     <main className="min-h-screen flex flex-col items-center justify-center px-4">
       <div className="max-w-2xl text-center">

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,7 +2,13 @@
 
 import type { ReactNode } from "react";
 import { SessionProvider } from "next-auth/react";
+import ThemeSync from "@/components/ThemeSync";
 
 export default function Providers({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <ThemeSync />
+      {children}
+    </SessionProvider>
+  );
 }

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -55,7 +55,7 @@ export default function ContributionGraph() {
 
   return (
     <div className="bg-slate-800 rounded-xl p-6">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex flex-wrap items-center justify-between mb-4 gap-2">
         <h2 className="text-white font-semibold text-lg">
           Commit Activity
         </h2>

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -54,23 +54,23 @@ export default function ContributionGraph() {
   }, [days]);
 
   return (
-    <div className="bg-slate-800 rounded-xl p-6">
+<div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <div className="flex flex-wrap items-center justify-between mb-4 gap-2">
-        <h2 className="text-white font-semibold text-lg">
+        <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
           Commit Activity
         </h2>
 
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-2">
     
-          <div className="flex gap-1 bg-slate-700 rounded-lg p-1">
+          <div className="flex gap-1 rounded-lg bg-[var(--control)] p-1">
             {RANGES.map((r) => (
               <button
                 key={r.days}
                 onClick={() => setDays(r.days)}
                 className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
                   days === r.days
-                    ? "bg-indigo-500 text-white"
-                    : "text-slate-400 hover:text-slate-200"
+                    ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                    : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
                 }`}
               >
                 {r.label}
@@ -80,15 +80,15 @@ export default function ContributionGraph() {
 
           {/* Chart Toggle Buttons */}
           {data.length > 0 && (
-            <div className="flex gap-1 bg-slate-700 rounded-lg p-1 text-sm">
+            <div className="flex gap-1 rounded-lg bg-[var(--control)] p-1 text-sm">
               {charts.map((chart) => (
                 <button
                   key={chart.key}
                   onClick={() => setChartType(chart.key)}
                   className={`px-3 py-1 rounded-md transition-colors duration-200 ${
                     chartType === chart.key
-                      ? "bg-indigo-500 text-white"
-                      : "text-slate-400 hover:text-slate-200"
+                      ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                      : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
                   }`}
                 >
                   {chart.label}
@@ -100,57 +100,59 @@ export default function ContributionGraph() {
       </div>
 
       {loading ? (
-        <div className="h-[200px] bg-slate-700 rounded animate-pulse" />
+        <div className="h-[200px] rounded bg-[var(--card-muted)] animate-pulse" />
       ) : data.length === 0 ? (
-        <p className="text-slate-400 text-sm h-[200px] flex items-center">
+        <p className="flex h-[200px] items-center text-sm text-[var(--muted-foreground)]">
           No commits in the last {days} days.
         </p>
       ) : (
         <ResponsiveContainer width="100%" height={200}>
           {chartType === "bar" ? (
             <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
               <XAxis dataKey="day" hide />
-              <YAxis stroke="#94a3b8" allowDecimals={false} />
+              <YAxis stroke="var(--muted-foreground)" allowDecimals={false} />
               <Tooltip
                 contentStyle={{
-                  background: "#1e293b",
-                  border: "none",
+                  background: "var(--tooltip)",
+                  color: "var(--tooltip-foreground)",
+                  border: "1px solid var(--border)",
                   borderRadius: "8px",
                 }}
                 labelStyle={{
-                  color: "#f8fafc",
+                  color: "var(--tooltip-foreground)",
                   fontSize: "12px",
                 }}
-                cursor={{ fill: "#334155" }}
+                cursor={{ fill: "var(--card-muted)" }}
               />
               <Bar
                 dataKey="commits"
-                fill="#6366f1"
+                fill="var(--accent)"
                 radius={[4, 4, 0, 0]}
               />
             </BarChart>
           ) : (
             <LineChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
               <XAxis dataKey="day" hide />
-              <YAxis stroke="#94a3b8" allowDecimals={false} />
+              <YAxis stroke="var(--muted-foreground)" allowDecimals={false} />
               <Tooltip
                 contentStyle={{
-                  background: "#1e293b",
-                  border: "none",
+                  background: "var(--tooltip)",
+                  color: "var(--tooltip-foreground)",
+                  border: "1px solid var(--border)",
                   borderRadius: "8px",
                 }}
                 labelStyle={{
-                  color: "#f8fafc",
+                  color: "var(--tooltip-foreground)",
                   fontSize: "12px",
                 }}
-                cursor={{ fill: "#334155" }}
+                cursor={{ fill: "var(--card-muted)" }}
               />
               <Line
                 type="monotone"
                 dataKey="commits"
-                stroke="#6366f1"
+                stroke="var(--accent)"
                 strokeWidth={2}
                 dot={false}
               />

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,19 +1,21 @@
 "use client"
 
 import SignOutButton from "@/components/SignOutButton";
+import ThemeToggle from "@/components/ThemeToggle";
 import UserAvatar from "@/components/UserAvatar";
 
 
 export default function DashboardHeader() {
-    return (
-        <header className="flex flex-wrap items-center justify-between p-4 mb-8 gap-3">
+return (
+        <header className="flex flex-wrap items-center justify-between p-4 mb-8 gap-3 border-b border-[var(--border)] pb-6">
             <div>
-                <h1 className="text-2xl md:text-3xl font-bold text-white">Dashboard</h1>
-                <p className="text-slate-400 mt-1">Your coding activity at a glance</p>
+                <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">Dashboard</h1>
+                <p className="mt-1 text-[var(--muted-foreground)]">Your coding activity at a glance</p>
             </div>
 
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-3">
                 <UserAvatar />
+                <ThemeToggle />
                 <SignOutButton />
             </div>
 

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -6,9 +6,9 @@ import UserAvatar from "@/components/UserAvatar";
 
 export default function DashboardHeader() {
     return (
-        <header className="flex items-center justify-between p-4 mb-8">
+        <header className="flex flex-wrap items-center justify-between p-4 mb-8 gap-3">
             <div>
-                <h1 className="text-3xl font-bold text-white">Dashboard</h1>
+                <h1 className="text-2xl md:text-3xl font-bold text-white">Dashboard</h1>
                 <p className="text-slate-400 mt-1">Your coding activity at a glance</p>
             </div>
 

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 interface Goal {
   id: string;
@@ -12,53 +12,48 @@ interface Goal {
 export default function GoalTracker() {
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
-  const [label, setLabel] = useState("");
-  const [target, setTarget] = useState(7);
-  const [creating, setCreating] = useState(false);
-
-  const loadGoals = useCallback(async () => {
-    const response = await fetch("/api/goals");
-    const data: { goals: Goal[] } = await response.json();
-    setGoals(data.goals ?? []);
-  }, []);
+  // Track which goal is awaiting delete confirmation
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  // Track which goal is currently being deleted (API in-flight)
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useEffect(() => {
-    loadGoals()
+    fetch("/api/goals")
+      .then((r) => r.json())
+      .then((data: { goals: Goal[] }) => setGoals(data.goals ?? []))
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, [loadGoals]);
+  }, []);
 
-  async function handleCreate(e: React.FormEvent) {
-    e.preventDefault();
-    setCreating(true);
+  async function handleDelete(id: string) {
+    // Optimistic update: remove goal immediately
+    const previousGoals = goals;
+    setGoals((prev) => prev.filter((g) => g.id !== id));
+    setConfirmingId(null);
+    setDeletingId(id);
 
     try {
-      const response = await fetch("/api/goals", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ label, target }),
-      });
-
-      if (!response.ok) {
-        throw new Error("Failed to create goal");
+      const res = await fetch(`/api/goals/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        // Restore on failure
+        setGoals(previousGoals);
       }
-
-      setLabel("");
-      setTarget(7);
-      await loadGoals();
+    } catch {
+      // Restore on network error
+      setGoals(previousGoals);
     } finally {
-      setCreating(false);
+      setDeletingId(null);
     }
   }
 
   if (loading) {
     return (
-      <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
-        <div className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse" />
+      <div className="bg-slate-800 rounded-xl p-6 h-full">
+        <div className="h-5 w-32 bg-slate-700 rounded animate-pulse mb-4" />
         {[1, 2, 3].map((i) => (
           <div key={i} className="mb-4">
-            <div className="mb-2 h-3 rounded bg-[var(--card-muted)] animate-pulse" />
-            <div className="h-2 rounded bg-[var(--card-muted)] animate-pulse" />
+            <div className="h-3 bg-slate-700 rounded animate-pulse mb-2" />
+            <div className="h-2 bg-slate-700 rounded animate-pulse" />
           </div>
         ))}
       </div>
@@ -66,27 +61,80 @@ export default function GoalTracker() {
   }
 
   return (
-    <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Weekly Goals</h2>
+    <div className="bg-slate-800 rounded-xl p-6 h-full">
+      <h2 className="text-white font-semibold text-lg mb-4">Weekly Goals</h2>
       {goals.length === 0 ? (
-        <p className="text-sm text-[var(--muted-foreground)]">
+        <p className="text-slate-400 text-sm">
           No goals yet. Create one via the API or future UI.
         </p>
       ) : (
         <ul className="space-y-4">
           {goals.map((goal) => {
             const pct = Math.min((goal.current / goal.target) * 100, 100);
+            const isConfirming = confirmingId === goal.id;
+            const isDeleting = deletingId === goal.id;
+
             return (
               <li key={goal.id}>
-                <div className="flex justify-between text-sm mb-1">
-                  <span className="text-[var(--card-foreground)]">{goal.label}</span>
-                  <span className="text-[var(--muted-foreground)]">
-                    {goal.current}/{goal.target}
-                  </span>
+                <div className="flex justify-between items-center text-sm mb-1">
+                  <span className="text-slate-300">{goal.label}</span>
+
+                  <div className="flex items-center gap-2">
+                    <span className="text-slate-400">
+                      {goal.current}/{goal.target}
+                    </span>
+
+                    {/* Delete / Confirm UI */}
+                    {isConfirming ? (
+                      <span className="flex items-center gap-1 text-xs">
+                        <span className="text-slate-400">Delete?</span>
+                        <button
+                          onClick={() => handleDelete(goal.id)}
+                          disabled={isDeleting}
+                          className="text-red-400 hover:text-red-300 font-semibold transition-colors disabled:opacity-50"
+                          aria-label={`Confirm delete goal: ${goal.label}`}
+                        >
+                          Yes
+                        </button>
+                        <span className="text-slate-600">/</span>
+                        <button
+                          onClick={() => setConfirmingId(null)}
+                          className="text-slate-400 hover:text-slate-200 transition-colors"
+                          aria-label="Cancel delete"
+                        >
+                          No
+                        </button>
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmingId(goal.id)}
+                        disabled={isDeleting}
+                        className="text-slate-500 hover:text-red-400 transition-colors disabled:opacity-50"
+                        aria-label={`Delete goal: ${goal.label}`}
+                        title="Delete goal"
+                      >
+                        {/* Trash icon (inline SVG, no extra dependency) */}
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                          className="w-4 h-4"
+                          aria-hidden="true"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
                 </div>
-                <div className="h-2 overflow-hidden rounded-full bg-[var(--control)]">
+
+                <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
                   <div
-                    className="h-full rounded-full bg-[var(--accent)] transition-all"
+                    className="h-full bg-indigo-500 rounded-full transition-all"
                     style={{ width: `${pct}%` }}
                   />
                 </div>
@@ -95,51 +143,6 @@ export default function GoalTracker() {
           })}
         </ul>
       )}
-      <form onSubmit={handleCreate} className="mt-6 space-y-3 border-t border-[var(--border)] pt-4">
-        <div>
-          <label htmlFor="goal-label" className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
-            Goal label
-          </label>
-          <input
-            id="goal-label"
-            type="text"
-            value={label}
-            onChange={(event) => setLabel(event.target.value)}
-            placeholder="Commit every day"
-            required
-            disabled={creating}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)]"
-          />
-        </div>
-        <div>
-          <label htmlFor="goal-target" className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
-            Weekly target
-          </label>
-          <input
-            id="goal-target"
-            type="number"
-            min={1}
-            value={target}
-            onChange={(event) => setTarget(Number(event.target.value))}
-            disabled={creating}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)]"
-          />
-        </div>
-        <button
-          type="submit"
-          disabled={creating || !label.trim()}
-          className="inline-flex items-center gap-2 rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {creating ? (
-            <>
-              <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-              Creating...
-            </>
-          ) : (
-            "Add goal"
-          )}
-        </button>
-      </form>
     </div>
   );
 }

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface Goal {
   id: string;
@@ -12,23 +12,53 @@ interface Goal {
 export default function GoalTracker() {
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
+  const [label, setLabel] = useState("");
+  const [target, setTarget] = useState(7);
+  const [creating, setCreating] = useState(false);
+
+  const loadGoals = useCallback(async () => {
+    const response = await fetch("/api/goals");
+    const data: { goals: Goal[] } = await response.json();
+    setGoals(data.goals ?? []);
+  }, []);
 
   useEffect(() => {
-    fetch("/api/goals")
-      .then((r) => r.json())
-      .then((data: { goals: Goal[] }) => setGoals(data.goals ?? []))
+    loadGoals()
       .catch(() => {})
       .finally(() => setLoading(false));
-  }, []);
+  }, [loadGoals]);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setCreating(true);
+
+    try {
+      const response = await fetch("/api/goals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label, target }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to create goal");
+      }
+
+      setLabel("");
+      setTarget(7);
+      await loadGoals();
+    } finally {
+      setCreating(false);
+    }
+  }
 
   if (loading) {
     return (
-      <div className="bg-slate-800 rounded-xl p-6 h-full">
-        <div className="h-5 w-32 bg-slate-700 rounded animate-pulse mb-4" />
+      <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
+        <div className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse" />
         {[1, 2, 3].map((i) => (
           <div key={i} className="mb-4">
-            <div className="h-3 bg-slate-700 rounded animate-pulse mb-2" />
-            <div className="h-2 bg-slate-700 rounded animate-pulse" />
+            <div className="mb-2 h-3 rounded bg-[var(--card-muted)] animate-pulse" />
+            <div className="h-2 rounded bg-[var(--card-muted)] animate-pulse" />
           </div>
         ))}
       </div>
@@ -36,10 +66,10 @@ export default function GoalTracker() {
   }
 
   return (
-    <div className="bg-slate-800 rounded-xl p-6 h-full">
-      <h2 className="text-white font-semibold text-lg mb-4">Weekly Goals</h2>
+    <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Weekly Goals</h2>
       {goals.length === 0 ? (
-        <p className="text-slate-400 text-sm">
+        <p className="text-sm text-[var(--muted-foreground)]">
           No goals yet. Create one via the API or future UI.
         </p>
       ) : (
@@ -49,14 +79,14 @@ export default function GoalTracker() {
             return (
               <li key={goal.id}>
                 <div className="flex justify-between text-sm mb-1">
-                  <span className="text-slate-300">{goal.label}</span>
-                  <span className="text-slate-400">
+                  <span className="text-[var(--card-foreground)]">{goal.label}</span>
+                  <span className="text-[var(--muted-foreground)]">
                     {goal.current}/{goal.target}
                   </span>
                 </div>
-                <div className="h-2 bg-slate-700 rounded-full overflow-hidden">
+                <div className="h-2 overflow-hidden rounded-full bg-[var(--control)]">
                   <div
-                    className="h-full bg-indigo-500 rounded-full transition-all"
+                    className="h-full rounded-full bg-[var(--accent)] transition-all"
                     style={{ width: `${pct}%` }}
                   />
                 </div>
@@ -65,6 +95,51 @@ export default function GoalTracker() {
           })}
         </ul>
       )}
+      <form onSubmit={handleCreate} className="mt-6 space-y-3 border-t border-[var(--border)] pt-4">
+        <div>
+          <label htmlFor="goal-label" className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+            Goal label
+          </label>
+          <input
+            id="goal-label"
+            type="text"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            placeholder="Commit every day"
+            required
+            disabled={creating}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)]"
+          />
+        </div>
+        <div>
+          <label htmlFor="goal-target" className="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+            Weekly target
+          </label>
+          <input
+            id="goal-target"
+            type="number"
+            min={1}
+            value={target}
+            onChange={(event) => setTarget(Number(event.target.value))}
+            disabled={creating}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)]"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={creating || !label.trim()}
+          className="inline-flex items-center gap-2 rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {creating ? (
+            <>
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+              Creating...
+            </>
+          ) : (
+            "Add goal"
+          )}
+        </button>
+      </form>
     </div>
   );
 }

--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Language {
+  name: string;
+  bytes: number;
+  percentage: number;
+}
+
+const LANG_COLORS: Record<string, string> = {
+  TypeScript: "#3178c6",
+  JavaScript: "#f7df1e",
+  Python: "#3572A5",
+  Go: "#00ADD8",
+  Rust: "#dea584",
+  Java: "#b07219",
+  CSS: "#563d7c",
+  HTML: "#e34c26",
+  Ruby: "#701516",
+  Shell: "#89e051",
+};
+
+const FALLBACK_COLOR = "#6b7280";
+
+function getColor(name: string): string {
+  return LANG_COLORS[name] ?? FALLBACK_COLOR;
+}
+
+export default function LanguageBreakdown() {
+  const [languages, setLanguages] = useState<Language[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch("/api/metrics/languages")
+      .then((r) => r.json())
+      .then((d: { languages: Language[] }) => setLanguages(d.languages ?? []))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="text-lg font-semibold text-[var(--card-foreground)] mb-4">
+        Language Breakdown
+      </h2>
+
+      {loading ? (
+        <div className="space-y-3">
+          <div className="h-6 rounded-full bg-[var(--card-muted)] animate-pulse" />
+          <div className="grid grid-cols-2 gap-2 mt-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="h-5 rounded bg-[var(--card-muted)] animate-pulse" />
+            ))}
+          </div>
+        </div>
+      ) : languages.length === 0 ? (
+        <p className="text-sm text-[var(--muted-foreground)]">
+          No language data available.
+        </p>
+      ) : (
+        <>
+          {/* Stacked bar */}
+          <div className="flex h-6 w-full overflow-hidden rounded-full bg-[var(--control)]">
+            {languages.map((lang) => (
+              <div
+                key={lang.name}
+                className="h-full transition-all duration-500 first:rounded-l-full last:rounded-r-full"
+                style={{
+                  width: `${lang.percentage}%`,
+                  backgroundColor: getColor(lang.name),
+                  minWidth: lang.percentage > 0 ? "4px" : "0px",
+                }}
+                title={`${lang.name}: ${lang.percentage}%`}
+              />
+            ))}
+          </div>
+
+          {/* Legend */}
+          <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2">
+            {languages.map((lang) => (
+              <div key={lang.name} className="flex items-center gap-2 text-sm">
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: getColor(lang.name) }}
+                />
+                <span className="truncate text-[var(--card-foreground)]">
+                  {lang.name}
+                </span>
+                <span className="ml-auto shrink-0 text-[var(--muted-foreground)]">
+                  {lang.percentage}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -12,13 +12,21 @@ interface PRData {
 export default function PRMetrics() {
   const [metrics, setMetrics] = useState<PRData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchMetrics = () => {
+    setLoading(true);
+    setError(null);
+
     fetch("/api/metrics/prs")
       .then((r) => r.json())
       .then((data: PRData) => setMetrics(data))
-      .catch(() => {})
+      .catch(() => setError("We couldn't load your PR analytics right now. Please try again in a moment."))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchMetrics();
   }, []);
 
   const stats = metrics
@@ -31,25 +39,36 @@ export default function PRMetrics() {
     : [];
 
   return (
-    <div className="bg-slate-800 rounded-xl p-6">
-      <h2 className="text-white font-semibold text-lg mb-4">PR Analytics</h2>
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Analytics</h2>
       {loading ? (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="bg-slate-700 rounded-lg p-4 h-20 animate-pulse" />
+            <div key={i} className="h-20 rounded-lg bg-[var(--card-muted)] p-4 animate-pulse" />
           ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchMetrics}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
         </div>
       ) : (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {stats.map((stat) => (
             <div
               key={stat.label}
-              className="bg-slate-700 rounded-lg p-4 text-center"
+              className="rounded-lg bg-[var(--control)] p-4 text-center"
             >
-              <div className="text-2xl font-bold text-indigo-400">
+              <div className="text-2xl font-bold text-[var(--accent)]">
                 {stat.value}
               </div>
-              <div className="text-slate-400 text-sm mt-1">{stat.label}</div>
+              <div className="mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
             </div>
           ))}
         </div>

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -2,11 +2,12 @@
 
 import { signOut } from "next-auth/react"
 
-export default function DashboardPage() {
+export default function SignOutButton() {
     return (
         <button 
+            type="button"
             onClick={() => signOut({ callbackUrl: "/" })}
-            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded ">
+            className="rounded-full border border-red-600/50 bg-red-600/80 px-4 py-2 font-semibold text-white transition-colors hover:bg-red-600">
             Sign-out
         </button>
     );

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -12,23 +12,49 @@ interface StreakData {
 export default function StreakTracker() {
   const [data, setData] = useState<StreakData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchStreak = () => {
+    setLoading(true);
+    setError(null);
+
     fetch("/api/metrics/streak")
       .then((r) => r.json())
       .then((d: StreakData) => setData(d))
-      .catch(() => {})
+      .catch(() => setError("We couldn't load your streak data right now. Please try again in a moment."))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchStreak();
   }, []);
 
   if (loading) {
     return (
-      <div className="bg-slate-800 rounded-xl p-6">
-        <div className="h-5 w-36 bg-slate-700 rounded animate-pulse mb-4" />
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
+        <div className="mb-4 h-5 w-36 rounded bg-[var(--card-muted)] animate-pulse" />
         <div className="grid grid-cols-2 gap-4">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="bg-slate-700 rounded-lg h-20 animate-pulse" />
+            <div key={i} className="h-20 rounded-lg bg-[var(--card-muted)] animate-pulse" />
           ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Commit Streaks</h2>
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchStreak}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
         </div>
       </div>
     );
@@ -42,6 +68,7 @@ export default function StreakTracker() {
           unit: "days",
           highlight: data.current > 0,
           icon: "🔥",
+          tooltip: "Current consecutive coding days",
         },
         {
           label: "Longest Streak",
@@ -49,6 +76,7 @@ export default function StreakTracker() {
           unit: "days",
           highlight: false,
           icon: "🏆",
+          tooltip: "Your longest streak ever",
         },
         {
           label: "Active Days (90d)",
@@ -56,6 +84,7 @@ export default function StreakTracker() {
           unit: "days",
           highlight: false,
           icon: "📅",
+          tooltip: "Days you made commits in the last 90 days",
         },
         {
           label: "Last Commit",
@@ -68,37 +97,38 @@ export default function StreakTracker() {
           unit: "",
           highlight: false,
           icon: "⚡",
+          tooltip: "Your most recent commit",
         },
       ]
     : [];
 
   return (
-    <div className="bg-slate-800 rounded-xl p-6">
-      <h2 className="text-white font-semibold text-lg mb-4">Commit Streaks</h2>
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Commit Streaks</h2>
       <div className="grid grid-cols-2 gap-3">
         {stats.map((stat) => (
           <div
             key={stat.label}
             className={`rounded-lg p-4 text-center ${
               stat.highlight
-                ? "bg-indigo-500/20 border border-indigo-500/40"
-                : "bg-slate-700"
+                ? "border border-[var(--accent)]/40 bg-[var(--accent-soft)]"
+                : "bg-[var(--control)]"
             }`}
           >
-            <div className="text-xl mb-1">{stat.icon}</div>
+            <div className="text-xl mb-1" title={stat.tooltip} aria-label={stat.tooltip} role="img">{stat.icon}</div>
             <div
               className={`text-2xl font-bold ${
-                stat.highlight ? "text-indigo-300" : "text-indigo-400"
+                stat.highlight ? "text-[var(--accent)]" : "text-[var(--accent)]"
               }`}
             >
               {stat.value}
               {stat.unit && (
-                <span className="text-sm font-normal text-slate-400 ml-1">
+                <span className="ml-1 text-sm font-normal text-[var(--muted-foreground)]">
                   {stat.unit}
                 </span>
               )}
             </div>
-            <div className="text-slate-400 text-xs mt-1">{stat.label}</div>
+            <div className="mt-1 text-xs text-[var(--muted-foreground)]">{stat.label}</div>
           </div>
         ))}
       </div>

--- a/src/components/ThemeSync.tsx
+++ b/src/components/ThemeSync.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useLayoutEffect } from "react";
+
+const STORAGE_KEY = "theme";
+
+export default function ThemeSync() {
+	useLayoutEffect(() => {
+		const storedTheme = localStorage.getItem(STORAGE_KEY);
+		const isDark = storedTheme ? storedTheme === "dark" : true;
+
+		document.documentElement.classList.toggle("dark", isDark);
+		document.documentElement.style.colorScheme = isDark ? "dark" : "light";
+		localStorage.setItem(STORAGE_KEY, isDark ? "dark" : "light");
+	}, []);
+
+	return null;
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "theme";
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(true);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem(STORAGE_KEY);
+    const isDark = storedTheme ? storedTheme === "dark" : true;
+
+    setDark(isDark);
+    document.documentElement.classList.toggle("dark", isDark);
+    document.documentElement.style.colorScheme = isDark ? "dark" : "light";
+    localStorage.setItem(STORAGE_KEY, isDark ? "dark" : "light");
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
+    document.documentElement.classList.toggle("dark", dark);
+    document.documentElement.style.colorScheme = dark ? "dark" : "light";
+    localStorage.setItem(STORAGE_KEY, dark ? "dark" : "light");
+  }, [dark, mounted]);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setDark((current) => !current)}
+      className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-medium text-[var(--card-foreground)] transition-colors hover:bg-[var(--control)]"
+      aria-label="Toggle theme"
+      aria-pressed={dark}
+    >
+      <span aria-hidden="true">{dark ? "☀️" : "🌙"}</span>
+      <span>{dark ? "Light" : "Dark"}</span>
+    </button>
+  );
+}

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -11,42 +11,58 @@ interface Repo {
 export default function TopRepos() {
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [days, setDays] = useState(30);
 
-  useEffect(() => {
+  const fetchRepos = () => {
     setLoading(true);
+    setError(null);
     fetch(`/api/metrics/repos?days=${days}`)
       .then((r) => r.json())
       .then((d: { repos: Repo[] }) => setRepos(d.repos ?? []))
-      .catch(() => {})
+      .catch(() => setError("We couldn't load your top repositories right now. Please try again in a moment."))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchRepos();
   }, [days]);
 
   const maxCommits = repos[0]?.commits ?? 1;
 
   return (
-    <div className="bg-slate-800 rounded-xl p-6">
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-white font-semibold text-lg">Top Repositories</h2>
+        <h2 className="text-lg font-semibold text-[var(--card-foreground)]">Top Repositories</h2>
         <select
           value={days}
           onChange={(e) => setDays(Number(e.target.value))}
-          className="bg-slate-700 text-slate-300 text-sm rounded-lg px-2 py-1 border border-slate-600 focus:outline-none focus:border-indigo-500"
+          className="rounded-lg border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--card-foreground)] focus:outline-none focus:border-[var(--accent)]"
         >
           <option value={7}>Last 7d</option>
           <option value={30}>Last 30d</option>
           <option value={90}>Last 90d</option>
         </select>
       </div>
-
       {loading ? (
         <div className="space-y-3">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-10 bg-slate-700 rounded animate-pulse" />
+            <div key={i} className="h-10 rounded bg-[var(--card-muted)] animate-pulse" />
           ))}
         </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchRepos}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
+        </div>
       ) : repos.length === 0 ? (
-        <p className="text-slate-400 text-sm">No commits in the last {days} days.</p>
+        <p className="text-sm text-[var(--muted-foreground)]">No commits in the last {days} days.</p>
       ) : (
         <ul className="space-y-3">
           {repos.map((repo, idx) => {
@@ -62,19 +78,19 @@ export default function TopRepos() {
                     href={repo.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-slate-300 hover:text-indigo-400 transition-colors truncate max-w-[70%]"
+                    className="max-w-[70%] truncate text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)]"
                     title={repo.name}
                   >
-                    <span className="text-slate-500 mr-1">#{idx + 1}</span>
+                    <span className="mr-1 text-[var(--muted-foreground)]">#{idx + 1}</span>
                     {shortName}
                   </a>
-                  <span className="text-slate-400 shrink-0">
+                  <span className="shrink-0 text-[var(--muted-foreground)]">
                     {repo.commits} commit{repo.commits !== 1 ? "s" : ""}
                   </span>
                 </div>
-                <div className="h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                <div className="h-1.5 overflow-hidden rounded-full bg-[var(--control)]">
                   <div
-                    className="h-full bg-indigo-500 rounded-full transition-all duration-500"
+                    className="h-full rounded-full bg-[var(--accent)] transition-all duration-500"
                     style={{ width: `${barWidth}%` }}
                   />
                 </div>

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -17,8 +17,8 @@ export default function UserAvatar() {
   const showImage = image && !imageFailed;
 
   return (
-    <div className="flex items-center gap-3 rounded-full border border-slate-700 bg-slate-800/80 px-3 py-2">
-      <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-slate-700 text-sm font-semibold text-white">
+    <div className="flex items-center gap-3 rounded-full border border-[var(--border)] bg-[var(--card)] px-3 py-2">
+      <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-[var(--control)] text-sm font-semibold text-[var(--card-foreground)]">
         {showImage ? (
           <Image
             src={image}
@@ -32,7 +32,7 @@ export default function UserAvatar() {
           <span aria-hidden="true">{getInitial(name)}</span>
         )}
       </div>
-      <span className="max-w-32 truncate text-sm font-medium text-slate-100">
+      <span className="max-w-32 truncate text-sm font-medium text-[var(--card-foreground)]">
         {name}
       </span>
     </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,10 @@ import { type NextAuthOptions } from "next-auth";
 import GitHubProvider from "next-auth/providers/github";
 import { supabaseAdmin } from "./supabase";
 
+const SESSION_MAX_AGE = 30 * 24 * 60 * 60;
+const SESSION_UPDATE_AGE = 24 * 60 * 60;
+const useSecureCookies = process.env.NODE_ENV === "production";
+
 export const authOptions: NextAuthOptions = {
   providers: [
     GitHubProvider({
@@ -12,6 +16,28 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
+  session: {
+    strategy: "jwt",
+    maxAge: SESSION_MAX_AGE,
+    updateAge: SESSION_UPDATE_AGE,
+  },
+  jwt: {
+    maxAge: SESSION_MAX_AGE,
+  },
+  cookies: {
+    sessionToken: {
+      name: useSecureCookies
+        ? "__Secure-next-auth.session-token"
+        : "next-auth.session-token",
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: useSecureCookies,
+        maxAge: SESSION_MAX_AGE,
+      },
+    },
+  },
   callbacks: {
     async signIn({ account, profile }) {
       if (account?.provider === "github" && profile) {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
Closes #98

Adds a delete button to individual goals in the GoalTracker component.

## Changes
- **New**: `src/app/api/goals/[id]/route.ts` — DELETE endpoint with session auth and user ownership guard
- **Modified**: `src/components/GoalTracker.tsx` — trash icon, inline Yes/No confirmation, optimistic UI

## Behavior
1. A 🗑 trash icon appears next to each goal
2. First click shows inline **"Delete? Yes / No"** (no `window.confirm`)
3. Clicking **Yes** removes the goal optimistically and calls `DELETE /api/goals/{id}`
4. If the API fails, the goal is restored automatically
5. Buttons are disabled while the delete request is in-flight

## Checklist
- [x] `npm run lint` — no new warnings
- [x] `npx tsc --noEmit` — 0 type errors
- [x] Follows existing auth & Supabase patterns from `goals/route.ts`
- [x] TypeScript types maintained, Tailwind CSS classes used
