### PR TITLE
feat: add custom 404 and error pages matching DevTrack design (#87)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[var(--background)] px-4 text-center">
+      <div className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 shadow-sm">
+        <div className="mb-6 flex justify-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-[var(--accent-soft)] text-[var(--accent)]">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="h-10 w-10"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          </div>
+        </div>
+        <h1 className="mb-2 text-2xl font-bold text-[var(--card-foreground)]">
+          Something went wrong!
+        </h1>
+        <p className="mb-6 text-sm text-[var(--muted-foreground)]">
+          An unexpected error occurred. Please try again.
+        </p>
+        <div className="mb-8 rounded-lg bg-[var(--control)] p-3 text-left text-xs text-[var(--muted-foreground)]">
+          <code className="break-words font-mono">
+            {error.message || "Unknown error"}
+          </code>
+        </div>
+        <button
+          onClick={() => reset()}
+          className="inline-flex w-full items-center justify-center rounded-lg bg-[var(--accent)] px-4 py-2.5 text-sm font-medium text-[var(--accent-foreground)] transition-opacity hover:opacity-90"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[var(--background)] px-4 text-center">
+      <div className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 shadow-sm">
+        <div className="mb-6 flex justify-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-[var(--accent-soft)]">
+            <span className="text-4xl" role="img" aria-label="Not Found">
+              🕳️
+            </span>
+          </div>
+        </div>
+        <h1 className="mb-2 text-4xl font-bold text-[var(--card-foreground)]">404</h1>
+        <h2 className="mb-4 text-xl font-semibold text-[var(--card-foreground)]">
+          Oops! Page not found
+        </h2>
+        <p className="mb-8 text-sm text-[var(--muted-foreground)]">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-flex w-full items-center justify-center rounded-lg bg-[var(--accent)] px-4 py-2.5 text-sm font-medium text-[var(--accent-foreground)] transition-opacity hover:opacity-90"
+        >
+          Return to Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Closes #87

Adds custom Next.js `not-found.tsx` and `error.tsx` boundary pages to replace the default unstyled Next.js error screens. These new pages are fully integrated with the DevTrack design system, utilizing existing CSS variables and Tailwind classes.

## Changes
- **New `src/app/not-found.tsx`**: A Server Component providing a friendly 404 page. It includes a "Return to Dashboard" button and centers a polished 404 card on the screen.
- **New `src/app/error.tsx`**: A Client Component acting as the global error boundary. It displays the `error.message` subtly inside a code block and provides a "Try again" button that triggers Next.js's `reset()` method to attempt recovery.

## Design Details
- Both pages strictly use existing CSS variables from `globals.css` (e.g., `var(--background)`, `var(--card)`, `var(--accent)`, `var(--muted-foreground)`). No hardcoded colors were introduced.
- Matched the border-radius, padding, and layout styles of existing dashboard components for a seamless user experience.

## Checklist
- [x] Tested both the 404 and error boundary states.
- [x] No hardcoded colors; fully supports the existing light/dark mode CSS variables.
- [x] `npm run lint` — ✅ no new warnings.
- [x] `npx tsc --noEmit` — ✅ 0 type errors.
