### PR TITLE
feat: add multi-GitHub account support (#63)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,9 @@ NEXTAUTH_SECRET=your_nextauth_secret_min_32_chars
 # GitHub OAuth App — create at github.com/settings/applications/new
 GITHUB_ID=your_github_oauth_app_client_id
 GITHUB_SECRET=your_github_oauth_app_client_secret
+# Second callback URL to register in your GitHub OAuth App settings:
+# {NEXTAUTH_URL}/api/auth/link-github/callback
+
+# 32-byte hex string for AES-256-GCM token encryption
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ENCRYPTION_KEY=

--- a/src/app/api/auth/link-github/callback/route.ts
+++ b/src/app/api/auth/link-github/callback/route.ts
@@ -1,0 +1,149 @@
+import { getServerSession } from "next-auth";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { encryptToken } from "@/lib/crypto";
+import { supabaseAdmin } from "@/lib/supabase";
+
+interface GitHubTokenResponse {
+  access_token?: string;
+}
+
+interface GitHubUserResponse {
+  id: number;
+  login: string;
+}
+
+function buildSettingsRedirect(errorOrSuccess: string, value: string): URL {
+  const baseUrl = process.env.NEXTAUTH_URL ?? "";
+  const url = new URL("/dashboard/settings", baseUrl);
+  url.searchParams.set(errorOrSuccess, value);
+  return url;
+}
+
+export async function GET(req: NextRequest) {
+  const state = req.nextUrl.searchParams.get("state");
+  const code = req.nextUrl.searchParams.get("code");
+
+  const cookieStore = cookies();
+  const stateCookie = cookieStore.get("link_github_state")?.value;
+
+  if (!stateCookie || !state || stateCookie !== state) {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "invalid_state"),
+      { status: 302 }
+    );
+  }
+
+  const session = await getServerSession(authOptions);
+
+  if (!session?.githubId) {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "unauthorized"),
+      { status: 302 }
+    );
+  }
+
+  const redirectUri = `${process.env.NEXTAUTH_URL ?? ""}/api/auth/link-github/callback`;
+
+  const tokenResponse = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+    },
+    body: new URLSearchParams({
+      client_id: process.env.GITHUB_ID ?? "",
+      client_secret: process.env.GITHUB_SECRET ?? "",
+      code: code ?? "",
+      redirect_uri: redirectUri,
+    }),
+    cache: "no-store",
+  });
+
+  const tokenData = (await tokenResponse.json()) as GitHubTokenResponse;
+  const accessToken = tokenData.access_token;
+
+  if (!accessToken) {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "token_exchange_failed"),
+      { status: 302 }
+    );
+  }
+
+  const profileResponse = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/vnd.github+json",
+    },
+    cache: "no-store",
+  });
+
+  if (!profileResponse.ok) {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "github_profile_failed"),
+      { status: 302 }
+    );
+  }
+
+  const profile = (await profileResponse.json()) as GitHubUserResponse;
+
+  if (String(profile.id) === session.githubId) {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "cannot_link_primary_account"),
+      { status: 302 }
+    );
+  }
+
+  const { data: user, error: userError } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", session.githubId)
+    .single();
+
+  if (userError || !user) {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "user_not_found"),
+      { status: 302 }
+    );
+  }
+
+  const { encrypted, iv } = encryptToken(accessToken);
+
+  const { error: insertError } = await supabaseAdmin
+    .from("user_github_accounts")
+    .insert({
+      user_id: user.id,
+      github_id: String(profile.id),
+      github_login: profile.login,
+      access_token_encrypted: encrypted,
+      access_token_iv: iv,
+    });
+
+  if (insertError?.code === "23505") {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "already_linked"),
+      { status: 302 }
+    );
+  }
+
+  if (insertError) {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "insert_failed"),
+      { status: 302 }
+    );
+  }
+
+  const response = NextResponse.redirect(
+    buildSettingsRedirect("success", "account_linked"),
+    { status: 302 }
+  );
+  response.cookies.set("link_github_state", "", {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+    secure: process.env.NODE_ENV === "production",
+  });
+
+  return response;
+}

--- a/src/app/api/auth/link-github/route.ts
+++ b/src/app/api/auth/link-github/route.ts
@@ -1,0 +1,36 @@
+import { getServerSession } from "next-auth";
+import { randomBytes } from "crypto";
+import { NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.githubId) {
+    return NextResponse.json(
+      { error: "Must be signed in to link an account" },
+      { status: 401 }
+    );
+  }
+
+  const state = randomBytes(32).toString("hex");
+  const baseUrl = process.env.NEXTAUTH_URL ?? "";
+  const redirectUri = `${baseUrl}/api/auth/link-github/callback`;
+
+  const githubUrl = new URL("https://github.com/login/oauth/authorize");
+  githubUrl.searchParams.set("client_id", process.env.GITHUB_ID ?? "");
+  githubUrl.searchParams.set("redirect_uri", redirectUri);
+  githubUrl.searchParams.set("scope", "read:user repo");
+  githubUrl.searchParams.set("state", state);
+
+  const response = NextResponse.redirect(githubUrl, { status: 307 });
+  response.cookies.set("link_github_state", state, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 600,
+    secure: process.env.NODE_ENV === "production",
+  });
+
+  return response;
+}

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -1,39 +1,55 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import {
+  getAccountToken,
+  getAllAccounts,
+  mergeMetrics,
+} from "@/lib/github-accounts";
+import { GITHUB_API } from "@/lib/github";
+import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
-const GITHUB_API = "https://api.github.com";
+interface ContributionResponse {
+  days: number;
+  total: number;
+  data: Record<string, number>;
+}
 
-export async function GET(req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.accessToken || !session.githubLogin) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+function mergeContributionDays(
+  a: Record<string, number>,
+  b: Record<string, number>
+): Record<string, number> {
+  const result = { ...a };
+  for (const [date, count] of Object.entries(b)) {
+    result[date] = (result[date] ?? 0) + count;
   }
+  return result;
+}
 
