### PR TITLE
Feat/friend comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -731,6 +731,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1162,6 +1163,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1604,6 +1606,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2421,6 +2424,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2589,6 +2593,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3992,6 +3997,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4867,6 +4873,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5037,6 +5044,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5117,6 +5125,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5129,6 +5138,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6135,6 +6145,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6304,6 +6315,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -731,7 +731,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1163,7 +1162,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1606,7 +1604,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2424,7 +2421,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2593,7 +2589,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3997,7 +3992,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4873,7 +4867,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5044,7 +5037,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5125,7 +5117,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5138,7 +5129,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6145,7 +6135,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6315,7 +6304,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/api/metrics/compare/route.ts
+++ b/src/app/api/metrics/compare/route.ts
@@ -1,0 +1,142 @@
+import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
+import { authOptions } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_API = "https://api.github.com";
+
+function dateDiffDays(a: string, b: string): number {
+  return (new Date(b).getTime() - new Date(a).getTime()) / (1000 * 60 * 60 * 24);
+}
+
+function toDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let username = req.nextUrl.searchParams.get("username");
+  if (!username) {
+    return Response.json({ error: "Username required" }, { status: 400 });
+  }
+
+  if (username === "me") {
+    username = session.githubLogin as string;
+  }
+
+  // 1. Verify user exists
+  const userRes = await fetch(`${GITHUB_API}/users/${username}`, {
+    headers: { Authorization: `Bearer ${session.accessToken}` },
+    next: { revalidate: 3600 },
+  });
+
+  if (!userRes.ok) {
+    if (userRes.status === 404) return Response.json({ error: "User not found" }, { status: 404 });
+    return Response.json({ error: "GitHub API error or User is private" }, { status: 502 });
+  }
+
+  // 2. Commits & Streak (fetch 90 days)
+  const since90 = new Date();
+  since90.setDate(since90.getDate() - 90);
+  const since90Str = since90.toISOString().slice(0, 10);
+  
+  const since30 = new Date();
+  since30.setDate(since30.getDate() - 30);
+  const since30Str = since30.toISOString().slice(0, 10);
+
+  const commitsRes = await fetch(
+    `${GITHUB_API}/search/commits?q=author:${username}+author-date:>=${since90Str}&per_page=100&sort=author-date&order=asc`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        Accept: "application/vnd.github+json",
+      },
+      next: { revalidate: 3600 },
+    }
+  );
+
+  let streak = 0;
+  let commits30d = 0;
+  let topLanguage = "Unknown";
+  
+  if (commitsRes.ok) {
+    const commitsData = await commitsRes.json();
+    const items = commitsData.items || [];
+    
+    const daySet: Record<string, true> = {};
+    for (const item of items) {
+      const dateStr = item.commit.author.date.slice(0, 10);
+      daySet[dateStr] = true;
+      if (dateStr >= since30Str) {
+        commits30d++;
+      }
+    }
+    const commitDays = Object.keys(daySet).sort();
+    
+    if (commitDays.length > 0) {
+      let currentRun = 1;
+      let runs: { end: string; length: number }[] = [];
+      let runStart = commitDays[0];
+      for (let i = 1; i < commitDays.length; i++) {
+        if (dateDiffDays(commitDays[i - 1], commitDays[i]) === 1) {
+          currentRun++;
+        } else {
+          runs.push({ end: commitDays[i - 1], length: currentRun });
+          runStart = commitDays[i];
+          currentRun = 1;
+        }
+      }
+      runs.push({ end: commitDays[commitDays.length - 1], length: currentRun });
+      
+      const today = toDateStr(new Date());
+      const yesterday = toDateStr(new Date(Date.now() - 86400000));
+      const lastRun = runs[runs.length - 1];
+      streak = (lastRun.end === today || lastRun.end === yesterday) ? lastRun.length : 0;
+    }
+  }
+
+  // 3. Top Language from repos
+  const reposRes = await fetch(`${GITHUB_API}/users/${username}/repos?per_page=100&sort=pushed`, {
+    headers: { Authorization: `Bearer ${session.accessToken}` },
+    next: { revalidate: 3600 },
+  });
+  
+  if (reposRes.ok) {
+    const reposData = await reposRes.json();
+    const langCounts: Record<string, number> = {};
+    for (const repo of reposData) {
+      if (repo.language) {
+        langCounts[repo.language] = (langCounts[repo.language] || 0) + 1;
+      }
+    }
+    const sortedLangs = Object.entries(langCounts).sort((a, b) => b[1] - a[1]);
+    if (sortedLangs.length > 0) topLanguage = sortedLangs[0][0];
+  }
+
+  // 4. PRs
+  const prsRes = await fetch(
+    `${GITHUB_API}/search/issues?q=type:pr+author:${username}&per_page=1`,
+    {
+      headers: { Authorization: `Bearer ${session.accessToken}` },
+      next: { revalidate: 3600 },
+    }
+  );
+  let prs = 0;
+  if (prsRes.ok) {
+    const prsData = await prsRes.json();
+    prs = prsData.total_count || 0;
+  }
+
+  return Response.json({
+    username,
+    streak,
+    commits30d,
+    topLanguage,
+    prs
+  });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
 import LanguageBreakdown from "@/components/LanguageBreakdown";
 import StreakAtRiskBanner from "@/components/StreakAtRiskBanner";
