### PR TITLE
fix: show inline error when goal creation fails

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -15,6 +15,7 @@ export default function GoalTracker() {
   const [label, setLabel] = useState("");
   const [target, setTarget] = useState(7);
   const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
 
   const loadGoals = useCallback(async () => {
     const response = await fetch("/api/goals");
@@ -31,6 +32,7 @@ export default function GoalTracker() {
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     setCreating(true);
+    setCreateError(null);
 
     try {
       const response = await fetch("/api/goals", {
@@ -42,13 +44,16 @@ export default function GoalTracker() {
       if (!response.ok) {
         throw new Error("Failed to create goal");
       }
-
-      setLabel("");
-      setTarget(7);
-      await loadGoals();
-    } finally {
+    } catch {
+      setCreateError("Failed to create goal. Please try again.");
       setCreating(false);
+      return;
     }
+
+    setLabel("");
+    setTarget(7);
+    await loadGoals().catch(() => {});
+    setCreating(false);
   }
 
   if (loading) {
@@ -139,6 +144,9 @@ export default function GoalTracker() {
             "Add goal"
           )}
         </button>
+        {createError && (
+          <p className="text-sm text-red-500">{createError}</p>
+        )}
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary

Show an inline error message below the submit button when goal creation
fails, instead of silently resetting the form.

Closes #90

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added `createError` state (`string | null`) to `GoalTracker.tsx`
- Clear `createError` at the start of each submission attempt
- Scoped `try/catch` to only the POST request so a `loadGoals()` failure after a successful creation doesn't show a false error
- Render error message below the submit button using `text-red-500`

## How to Test

Steps for the reviewer to verify this works:

1. Sign in and go to the dashboard
2. Open DevTools → Network tab → set to Offline
3. Type a goal label, set a target, click "Add goal"
4. Confirm "Failed to create goal. Please try again." appears below the button
5. Re-enable network, submit again — confirm error clears and goal is created

## Screenshots (if UI change)

N/A — error text appears below the submit button on failure

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
