### PR TITLE
[FEAT] Weekly digest summary card — closes #99

### DIFF
--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -1,0 +1,197 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import type { NextRequest } from "next/server";
+import { getLastWeekRange, getThisWeekRange } from "@/lib/dateUtils";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_API = "https://api.github.com";
+
+interface CommitSearchResponse {
+  total_count: number;
+  items: Array<{
+    repository: { full_name: string };
+    commit: { author: { date: string } };
+  }>;
+}
+
+interface PullRequestSearchResponse {
+  total_count: number;
+  items: Array<Record<string, unknown>>;
+}
+
+async function fetchGitHubJson<T>(
+  url: string,
+  accessToken: string,
+  accept: string = "application/vnd.github+json"
+): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: accept,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function fetchCommitSearch(
+  githubLogin: string,
+  accessToken: string,
+  start: string,
+  end: string
+): Promise<CommitSearchResponse> {
+  const query = encodeURIComponent(
+    `author:${githubLogin} committer-date:${start}..${end}`
+  );
+
+  // TODO: paginate for high-activity users
+  return fetchGitHubJson<CommitSearchResponse>(
+    `${GITHUB_API}/search/commits?q=${query}&per_page=100`,
+    accessToken,
+    "application/vnd.github+json"
+  );
+}
+
+async function fetchPullRequestsOpenedThisWeek(
+  githubLogin: string,
+  accessToken: string,
+  startDate: string,
+  endDate: string
+): Promise<number> {
+  const query = encodeURIComponent(
+    `type:pr author:${githubLogin} created:${startDate}..${endDate}`
+  );
+  const data = await fetchGitHubJson<PullRequestSearchResponse>(
+    `${GITHUB_API}/search/issues?q=${query}&per_page=100`,
+    accessToken
+  );
+
+  return data.items.length;
+}
+
+async function fetchPullRequestsMergedThisWeek(
+  githubLogin: string,
+  accessToken: string,
+  startDate: string,
+  endDate: string
+): Promise<number> {
+  const query = encodeURIComponent(
+    `type:pr author:${githubLogin} is:merged merged:${startDate}..${endDate}`
+  );
+  const data = await fetchGitHubJson<PullRequestSearchResponse>(
+    `${GITHUB_API}/search/issues?q=${query}&per_page=100`,
+    accessToken
+  );
+
+  return data.total_count;
+}
+
+function deriveMostActiveRepo(items: CommitSearchResponse["items"]): string | null {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const name = item.repository.full_name;
+    counts[name] = (counts[name] ?? 0) + 1;
+  }
+  const entries = Object.entries(counts);
+  if (entries.length === 0) return null;
+  return entries.reduce((a, b) => (b[1] > a[1] ? b : a))[0];
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const thisWeekRange = getThisWeekRange();
+  const lastWeekRange = getLastWeekRange();
+  const thisWeekStartDate = thisWeekRange.start.slice(0, 10);
+  const thisWeekEndDate = thisWeekRange.end.slice(0, 10);
+
+  const results = await Promise.allSettled([
+    fetchCommitSearch(
+      session.githubLogin,
+      session.accessToken,
+      thisWeekRange.start,
+      thisWeekRange.end
+    ),
+    fetchCommitSearch(
+      session.githubLogin,
+      session.accessToken,
+      lastWeekRange.start,
+      lastWeekRange.end
+    ),
+    fetchPullRequestsOpenedThisWeek(
+      session.githubLogin,
+      session.accessToken,
+      thisWeekStartDate,
+      thisWeekEndDate
+    ),
+    fetchPullRequestsMergedThisWeek(
+      session.githubLogin,
+      session.accessToken,
+      thisWeekStartDate,
+      thisWeekEndDate
+    ),
+    fetch(`${process.env.NEXTAUTH_URL ?? "http://localhost:3000"}/api/metrics/streak`, {
+      headers: { cookie: req.headers.get("cookie") ?? "" },
+      cache: "no-store",
+    }).then((r) => (r.ok ? r.json() : Promise.reject(r.status))),
+  ]);
+
+  const fulfilledCount = results.filter(
+    (result) => result.status === "fulfilled"
+  ).length;
+
+  if (fulfilledCount === 0) {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+
+  const currentWeekCommits =
+    results[0].status === "fulfilled" ? results[0].value.total_count : null;
+  const lastWeekCommits =
+    results[1].status === "fulfilled" ? results[1].value.total_count : null;
+  const openedPRs = results[2].status === "fulfilled" ? results[2].value : null;
+  const mergedPRs = results[3].status === "fulfilled" ? results[3].value : null;
+  const mostActiveRepo =
+    results[0].status === "fulfilled"
+      ? deriveMostActiveRepo(results[0].value.items)
+      : null;
+  const activeDayCommitData =
+    results[0].status === "fulfilled" ? results[0].value.items : null;
+
+  const activeDays = activeDayCommitData
+    ? new Set(activeDayCommitData.map((item) => item.commit.author.date.slice(0, 10)))
+        .size
+    : null;
+  const streak =
+    results[4].status === "fulfilled"
+      ? (results[4].value as { currentStreak: number }).currentStreak
+      : null;
+
+  return Response.json({
+    commits: {
+      current: currentWeekCommits,
+      last: lastWeekCommits,
+      delta:
+        currentWeekCommits !== null && lastWeekCommits !== null
+          ? currentWeekCommits - lastWeekCommits
+          : null,
+    },
+    pullRequests: {
+      opened: openedPRs,
+      merged: mergedPRs,
+    },
+    activeDays,
+    streak,
+    mostActiveRepo,
+    weekStart: thisWeekRange.start,
+    generatedAt: new Date().toISOString(),
+  });
+}