+import FriendComparison from "@/components/FriendComparison";
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
@@ -23,13 +24,14 @@ export default async function DashboardPage() {
 
         <StreakAtRiskBanner />
 
-      {/* Row 1: Contribution graph + Streak + Goals */}
+      {/* Row 1: Contribution graph + Streak + Friend Comparison */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
           <ContributionGraph />
         </div>
         <div className="flex flex-col gap-6">
           <StreakTracker />
+          <FriendComparison />
         </div>
       </div>
 

--- a/src/components/FriendComparison.tsx
+++ b/src/components/FriendComparison.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface CompareData {
+  username: string;
+  streak: number;
+  commits30d: number;
+  topLanguage: string;
+  prs: number;
+}
+
+export default function FriendComparison() {
+  const [friendUsername, setFriendUsername] = useState("");
+  const [comparingUser, setComparingUser] = useState("");
+  const [myData, setMyData] = useState<CompareData | null>(null);
+  const [friendData, setFriendData] = useState<CompareData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  // Fetch my data on mount
+  useEffect(() => {
+    fetch("/api/metrics/compare?username=me")
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data.error) setMyData(data);
+      })
+      .catch(() => {});
+  }, []);
+
+  const handleCompare = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!friendUsername.trim()) return;
+
+    setLoading(true);
+    setError("");
+    setFriendData(null);
+    setComparingUser(friendUsername.trim());
+
+    try {
+      const res = await fetch(`/api/metrics/compare?username=${encodeURIComponent(friendUsername.trim())}`);
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || "Failed to fetch user");
+      } else {
+        setFriendData(data);
+      }
+    } catch (err) {
+      setError("An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearComparison = () => {
+    setFriendUsername("");
+    setComparingUser("");
+    setFriendData(null);
+    setError("");
+  };
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <div className="flex flex-col md:flex-row md:items-center justify-between mb-6 gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">Friend Comparison</h2>
+          <p className="text-sm text-[var(--muted-foreground)]">See how you stack up against others</p>
+        </div>
+
+        <form onSubmit={handleCompare} className="flex gap-2">
+          <input
+            type="text"
+            placeholder="GitHub username..."
+            value={friendUsername}
+            onChange={(e) => setFriendUsername(e.target.value)}
+            className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 text-sm outline-none focus:border-[var(--accent)]"
+          />
+          <button
+            type="submit"
+            disabled={loading || !friendUsername.trim()}
+            className="rounded-md bg-[var(--accent)] px-4 py-1.5 text-sm font-medium text-[var(--accent-foreground)] disabled:opacity-50 transition-colors"
+          >
+            {loading ? "Loading..." : "Compare"}
+          </button>
+        </form>
+      </div>
+
+      {error && (
+        <div className="p-4 mb-4 rounded-md bg-red-500/10 border border-red-500/20 text-red-500 text-sm flex justify-between items-center">
+          <span>{error}</span>
+          <button onClick={() => setError("")} className="hover:underline">Dismiss</button>
+        </div>
+      )}
+
+      {friendData && myData && (
+        <div className="space-y-4">
+          <div className="flex justify-between items-center text-sm font-medium text-[var(--muted-foreground)] px-2">
+            <div className="w-1/3 text-left">You ({myData.username})</div>
+            <div className="w-1/3 text-center uppercase tracking-wider text-xs">Metric</div>
+            <div className="w-1/3 text-right">Them ({friendData.username})</div>
+          </div>
+
+          <div className="space-y-2">
+            <ComparisonRow 
+              label="Current Streak" 
+              myValue={myData.streak} 
+              theirValue={friendData.streak} 
+              suffix=" days" 
+            />
+            <ComparisonRow 
+              label="Commits (30d)" 
+              myValue={myData.commits30d} 
+              theirValue={friendData.commits30d} 
+            />
+            <ComparisonRow 
+              label="Pull Requests" 
+              myValue={myData.prs} 
+              theirValue={friendData.prs} 
+            />
+            <ComparisonRow 
+              label="Top Language" 
+              myValue={myData.topLanguage} 
+              theirValue={friendData.topLanguage} 
+              isString 
+            />
+          </div>
+
+          <div className="flex justify-end pt-4">
+            <button
+              onClick={clearComparison}
+              className="text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+            >
+              Clear Comparison
+            </button>
+          </div>
+        </div>
+      )}
+      
+      {!friendData && !loading && !error && (
+        <div className="flex items-center justify-center h-32 border-2 border-dashed border-[var(--border)] rounded-lg text-[var(--muted-foreground)] text-sm">
+          Enter a username above to start comparing
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ComparisonRow({ 
+  label, 
+  myValue, 
+  theirValue, 
+  suffix = "",
+  isString = false
+}: { 
+  label: string; 
+  myValue: string | number; 
+  theirValue: string | number;
+  suffix?: string;
+  isString?: boolean;
+}) {
+  let myWin = false;
+  let theirWin = false;
+  
+  if (!isString) {
+    if (Number(myValue) > Number(theirValue)) myWin = true;
+    if (Number(theirValue) > Number(myValue)) theirWin = true;
+  }
+
+  return (
+    <div className="flex items-center justify-between p-3 rounded-lg bg-[var(--control)]">
+      <div className={`w-1/3 text-left font-medium ${myWin ? "text-[var(--accent)]" : "text-[var(--foreground)]"}`}>
+        {myValue}{suffix}
+      </div>
+      <div className="w-1/3 text-center text-xs text-[var(--muted-foreground)] font-medium">
+        {label}
+      </div>
+      <div className={`w-1/3 text-right font-medium ${theirWin ? "text-[var(--accent)]" : "text-[var(--foreground)]"}`}>
+        {theirValue}{suffix}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new Friend Comparison widget to the dashboard, allowing users to enter a GitHub username and see a side-by-side comparison of their stats versus their friend's stats. 

*(If there is a specific issue number this closes, replace this text with: Closes #ISSUE_NUMBER)*

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Created `FriendComparison.tsx` client component for searching and displaying side-by-side metrics.
- Added `/api/metrics/compare` endpoint to aggregate GitHub API stats (Streak, 30d commits, top language, and PRs) with a 1-hour cache.
- Updated `src/app/dashboard/page.tsx` to include the new widget in the layout.
- Gracefully handles users that are not found or have private data.
- Resolved merge conflict with the newly added upstream widgets.

## How to Test

Steps for the reviewer to verify this works:

1. Pull the branch and run `npm run dev`.
2. Navigate to the dashboard.
3. Locate the new "Friend Comparison" widget below the Streak Tracker.
4. Type in a valid GitHub username (e.g., `torvalds`) and click "Compare".
5. Verify the side-by-side stats load correctly. 
6. Type an invalid username to verify the error state displays gracefully.

## Screenshots (if UI change)
*(Feel free to take a quick screenshot of the widget running locally and drag-and-drop it here!)*

## Checklist
- [x] Code follows the project's style guidelines
- [x] Lint and type-check passed (`npm run lint` & `npm run type-check`)
