### PR TITLE
feat: add streak at-risk alert banner for late day with no commit (#85)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import DashboardHeader from "@/components/DashboardHeader";
 import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
 import LanguageBreakdown from "@/components/LanguageBreakdown";
+import StreakAtRiskBanner from "@/components/StreakAtRiskBanner";
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
@@ -19,6 +20,8 @@ export default async function DashboardPage() {
  return (
       <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors">
         <DashboardHeader />
+
+        <StreakAtRiskBanner />
 
       {/* Row 1: Contribution graph + Streak + Goals */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/components/StreakAtRiskBanner.tsx
+++ b/src/components/StreakAtRiskBanner.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface StreakAtRiskBannerProps {
+  lastCommitDate?: string | null;
+  currentStreak?: number;
+  hasStreakFreeze?: boolean;
+}
+
+export default function StreakAtRiskBanner({
+  lastCommitDate: propsLastCommitDate,
+  currentStreak: propsCurrentStreak,
+  hasStreakFreeze,
+}: StreakAtRiskBannerProps) {
+  const [dismissed, setDismissed] = useState(false);
+  const [lastCommitDate, setLastCommitDate] = useState(propsLastCommitDate);
+  const [currentStreak, setCurrentStreak] = useState(propsCurrentStreak);
+  const [isAtRisk, setIsAtRisk] = useState(false);
+
+  useEffect(() => {
+    // If props weren't passed (e.g. from a Server Component), fetch them
+    if (propsLastCommitDate === undefined || propsCurrentStreak === undefined) {
+      fetch("/api/metrics/streak")
+        .then((r) => r.json())
+        .then((data) => {
+          setLastCommitDate(data.lastCommitDate);
+          setCurrentStreak(data.current);
+        })
+        .catch(() => {});
+    } else {
+      setLastCommitDate(propsLastCommitDate);
+      setCurrentStreak(propsCurrentStreak);
+    }
+  }, [propsLastCommitDate, propsCurrentStreak]);
+
+  useEffect(() => {
+    if (
+      dismissed ||
+      hasStreakFreeze ||
+      currentStreak === undefined ||
+      currentStreak <= 0 ||
+      !lastCommitDate
+    ) {
+      setIsAtRisk(false);
+      return;
+    }
+
+    const now = new Date();
+    // 1. Check if current time is past 20:00 (8pm)
+    if (now.getHours() < 20) {
+      setIsAtRisk(false);
+      return;
+    }
+
+    // 2. Check if lastCommitDate is NOT today
+    // Convert to local YYYY-MM-DD for comparison
+    const todayStr = now.toLocaleDateString("en-CA"); // "YYYY-MM-DD" in local time
+    // lastCommitDate comes as "YYYY-MM-DD" from API
+    if (lastCommitDate === todayStr) {
+      setIsAtRisk(false);
+      return;
+    }
+
+    setIsAtRisk(true);
+  }, [lastCommitDate, currentStreak, hasStreakFreeze, dismissed]);
+
+  if (!isAtRisk || dismissed) return null;
+
+  return (
+    <div className="mb-6 flex items-center justify-between rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-amber-500 shadow-sm transition-all animate-in fade-in slide-in-from-top-4">
+      <div className="flex items-center gap-3">
+        <span className="text-xl" role="img" aria-label="Warning">
+          ⚠️
+        </span>
+        <div>
+          <p className="font-semibold">
+            No commit yet today — your streak is at risk!
+          </p>
+          <p className="text-sm opacity-90">
+            You have a {currentStreak} day streak. Don&apos;t break it!
+          </p>
+        </div>
+      </div>
+      <button
+        onClick={() => setDismissed(true)}
+        className="ml-4 rounded-md p-1.5 opacity-70 hover:bg-amber-500/20 hover:opacity-100 transition-all"
+        aria-label="Dismiss banner"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Closes #85

Adds a sticky warning banner at the top of the dashboard to alert users when their active streak is at risk of being lost.

## Logic & Behavior
The banner logic is completely client-side. It only appears if **all** of the following conditions are met:
1. The user has an active streak (`currentStreak > 0`).
2. The user has **not** made a commit today (compares `lastCommitDate` against the local `YYYY-MM-DD`).
3. The current local time is past **8:00 PM** (20:00).
4. The user has not dismissed the banner during the current session.
5. The user does not have an active streak freeze.

## Changes
- **New `src/components/StreakAtRiskBanner.tsx`**: A client-side component holding the logic, the amber/yellow warning UI (using existing Tailwind classes, no hardcoded hex colors), and the dismissible state. If props aren't provided by the parent Server Component, it seamlessly fetches the necessary streak metrics itself to avoid blocking dashboard rendering.
- **Modified `src/app/dashboard/page.tsx`**: Imported the banner and placed it above the primary dashboard grid so it's the first thing the user sees.

## Checklist
- [x] Tested the local time and date comparison logic.
- [x] Smooth fade-in/slide-in animation implemented.
- [x] `npm run lint` — ✅ no new warnings.
- [x] `npx tsc --noEmit` — ✅ 0 type errors.
- [x] Purely client-side logic; no new backend routes added.
