### PR TITLE
fix: add error state to ContributionGraph fetch failures

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -37,9 +37,11 @@ export default function ContributionGraph() {
   const [loading, setLoading] = useState(true);
   const [days, setDays] = useState(30);
   const [chartType, setChartType] = useState<ViewMode>("bar");
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
+    setError(null);
     fetch(`/api/metrics/contributions?days=${days}`)
       .then((r) => r.json())
       .then((res: { data: Record<string, number> }) => {
@@ -49,29 +51,30 @@ export default function ContributionGraph() {
 
         setData(sorted);
       })
-      .catch(() => {})
+      .catch(() => {
+        setError("Failed to load contribution data.");
+      })
       .finally(() => setLoading(false));
   }, [days]);
 
   return (
-<div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <div className="flex flex-wrap items-center justify-between mb-4 gap-2">
         <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
           Commit Activity
         </h2>
 
         <div className="flex flex-wrap items-center gap-2">
-    
+
           <div className="flex gap-1 rounded-lg bg-[var(--control)] p-1">
             {RANGES.map((r) => (
               <button
                 key={r.days}
                 onClick={() => setDays(r.days)}
-                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
-                  days === r.days
+                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${days === r.days
                     ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
                     : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
-                }`}
+                  }`}
               >
                 {r.label}
               </button>
@@ -79,17 +82,16 @@ export default function ContributionGraph() {
           </div>
 
           {/* Chart Toggle Buttons */}
-          {data.length > 0 && (
+          {data.length > 0 && !error && (
             <div className="flex gap-1 rounded-lg bg-[var(--control)] p-1 text-sm">
               {charts.map((chart) => (
                 <button
                   key={chart.key}
                   onClick={() => setChartType(chart.key)}
-                  className={`px-3 py-1 rounded-md transition-colors duration-200 ${
-                    chartType === chart.key
+                  className={`px-3 py-1 rounded-md transition-colors duration-200 ${chartType === chart.key
                       ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
                       : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
-                  }`}
+                    }`}
                 >
                   {chart.label}
                 </button>
@@ -101,6 +103,12 @@ export default function ContributionGraph() {
 
       {loading ? (
         <div className="h-[200px] rounded bg-[var(--card-muted)] animate-pulse" />
+      ) : error ? (
+        <div className="flex h-[200px] items-center rounded-lg border border-red-500/30 bg-red-500/10 px-4">
+          <p className="text-sm text-red-400">
+            {error} Please try refreshing.
+          </p>
+        </div>
       ) : data.length === 0 ? (
         <p className="flex h-[200px] items-center text-sm text-[var(--muted-foreground)]">
           No commits in the last {days} days.


### PR DESCRIPTION
## Summary

Adds a user-friendly error state to `ContributionGraph` when the contributions API request fails instead of silently rendering a blank chart.

Closes #39

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Added `error` state using `useState<string | null>(null)`
* Cleared previous errors before each fetch request
* Replaced silent `.catch(() => {})` with `setError(...)`
* Added conditional error UI with dark-theme styling
* Hid chart toggle controls when an error is present
* Preserved existing loading and empty states
* Kept accessibility improvements for chart toggle buttons

## How to Test

Steps for the reviewer to verify this works:

1. Start the app locally
2. Open the dashboard containing `ContributionGraph`
3. Simulate a failed API request:
   * stop/mock the API OR
   * temporarily change the fetch URL
4. Verify:
   * error message appears inside the card
   * chart is hidden
   * loading state still works correctly
5. Restore the API and confirm charts render normally

## Screenshots (if UI change)

N/A

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable

