### PR TITLE
Persist GitHub metrics in Supabase + webhook invalidation (plus small UI fixes)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,6 +71,12 @@ NEXT_PUBLIC_SUPABASE_URL=https://xxxxxxxxxxxx.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 SUPABASE_SERVICE_ROLE_KEY=eyJ...
 
+# Supabase-backed metrics cache and webhook
+# Table used to persist cached GitHub metrics (created via supabase/migrations)
+GITHUB_CACHE_TABLE=github_metrics_cache
+# Webhook secret for GitHub to call /api/webhooks/github
+GITHUB_WEBHOOK_SECRET=your_webhook_secret
+
 # NextAuth
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=generate_with_openssl_rand_base64_32

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { supabaseAdmin } from "@/lib/supabase";
+
+const table = process.env.GITHUB_CACHE_TABLE || "github_metrics_cache";
+
+function verifySignature(secret: string, body: string, signature: string | null) {
+  if (!signature) return false;
+  const hmac = crypto.createHmac("sha256", secret);
+  hmac.update(body);
+  const digest = `sha256=${hmac.digest("hex")}`;
+  // constant-time compare
+  return crypto.timingSafeEqual(Buffer.from(digest), Buffer.from(signature));
+}
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET;
+  const body = await req.text();
+  const signature = req.headers.get("x-hub-signature-256");
+
+  if (!secret) return NextResponse.json({ error: "Webhook secret not configured" }, { status: 500 });
+  if (!verifySignature(secret, body, signature)) return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+
+  const event = req.headers.get("x-github-event") || "";
+
+  try {
+    // Simple invalidation strategy: delete any cached issue metrics entries.
+    await supabaseAdmin.from(table).delete().like("key", "issuesMetrics:%");
+  } catch (err) {
+    console.error("Failed to invalidate cache:", err);
+  }
+
+  return NextResponse.json({ ok: true, event });
+}