--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -172,7 +172,7 @@ export async function GET(req: NextRequest) {
     : null;
   const streak =
     results[4].status === "fulfilled"
-      ? (results[4].value as { currentStreak: number }).currentStreak
+      ? (results[4].value as { current: number }).current
       : null;
 
   return Response.json({

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import LanguageBreakdown from "@/components/LanguageBreakdown";
 import IssueMetrics from "@/components/IssueMetrics";
 import StreakAtRiskBanner from "@/components/StreakAtRiskBanner";
 import FriendComparison from "@/components/FriendComparison";
+import WeeklySummaryCard from "@/components/WeeklySummaryCard";
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
@@ -25,6 +26,8 @@ export default async function DashboardPage() {
       <DashboardHeader />
 
       <StreakAtRiskBanner />
+
+      <WeeklySummaryCard />
 
       {/* Row 1: Contribution graph + Streak + Friend Comparison */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface WeeklySummaryData {
+  commits: { current: number | null; last: number | null; delta: number | null };
+  pullRequests: { opened: number | null; merged: number | null };
+  activeDays: number | null;
+  streak: number | null;
+  mostActiveRepo: string | null;
+  weekStart: string;
+  generatedAt: string;
+}
+
+function DeltaBadge({ delta }: { delta: number | null }) {
+  if (delta === null) {
+    return (
+      <span className="text-sm font-medium text-[var(--muted-foreground)]">
+        —
+      </span>
+    );
+  }
+
+  if (delta > 0) {
+    return <span className="text-sm font-medium text-green-500">↑ {delta}</span>;
+  }
+
+  if (delta < 0) {
+    return (
+      <span className="text-sm font-medium text-red-400">
+        ↓ {Math.abs(delta)}
+      </span>
+    );
+  }
+
+  return (
+    <span className="text-sm font-medium text-[var(--muted-foreground)]">
+      0
+    </span>
+  );
+}
+
+function formatRepoName(repo: string | null): string {
+  if (!repo) return "—";
+  return repo.split("/")[1] ?? repo;
+}
+
+export default function WeeklySummaryCard() {
+  const [data, setData] = useState<WeeklySummaryData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("weekly-summary-collapsed");
+    if (stored !== null) {
+      setIsCollapsed(stored === "true");
+    }
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/metrics/weekly-summary")
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to fetch weekly summary");
+        }
+
+        return response.json();
+      })
+      .then((summary: WeeklySummaryData) => {
+        setData(summary);
+        setError(false);
+      })
+      .catch(() => {
+        setError(true);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  const toggleCollapsed = () => {
+    const nextValue = !isCollapsed;
+    setIsCollapsed(nextValue);
+    window.localStorage.setItem(
+      "weekly-summary-collapsed",
+      String(nextValue)
+    );
+  };
+
+  const showCollapsed = isHydrated && !isLoading && isCollapsed;
+
+  return (
+    <div className="mb-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        className="flex w-full items-center justify-between text-left"
+        aria-expanded={!showCollapsed}
+        aria-label="Toggle weekly summary"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-lg" role="img" aria-label="Calendar">
+            📅
+          </span>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            This Week
+          </h2>
+        </div>
+        <span className="text-sm text-[var(--muted-foreground)]">
+          {showCollapsed ? "v" : "^"}
+        </span>
+      </button>
+
+      {showCollapsed ? null : isLoading ? (
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="rounded-lg bg-[var(--control)] p-4 text-center"
+            >
+              <div className="mx-auto mb-3 h-4 w-20 rounded bg-[var(--card-muted)] animate-pulse" />
+              <div className="mx-auto h-8 w-24 rounded bg-[var(--card-muted)] animate-pulse" />
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <p className="mt-4 text-sm text-[var(--muted-foreground)]">
+          Unable to load weekly stats
+        </p>
+      ) : (
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">Commits</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.commits.current ?? "—"}
+            </div>
+            <div className="mt-1">
+              <DeltaBadge delta={data?.commits.delta ?? null} />
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">PRs Open</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.pullRequests.opened ?? "—"}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">PRs Merged</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.pullRequests.merged ?? "—"}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">Active Days</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.activeDays !== null && data?.activeDays !== undefined
+                ? `${data.activeDays} / 7`
+                : "— / 7"}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">Streak</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.streak !== null && data?.streak !== undefined
+                ? `${data.streak} days`
+                : "—"}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">Top Repo</div>
+            <div className="mt-2 truncate text-2xl font-bold text-[var(--accent)]">
+              {formatRepoName(data?.mostActiveRepo ?? null)}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,47 @@
+import { startOfWeek, subWeeks } from "date-fns";
+
+function toUtcWallClock(date: Date): Date {
+  return new Date(date.getTime() + date.getTimezoneOffset() * 60_000);
+}
+
+function fromUtcWallClock(date: Date): Date {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+}
+
+function getUtcWeekStart(date: Date): Date {
+  const utcWallClock = toUtcWallClock(date);
+  const weekStart = startOfWeek(utcWallClock, { weekStartsOn: 1 });
+  const utcWeekStart = fromUtcWallClock(weekStart);
+  utcWeekStart.setUTCHours(0, 0, 0, 0);
+  return utcWeekStart;
+}
+
+export function toDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function getThisWeekRange(): { start: string; end: string } {
+  const now = new Date();
+  const weekStart = getUtcWeekStart(now);
+  const end = new Date(now);
+  end.setUTCHours(23, 59, 59, 0);
+
+  return {
+    start: weekStart.toISOString(),
+    end: end.toISOString(),
+  };
+}
+
+export function getLastWeekRange(): { start: string; end: string } {
+  const thisWeekStart = getUtcWeekStart(new Date());
+  const lastWeekStart = subWeeks(thisWeekStart, 1);
+  lastWeekStart.setUTCHours(0, 0, 0, 0);
+  const lastWeekEnd = new Date(thisWeekStart);
+  lastWeekEnd.setUTCDate(lastWeekEnd.getUTCDate() - 1);
+  lastWeekEnd.setUTCHours(23, 59, 59, 0);
+
+  return {
+    start: lastWeekStart.toISOString(),
+    end: lastWeekEnd.toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary

Adds a collapsible "This Week" summary card at the top of the dashboard showing key stats for the current week at a glance.

Closes #99

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- **Backend:** Added `src/lib/dateUtils.ts` for centralized UTC week boundary calculations using `date-fns`.
- **Backend:** Created `src/app/api/metrics/weekly-summary/route.ts` which fetches GitHub Search (commits, PRs) and internal streak data concurrently via `Promise.allSettled`. Partial failures return `null` instead of 502ing the whole response.
- **Frontend:** Built `src/components/WeeklySummaryCard.tsx` with a persistent collapsible state (saved to `localStorage` with a hydration guard).
- **Frontend:** Injected the summary card at the top of `src/app/dashboard/page.tsx`.
- **Optimization:** Derived the "most active repo" directly from commit frequency payloads to save an extra GitHub API call.

## How to Test

Steps for the reviewer to verify this works:

1. Pull the branch locally and start the dev server (`npm run dev`).
2. Navigate to the dashboard.
3. Verify the "This Week" summary card renders at the top with stats (commits, PRs, active days, streak).
4. Click the card header to collapse it. Refresh the page and ensure the collapsed state persists.
5. Inspect the network tab to ensure `/api/metrics/weekly-summary` resolves successfully and does not block the rest of the dashboard from loading.

## Screenshots (if UI change)

<img width="1905" height="940" alt="image" src="https://github.com/user-attachments/assets/8f4d7d1c-8c31-46ea-97b6-f28282711507" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally

