### PR TITLE
Feat/pinned repos widget 96

### DIFF
--- a/src/app/api/metrics/pinned-repos/route.ts
+++ b/src/app/api/metrics/pinned-repos/route.ts
@@ -1,0 +1,76 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+interface PinnedRepo {
+  name: string;
+  description: string | null;
+  url: string;
+  stargazerCount: number;
+  forkCount: number;
+  primaryLanguage: { name: string; color: string } | null;
+}
+
+const PINNED_REPOS_QUERY = `
+  query {
+    viewer {
+      pinnedItems(first: 6, types: REPOSITORY) {
+        nodes {
+          ... on Repository {
+            name
+            description
+            url
+            stargazerCount
+            forkCount
+            primaryLanguage {
+              name
+              color
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const response = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+      body: JSON.stringify({ query: PINNED_REPOS_QUERY }),
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+
+    const data = (await response.json()) as {
+      data?: {
+        viewer?: {
+          pinnedItems?: {
+            nodes?: Array<PinnedRepo | null | undefined>;
+          };
+        };
+      };
+    };
+
+    const nodes = (data.data?.viewer?.pinnedItems?.nodes ?? []).filter(
+      (node): node is PinnedRepo => node != null
+    );
+
+    return Response.json({ pinnedRepos: nodes });
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+}

--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -1,0 +1,197 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import type { NextRequest } from "next/server";
+import { getLastWeekRange, getThisWeekRange } from "@/lib/dateUtils";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_API = "https://api.github.com";
+
+interface CommitSearchResponse {
+  total_count: number;
+  items: Array<{
+    repository: { full_name: string };
+    commit: { author: { date: string } };
+  }>;
+}
+
+interface PullRequestSearchResponse {
+  total_count: number;
+  items: Array<Record<string, unknown>>;
+}
+
+async function fetchGitHubJson<T>(
+  url: string,
+  accessToken: string,
+  accept: string = "application/vnd.github+json"
+): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: accept,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function fetchCommitSearch(
+  githubLogin: string,
+  accessToken: string,
+  start: string,
+  end: string
+): Promise<CommitSearchResponse> {
+  const query = encodeURIComponent(
+    `author:${githubLogin} committer-date:${start}..${end}`
+  );
+
+  // TODO: paginate for high-activity users
+  return fetchGitHubJson<CommitSearchResponse>(
+    `${GITHUB_API}/search/commits?q=${query}&per_page=100`,
+    accessToken,
+    "application/vnd.github+json"
+  );
+}
+
+async function fetchPullRequestsOpenedThisWeek(
+  githubLogin: string,
+  accessToken: string,
+  startDate: string,
+  endDate: string
+): Promise<number> {
+  const query = encodeURIComponent(
+    `type:pr author:${githubLogin} created:${startDate}..${endDate}`
+  );
+  const data = await fetchGitHubJson<PullRequestSearchResponse>(
+    `${GITHUB_API}/search/issues?q=${query}&per_page=100`,
+    accessToken
+  );
+
+  return data.items.length;
+}
+
+async function fetchPullRequestsMergedThisWeek(
+  githubLogin: string,
+  accessToken: string,
+  startDate: string,
+  endDate: string
+): Promise<number> {
+  const query = encodeURIComponent(
+    `type:pr author:${githubLogin} is:merged merged:${startDate}..${endDate}`
+  );
+  const data = await fetchGitHubJson<PullRequestSearchResponse>(
+    `${GITHUB_API}/search/issues?q=${query}&per_page=100`,
+    accessToken
+  );
+
+  return data.total_count;
+}
+
+function deriveMostActiveRepo(items: CommitSearchResponse["items"]): string | null {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const name = item.repository.full_name;
+    counts[name] = (counts[name] ?? 0) + 1;
+  }
+  const entries = Object.entries(counts);
+  if (entries.length === 0) return null;
+  return entries.reduce((a, b) => (b[1] > a[1] ? b : a))[0];
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const thisWeekRange = getThisWeekRange();
+  const lastWeekRange = getLastWeekRange();
+  const thisWeekStartDate = thisWeekRange.start.slice(0, 10);
+  const thisWeekEndDate = thisWeekRange.end.slice(0, 10);
+
+  const results = await Promise.allSettled([
+    fetchCommitSearch(
+      session.githubLogin,
+      session.accessToken,
+      thisWeekRange.start,
+      thisWeekRange.end
+    ),
+    fetchCommitSearch(
+      session.githubLogin,
+      session.accessToken,
+      lastWeekRange.start,
+      lastWeekRange.end
+    ),
+    fetchPullRequestsOpenedThisWeek(
+      session.githubLogin,
+      session.accessToken,
+      thisWeekStartDate,
+      thisWeekEndDate
+    ),
+    fetchPullRequestsMergedThisWeek(
+      session.githubLogin,
+      session.accessToken,
+      thisWeekStartDate,
+      thisWeekEndDate
+    ),
+    fetch(`${process.env.NEXTAUTH_URL ?? "http://localhost:3000"}/api/metrics/streak`, {
+      headers: { cookie: req.headers.get("cookie") ?? "" },
+      cache: "no-store",
+    }).then((r) => (r.ok ? r.json() : Promise.reject(r.status))),
+  ]);
+
+  const fulfilledCount = results.filter(
+    (result) => result.status === "fulfilled"
+  ).length;
+
+  if (fulfilledCount === 0) {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+
+  const currentWeekCommits =
+    results[0].status === "fulfilled" ? results[0].value.total_count : null;
+  const lastWeekCommits =
+    results[1].status === "fulfilled" ? results[1].value.total_count : null;
+  const openedPRs = results[2].status === "fulfilled" ? results[2].value : null;
+  const mergedPRs = results[3].status === "fulfilled" ? results[3].value : null;
+  const mostActiveRepo =
+    results[0].status === "fulfilled"
+      ? deriveMostActiveRepo(results[0].value.items)
+      : null;
+  const activeDayCommitData =
+    results[0].status === "fulfilled" ? results[0].value.items : null;
+
+  const activeDays = activeDayCommitData
+    ? new Set(activeDayCommitData.map((item) => item.commit.author.date.slice(0, 10)))
+        .size
+    : null;
+  const streak =
+    results[4].status === "fulfilled"
+      ? (results[4].value as { currentStreak: number }).currentStreak
+      : null;
+
+  return Response.json({
+    commits: {
+      current: currentWeekCommits,
+      last: lastWeekCommits,
+      delta:
+        currentWeekCommits !== null && lastWeekCommits !== null
+          ? currentWeekCommits - lastWeekCommits
+          : null,
+    },
+    pullRequests: {
+      opened: openedPRs,
+      merged: mergedPRs,
+    },
+    activeDays,
+    streak,
+    mostActiveRepo,
+    weekStart: thisWeekRange.start,
+    generatedAt: new Date().toISOString(),
+  });
+}

--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -172,7 +172,7 @@ export async function GET(req: NextRequest) {
     : null;
   const streak =
     results[4].status === "fulfilled"
-      ? (results[4].value as { currentStreak: number }).currentStreak
+      ? (results[4].value as { current: number }).current
       : null;
 
   return Response.json({

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import GoalTracker from "@/components/GoalTracker";
 import DashboardHeader from "@/components/DashboardHeader";
 import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
+import PinnedRepos from "@/components/PinnedRepos";
 import LanguageBreakdown from "@/components/LanguageBreakdown";
 import IssueMetrics from "@/components/IssueMetrics";
 import StreakAtRiskBanner from "@/components/StreakAtRiskBanner";
@@ -52,7 +53,12 @@ export default async function DashboardPage() {
         <IssueMetrics />
       </div>
 
-      {/* Row 4: Top repos + Language breakdown + Goal tracker */}
+      {/* Row 4: Pinned repositories */}
+      <div className="mt-6">
+        <PinnedRepos />
+      </div>
+
+      {/* Row 5: Top repos + Language breakdown + Goal tracker */}
       <div className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
         <TopRepos />
         <LanguageBreakdown />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import LanguageBreakdown from "@/components/LanguageBreakdown";
 import IssueMetrics from "@/components/IssueMetrics";
 import StreakAtRiskBanner from "@/components/StreakAtRiskBanner";
 import FriendComparison from "@/components/FriendComparison";
+import WeeklySummaryCard from "@/components/WeeklySummaryCard";
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
@@ -25,6 +26,8 @@ export default async function DashboardPage() {
       <DashboardHeader />
 
       <StreakAtRiskBanner />
+
+      <WeeklySummaryCard />
 
       {/* Row 1: Contribution graph + Streak + Friend Comparison */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/components/PinnedRepos.tsx
+++ b/src/components/PinnedRepos.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+interface PinnedRepo {
+  name: string;
+  description: string | null;
+  url: string;
+  stargazerCount: number;
+  forkCount: number;
+  primaryLanguage: { name: string; color: string } | null;
+}
+
+export default function PinnedRepos() {
+  const [pinnedRepos, setPinnedRepos] = useState<PinnedRepo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPinnedRepos = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    fetch("/api/metrics/pinned-repos")
+      .then((r) => {
+        if (!r.ok) throw new Error("API error");
+        return r.json();
+      })
+      .then((data: { pinnedRepos?: PinnedRepo[] }) =>
+        setPinnedRepos(data.pinnedRepos ?? [])
+      )
+      .catch(() =>
+        setError("We couldn't load your pinned repositories right now. Please try again in a moment.")
+      )
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetchPinnedRepos();
+  }, [fetchPinnedRepos]);
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
+        Pinned Repositories
+      </h2>
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="h-24 rounded-lg bg-[var(--card-muted)] animate-pulse" />
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchPinnedRepos}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
+        </div>
+      ) : pinnedRepos.length === 0 ? (
+        <p className="text-sm text-[var(--muted-foreground)]">
+          No pinned repositories.{" "}
+          <a
+            href="https://github.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-[var(--accent)]"
+          >
+            Pin some on GitHub
+          </a>
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {pinnedRepos.map((repo) => (
+            <a
+              key={repo.url}
+              href={repo.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex flex-col gap-2 rounded-lg border border-[var(--border)] bg-[var(--card-muted)] p-4 transition-colors hover:border-[var(--accent)]"
+            >
+              <span className="truncate text-sm font-semibold text-[var(--card-foreground)]">
+                {repo.name}
+              </span>
+
+              <span className="line-clamp-2 flex-1 text-xs text-[var(--muted-foreground)]">
+                {repo.description ?? "No description"}
+              </span>
+
+              <div className="flex items-center gap-3 text-xs text-[var(--muted-foreground)]">
+                {repo.primaryLanguage && (
+                  <span className="flex items-center gap-1">
+                    <span
+                      className="inline-block h-2.5 w-2.5 rounded-full"
+                      style={{
+                        backgroundColor:
+                          repo.primaryLanguage.color ?? "#8b949e",
+                      }}
+                    />
+                    {repo.primaryLanguage.name}
+                  </span>
+                )}
+                <span>⭐ {repo.stargazerCount}</span>
+                <span>🍴 {repo.forkCount}</span>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface WeeklySummaryData {
+  commits: { current: number | null; last: number | null; delta: number | null };
+  pullRequests: { opened: number | null; merged: number | null };
+  activeDays: number | null;
+  streak: number | null;
+  mostActiveRepo: string | null;
+  weekStart: string;
+  generatedAt: string;
+}
+
+function DeltaBadge({ delta }: { delta: number | null }) {
+  if (delta === null) {
+    return (
+      <span className="text-sm font-medium text-[var(--muted-foreground)]">
+        —
+      </span>
+    );
+  }
+
+  if (delta > 0) {
+    return <span className="text-sm font-medium text-green-500">↑ {delta}</span>;
+  }
+
+  if (delta < 0) {
+    return (
+      <span className="text-sm font-medium text-red-400">
+        ↓ {Math.abs(delta)}
+      </span>
+    );
+  }
+
+  return (
+    <span className="text-sm font-medium text-[var(--muted-foreground)]">
+      0
+    </span>
+  );
+}
+
+function formatRepoName(repo: string | null): string {
+  if (!repo) return "—";
+  return repo.split("/")[1] ?? repo;
+}
+
+export default function WeeklySummaryCard() {
+  const [data, setData] = useState<WeeklySummaryData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("weekly-summary-collapsed");
+    if (stored !== null) {
+      setIsCollapsed(stored === "true");
+    }
+    setIsHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/metrics/weekly-summary")
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Failed to fetch weekly summary");
+        }
+
+        return response.json();
+      })
+      .then((summary: WeeklySummaryData) => {
+        setData(summary);
+        setError(false);
+      })
+      .catch(() => {
+        setError(true);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  const toggleCollapsed = () => {
+    const nextValue = !isCollapsed;
+    setIsCollapsed(nextValue);
+    window.localStorage.setItem(
+      "weekly-summary-collapsed",
+      String(nextValue)
+    );
+  };
+
+  const showCollapsed = isHydrated && !isLoading && isCollapsed;
+
+  return (
+    <div className="mb-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <button
+        type="button"
+        onClick={toggleCollapsed}
+        className="flex w-full items-center justify-between text-left"
+        aria-expanded={!showCollapsed}
+        aria-label="Toggle weekly summary"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-lg" role="img" aria-label="Calendar">
+            📅
+          </span>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            This Week
+          </h2>
+        </div>
+        <span className="text-sm text-[var(--muted-foreground)]">
+          {showCollapsed ? "v" : "^"}
+        </span>
+      </button>
+
+      {showCollapsed ? null : isLoading ? (
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="rounded-lg bg-[var(--control)] p-4 text-center"
+            >
+              <div className="mx-auto mb-3 h-4 w-20 rounded bg-[var(--card-muted)] animate-pulse" />
+              <div className="mx-auto h-8 w-24 rounded bg-[var(--card-muted)] animate-pulse" />
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <p className="mt-4 text-sm text-[var(--muted-foreground)]">
+          Unable to load weekly stats
+        </p>
+      ) : (
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">Commits</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.commits.current ?? "—"}
+            </div>
+            <div className="mt-1">
+              <DeltaBadge delta={data?.commits.delta ?? null} />
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">PRs Open</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.pullRequests.opened ?? "—"}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">PRs Merged</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.pullRequests.merged ?? "—"}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">Active Days</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.activeDays !== null && data?.activeDays !== undefined
+                ? `${data.activeDays} / 7`
+                : "— / 7"}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">Streak</div>
+            <div className="mt-2 text-2xl font-bold text-[var(--accent)]">
+              {data?.streak !== null && data?.streak !== undefined
+                ? `${data.streak} days`
+                : "—"}
+            </div>
+          </div>
+          <div className="rounded-lg bg-[var(--control)] p-4 text-center">
+            <div className="text-sm text-[var(--muted-foreground)]">Top Repo</div>
+            <div className="mt-2 truncate text-2xl font-bold text-[var(--accent)]">
+              {formatRepoName(data?.mostActiveRepo ?? null)}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,47 @@
+import { startOfWeek, subWeeks } from "date-fns";
+
+function toUtcWallClock(date: Date): Date {
+  return new Date(date.getTime() + date.getTimezoneOffset() * 60_000);
+}
+
+function fromUtcWallClock(date: Date): Date {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+}
+
+function getUtcWeekStart(date: Date): Date {
+  const utcWallClock = toUtcWallClock(date);
+  const weekStart = startOfWeek(utcWallClock, { weekStartsOn: 1 });
+  const utcWeekStart = fromUtcWallClock(weekStart);
+  utcWeekStart.setUTCHours(0, 0, 0, 0);
+  return utcWeekStart;
+}
+
+export function toDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function getThisWeekRange(): { start: string; end: string } {
+  const now = new Date();
+  const weekStart = getUtcWeekStart(now);
+  const end = new Date(now);
+  end.setUTCHours(23, 59, 59, 0);
+
+  return {
+    start: weekStart.toISOString(),
+    end: end.toISOString(),
+  };
+}
+
+export function getLastWeekRange(): { start: string; end: string } {
+  const thisWeekStart = getUtcWeekStart(new Date());
+  const lastWeekStart = subWeeks(thisWeekStart, 1);
+  lastWeekStart.setUTCHours(0, 0, 0, 0);
+  const lastWeekEnd = new Date(thisWeekStart);
+  lastWeekEnd.setUTCDate(lastWeekEnd.getUTCDate() - 1);
+  lastWeekEnd.setUTCHours(23, 59, 59, 0);
+
+  return {
+    start: lastWeekStart.toISOString(),
+    end: lastWeekEnd.toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary
Adds a Pinned Repositories widget to the developer dashboard, displaying up to 6 of the user's GitHub pinned repos — mirroring what appears on their public GitHub profile.
Closes #96

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made
- Added `GET /api/metrics/pinned-repos` route — queries the GitHub GraphQL API (`pinnedItems`) using the authenticated session token
- Created `PinnedRepos` widget component — responsive 3-column card grid showing repo name, description, primary language (with color dot), star count, and fork count. Each card links to the repo URL
- Wired `<PinnedRepos />` into the dashboard as a full-width row between Issue Metrics and the Top Repos row
- Loading skeleton (6 pulse cards), error state with retry button, and empty state with link to GitHub profile settings

## How to Test
1. Sign in with a GitHub account that has at least one pinned repository
2. Navigate to the dashboard — the **Pinned Repositories** widget should appear between Issue Metrics and Top Repos
3. Verify each card shows: repo name (linked), description, language dot + name, star count, fork count
4. Unpin all repos on GitHub, refresh dashboard — confirm the empty state renders: *"No pinned repositories. Pin some on GitHub"
5. To test error state: temporarily change the endpoint URL in `PinnedRepos.tsx` to a bad path, refresh, confirm the error UI and **Try again** button appear, then revert

## Checklist
- [x] Linked issue in summary
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
