### PR TITLE
add GraphQL fetching + pagination, TTL cache, and lazy Supabase init

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -58,6 +58,16 @@ export interface IssuesMetrics {
 export async function fetchIssuesMetrics(
   token: string
 ): Promise<IssuesMetrics> {
+  // Prefer GraphQL implementation when enabled for better pagination and fewer requests
+  try {
+    if (process.env.GITHUB_USE_GRAPHQL === "true") {
+      // dynamic import to avoid changing runtime for environments that don't need it
+      const mod = await import("./githubGraphql");
+      return await mod.fetchIssuesMetricsGraphQL(token);
+    }
+  } catch (err) {
+    console.warn("GraphQL fetch failed, falling back to REST:", err);
+  }
   const headers = {
     Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github+json",

--- a/src/lib/githubGraphql.ts
+++ b/src/lib/githubGraphql.ts
@@ -1,0 +1,140 @@
+const GRAPHQL_API = "https://api.github.com/graphql";
+
+type CacheEntry<T> = { value: T; expiry: number };
+
+const cache = new Map<string, CacheEntry<any>>();
+
+function getFromCache<T>(key: string): T | null {
+  const ttl = process.env.GITHUB_CACHE_TTL ? parseInt(process.env.GITHUB_CACHE_TTL, 10) : 60;
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiry) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.value as T;
+}
+
+function setCache<T>(key: string, value: T) {
+  const ttl = process.env.GITHUB_CACHE_TTL ? parseInt(process.env.GITHUB_CACHE_TTL, 10) : 60;
+  cache.set(key, { value, expiry: Date.now() + ttl * 1000 });
+}
+
+async function graphqlRequest(token: string, body: object) {
+  const res = await fetch(GRAPHQL_API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (res.status === 401) throw new Error("GitHub auth error: unauthorized");
+  if (res.status === 403 || res.status === 429) {
+    const reset = res.headers.get("x-ratelimit-reset");
+    throw new Error(`GitHub rate limit: ${res.status}${reset ? ` reset=${reset}` : ""}`);
+  }
+
+  if (!res.ok) throw new Error(`GitHub GraphQL error: ${res.status}`);
+  return res.json();
+}
+
+export interface IssuesMetrics {
+  opened: number;
+  closed: number;
+  currentlyOpen: number;
+  avgCloseTimeDays: number;
+  trend: number;
+}
+
+export async function fetchIssuesMetricsGraphQL(token: string): Promise<IssuesMetrics> {
+  const since30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const cacheKey = `issuesMetrics:${token}:${since30d}`;
+
+  const cached = getFromCache<IssuesMetrics>(cacheKey);
+  if (cached) return cached;
+
+  const pageCap = process.env.GITHUB_PAGE_CAP ? parseInt(process.env.GITHUB_PAGE_CAP, 10) : 1000;
+
+  const perPage = 100; // GraphQL max for search edges traversal
+  let after: string | null = null;
+  let fetched = 0;
+  const items: Array<{ state: string; createdAt: string; closedAt?: string | null }> = [];
+
+  const baseQuery = `type:issue author:@me created:>=${since30d}`;
+
+  while (fetched < pageCap) {
+    const query = `
+      query($q:String!, $first:Int!, $after:String) {
+        search(query: $q, type: ISSUE, first: $first, after: $after) {
+          issueCount
+          pageInfo { endCursor hasNextPage }
+          nodes {
+            ... on Issue { state createdAt closedAt }
+          }
+        }
+      }
+    `;
+
+    const vars: any = { q: baseQuery, first: perPage };
+    if (after) vars.after = after;
+
+    const data = await graphqlRequest(token, { query, variables: vars });
+    const search = data.data.search;
+    const nodes = search.nodes || [];
+
+    for (const n of nodes) {
+      items.push({ state: n.state, createdAt: n.createdAt, closedAt: n.closedAt || null });
+      fetched += 1;
+      if (fetched >= pageCap) break;
+    }
+
+    if (!search.pageInfo.hasNextPage) break;
+    after = search.pageInfo.endCursor;
+  }
+
+  const opened = items.length;
+  const closedItems = items.filter((i) => i.state === "CLOSED" && i.closedAt);
+  const closed = closedItems.length;
+  const currentlyOpen = items.filter((i) => i.state === "OPEN").length;
+
+  const avgCloseTimeDays =
+    closedItems.length > 0
+      ? Math.round(
+          closedItems.reduce((sum, i) => sum + (new Date(i.closedAt!).getTime() - new Date(i.createdAt).getTime()), 0) /
+            closedItems.length /
+            86400000
+        )
+      : 0;
+
+  // thisMonth / lastMonth counts via small queries that return only counts
+  const now = new Date();
+  const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+  const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString().slice(0, 10);
+  const lastMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0).toISOString().slice(0, 10);
+
+  const countQuery = `query($q:String!){ search(query:$q,type:ISSUE, first:1){ issueCount } }`;
+
+  const thisMonthData = await graphqlRequest(token, { query: countQuery, variables: { q: `type:issue author:@me created:>=${thisMonthStart}` } });
+  const lastMonthData = await graphqlRequest(token, { query: countQuery, variables: { q: `type:issue author:@me created:${lastMonthStart}..${lastMonthEnd}` } });
+
+  const thisMonthCount = thisMonthData.data.search.issueCount || 0;
+  const lastMonthCount = lastMonthData.data.search.issueCount || 0;
+
+  const result: IssuesMetrics = {
+    opened,
+    closed,
+    currentlyOpen,
+    avgCloseTimeDays,
+    trend: thisMonthCount - lastMonthCount,
+  };
+
+  setCache(cacheKey, result);
+  return result;
+}
+
+export function clearGraphQLCache() {
+  cache.clear();
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,17 +1,39 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
-// Server-side only — use in API routes, never import in client components.
-// Service role bypasses RLS; auth is enforced by getServerSession checks.
-if (!supabaseUrl || !serviceRoleKey) {
-  throw new Error(
-    "Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set. See DEVELOPMENT.md for setup."
-  );
+// Lazy-initialize the Supabase admin client to avoid crashing at module import
+// time when env vars are not present (e.g., during Next.js static builds).
+let _supabaseClient: SupabaseClient | null = null;
+
+function getSupabaseClient(): SupabaseClient {
+  if (_supabaseClient) return _supabaseClient;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      "Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set. See DEVELOPMENT.md for setup."
+    );
+  }
+  _supabaseClient = createClient(supabaseUrl, serviceRoleKey);
+  return _supabaseClient;
 }
 
-export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+// Export a Proxy that forwards calls to the real client once initialized.
+// This preserves existing import sites that expect `supabaseAdmin` to be the
+// Supabase client while deferring the env-var error until the first use.
+export const supabaseAdmin: any = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      const client = getSupabaseClient();
+      // @ts-ignore
+      const value = (client as any)[prop];
+      if (typeof value === "function") return value.bind(client);
+      return value;
+    },
+  }
+);
 
 interface User {
   id: string;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,10 +1,16 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 // Server-side only — use in API routes, never import in client components.
 // Service role bypasses RLS; auth is enforced by getServerSession checks.
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error(
+    "Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set. See DEVELOPMENT.md for setup."
+  );
+}
+
 export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 
 interface User {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,5 +1,3 @@
-import { createClient } from "@supabase/supabase-js";
-
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
 // Lazy-initialize the Supabase admin client to avoid crashing at module import


### PR DESCRIPTION
Add a GraphQL-based GitHub fetcher with cursor pagination and a small TTL cache; wire it behind GITHUB_USE_GRAPHQL (falls back to existing REST). Make supabaseAdmin lazy-initialise to avoid import-time crashes when env vars are missing. Document new env vars.

What I implemented

fetchIssuesMetricsGraphQL using GitHub GraphQL with cursor pagination and GITHUB_PAGE_CAP.
Simple in-memory TTL cache controlled by GITHUB_CACHE_TTL.github.ts prefers GraphQL when GITHUB_USE_GRAPHQL=true, otherwise falls back to REST.
supabaseAdmin now lazy-initialises and throws a clear error when NEXT_PUBLIC_SUPABASE_URL/ SUPABASE_SERVICE_ROLE_KEY are missing (prevents import-time crash).
Added env var docs to DEVELOPMENT.md

Author: @goyaljiiiiii
Reference issue: #146 