### PR TITLE
feat: add PR breakdown donut chart by state

### DIFF
--- a/src/app/api/metrics/pr-breakdown/route.ts
+++ b/src/app/api/metrics/pr-breakdown/route.ts
@@ -1,0 +1,54 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_API = "https://api.github.com";
+
+interface PRItem {
+  state: string;
+  draft?: boolean;
+  pull_request?: {
+    merged_at: string | null;
+  };
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const res = await fetch(
+    `${GITHUB_API}/search/issues?q=type:pr+author:@me&per_page=100`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        Accept: "application/vnd.github+json",
+      },
+      cache: "no-store",
+    }
+  );
+
+  if (!res.ok) {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+
+  const data = (await res.json()) as { items: PRItem[] };
+
+  let draft = 0, open = 0, merged = 0, closed = 0;
+
+  for (const pr of data.items) {
+    if (pr.state === "open" && pr.draft) {
+      draft++;
+    } else if (pr.state === "open") {
+      open++;
+    } else if (pr.pull_request?.merged_at) {
+      merged++;
+    } else {
+      closed++;
+    }
+  }
+
+  return Response.json({ draft, open, merged, closed });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import ContributionGraph from "@/components/ContributionGraph";
 import PRMetrics from "@/components/PRMetrics";
+import PRBreakdownChart from "@/components/PRBreakdownChart";
 import GoalTracker from "@/components/GoalTracker";
 import DashboardHeader from "@/components/DashboardHeader";
 import StreakTracker from "@/components/StreakTracker";
@@ -36,9 +37,10 @@ export default async function DashboardPage() {
         </div>
       </div>
 
-      {/* Row 2: PR metrics */}
-      <div className="mt-6">
+      {/* Row 2: PR metrics + PR breakdown */}
+      <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
         <PRMetrics />
+        <PRBreakdownChart />
       </div>
 
       {/* Row 3: Issue metrics */}

--- a/src/components/PRBreakdownChart.tsx
+++ b/src/components/PRBreakdownChart.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+
+interface PRBreakdown {
+  draft: number;
+  open: number;
+  merged: number;
+  closed: number;
+}
+
+const SLICES: { key: keyof PRBreakdown; label: string; color: string }[] = [
+  { key: "open",   label: "Open",   color: "#6366f1" },
+  { key: "merged", label: "Merged", color: "#34d399" },
+  { key: "closed", label: "Closed", color: "#fb923c" },
+  { key: "draft",  label: "Draft",  color: "#94a3b8" },
+];
+
+export default function PRBreakdownChart() {
+  const [breakdown, setBreakdown] = useState<PRBreakdown | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBreakdown = () => {
+    setLoading(true);
+    setError(null);
+
+    fetch("/api/metrics/pr-breakdown")
+      .then((r) => r.json())
+      .then((d: PRBreakdown) => setBreakdown(d))
+      .catch(() =>
+        setError("We couldn't load your PR breakdown right now. Please try again in a moment.")
+      )
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchBreakdown();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <div className="mb-4 h-5 w-40 rounded bg-[var(--card-muted)] animate-pulse" />
+        <div className="h-[200px] rounded bg-[var(--card-muted)] animate-pulse" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Breakdown</h2>
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchBreakdown}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const total = breakdown ? SLICES.reduce((sum, s) => sum + breakdown[s.key], 0) : 0;
+  const chartData = breakdown
+    ? SLICES.map((s) => ({ name: s.label, value: breakdown[s.key], color: s.color })).filter(
+        (d) => d.value > 0
+      )
+    : [];
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Breakdown</h2>
+      {total === 0 ? (
+        <p className="flex h-[200px] items-center justify-center text-sm text-[var(--muted-foreground)]">
+          No pull requests found.
+        </p>
+      ) : (
+        <>
+          <ResponsiveContainer width="100%" height={200}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={55}
+                outerRadius={80}
+                dataKey="value"
+                paddingAngle={2}
+              >
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
+              </Pie>
+              <Tooltip
+                contentStyle={{
+                  background: "var(--tooltip)",
+                  color: "var(--tooltip-foreground)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "8px",
+                  fontSize: "12px",
+                }}
+                formatter={(value: number) => [
+                  `${value} (${Math.round((value / total) * 100)}%)`,
+                ]}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+          <div className="mt-3 flex flex-wrap justify-center gap-4">
+            {SLICES.map((s) => (
+              <div
+                key={s.key}
+                className="flex items-center gap-1.5 text-xs text-[var(--muted-foreground)]"
+              >
+                <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: s.color }} />
+                {s.label}: {breakdown?.[s.key] ?? 0}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add a Pie/Donut chart that visualizes pull request counts grouped by
state: Open, Merged, Closed, and Draft.

Closes #58

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Created `src/app/api/metrics/pr-breakdown/route.ts` — fetches all PRs
  via GitHub Search API and classifies each into Draft / Open / Merged / Closed
  in a single request
- Created `src/components/PRBreakdownChart.tsx` — Recharts Pie/Donut chart
  with accessible colors, tooltip showing count + percentage, loading skeleton,
  and error state
- Updated `src/app/dashboard/page.tsx` — PR metrics row is now a 2-column
  grid with PRMetrics and PRBreakdownChart side by side

## How to Test

1. Sign in and go to the dashboard
2. Confirm the PR Breakdown donut chart appears alongside PR Analytics
3. Hover over chart slices — confirm tooltip shows count and percentage
4. Open DevTools → Network → Offline, refresh — confirm error state with
   "Try again" button appears
5. Restore network, click "Try again" — confirm chart loads

## Screenshots (if UI change)

<!-- Add a screenshot of the donut chart if possible -->

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
