### PR TITLE
[Fix]: Overflowing Text at PR-Analytics Grid

### DIFF
--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -58,7 +58,7 @@ export default function PRMetrics() {
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Analytics</h2>
       {loading ? (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 gap-4">
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
@@ -78,7 +78,7 @@ export default function PRMetrics() {
           </button>
         </div>
       ) : (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 gap-4">
           {stats.map((stat) => (
             <div
               key={stat.label}

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -58,7 +58,7 @@ export default function PRMetrics() {
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Analytics</h2>
       {loading ? (
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
@@ -78,16 +78,16 @@ export default function PRMetrics() {
           </button>
         </div>
       ) : (
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {stats.map((stat) => (
             <div
               key={stat.label}
-              className="rounded-lg bg-[var(--control)] p-4 text-center"
+              className="rounded-lg bg-[var(--control)] p-4 text-center min-w-0"
             >
-              <div className="text-2xl font-bold text-[var(--accent)]">
+              <div className="truncate text-2xl font-bold text-[var(--accent)]">
                 {stat.value}
               </div>
-              <div className="mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
+              <div className="truncate mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Earlier, upon zooming in (or entering medium screen metric), the PR ANALYTICS section of the site had overflowing text, and broken grid structure. The PR removes un-necessary medium screen metrics (`md:grid-cols-4`), which removes the issue completely.

Also now, upon zooming in or zooming out, the grid adapts itself according to the screen, and fills the div automatically.

Closes #143 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Removed tailwind css class `md:grid-cols-4` from file `PRmetrics.tsx`

## How to Test

Steps for the reviewer to verify this works:

1. Go to the site 
2. Navigate to PR Analytics section
3. Notice that the grid are now equally spaced, and there is no overflowing text
4. Try zooming in and out, and notice that grid fills itself according to the screen, ensure there is no void space at div left.

## Screenshots (if UI change)

|Before | After |
| --- | --- |
|<img width="584" height="617" alt="Screenshot 2026-05-16 135421" src="https://github.com/user-attachments/assets/1feb5920-30ae-4fce-b494-6627441ee4e7" /> | <img width="447" height="639" alt="Screenshot 2026-05-16 135731" src="https://github.com/user-attachments/assets/eb008514-3f0a-4cb3-90b0-6b86e73a13e6" /> |


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