--- a/src/components/BadgeSection.tsx
+++ b/src/components/BadgeSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Image from "next/image";
 
 interface BadgeSectionProps {
   username: string;
@@ -48,7 +49,7 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
             Streak Badge
           </h3>
           <div className="mb-2">
-            <img src={streakBadgePreviewUrl} alt="DevTrack Streak" />
+            <Image src={streakBadgePreviewUrl} alt="DevTrack Streak" width={200} height={36} />
           </div>
           <CopyableCodeBlock code={streakMarkdown} />
         </div>
@@ -59,7 +60,7 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
             Commits Badge
           </h3>
           <div className="mb-2">
-            <img src={commitsBadgePreviewUrl} alt="DevTrack Commits" />
+            <Image src={commitsBadgePreviewUrl} alt="DevTrack Commits" width={200} height={36} />
           </div>
           <CopyableCodeBlock code={commitsMarkdown} />
         </div>
@@ -70,8 +71,8 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
             Combined (Both Badges)
           </h3>
           <div className="mb-2 flex gap-1">
-            <img src={streakBadgePreviewUrl} alt="DevTrack Streak" />
-            <img src={commitsBadgePreviewUrl} alt="DevTrack Commits" />
+            <Image src={streakBadgePreviewUrl} alt="DevTrack Streak" width={140} height={32} />
+            <Image src={commitsBadgePreviewUrl} alt="DevTrack Commits" width={140} height={32} />
           </div>
           <CopyableCodeBlock code={combinedMarkdown} />
         </div>

--- a/src/components/CommitTimeChart.tsx
+++ b/src/components/CommitTimeChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import {
   BarChart,
   Bar,
@@ -27,7 +27,7 @@ export default function CommitTimeChart() {
   const [days, setDays] = useState(30);
   const [peakTime, setPeakTime] = useState<string | null>(null);
 
-  const fetchContributions = () => {
+  const fetchContributions = useCallback(() => {
     setLoading(true);
     setError(null);
     fetch(`/api/metrics/contributions?days=${days}`)
@@ -77,15 +77,13 @@ export default function CommitTimeChart() {
         setData(chartData);
         setPeakTime(peak.commits > 0 ? peak.name : null);
       })
-      .catch(() =>
-        setError("We couldn't load your time-of-day data right now."),
-      )
+      .catch(() => setError("We couldn't load your time-of-day data right now."))
       .finally(() => setLoading(false));
-  };
+  }, [days]);
 
   useEffect(() => {
     fetchContributions();
-  }, [days]);
+  }, [fetchContributions]);
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm flex flex-col h-full">

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -58,6 +58,16 @@ export interface IssuesMetrics {
 export async function fetchIssuesMetrics(
   token: string
 ): Promise<IssuesMetrics> {
+  // Prefer GraphQL implementation when enabled for better pagination and fewer requests
+  try {
+    if (process.env.GITHUB_USE_GRAPHQL === "true") {
+      // dynamic import to avoid changing runtime for environments that don't need it
+      const mod = await import("./githubGraphql");
+      return await mod.fetchIssuesMetricsGraphQL(token);
+    }
+  } catch (err) {
+    console.warn("GraphQL fetch failed, falling back to REST:", err);
+  }
   const headers = {
     Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github+json",

--- a/src/lib/githubGraphql.ts
+++ b/src/lib/githubGraphql.ts
@@ -1,0 +1,140 @@
+const GRAPHQL_API = "https://api.github.com/graphql";
+
+type CacheEntry<T> = { value: T; expiry: number };
+
+const cache = new Map<string, CacheEntry<any>>();
+
+function getFromCache<T>(key: string): T | null {
+  const ttl = process.env.GITHUB_CACHE_TTL ? parseInt(process.env.GITHUB_CACHE_TTL, 10) : 60;
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiry) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.value as T;
+}
+
+function setCache<T>(key: string, value: T) {
+  const ttl = process.env.GITHUB_CACHE_TTL ? parseInt(process.env.GITHUB_CACHE_TTL, 10) : 60;
+  cache.set(key, { value, expiry: Date.now() + ttl * 1000 });
+}
+
+async function graphqlRequest(token: string, body: object) {
+  const res = await fetch(GRAPHQL_API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (res.status === 401) throw new Error("GitHub auth error: unauthorized");
+  if (res.status === 403 || res.status === 429) {
+    const reset = res.headers.get("x-ratelimit-reset");
+    throw new Error(`GitHub rate limit: ${res.status}${reset ? ` reset=${reset}` : ""}`);
+  }
+
+  if (!res.ok) throw new Error(`GitHub GraphQL error: ${res.status}`);
+  return res.json();
+}
+
+export interface IssuesMetrics {
+  opened: number;
+  closed: number;
+  currentlyOpen: number;
+  avgCloseTimeDays: number;
+  trend: number;
+}
+
+export async function fetchIssuesMetricsGraphQL(token: string): Promise<IssuesMetrics> {
+  const since30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const cacheKey = `issuesMetrics:${token}:${since30d}`;
+
+  const cached = getFromCache<IssuesMetrics>(cacheKey);
+  if (cached) return cached;
+
+  const pageCap = process.env.GITHUB_PAGE_CAP ? parseInt(process.env.GITHUB_PAGE_CAP, 10) : 1000;
+
+  const perPage = 100; // GraphQL max for search edges traversal
+  let after: string | null = null;
+  let fetched = 0;
+  const items: Array<{ state: string; createdAt: string; closedAt?: string | null }> = [];
+
+  const baseQuery = `type:issue author:@me created:>=${since30d}`;
+
+  while (fetched < pageCap) {
+    const query = `
+      query($q:String!, $first:Int!, $after:String) {
+        search(query: $q, type: ISSUE, first: $first, after: $after) {
+          issueCount
+          pageInfo { endCursor hasNextPage }
+          nodes {
+            ... on Issue { state createdAt closedAt }
+          }
+        }
+      }
+    `;
+
+    const vars: any = { q: baseQuery, first: perPage };
+    if (after) vars.after = after;
+
+    const data = await graphqlRequest(token, { query, variables: vars });
+    const search = data.data.search;
+    const nodes = search.nodes || [];
+
+    for (const n of nodes) {
+      items.push({ state: n.state, createdAt: n.createdAt, closedAt: n.closedAt || null });
+      fetched += 1;
+      if (fetched >= pageCap) break;
+    }
+
+    if (!search.pageInfo.hasNextPage) break;
+    after = search.pageInfo.endCursor;
+  }
+
+  const opened = items.length;
+  const closedItems = items.filter((i) => i.state === "CLOSED" && i.closedAt);
+  const closed = closedItems.length;
+  const currentlyOpen = items.filter((i) => i.state === "OPEN").length;
+
+  const avgCloseTimeDays =
+    closedItems.length > 0
+      ? Math.round(
+          closedItems.reduce((sum, i) => sum + (new Date(i.closedAt!).getTime() - new Date(i.createdAt).getTime()), 0) /
+            closedItems.length /
+            86400000
+        )
+      : 0;
+
+  // thisMonth / lastMonth counts via small queries that return only counts
+  const now = new Date();
+  const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+  const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString().slice(0, 10);
+  const lastMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0).toISOString().slice(0, 10);
+
+  const countQuery = `query($q:String!){ search(query:$q,type:ISSUE, first:1){ issueCount } }`;
+
+  const thisMonthData = await graphqlRequest(token, { query: countQuery, variables: { q: `type:issue author:@me created:>=${thisMonthStart}` } });
+  const lastMonthData = await graphqlRequest(token, { query: countQuery, variables: { q: `type:issue author:@me created:${lastMonthStart}..${lastMonthEnd}` } });
+
+  const thisMonthCount = thisMonthData.data.search.issueCount || 0;
+  const lastMonthCount = lastMonthData.data.search.issueCount || 0;
+
+  const result: IssuesMetrics = {
+    opened,
+    closed,
+    currentlyOpen,
+    avgCloseTimeDays,
+    trend: thisMonthCount - lastMonthCount,
+  };
+
+  setCache(cacheKey, result);
+  return result;
+}
+
+export function clearGraphQLCache() {
+  cache.clear();
+}

--- a/src/lib/githubGraphql.ts
+++ b/src/lib/githubGraphql.ts
@@ -1,4 +1,6 @@
 const GRAPHQL_API = "https://api.github.com/graphql";
+import crypto from "crypto";
+import { supabaseAdmin } from "./supabase";
 
 type CacheEntry<T> = { value: T; expiry: number };
 
@@ -51,10 +53,24 @@ export interface IssuesMetrics {
 
 export async function fetchIssuesMetricsGraphQL(token: string): Promise<IssuesMetrics> {
   const since30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  const cacheKey = `issuesMetrics:${token}:${since30d}`;
+  const tokenHash = crypto.createHash("sha256").update(token).digest("hex");
+  const cacheKey = `issuesMetrics:${tokenHash}:${since30d}`;
 
-  const cached = getFromCache<IssuesMetrics>(cacheKey);
-  if (cached) return cached;
+  // Try Supabase persistent cache first, fall back to in-memory
+  try {
+    const table = process.env.GITHUB_CACHE_TABLE || "github_metrics_cache";
+    const { data, error } = await supabaseAdmin
+      .from(table)
+      .select("value,ttl_expires_at")
+      .eq("key", cacheKey)
+      .single();
+    if (!error && data && new Date(data.ttl_expires_at) > new Date()) {
+      return data.value as IssuesMetrics;
+    }
+  } catch (err) {
+    // Supabase unavailable or not configured — continue with in-memory cache
+    // console.warn("Supabase cache read failed, falling back to in-memory:", err);
+  }
 
   const pageCap = process.env.GITHUB_PAGE_CAP ? parseInt(process.env.GITHUB_PAGE_CAP, 10) : 1000;
 
@@ -131,7 +147,17 @@ export async function fetchIssuesMetricsGraphQL(token: string): Promise<IssuesMe
     trend: thisMonthCount - lastMonthCount,
   };
 
-  setCache(cacheKey, result);
+  // Write to Supabase persistent cache if available
+  try {
+    const table = process.env.GITHUB_CACHE_TABLE || "github_metrics_cache";
+    const ttl = process.env.GITHUB_CACHE_TTL ? parseInt(process.env.GITHUB_CACHE_TTL, 10) : 60;
+    const expiresAt = new Date(Date.now() + ttl * 1000).toISOString();
+    await supabaseAdmin.from(table).upsert({ key: cacheKey, value: result, ttl_expires_at: expiresAt });
+  } catch (err) {
+    // ignore cache write failures and fall back to in-memory
+    setCache(cacheKey, result);
+  }
+
   return result;
 }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,17 +1,39 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
-// Server-side only — use in API routes, never import in client components.
-// Service role bypasses RLS; auth is enforced by getServerSession checks.
-if (!supabaseUrl || !serviceRoleKey) {
-  throw new Error(
-    "Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set. See DEVELOPMENT.md for setup."
-  );
+// Lazy-initialize the Supabase admin client to avoid crashing at module import
+// time when env vars are not present (e.g., during Next.js static builds).
+let _supabaseClient: SupabaseClient | null = null;
+
+function getSupabaseClient(): SupabaseClient {
+  if (_supabaseClient) return _supabaseClient;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      "Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set. See DEVELOPMENT.md for setup."
+    );
+  }
+  _supabaseClient = createClient(supabaseUrl, serviceRoleKey);
+  return _supabaseClient;
 }
 
-export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+// Export a Proxy that forwards calls to the real client once initialized.
+// This preserves existing import sites that expect `supabaseAdmin` to be the
+// Supabase client while deferring the env-var error until the first use.
+export const supabaseAdmin: any = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      const client = getSupabaseClient();
+      // @ts-ignore
+      const value = (client as any)[prop];
+      if (typeof value === "function") return value.bind(client);
+      return value;
+    },
+  }
+);
 
 interface User {
   id: string;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,10 +1,16 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 // Server-side only — use in API routes, never import in client components.
 // Service role bypasses RLS; auth is enforced by getServerSession checks.
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error(
+    "Missing Supabase env vars: NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set. See DEVELOPMENT.md for setup."
+  );
+}
+
 export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
 
 interface User {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,5 +1,3 @@
-import { createClient } from "@supabase/supabase-js";
-
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
 // Lazy-initialize the Supabase admin client to avoid crashing at module import

--- a/supabase/migrations/20260516000000_create_github_metrics_cache.sql
+++ b/supabase/migrations/20260516000000_create_github_metrics_cache.sql
@@ -1,0 +1,10 @@
+-- Create persistent cache for GitHub metrics
+CREATE TABLE IF NOT EXISTS github_metrics_cache (
+  key text PRIMARY KEY,
+  value jsonb NOT NULL,
+  ttl_expires_at timestamptz NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_metrics_cache_ttl ON github_metrics_cache(ttl_expires_at);


### PR DESCRIPTION
Persist GitHub metrics to a Supabase github_metrics_cache table and read/write from githubGraphql.ts.
Add webhook endpoint route.ts to verify signatures and invalidate cache.
Lazy init supabaseAdmin and document env vars in DEVELOPMENT.md.
Small UI fixes: use next/image and fix effect deps in BadgeSection.tsx and CommitTimeChart.tsx

Author: @goyaljiiiiii
refernece issue: #150 