### PR TITLE
fix: add loading state to sign out button

### DIFF
--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -1,14 +1,35 @@
 "use client"
 
+import { useState } from "react"
 import { signOut } from "next-auth/react"
 
 export default function SignOutButton() {
+    const [signingOut, setSigningOut] = useState(false)
+
+    const handleSignOut = async () => {
+        setSigningOut(true)
+        try {
+            await signOut({ callbackUrl: "/" })
+        } catch (error) {
+            console.error("Sign out error:", error)
+            setSigningOut(false)
+        }
+    }
+
     return (
         <button 
             type="button"
-            onClick={() => signOut({ callbackUrl: "/" })}
-            className="rounded-full border border-red-600/50 bg-red-600/80 px-4 py-2 font-semibold text-white transition-colors hover:bg-red-600">
-            Sign-out
+            disabled={signingOut}
+            onClick={handleSignOut}
+            className="flex items-center gap-2 rounded-full border border-red-600/50 bg-red-600/80 px-4 py-2 font-semibold text-white transition-colors hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-70">
+            {signingOut && (
+                <svg className="h-4 w-4 animate-spin text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+            )}
+            {signingOut ? "Signing out..." : "Sign out"}
         </button>
     );
 }
+


### PR DESCRIPTION
## Summary

Adds loading feedback to the SignOutButton component while NextAuth clears the session.

Closes #100

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added `signingOut` state using `useState`
- Disabled the sign out button while the sign out process is running
- Added a loading spinner during sign out
- Updated button text from `Sign out` to `Signing out...`
- Added disabled styles for better visual feedback and accessibility
- Prevented multiple rapid sign out clicks

## How to Test

Steps for the reviewer to verify this works:

1. Run the app locally using `npm run dev`
2. Sign in with GitHub
3. Navigate to the dashboard/header
4. Click the `Sign out` button
5. Verify:
   - Button text changes to `Signing out...`
   - Loading spinner appears
   - Button becomes disabled
   - Multiple rapid clicks are prevented
   - User is redirected correctly after sign out

## Screenshots (if UI change)

<img width="436" height="69" alt="Screenshot 2026-05-15 161326" src="https://github.com/user-attachments/assets/de491a1f-b298-47a4-ad98-924d0e836f56" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable