### PR TITLE
fix: add other bucket to language breakdown

### DIFF
--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -40,6 +40,18 @@ export default function LanguageBreakdown() {
       .finally(() => setLoading(false));
   }, []);
 
+  const totalPercentage = languages.reduce((sum, lang) => sum + lang.percentage, 0);
+  const roundedTotal = Math.round(totalPercentage * 10) / 10;
+  
+  const displayLanguages = [...languages];
+  if (roundedTotal < 100 && languages.length > 0) {
+    displayLanguages.push({
+      name: "Other",
+      bytes: 0,
+      percentage: Math.round((100 - roundedTotal) * 10) / 10,
+    });
+  }
+
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <h2 className="text-lg font-semibold text-[var(--card-foreground)] mb-4">
@@ -63,13 +75,13 @@ export default function LanguageBreakdown() {
         <>
           {/* Stacked bar */}
           <div className="flex h-6 w-full overflow-hidden rounded-full bg-[var(--control)]">
-            {languages.map((lang) => (
+            {displayLanguages.map((lang) => (
               <div
                 key={lang.name}
                 className="h-full transition-all duration-500 first:rounded-l-full last:rounded-r-full"
                 style={{
                   width: `${lang.percentage}%`,
-                  backgroundColor: getColor(lang.name),
+                  backgroundColor: lang.name === "Other" ? "var(--control)" : getColor(lang.name),
                   minWidth: lang.percentage > 0 ? "4px" : "0px",
                 }}
                 title={`${lang.name}: ${lang.percentage}%`}
@@ -79,11 +91,11 @@ export default function LanguageBreakdown() {
 
           {/* Legend */}
           <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2">
-            {languages.map((lang) => (
+            {displayLanguages.map((lang) => (
               <div key={lang.name} className="flex items-center gap-2 text-sm">
                 <span
                   className="inline-block h-3 w-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: getColor(lang.name) }}
+                  style={{ backgroundColor: lang.name === "Other" ? "var(--control)" : getColor(lang.name) }}
                 />
                 <span className="truncate text-[var(--card-foreground)]">
                   {lang.name}


### PR DESCRIPTION
## Summary

Fixes the LanguageBreakdown widget by adding an "Other" segment when the top 6 languages do not sum to 100%, ensuring the stacked bar fully fills the available width.

Closes #88

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Calculated the remaining percentage after the top 6 languages
- Added an "Other" segment when total percentage is less than 100%
- Rendered the "Other" segment in both the stacked bar and legend
- Applied `var(--control)` color to the "Other" bucket
- Prevented rendering of unnecessary `Other 0%` entries

## How to Test

Steps for the reviewer to verify this works:

1. Run the application locally
2. Open the dashboard and navigate to the LanguageBreakdown widget
3. Verify the stacked language bar fills the full width without any empty gap
4. Confirm an "Other" entry appears in the legend when total language percentages are below 100%
5. Verify the "Other" segment uses the neutral grey color
6. Confirm no "Other" entry appears when the total already equals 100%

## Screenshots (if UI change)

N/A

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable