### PR TITLE
feat: show frozen days in streak calendar (#101)

### DIFF
--- a/src/app/api/streak/freeze/route.ts
+++ b/src/app/api/streak/freeze/route.ts
@@ -35,7 +35,21 @@ export async function GET() {
 
   const hasFreeze = Array.isArray(pending) && pending.length > 0;
 
-  return Response.json({ hasFreeze, freezeDate: hasFreeze ? pending![0].freeze_date : null });
+  const { data: allFreezes } = await supabaseAdmin
+    .from("streak_freezes")
+    .select("freeze_date")
+    .eq("user_id", user.id)
+    .order("freeze_date", { ascending: true });
+
+  const freezeDates: string[] = Array.isArray(allFreezes)
+    ? allFreezes.map((r) => r.freeze_date)
+    : [];
+
+  return Response.json({
+    hasFreeze,
+    freezeDate: hasFreeze ? pending![0].freeze_date : null,
+    freezeDates,
+  });
 }
 
 // POST /api/streak/freeze

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -17,6 +17,8 @@ interface ContributionData {
 
 interface FreezeData {
   hasFreeze: boolean;
+  freezeDate?: string | null;
+  freezeDates?: string[];
 }
 
 export default function StreakTracker() {
@@ -281,6 +283,7 @@ export default function StreakTracker() {
       {contributionData ? (
         <StreakCalendar
           contributions={contributionData.data}
+          freezeDates={freeze?.freezeDates ?? []}
           currentMonth={calendarMonth}
           onMonthChange={setCalendarMonth}
         />
@@ -291,11 +294,13 @@ export default function StreakTracker() {
 
 interface StreakCalendarProps {
   contributions: Record<string, number>;
+  freezeDates: string[];
   currentMonth: Date;
   onMonthChange: (date: Date) => void;
 }
 
-function StreakCalendar({ contributions, currentMonth, onMonthChange }: StreakCalendarProps) {
+function StreakCalendar({ contributions, freezeDates, currentMonth, onMonthChange }: StreakCalendarProps) {
+  const freezeSet = new Set(freezeDates);
   const today = new Date();
   const year = currentMonth.getFullYear();
   const month = currentMonth.getMonth();
@@ -362,19 +367,27 @@ function StreakCalendar({ contributions, currentMonth, onMonthChange }: StreakCa
 
           const dateStr = dayData.date.toISOString().slice(0, 10);
           const commitCount = contributions[dateStr] ?? 0;
+          const isFrozen = freezeSet.has(dateStr);
           const isFuture = dayData.date > today;
           const isToday = dayData.date.toDateString() === today.toDateString();
 
           let bgColor = "bg-white dark:bg-transparent";
           let borderColor = "border border-[var(--border)]";
+          let dayStatus = "";
 
           if (!isFuture) {
             if (commitCount > 0) {
               bgColor = "bg-green-500";
               borderColor = "border border-green-600";
+              dayStatus = "Committed";
+            } else if (isFrozen) {
+              bgColor = "bg-blue-500";
+              borderColor = "border border-blue-600";
+              dayStatus = "Freeze used";
             } else {
               bgColor = "bg-gray-500";
               borderColor = "border border-gray-600";
+              dayStatus = "Missed";
             }
           }
 
@@ -383,7 +396,7 @@ function StreakCalendar({ contributions, currentMonth, onMonthChange }: StreakCa
                 weekday: "short",
                 month: "short",
                 day: "numeric",
-              })}: ${commitCount > 0 ? "Committed" : "Missed"}`
+              })}: ${dayStatus}`
             : "";
 
           return (
@@ -414,6 +427,10 @@ function StreakCalendar({ contributions, currentMonth, onMonthChange }: StreakCa
         <div className="flex items-center gap-2">
           <div className="h-3 w-3 rounded bg-green-500" />
           <span>Committed</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-3 w-3 rounded bg-blue-500" />
+          <span>Freeze used</span>
         </div>
         <div className="flex items-center gap-2">
           <div className="h-3 w-3 rounded bg-gray-500" />


### PR DESCRIPTION
## Summary

The streak calendar was already showing committed/missed days but had no 
awareness of streak freezes. Extended the existing `/api/streak/freeze` 
GET response to include all freeze dates, then passed them into 
`StreakCalendar` to render as blue cells with a "Freeze used" tooltip.

Closes #101

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- `GET /api/streak/freeze` now returns `freezeDates[]` alongside the existing `hasFreeze`/`freezeDate` fields
- `StreakCalendar` accepts a `freezeDates` prop and uses a `Set` for lookups
- Frozen days render blue (`bg-blue-500`) with tooltip "Freeze used"
- Priority: committed (green) → frozen (blue) → missed (grey) → future (empty)
- Added "Freeze used" entry to the calendar legend

## How to Test

1. Apply a streak freeze via the freeze button on the dashboard
2. Open the streak calendar — the frozen day should appear **blue**
3. Hover over it — tooltip should say `[Day, Mon DD]: Freeze used`
4. Navigate to a month with no freezes — all past days show green or grey as expected
5. Future days remain empty
 

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