-  const days = Number(req.nextUrl.searchParams.get("days")) || 30;
-
+async function fetchContributionsForAccount(
+  token: string,
+  githubLogin: string,
+  days: number
+): Promise<ContributionResponse> {
   const since = new Date();
   since.setDate(since.getDate() - days);
   const sinceStr = since.toISOString().slice(0, 10);
 
-  // Commits search API captures all commits authored by the user —
-  // including web UI commits, merge commits, PRs — unlike the events API
-  // which only catches PushEvents from direct pushes.
   const searchRes = await fetch(
-    `${GITHUB_API}/search/commits?q=author:${session.githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
+    `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
     {
       headers: {
-        Authorization: `Bearer ${session.accessToken}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
       cache: "no-store",
-    },
+    }
   );
 
   if (!searchRes.ok) {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+    throw new Error("GitHub API error");
   }
 
   const data = (await searchRes.json()) as {
@@ -42,34 +58,117 @@ export async function GET(req: NextRequest) {
   };
 
   const commitsByDay: Record<string, number> = {};
-  const timeBlocks = {
-    morning: 0, // 6-11
-    afternoon: 0, // 12-17
-    evening: 0, // 18-21
-    night: 0, // 22-5
-  };
-
   for (const item of data.items) {
-    const rawDate = item.commit.author.date;
-    const date = rawDate.slice(0, 10);
+    const date = item.commit.author.date.slice(0, 10);
     commitsByDay[date] = (commitsByDay[date] ?? 0) + 1;
+  }
 
-    const hour = new Date(rawDate).getHours();
-    if (hour >= 6 && hour < 12) {
-      timeBlocks.morning++;
-    } else if (hour >= 12 && hour < 18) {
-      timeBlocks.afternoon++;
-    } else if (hour >= 18 && hour < 22) {
-      timeBlocks.evening++;
-    } else {
-      timeBlocks.night++;
+  return { days, total: data.total_count, data: commitsByDay };
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const days = Number(req.nextUrl.searchParams.get("days")) || 30;
+  const accountId = req.nextUrl.searchParams.get("accountId");
+
+  if (!accountId) {
+    try {
+      const result = await fetchContributionsForAccount(
+        session.accessToken,
+        session.githubLogin,
+        days
+      );
+      return Response.json(result);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
 
-  return Response.json({
-    days,
-    total: data.total_count,
-    data: commitsByDay,
-    timeBlocks,
-  });
+  if (!session.githubId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: userRow } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", session.githubId)
+    .single();
+
+  if (!userRow) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (accountId === "combined") {
+    const accounts = await getAllAccounts(
+      {
+        token: session.accessToken,
+        githubId: session.githubId,
+        githubLogin: session.githubLogin,
+      },
+      userRow.id
+    );
+
+    const results = await Promise.allSettled(
+      accounts.map((account) =>
+        fetchContributionsForAccount(account.token, account.githubLogin, days)
+      )
+    );
+
+    const merged = mergeMetrics(results, (a, b) => ({
+      days: a.days,
+      total: a.total + b.total,
+      data: mergeContributionDays(a.data, b.data),
+    }));
+
+    if (!merged) {
+      return Response.json({ error: "All accounts failed" }, { status: 502 });
+    }
+
+    return Response.json(merged);
+  }
+
+  if (accountId === session.githubId) {
+    try {
+      const result = await fetchContributionsForAccount(
+        session.accessToken,
+        session.githubLogin,
+        days
+      );
+      return Response.json(result);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  const accountToken = await getAccountToken(userRow.id, accountId);
+
+  if (!accountToken) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  const { data: accountRow } = await supabaseAdmin
+    .from("user_github_accounts")
+    .select("github_login")
+    .eq("user_id", userRow.id)
+    .eq("github_id", accountId)
+    .single();
+
+  if (!accountRow?.github_login) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  try {
+    const result = await fetchContributionsForAccount(
+      accountToken,
+      accountRow.github_login,
+      days
+    );
+    return Response.json(result);
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
 }

--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -1,26 +1,35 @@
 import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import {
+  getAccountToken,
+  getAllAccounts,
+  mergeMetrics,
+} from "@/lib/github-accounts";
+import { GITHUB_API } from "@/lib/github";
+import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
-const GITHUB_API = "https://api.github.com";
+interface PRMetricsBase {
+  open: number;
+  merged: number;
+  total: number;
+  avgReviewHours: number;
+  mergeRate: number;
+}
 
-export async function GET() {
-  const session = await getServerSession(authOptions);
-  if (!session?.accessToken) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   const searchRes = await fetch(
     `${GITHUB_API}/search/issues?q=type:pr+author:@me&per_page=100`,
     {
-      headers: { Authorization: `Bearer ${session.accessToken}` },
+      headers: { Authorization: `Bearer ${token}` },
       cache: "no-store",
     }
   );
 
   if (!searchRes.ok) {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+    throw new Error("GitHub API error");
   }
 
   const data = (await searchRes.json()) as {
@@ -43,14 +52,111 @@ export async function GET() {
         ) / closedPRs.length
       : 0;
 
-  return Response.json({
+  return {
     open,
     merged,
     total: data.total_count,
     avgReviewHours: Math.round(avgReviewMs / 3600000),
+    mergeRate: data.total_count > 0 ? merged / data.total_count : 0,
+  };
+}
+
+function formatPRMetrics(metrics: PRMetricsBase) {
+  return {
+    open: metrics.open,
+    merged: metrics.merged,
+    total: metrics.total,
+    avgReviewHours: metrics.avgReviewHours,
     mergeRate:
-      data.total_count > 0
-        ? `${Math.round((merged / data.total_count) * 100)}%`
+      metrics.total > 0
+        ? `${Math.round(metrics.mergeRate * 100)}%`
         : "0%",
-  });
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const accountId = req.nextUrl.searchParams.get("accountId");
+
+  if (!accountId) {
+    try {
+      const result = await fetchPRMetrics(session.accessToken);
+      return Response.json(formatPRMetrics(result));
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  if (!session.githubId || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: userRow } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", session.githubId)
+    .single();
+
+  if (!userRow) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (accountId === "combined") {
+    const accounts = await getAllAccounts(
+      {
+        token: session.accessToken,
+        githubId: session.githubId,
+        githubLogin: session.githubLogin,
+      },
+      userRow.id
+    );
+
+    const results = await Promise.allSettled(
+      accounts.map((account) => fetchPRMetrics(account.token))
+    );
+
+    const merged = mergeMetrics(results, (a, b) => {
+      const total = a.total + b.total;
+      const mergedCount = a.merged + b.merged;
+      const avgReviewHours =
+        total > 0
+          ? (a.avgReviewHours * a.total + b.avgReviewHours * b.total) / total
+          : 0;
+
+      return {
+        open: a.open + b.open,
+        merged: mergedCount,
+        total,
+        avgReviewHours: Math.round(avgReviewHours * 10) / 10,
+        mergeRate:
+          total > 0 ? Math.round((mergedCount / total) * 100) / 100 : 0,
+      };
+    });
+
+    if (!merged) {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+
+    return Response.json(formatPRMetrics(merged));
+  }
+
+  const token =
+    accountId === session.githubId
+      ? session.accessToken
+      : await getAccountToken(userRow.id, accountId);
+
+  if (!token) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  try {
+    const result = await fetchPRMetrics(token);
+    return Response.json(formatPRMetrics(result));
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
 }

--- a/src/app/api/metrics/repos/route.ts
+++ b/src/app/api/metrics/repos/route.ts
@@ -1,27 +1,53 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import {
+  getAccountToken,
+  getAllAccounts,
+  mergeMetrics,
+} from "@/lib/github-accounts";
+import { GITHUB_API } from "@/lib/github";
+import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
-const GITHUB_API = "https://api.github.com";
+interface RepoSummary {
+  name: string;
+  commits: number;
+}
 
-export async function GET(req: NextRequest) {
-  const session = await getServerSession(authOptions);
-  if (!session?.accessToken || !session.githubLogin) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+interface RepoResponse {
+  repos: RepoSummary[];
+  days: number;
+}
+
+function mergeRepoCommits(
+  a: Array<{ name: string; commits: number }>,
+  b: Array<{ name: string; commits: number }>
+): Array<{ name: string; commits: number }> {
+  const map = new Map<string, number>();
+  for (const repo of [...a, ...b]) {
+    map.set(repo.name, (map.get(repo.name) ?? 0) + repo.commits);
   }
+  return Array.from(map.entries())
+    .map(([name, commits]) => ({ name, commits }))
+    .sort((x, y) => y.commits - x.commits);
+}
 
-  const days = Number(req.nextUrl.searchParams.get("days")) || 30;
+async function fetchReposForAccount(
+  token: string,
+  githubLogin: string,
+  days: number
+): Promise<RepoResponse> {
   const since = new Date();
   since.setDate(since.getDate() - days);
   const sinceStr = since.toISOString().slice(0, 10);
 
   const searchRes = await fetch(
-    `${GITHUB_API}/search/commits?q=author:${session.githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
+    `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
     {
       headers: {
-        Authorization: `Bearer ${session.accessToken}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
       cache: "no-store",
@@ -29,7 +55,7 @@ export async function GET(req: NextRequest) {
   );
 
   if (!searchRes.ok) {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+    throw new Error("GitHub API error");
   }
 
   const data = (await searchRes.json()) as {
@@ -39,20 +65,122 @@ export async function GET(req: NextRequest) {
     }>;
   };
 
-  // Aggregate commits per repo
-  const repoMap: Record<string, { commits: number; url: string }> = {};
+  const repoMap: Record<string, number> = {};
   for (const item of data.items) {
     const name = item.repository.full_name;
-    if (!repoMap[name]) {
-      repoMap[name] = { commits: 0, url: item.repository.html_url };
-    }
-    repoMap[name].commits++;
+    repoMap[name] = (repoMap[name] ?? 0) + 1;
   }
 
   const repos = Object.entries(repoMap)
-    .map(([name, info]) => ({ name, ...info }))
+    .map(([name, commits]) => ({ name, commits }))
     .sort((a, b) => b.commits - a.commits)
     .slice(0, 6);
 
-  return Response.json({ repos, days });
+  return { repos, days };
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const days = Number(req.nextUrl.searchParams.get("days")) || 30;
+  const accountId = req.nextUrl.searchParams.get("accountId");
+
+  if (!accountId) {
+    try {
+      const result = await fetchReposForAccount(
+        session.accessToken,
+        session.githubLogin,
+        days
+      );
+      return Response.json(result);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  if (!session.githubId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: userRow } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", session.githubId)
+    .single();
+
+  if (!userRow) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (accountId === "combined") {
+    const accounts = await getAllAccounts(
+      {
+        token: session.accessToken,
+        githubId: session.githubId,
+        githubLogin: session.githubLogin,
+      },
+      userRow.id
+    );
+
+    const results = await Promise.allSettled(
+      accounts.map((account) =>
+        fetchReposForAccount(account.token, account.githubLogin, days)
+      )
+    );
+
+    const merged = mergeMetrics(results, (a, b) => ({
+      days: a.days,
+      repos: mergeRepoCommits(a.repos, b.repos),
+    }));
+
+    if (!merged) {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+
+    return Response.json(merged);
+  }
+
+  if (accountId === session.githubId) {
+    try {
+      const result = await fetchReposForAccount(
+        session.accessToken,
+        session.githubLogin,
+        days
+      );
+      return Response.json(result);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  const accountToken = await getAccountToken(userRow.id, accountId);
+
+  if (!accountToken) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  const { data: accountRow } = await supabaseAdmin
+    .from("user_github_accounts")
+    .select("github_login")
+    .eq("user_id", userRow.id)
+    .eq("github_id", accountId)
+    .single();
+
+  if (!accountRow?.github_login) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  try {
+    const result = await fetchReposForAccount(
+      accountToken,
+      accountRow.github_login,
+      days
+    );
+    return Response.json(result);
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
 }

--- a/src/app/api/metrics/streak/route.ts
+++ b/src/app/api/metrics/streak/route.ts
@@ -1,10 +1,11 @@
 import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import { getAccountToken, getAllAccounts } from "@/lib/github-accounts";
+import { GITHUB_API } from "@/lib/github";
 import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
-
-const GITHUB_API = "https://api.github.com";
 
 function dateDiffDays(a: string, b: string): number {
   return (
@@ -16,22 +17,19 @@ function toDateStr(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
-export async function GET() {
-  const session = await getServerSession(authOptions);
-  if (!session?.accessToken || !session.githubLogin || !session.githubId) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  // Fetch 90 days to calculate a meaningful longest streak
+async function fetchActiveDates(
+  githubLogin: string,
+  token: string
+): Promise<Set<string>> {
   const since = new Date();
   since.setDate(since.getDate() - 90);
   const sinceStr = since.toISOString().slice(0, 10);
 
   const searchRes = await fetch(
-    `${GITHUB_API}/search/commits?q=author:${session.githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
+    `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
     {
       headers: {
-        Authorization: `Bearer ${session.accessToken}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
       cache: "no-store",
@@ -39,47 +37,45 @@ export async function GET() {
   );
 
   if (!searchRes.ok) {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+    throw new Error("GitHub API error");
   }
 
   const data = (await searchRes.json()) as {
     items: Array<{ commit: { author: { date: string } } }>;
   };
 
-  // Unique commit days
-  const daySet: Record<string, true> = {};
+  const activeDates = new Set<string>();
   for (const item of data.items) {
-    daySet[item.commit.author.date.slice(0, 10)] = true;
+    activeDates.add(item.commit.author.date.slice(0, 10));
   }
 
-  // Fetch the user's freeze dates from Supabase and merge them in as active days
-  const { data: dbUser } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  return activeDates;
+}
 
-  if (dbUser) {
-    const { data: freezes } = await supabaseAdmin
-      .from("streak_freezes")
-      .select("freeze_date")
-      .eq("user_id", dbUser.id)
-      .gte("freeze_date", sinceStr);
-
-    if (Array.isArray(freezes)) {
-      for (const row of freezes) {
-        daySet[row.freeze_date] = true;
-      }
-    }
-  }
-
-  const commitDays = Object.keys(daySet).sort();
+function calculateStreakFromDates(
+  activeDates: Set<string>,
+  freezeDates: Set<string>
+): {
+  current: number;
+  longest: number;
+  lastCommitDate: string | null;
+  totalActiveDays: number;
+} {
+  const combinedDates = new Set<string>([
+    ...Array.from(activeDates),
+    ...Array.from(freezeDates),
+  ]);
+  const commitDays = Array.from(combinedDates).sort();
 
   if (commitDays.length === 0) {
-    return Response.json({ current: 0, longest: 0, lastCommitDate: null });
+    return {
+      current: 0,
+      longest: 0,
+      lastCommitDate: null,
+      totalActiveDays: 0,
+    };
   }
 
-  // Build streaks
   let longestStreak = 1;
   let currentRun = 1;
   const runs: { start: string; end: string; length: number }[] = [];
@@ -89,16 +85,21 @@ export async function GET() {
     const diff = dateDiffDays(commitDays[i - 1], commitDays[i]);
     if (diff === 1) {
       currentRun++;
-      if (currentRun > longestStreak) longestStreak = currentRun;
+      if (currentRun > longestStreak) {
+        longestStreak = currentRun;
+      }
     } else {
       runs.push({ start: runStart, end: commitDays[i - 1], length: currentRun });
       runStart = commitDays[i];
       currentRun = 1;
     }
   }
-  runs.push({ start: runStart, end: commitDays[commitDays.length - 1], length: currentRun });
+  runs.push({
+    start: runStart,
+    end: commitDays[commitDays.length - 1],
+    length: currentRun,
+  });
 
-  // Current streak: check if last commit day is today or yesterday
   const lastDay = commitDays[commitDays.length - 1];
   const today = toDateStr(new Date());
   const yesterday = toDateStr(new Date(Date.now() - 86400000));
@@ -107,10 +108,139 @@ export async function GET() {
   const currentStreak =
     lastRun.end === today || lastRun.end === yesterday ? lastRun.length : 0;
 
-  return Response.json({
+  return {
     current: currentStreak,
     longest: longestStreak,
     lastCommitDate: lastDay,
     totalActiveDays: commitDays.length,
-  });
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin || !session.githubId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const accountId = req.nextUrl.searchParams.get("accountId");
+  let appUserId: string | null = null;
+
+  if (accountId) {
+    const { data: userRow } = await supabaseAdmin
+      .from("users")
+      .select("id")
+      .eq("github_id", session.githubId)
+      .single();
+
+    if (!userRow) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    appUserId = userRow.id;
+  } else {
+    const { data: dbUser } = await supabaseAdmin
+      .from("users")
+      .select("id")
+      .eq("github_id", session.githubId)
+      .single();
+
+    if (dbUser) {
+      appUserId = dbUser.id;
+    }
+  }
+
+  const since = new Date();
+  since.setDate(since.getDate() - 90);
+  const sinceStr = since.toISOString().slice(0, 10);
+
+  const freezeDates = new Set<string>();
+  if (appUserId) {
+    const { data: freezes } = await supabaseAdmin
+      .from("streak_freezes")
+      .select("freeze_date")
+      .eq("user_id", appUserId)
+      .gte("freeze_date", sinceStr);
+
+    if (Array.isArray(freezes)) {
+      for (const row of freezes) {
+        freezeDates.add(row.freeze_date);
+      }
+    }
+  }
+
+  if (!accountId) {
+    try {
+      const activeDates = await fetchActiveDates(
+        session.githubLogin,
+        session.accessToken
+      );
+      return Response.json(
+        calculateStreakFromDates(activeDates, freezeDates)
+      );
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  if (!appUserId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (accountId === "combined") {
+    const accounts = await getAllAccounts(
+      {
+        token: session.accessToken,
+        githubId: session.githubId,
+        githubLogin: session.githubLogin,
+      },
+      appUserId
+    );
+
+    const dateResults = await Promise.allSettled(
+      accounts.map((account) =>
+        fetchActiveDates(account.githubLogin, account.token)
+      )
+    );
+
+    const unifiedDates = new Set<string>();
+    for (const result of dateResults) {
+      if (result.status === "fulfilled") {
+        result.value.forEach((date) => unifiedDates.add(date));
+      }
+    }
+
+    return Response.json(calculateStreakFromDates(unifiedDates, freezeDates));
+  }
+
+  let resolvedToken = session.accessToken;
+  let resolvedLogin = session.githubLogin;
+
+  if (accountId !== session.githubId) {
+    const accountToken = await getAccountToken(appUserId, accountId);
+
+    if (!accountToken) {
+      return Response.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    const { data: accountRow } = await supabaseAdmin
+      .from("user_github_accounts")
+      .select("github_login")
+      .eq("user_id", appUserId)
+      .eq("github_id", accountId)
+      .single();
+
+    if (!accountRow?.github_login) {
+      return Response.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    resolvedToken = accountToken;
+    resolvedLogin = accountRow.github_login;
+  }
+
+  try {
+    const activeDates = await fetchActiveDates(resolvedLogin, resolvedToken);
+    return Response.json(calculateStreakFromDates(activeDates, freezeDates));
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
 }

--- a/src/app/api/user/github-accounts/[githubId]/route.ts
+++ b/src/app/api/user/github-accounts/[githubId]/route.ts
@@ -1,0 +1,51 @@
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { githubId: string } }
+) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.githubId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: userRow } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", session.githubId)
+    .single();
+
+  if (!userRow) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (params.githubId === session.githubId) {
+    return NextResponse.json(
+      { error: "Cannot remove primary account" },
+      { status: 400 }
+    );
+  }
+
+  const { data: deletedRows, error } = await supabaseAdmin
+    .from("user_github_accounts")
+    .delete()
+    .eq("user_id", userRow.id)
+    .eq("github_id", params.githubId)
+    .select("github_id");
+
+  if (error) {
+    return NextResponse.json({ error: "Delete failed" }, { status: 500 });
+  }
+
+  if (!deletedRows || deletedRows.length === 0) {
+    return NextResponse.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/user/github-accounts/route.ts
+++ b/src/app/api/user/github-accounts/route.ts
@@ -1,0 +1,46 @@
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.githubId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: userRow } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", session.githubId)
+    .single();
+
+  if (!userRow) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: accounts, error } = await supabaseAdmin
+    .from("user_github_accounts")
+    .select("id, github_id, github_login, added_at")
+    .eq("user_id", userRow.id)
+    .order("added_at", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch accounts" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    accounts: (accounts ?? []).map((account) => ({
+      id: account.id,
+      githubId: account.github_id,
+      githubLogin: account.github_login,
+      addedAt: account.added_at,
+    })),
+  });
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
-import { redirect } from "next/navigation";
+import { redirect, useSearchParams } from "next/navigation";
 
 interface UserSettings {
   id: string;
@@ -10,12 +10,116 @@ interface UserSettings {
   is_public: boolean;
 }
 
-export default function SettingsPage() {
+interface LinkedAccount {
+  id: string;
+  githubId: string;
+  githubLogin: string;
+  addedAt: string;
+}
+
+interface AccountsResponse {
+  accounts: LinkedAccount[];
+}
+
+function formatAddedDate(addedAt: string): string {
+  return `Added ${new Date(addedAt).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })}`;
+}
+
+function getStatusMessage(
+  success: string | null,
+  error: string | null
+): { kind: "success" | "error"; message: string } | null {
+  if (success === "account_linked") {
+    return {
+      kind: "success",
+      message: "Account linked successfully",
+    };
+  }
+
+  if (!error) {
+    return null;
+  }
+
+  if (error === "already_linked") {
+    return {
+      kind: "error",
+      message: "This account is already linked",
+    };
+  }
+
+  if (error === "cannot_link_primary_account") {
+    return {
+      kind: "error",
+      message: "You cannot link your primary account",
+    };
+  }
+
+  if (error === "invalid_state") {
+    return {
+      kind: "error",
+      message: "Link failed: invalid state. Please try again.",
+    };
+  }
+
+  if (error === "oauth_cancelled") {
+    return {
+      kind: "error",
+      message: "Account linking was cancelled",
+    };
+  }
+
+  return {
+    kind: "error",
+    message: "Account linking failed. Please try again.",
+  };
+}
+
+function SettingsPageFallback() {
+  return (
+    <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors">
+      <div className="max-w-2xl mx-auto">
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
+          <div className="h-8 w-48 bg-[var(--card-muted)] rounded animate-pulse mb-4" />
+          <div className="space-y-4">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="h-20 bg-[var(--card-muted)] rounded animate-pulse"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SettingsPageContent() {
   const { data: session, status } = useSession();
+  const searchParams = useSearchParams();
   const [settings, setSettings] = useState<UserSettings | null>(null);
+  const [linkedAccounts, setLinkedAccounts] = useState<LinkedAccount[]>([]);
   const [loading, setLoading] = useState(true);
+  const [accountsLoading, setAccountsLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const [removingAccountId, setRemovingAccountId] = useState<string | null>(
+    null
+  );
+
+  const statusMessage = useMemo(
+    () =>
+      getStatusMessage(
+        searchParams.get("success"),
+        searchParams.get("error")
+      ),
+    [searchParams]
+  );
 
   // Redirect to signin if not authenticated
   useEffect(() => {
@@ -45,6 +149,32 @@ export default function SettingsPage() {
     }
 
     loadSettings();
+  }, [session, status]);
+
+  useEffect(() => {
+    if (status !== "authenticated" || !session?.githubLogin) {
+      return;
+    }
+
+    async function loadLinkedAccounts() {
+      try {
+        const res = await fetch("/api/user/github-accounts");
+        if (!res.ok) {
+          setLinkedAccounts([]);
+          return;
+        }
+
+        const data = (await res.json()) as AccountsResponse;
+        setLinkedAccounts(data.accounts ?? []);
+      } catch (error) {
+        console.error("Failed to load linked accounts:", error);
+        setLinkedAccounts([]);
+      } finally {
+        setAccountsLoading(false);
+      }
+    }
+
+    loadLinkedAccounts();
   }, [session, status]);
 
   const handleTogglePublic = async (value: boolean) => {
@@ -78,6 +208,31 @@ export default function SettingsPage() {
     navigator.clipboard.writeText(link);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleRemoveAccount = async (githubId: string) => {
+    setRemoveError(null);
+    setRemovingAccountId(githubId);
+
+    try {
+      const res = await fetch(`/api/user/github-accounts/${githubId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        setRemoveError(data.error ?? "Failed to remove account");
+        return;
+      }
+
+      setLinkedAccounts((current) =>
+        current.filter((account) => account.githubId !== githubId)
+      );
+    } catch {
+      setRemoveError("Failed to remove account");
+    } finally {
+      setRemovingAccountId(null);
+    }
   };
 
   if (status === "loading" || loading) {
@@ -123,6 +278,18 @@ export default function SettingsPage() {
             Manage your profile and preferences
           </p>
         </div>
+
+        {statusMessage && (
+          <div
+            className={`mb-6 rounded-xl border p-4 text-sm ${
+              statusMessage.kind === "success"
+                ? "border-green-500/30 bg-green-500/10 text-green-400"
+                : "border-red-500/30 bg-red-500/10 text-red-400"
+            }`}
+          >
+            {statusMessage.message}
+          </div>
+        )}
 
         {/* Public Profile Section */}
         <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
@@ -194,7 +361,89 @@ export default function SettingsPage() {
             </div>
           )}
         </div>
+
+        <div className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-[var(--card-foreground)]">
+                Connected Accounts
+              </h2>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                Link additional GitHub accounts and switch between them on the
+                dashboard.
+              </p>
+            </div>
+
+            <a
+              href="/api/auth/link-github"
+              className="inline-flex items-center justify-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-medium text-[var(--accent-foreground)] hover:opacity-90 transition-opacity"
+            >
+              Add GitHub Account
+            </a>
+          </div>
+
+          {removeError && (
+            <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400">
+              {removeError}
+            </div>
+          )}
+
+          <div className="mt-6">
+            {accountsLoading ? (
+              <div className="space-y-3">
+                {[1, 2].map((i) => (
+                  <div
+                    key={i}
+                    className="h-20 rounded-lg bg-[var(--card-muted)] animate-pulse"
+                  />
+                ))}
+              </div>
+            ) : linkedAccounts.length === 0 ? (
+              <div className="rounded-lg border border-[var(--border)] bg-[var(--control)] p-4 text-sm text-[var(--muted-foreground)]">
+                No linked GitHub accounts yet.
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {linkedAccounts.map((account) => (
+                  <div
+                    key={account.id}
+                    className="flex flex-col gap-3 rounded-lg border border-[var(--border)] bg-[var(--control)] p-4 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div>
+                      <div className="text-sm font-semibold text-[var(--card-foreground)]">
+                        {account.githubLogin}
+                      </div>
+                      <div className="mt-1 text-sm text-[var(--muted-foreground)]">
+                        {formatAddedDate(account.addedAt)}
+                      </div>
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveAccount(account.githubId)}
+                      aria-label={`Remove ${account.githubLogin}`}
+                      disabled={removingAccountId === account.githubId}
+                      className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--card-foreground)] transition-colors hover:bg-red-500/10 hover:text-red-400 disabled:opacity-60"
+                    >
+                      {removingAccountId === account.githubId
+                        ? "Removing..."
+                        : "Remove"}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     </div>
+  );
+}
+
+export default function SettingsPage() {
+  return (
+    <Suspense fallback={<SettingsPageFallback />}>
+      <SettingsPageContent />
+    </Suspense>
   );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,14 +2,17 @@
 
 import type { ReactNode } from "react";
 import { SessionProvider } from "next-auth/react";
+import { AccountProvider } from "@/components/AccountContext";
 import { ThemeProvider } from "@/components/ThemeContext";
 
 export default function Providers({ children }: { children: ReactNode }) {
   return (
     <SessionProvider>
-      <ThemeProvider>
-        {children}
-      </ThemeProvider>
+      <AccountProvider>
+        <ThemeProvider>
+          {children}
+        </ThemeProvider>
+      </AccountProvider>
     </SessionProvider>
   );
 }

--- a/src/components/AccountContext.tsx
+++ b/src/components/AccountContext.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useState,
+} from "react";
+
+export interface AccountContextValue {
+  selectedAccount: string | null;
+  setSelectedAccount: (account: string | null) => void;
+}
+
+export const AccountContext = createContext<AccountContextValue>({
+  selectedAccount: null,
+  setSelectedAccount: () => {},
+});
+
+export function AccountProvider({ children }: { children: ReactNode }) {
+  const [selectedAccount, setSelectedAccount] = useState<string | null>(null);
+
+  return (
+    <AccountContext.Provider value={{ selectedAccount, setSelectedAccount }}>
+      {children}
+    </AccountContext.Provider>
+  );
+}
+
+export function useAccount(): AccountContextValue {
+  return useContext(AccountContext);
+}

--- a/src/components/AccountToggle.tsx
+++ b/src/components/AccountToggle.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useAccount } from "@/components/AccountContext";
+
+interface LinkedAccount {
+  githubId: string;
+  githubLogin: string;
+}
+
+interface AccountsResponse {
+  accounts: Array<{
+    githubId: string;
+    githubLogin: string;
+  }>;
+}
+
+export default function AccountToggle() {
+  const { selectedAccount, setSelectedAccount } = useAccount();
+  const { data: session } = useSession();
+  const [linkedAccounts, setLinkedAccounts] = useState<LinkedAccount[]>([]);
+
+  useEffect(() => {
+    async function loadAccounts() {
+      try {
+        const response = await fetch("/api/user/github-accounts");
+        if (!response.ok) {
+          setLinkedAccounts([]);
+          return;
+        }
+
+        const data = (await response.json()) as AccountsResponse;
+        setLinkedAccounts(
+          (data.accounts ?? []).map((account) => ({
+            githubId: account.githubId,
+            githubLogin: account.githubLogin,
+          }))
+        );
+      } catch {
+        setLinkedAccounts([]);
+      }
+    }
+
+    if (session?.githubLogin) {
+      loadAccounts();
+    }
+  }, [session?.githubLogin]);
+
+  if (!session?.githubLogin || linkedAccounts.length === 0) {
+    return null;
+  }
+
+  const options: Array<{ label: string; value: string | null }> = [
+    { label: session.githubLogin, value: null },
+    ...linkedAccounts.map((account) => ({
+      label: account.githubLogin,
+      value: account.githubId,
+    })),
+    { label: "Combined", value: "combined" },
+  ];
+
+  return (
+    <div
+      className="mt-4 flex flex-wrap gap-2"
+      role="group"
+      aria-label="Select GitHub account"
+    >
+      {options.map((option) => {
+        const isActive = selectedAccount === option.value;
+
+        return (
+          <button
+            key={`${option.label}-${option.value ?? "primary"}`}
+            type="button"
+            onClick={() => setSelectedAccount(option.value)}
+            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+              isActive
+                ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-foreground)]"
+                : "border-[var(--border)] bg-[var(--control)] text-[var(--card-foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useAccount } from "@/components/AccountContext";
 import {
   BarChart,
   Bar,
@@ -33,18 +34,23 @@ const charts: { key: ViewMode; label: string }[] = [
 ];
 
 export default function ContributionGraph() {
+  const { selectedAccount } = useAccount();
   const [data, setData] = useState<DayData[]>([]);
   const [loading, setLoading] = useState(true);
   const [days, setDays] = useState(30);
   const [chartType, setChartType] = useState<ViewMode>("bar");
-  const [lastUpdated, setLastUpdated] = useState<Date|null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
     setError(null);
-    fetch(`/api/metrics/contributions?days=${days}`)
+    const accountParam =
+      selectedAccount !== null
+        ? `&accountId=${encodeURIComponent(selectedAccount)}`
+        : "";
+    fetch(`/api/metrics/contributions?days=${days}${accountParam}`)
       .then((r) => {
         if (!r.ok) throw new Error("API error");
         return r.json();
@@ -64,7 +70,7 @@ export default function ContributionGraph() {
         setLastUpdated(new Date());
         setMinutesAgo(0);
       });
-  }, [days]);
+  }, [days, selectedAccount]);
 
   useEffect(() => {
     if (!lastUpdated) return;
@@ -91,11 +97,10 @@ export default function ContributionGraph() {
                 onClick={() => setDays(r.days)}
                 aria-label={`Show ${r.days}-day range`}
                 aria-pressed={days === r.days}
-                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
-                  days === r.days
-                    ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
-                    : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
-                }`}
+                className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${days === r.days
+                  ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                  : "text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
+                  }`}
               >
                 {r.label}
               </button>
@@ -196,10 +201,12 @@ export default function ContributionGraph() {
         </ResponsiveContainer>
       )}
       {lastUpdated && (
-        <p className="text-xs text-[var(--muted-foreground)] mt-2 text-right">
-           {minutesAgo === 0 ? "Updated just now" : `Updated ${minutesAgo} min ago`}
+        <p className="mt-2 text-right text-xs text-[var(--muted-foreground)]">
+          {minutesAgo === 0
+            ? "Updated just now"
+            : `Updated ${minutesAgo} min ago`}
         </p>
-    )}
+      )}
     </div>
   );
 }

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
+import AccountToggle from "@/components/AccountToggle";
 import SignOutButton from "@/components/SignOutButton";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserAvatar from "@/components/UserAvatar";
@@ -11,10 +12,8 @@ interface UserSettings {
 }
 
 export default function DashboardHeader() {
-  const { data: session, status } = useSession();
+  const { data: session } = useSession();
   const [settings, setSettings] = useState<UserSettings | null>(null);
-  const [totalCommits, setTotalCommits] = useState<number | null>(null);
-  const [isLoadingCommits, setIsLoadingCommits] = useState(false);
 
   useEffect(() => {
     if (!session) return;
@@ -34,84 +33,37 @@ export default function DashboardHeader() {
     loadSettings();
   }, [session]);
 
-  useEffect(() => {
-    if (status !== "authenticated") {
-      setTotalCommits(null);
-      setIsLoadingCommits(false);
-      return;
-    }
-
-    const controller = new AbortController();
-
-    async function loadCommits() {
-      setIsLoadingCommits(true);
-
-      try {
-        const res = await fetch("/api/metrics/contributions?days=30", {
-          signal: controller.signal,
-        });
-
-        if (!res.ok) {
-          setTotalCommits(null);
-          return;
-        }
-
-        const data = (await res.json()) as { total?: number };
-        setTotalCommits(typeof data.total === "number" ? data.total : null);
-      } catch (error) {
-        if ((error as Error).name !== "AbortError") {
-          setTotalCommits(null);
-        }
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsLoadingCommits(false);
-        }
-      }
-    }
-
-    loadCommits();
-
-    return () => controller.abort();
-  }, [status]);
-
   return (
-    <header className="flex flex-wrap items-center justify-between p-4 mb-8 gap-3 border-b border-[var(--border)] pb-6">
-      <div>
-        <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">
-          Dashboard
-        </h1>
-        <p className="mt-1 text-[var(--muted-foreground)]">
-          Your coding activity at a glance
-        </p>
+    <header className="mb-8 border-b border-[var(--border)] p-4 pb-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">
+            Dashboard
+          </h1>
+          <p className="mt-1 text-[var(--muted-foreground)]">
+            Your coding activity at a glance
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {settings?.is_public && session?.githubLogin && (
+            <a
+              href={`/u/${session.githubLogin}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--control)] text-[var(--card-foreground)] text-sm font-medium hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] transition-colors"
+              title="View your public profile"
+            >
+              Share Profile
+            </a>
+          )}
+          <UserAvatar />
+          <ThemeToggle />
+          <SignOutButton />
+        </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
-        {settings?.is_public && session?.githubLogin && (
-          <a
-            href={`/u/${session.githubLogin}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--control)] text-[var(--card-foreground)] text-sm font-medium hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] transition-colors"
-            title="View your public profile"
-          >
-            Share Profile
-          </a>
-        )}
-        <UserAvatar />
-        {isLoadingCommits && (
-          <span
-            aria-hidden="true"
-            className="h-10 w-32 animate-pulse rounded-full border border-[var(--border)] bg-[var(--control)]"
-          />
-        )}
-        {!isLoadingCommits && totalCommits !== null && (
-          <span className="inline-flex h-10 items-center rounded-full border border-[var(--border)] bg-[var(--control)] px-4 text-sm font-medium text-[var(--card-foreground)] shadow-sm">
-            {totalCommits.toLocaleString()} commits
-          </span>
-        )}
-        <ThemeToggle />
-        <SignOutButton />
-      </div>
+      <AccountToggle />
     </header>
   );
 }

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useAccount } from "@/components/AccountContext";
 
 interface PRData {
   open: number;
@@ -10,41 +11,34 @@ interface PRData {
 }
 
 export default function PRMetrics() {
+  const { selectedAccount } = useAccount();
   const [metrics, setMetrics] = useState<PRData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  const [minutesAgo, setMinutesAgo] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchMetrics = () => {
+  const fetchMetrics = useCallback(() => {
     setLoading(true);
     setError(null);
 
-    fetch("/api/metrics/prs")
+    const url =
+      selectedAccount !== null
+        ? `/api/metrics/prs?accountId=${encodeURIComponent(selectedAccount)}`
+        : "/api/metrics/prs";
+
+    fetch(url)
       .then((r) => {
         if (!r.ok) throw new Error("API error");
         return r.json();
       })
       .then((data: PRData) => setMetrics(data))
       .catch(() => setError("We couldn't load your PR analytics right now. Please try again in a moment."))
-      .finally(() => {
-        setLoading(false);
-        setLastUpdated(new Date());
-        setMinutesAgo(0);
-      });
-  };
+      .finally(() => setLoading(false));
+  }, [selectedAccount]);
 
   useEffect(() => {
     fetchMetrics();
-  }, []);
-  useEffect(() => {
-   if (!lastUpdated) return;
-   const interval = setInterval(() => {
-    const diff = Math.floor((Date.now() - lastUpdated.getTime()) / 60000);
-    setMinutesAgo(diff);
-  }, 60000);
-  return () => clearInterval(interval);
-  }, [lastUpdated]);
+  }, [fetchMetrics]);
+
   const stats = metrics
     ? [
         { label: "Open PRs", value: metrics.open },
@@ -91,11 +85,6 @@ export default function PRMetrics() {
             </div>
           ))}
         </div>
-      )}
-      {lastUpdated && (
-        <p className="text-xs text-[var(--muted-foreground)] mt-2 text-right">
-          {minutesAgo === 0 ? "Updated just now" : `Updated ${minutesAgo} min ago`}
-        </p>
       )}
     </div>
   );

--- a/src/components/StreakAtRiskBanner.tsx
+++ b/src/components/StreakAtRiskBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useAccount } from "@/components/AccountContext";
 
 interface StreakAtRiskBannerProps {
   lastCommitDate?: string | null;
@@ -13,6 +14,7 @@ export default function StreakAtRiskBanner({
   currentStreak: propsCurrentStreak,
   hasStreakFreeze,
 }: StreakAtRiskBannerProps) {
+  const { selectedAccount } = useAccount();
   const [dismissed, setDismissed] = useState(false);
   const [lastCommitDate, setLastCommitDate] = useState(propsLastCommitDate);
   const [currentStreak, setCurrentStreak] = useState(propsCurrentStreak);
@@ -21,7 +23,11 @@ export default function StreakAtRiskBanner({
   useEffect(() => {
     // If props weren't passed (e.g. from a Server Component), fetch them
     if (propsLastCommitDate === undefined || propsCurrentStreak === undefined) {
-      fetch("/api/metrics/streak")
+      const url =
+        selectedAccount !== null
+          ? `/api/metrics/streak?accountId=${encodeURIComponent(selectedAccount)}`
+          : "/api/metrics/streak";
+      fetch(url)
         .then((r) => r.json())
         .then((data) => {
           setLastCommitDate(data.lastCommitDate);
@@ -32,7 +38,7 @@ export default function StreakAtRiskBanner({
       setLastCommitDate(propsLastCommitDate);
       setCurrentStreak(propsCurrentStreak);
     }
-  }, [propsLastCommitDate, propsCurrentStreak]);
+  }, [propsLastCommitDate, propsCurrentStreak, selectedAccount]);
 
   useEffect(() => {
     if (

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useAccount } from "@/components/AccountContext";
 
 interface StreakData {
   current: number;
@@ -20,6 +21,7 @@ interface FreezeData {
 }
 
 export default function StreakTracker() {
+  const { selectedAccount } = useAccount();
   const [data, setData] = useState<StreakData | null>(null);
   const [contributionData, setContributionData] = useState<ContributionData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -33,14 +35,22 @@ export default function StreakTracker() {
   const [cancelling, setCancelling] = useState(false);
   const [confirmCancel, setConfirmCancel] = useState(false);
 
-  const fetchStreak = async () => {
+  const fetchStreak = useCallback(async () => {
     setLoading(true);
     setError(null);
 
     try {
+      const streakUrl =
+        selectedAccount !== null
+          ? `/api/metrics/streak?accountId=${encodeURIComponent(selectedAccount)}`
+          : "/api/metrics/streak";
+      const contributionUrl =
+        selectedAccount !== null
+          ? `/api/metrics/contributions?days=365&accountId=${encodeURIComponent(selectedAccount)}`
+          : "/api/metrics/contributions?days=365";
       const [streakRes, contributionRes] = await Promise.all([
-        fetch("/api/metrics/streak"),
-        fetch("/api/metrics/contributions?days=365"),
+        fetch(streakUrl),
+        fetch(contributionUrl),
       ]);
 
       if (!streakRes.ok || !contributionRes.ok) {
@@ -59,7 +69,7 @@ export default function StreakTracker() {
       setLastUpdated(new Date());
       setMinutesAgo(0);
     }
-  };
+  }, [selectedAccount]);
 
   const fetchFreeze = () => {
     setFreezeLoading(true);
@@ -73,14 +83,15 @@ export default function StreakTracker() {
   useEffect(() => {
     fetchStreak();
     fetchFreeze();
-  }, []);
+  }, [fetchStreak]);
+
   useEffect(() => {
     if (!lastUpdated) return;
-    const interval= setInterval(() => {
-     const diff= Math.floor((Date.now()-lastUpdated.getTime())/60000);
-    setMinutesAgo(diff);
-   }, 60000);
-   return ()=> clearInterval(interval);
+    const interval = setInterval(() => {
+      const diff = Math.floor((Date.now() - lastUpdated.getTime()) / 60000);
+      setMinutesAgo(diff);
+    }, 60000);
+    return () => clearInterval(interval);
   }, [lastUpdated]);
 
   async function handleCancelFreeze() {
@@ -96,8 +107,12 @@ export default function StreakTracker() {
 
       setConfirmCancel(false);
 
+      const streakUrl =
+        selectedAccount !== null
+          ? `/api/metrics/streak?accountId=${encodeURIComponent(selectedAccount)}`
+          : "/api/metrics/streak";
       const [streakRes, freezeRes] = await Promise.all([
-        fetch("/api/metrics/streak"),
+        fetch(streakUrl),
         fetch("/api/streak/freeze"),
       ]);
       const [streakData, freezeData] = await Promise.all([
@@ -269,8 +284,10 @@ export default function StreakTracker() {
         </div>
       )}
       {lastUpdated && (
-        <p className="text-xs text-[var(--muted-foreground)] mt-2 text-right">
-          {minutesAgo === 0 ? "Updated just now" : `Updated ${minutesAgo} min ago`}
+        <p className="mt-2 text-right text-xs text-[var(--muted-foreground)]">
+          {minutesAgo === 0
+            ? "Updated just now"
+            : `Updated ${minutesAgo} min ago`}
         </p>
       )}
 

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useAccount } from "@/components/AccountContext";
 import type { RepoHealthScore } from "@/types/repo-health";
 
 interface Repo {
@@ -10,6 +11,7 @@ interface Repo {
 }
 
 export default function TopRepos() {
+  const { selectedAccount } = useAccount();
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,8 +24,9 @@ export default function TopRepos() {
   const fetchRepos = useCallback(() => {
     setLoading(true);
     setError(null);
-    const accountId = new URLSearchParams(window.location.search).get("accountId");
-    const accountParam = accountId ? `&accountId=${encodeURIComponent(accountId)}` : "";
+    const accountParam = selectedAccount !== null
+      ? `&accountId=${encodeURIComponent(selectedAccount)}`
+      : "";
     fetch(`/api/metrics/repos?days=${days}${accountParam}`)
       .then((r) => r.json())
       .then((d: { repos: Repo[] }) => setRepos(d.repos ?? []))
@@ -33,11 +36,14 @@ export default function TopRepos() {
         setLastUpdated(new Date());
         setMinutesAgo(0);
       });
-  }, [days]);
+  }, [days, selectedAccount]);
 
   const fetchHealthScores = useCallback(() => {
     setHealthLoading(true);
-    fetch(`/api/metrics/repo-health`)
+    const accountParam = selectedAccount !== null
+      ? `?accountId=${encodeURIComponent(selectedAccount)}`
+      : "";
+    fetch(`/api/metrics/repo-health${accountParam}`)
       .then((r) => r.json())
       .then((d: { repos: RepoHealthScore[] }) => {
         const map: Record<string, RepoHealthScore> = {};
@@ -48,7 +54,7 @@ export default function TopRepos() {
       })
       .catch(() => setHealthScores({}))
       .finally(() => setHealthLoading(false));
-  }, []);
+  }, [selectedAccount]);
 
   useEffect(() => {
     if (!lastUpdated) return;
@@ -63,7 +69,7 @@ export default function TopRepos() {
   useEffect(() => {
     fetchRepos();
     fetchHealthScores();
-  }, [fetchRepos, fetchHealthScores]);
+  }, [fetchRepos, fetchHealthScores, selectedAccount]);
 
   const maxCommits = repos[0]?.commits ?? 1;
 

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,69 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+} from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const KEY_ERROR_MESSAGE =
+  "ENCRYPTION_KEY env var must be a 32-byte hex string";
+
+function getEncryptionKey(): Buffer {
+  const key = process.env.ENCRYPTION_KEY;
+
+  if (!key || !/^[0-9a-fA-F]{64}$/.test(key)) {
+    throw new Error(KEY_ERROR_MESSAGE);
+  }
+
+  const keyBuffer = Buffer.from(key, "hex");
+
+  if (keyBuffer.length !== 32) {
+    throw new Error(KEY_ERROR_MESSAGE);
+  }
+
+  return keyBuffer;
+}
+
+export function encryptToken(plaintext: string): {
+  encrypted: string;
+  iv: string;
+} {
+  const key = getEncryptionKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    encrypted: Buffer.concat([encrypted, authTag]).toString("hex"),
+    iv: iv.toString("hex"),
+  };
+}
+
+export function decryptToken(encrypted: string, iv: string): string {
+  const key = getEncryptionKey();
+  const encryptedBuffer = Buffer.from(encrypted, "hex");
+  const ivBuffer = Buffer.from(iv, "hex");
+
+  const ciphertext = encryptedBuffer.subarray(
+    0,
+    encryptedBuffer.length - AUTH_TAG_LENGTH
+  );
+  const authTag = encryptedBuffer.subarray(
+    encryptedBuffer.length - AUTH_TAG_LENGTH
+  );
+
+  const decipher = createDecipheriv(ALGORITHM, key, ivBuffer);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}

--- a/src/lib/github-accounts.ts
+++ b/src/lib/github-accounts.ts
@@ -1,0 +1,179 @@
+import { decryptToken } from "@/lib/crypto";
+import { supabaseAdmin } from "@/lib/supabase";
+
+interface UserGitHubAccountRow {
+  github_id?: string;
+  github_login?: string;
+  access_token_encrypted: string;
+  access_token_iv: string;
+}
+
+interface GitHubRateLimitResponse {
+  resources?: {
+    core?: {
+      remaining?: number;
+    };
+  };
+}
+
+export interface LinkedAccount {
+  githubId: string;
+  githubLogin: string;
+  token: string;
+}
+
+export async function getLinkedTokens(userId: string): Promise<string[]> {
+  const { data, error } = await supabaseAdmin
+    .from("user_github_accounts")
+    .select("access_token_encrypted, access_token_iv")
+    .eq("user_id", userId);
+
+  if (error) {
+    throw new Error("Failed to fetch linked accounts");
+  }
+
+  const rows = (data ?? []) as UserGitHubAccountRow[];
+
+  return rows.map((row) =>
+    decryptToken(row.access_token_encrypted, row.access_token_iv)
+  );
+}
+
+export async function getRateLimitRemaining(token: string): Promise<number> {
+  try {
+    const response = await fetch("https://api.github.com/rate_limit", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return 0;
+    }
+
+    const data = (await response.json()) as GitHubRateLimitResponse;
+    const remaining = data.resources?.core?.remaining;
+
+    return typeof remaining === "number" ? remaining : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function pickBestToken(tokens: string[]): Promise<string> {
+  if (tokens.length === 0) {
+    throw new Error("No tokens available");
+  }
+
+  const remainingValues = await Promise.all(
+    tokens.map((token) => getRateLimitRemaining(token))
+  );
+
+  let bestIndex = 0;
+
+  for (let i = 1; i < remainingValues.length; i++) {
+    if (remainingValues[i] > remainingValues[bestIndex]) {
+      bestIndex = i;
+    }
+  }
+
+  return tokens[bestIndex];
+}
+
+export async function getAllTokens(
+  primaryToken: string,
+  userId: string
+): Promise<string[]> {
+  const linkedTokens = await getLinkedTokens(userId);
+  const dedupedLinkedTokens = linkedTokens.filter(
+    (token) => token !== primaryToken
+  );
+
+  return [primaryToken, ...dedupedLinkedTokens];
+}
+
+export async function getLinkedAccounts(
+  userId: string
+): Promise<LinkedAccount[]> {
+  const { data, error } = await supabaseAdmin
+    .from("user_github_accounts")
+    .select(
+      "github_id, github_login, access_token_encrypted, access_token_iv"
+    )
+    .eq("user_id", userId);
+
+  if (error) {
+    throw new Error("Failed to fetch linked accounts");
+  }
+
+  const rows = (data ?? []) as UserGitHubAccountRow[];
+
+  return rows.map((row) => ({
+    githubId: row.github_id ?? "",
+    githubLogin: row.github_login ?? "",
+    token: decryptToken(row.access_token_encrypted, row.access_token_iv),
+  }));
+}
+
+export async function getAllAccounts(
+  primary: { token: string; githubId: string; githubLogin: string },
+  userId: string
+): Promise<LinkedAccount[]> {
+  const linkedAccounts = await getLinkedAccounts(userId);
+  const filteredLinkedAccounts = linkedAccounts.filter(
+    (account) => account.githubId !== primary.githubId
+  );
+
+  return [
+    {
+      token: primary.token,
+      githubId: primary.githubId,
+      githubLogin: primary.githubLogin,
+    },
+    ...filteredLinkedAccounts,
+  ];
+}
+
+export async function getAccountToken(
+  userId: string,
+  accountGithubId: string
+): Promise<string | null> {
+  const { data, error } = await supabaseAdmin
+    .from("user_github_accounts")
+    .select("access_token_encrypted, access_token_iv")
+    .eq("user_id", userId)
+    .eq("github_id", accountGithubId)
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+
+  const row = data as UserGitHubAccountRow;
+
+  return decryptToken(row.access_token_encrypted, row.access_token_iv);
+}
+
+export function mergeMetrics<T>(
+  results: PromiseSettledResult<T>[],
+  merge: (a: T, b: T) => T
+): T | null {
+  const fulfilled = results.filter(
+    (result): result is PromiseFulfilledResult<T> =>
+      result.status === "fulfilled"
+  );
+
+  if (fulfilled.length === 0) {
+    return null;
+  }
+
+  if (fulfilled.length === 1) {
+    return fulfilled[0].value;
+  }
+
+  return fulfilled
+    .slice(1)
+    .reduce((acc, result) => merge(acc, result.value), fulfilled[0].value);
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,4 +1,4 @@
-const GITHUB_API = "https://api.github.com";
+export const GITHUB_API = "https://api.github.com";
 
 export async function fetchUserEvents(token: string): Promise<GitHubEvent[]> {
   const res = await fetch(`${GITHUB_API}/user/events?per_page=100`, {

--- a/supabase/migrations/20260516000000_add_user_github_accounts.sql
+++ b/supabase/migrations/20260516000000_add_user_github_accounts.sql
@@ -1,0 +1,13 @@
+create table if not exists user_github_accounts (
+  id                     text primary key default gen_random_uuid()::text,
+  user_id                text not null references users(id) on delete cascade,
+  github_id              text not null,
+  github_login           text not null,
+  access_token_encrypted text not null,
+  access_token_iv        text not null,
+  added_at               timestamptz default now(),
+  unique (user_id, github_id)
+);
+
+create index if not exists user_github_accounts_user_id_idx
+  on user_github_accounts(user_id);


### PR DESCRIPTION
## Summary

Adds multi-GitHub account support, allowing users to link additional GitHub
accounts and view aggregated or per-account metrics in one dashboard.

Closes #63

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

**Database**
- Migration: new `user_github_accounts` table (user_id, github_id, 
  github_login, access_token_encrypted, access_token_iv, added_at)
- Composite unique constraint on (user_id, github_id) prevents duplicate links
- Index on user_id for fast per-user lookups

**Auth / OAuth**
- New `GET /api/auth/link-github` — initiates a secondary GitHub OAuth flow
  with CSRF state cookie, without touching the primary NextAuth session
- New `GET /api/auth/link-github/callback` — validates CSRF, exchanges code,
  prevents self-linking, encrypts and stores the new token
- Register `/api/auth/link-github/callback` as a second callback URL in your
  GitHub OAuth App settings

**Crypto**
- `src/lib/crypto.ts` — AES-256-GCM encrypt/decrypt using Node built-in
  `crypto`. Tokens are never stored in plaintext.
- Requires new `ENCRYPTION_KEY` env var (32-byte hex string)

**Multi-account Logic**
- `src/lib/github-accounts.ts` — helpers for fetching/decrypting linked
  tokens, rate-limit pooling (`pickBestToken`), and a generic `mergeMetrics`
  utility for combining parallel results

**API Endpoints** (contributions, prs, streak, repos)
- All four accept optional `?accountId=` query param
- `accountId=combined` fetches all accounts concurrently and merges results
- `accountId=<githubId>` fetches a specific linked account
- Omitting `accountId` preserves existing single-account behavior exactly
- Combined streak merges active date sets across accounts and recalculates
  (not a simple max)
- Combined PRs use weighted average for `avgReviewHours` and recalculate
  `mergeRate` from summed totals

**Account Management API**
- `GET /api/user/github-accounts` — lists linked accounts (no token fields)
- `DELETE /api/user/github-accounts/[githubId]` — removes a linked account,
  prevents removing primary

**Frontend**
- `AccountContext` + `AccountProvider` — shared toggle state across dashboard
- `AccountToggle` component — renders per-account and Combined tabs, hidden
  when no accounts are linked
- Toggle placed in `DashboardHeader`, visible above all metrics
- Settings page: new "Connected Accounts" section with Add/Remove UI,
  success/error feedback from OAuth callback query params
- All 5 metric widgets (`ContributionGraph`, `PRMetrics`, `StreakTracker`,
  `StreakAtRiskBanner`, `TopRepos`) re-fetch when selected account changes

## How to Test

1. Generate an encryption key and add it to `.env.local`:
node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
   
2. Add `/api/auth/link-github/callback` as a second authorized callback URL
   in your GitHub OAuth App settings (github.com/settings/developers)

3. Run the Supabase migration:
supabase db push

4. Sign in with your primary GitHub account

5. Go to **Settings → Connected Accounts** and click **Add GitHub Account**
   — authorize with a second GitHub account
   — confirm you are redirected back to settings with "Account linked 
     successfully"

6. Return to the dashboard — the account toggle should now appear in the
   header showing `[PrimaryLogin] [SecondLogin] [Combined]`

7. Click each toggle tab and confirm the metrics cards update to reflect
   that account's data

8. Click **Combined** — confirm contributions, PRs, streak, and repos show
   aggregated data across both accounts

9. Go back to Settings → Connected Accounts → click **Remove** on the linked
   account — confirm it disappears without a page reload and the toggle
   reverts to single-account mode

10. Verify edge cases:
    - Linking the same account twice shows "This account is already linked"
    - Clicking Cancel on GitHub OAuth shows "Account linking was cancelled"

## Checklist

- [x] Linked issue in summary
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
