### PR TITLE
Fix FriendComparison responsive overflow issue ( #131 )

### DIFF
--- a/src/components/FriendComparison.tsx
+++ b/src/components/FriendComparison.tsx
@@ -68,18 +68,22 @@ export default function FriendComparison() {
           <p className="text-sm text-[var(--muted-foreground)]">See how you stack up against others</p>
         </div>
 
-        <form onSubmit={handleCompare} className="flex gap-2">
+        <form
+          onSubmit={handleCompare}
+          className="flex flex-wrap sm:flex-nowrap items-stretch gap-2 w-full md:w-auto"
+        >
           <input
             type="text"
             placeholder="GitHub username..."
             value={friendUsername}
             onChange={(e) => setFriendUsername(e.target.value)}
-            className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 text-sm outline-none focus:border-[var(--accent)]"
+            className="min-w-0 flex-1 basis-[220px] rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 text-sm outline-none focus:border-[var(--accent)]"
           />
+
           <button
             type="submit"
             disabled={loading || !friendUsername.trim()}
-            className="rounded-md bg-[var(--accent)] px-4 py-1.5 text-sm font-medium text-[var(--accent-foreground)] disabled:opacity-50 transition-colors"
+            className="w-full sm:w-auto shrink-0 rounded-md bg-[var(--accent)] px-4 py-1.5 text-sm font-medium text-[var(--accent-foreground)] transition-colors disabled:opacity-50"
           >
             {loading ? "Loading..." : "Compare"}
           </button>

--- a/src/components/FriendComparison.tsx
+++ b/src/components/FriendComparison.tsx
@@ -62,33 +62,38 @@ export default function FriendComparison() {
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <div className="flex flex-col md:flex-row md:items-center justify-between mb-6 gap-4">
+      <div className="mb-6 space-y-4">
         <div>
-          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">Friend Comparison</h2>
-          <p className="text-sm text-[var(--muted-foreground)]">See how you stack up against others</p>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            Friend Comparison
+          </h2>
+
+          <p className="text-sm text-[var(--muted-foreground)]">
+            See how you stack up against others
+          </p>
         </div>
 
-        <form
-          onSubmit={handleCompare}
-          className="flex flex-wrap sm:flex-nowrap items-stretch gap-2 w-full md:w-auto"
-        >
-          <input
-            type="text"
-            placeholder="GitHub username..."
-            value={friendUsername}
-            onChange={(e) => setFriendUsername(e.target.value)}
-            className="min-w-0 flex-1 basis-[220px] rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-1.5 text-sm outline-none focus:border-[var(--accent)]"
-          />
+      <form
+        onSubmit={handleCompare}
+        className="flex flex-col sm:flex-row gap-2 w-full"
+      >
+        <input
+          type="text"
+          placeholder="GitHub username..."
+          value={friendUsername}
+          onChange={(e) => setFriendUsername(e.target.value)}
+          className="min-w-0 flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm outline-none focus:border-[var(--accent)]"
+        />
 
-          <button
-            type="submit"
-            disabled={loading || !friendUsername.trim()}
-            className="w-full sm:w-auto shrink-0 rounded-md bg-[var(--accent)] px-4 py-1.5 text-sm font-medium text-[var(--accent-foreground)] transition-colors disabled:opacity-50"
-          >
-            {loading ? "Loading..." : "Compare"}
-          </button>
-        </form>
-      </div>
+        <button
+          type="submit"
+          disabled={loading || !friendUsername.trim()}
+          className="w-full sm:w-auto shrink-0 whitespace-nowrap rounded-md bg-[var(--accent)] px-4 py-2 text-sm font-medium text-[var(--accent-foreground)] transition-colors disabled:opacity-50"
+        >
+          {loading ? "Loading..." : "Compare"}
+        </button>
+      </form>
+    </div>
 
       {error && (
         <div className="p-4 mb-4 rounded-md bg-red-500/10 border border-red-500/20 text-red-500 text-sm flex justify-between items-center">


### PR DESCRIPTION
## Summary

Fixes the responsive layout issue in the Friend Comparison component where the "Compare" button overflowed outside the card/container on constrained desktop widths and mobile screens.

The layout was restructured to improve responsiveness and prevent horizontal overflow across all screen sizes.

Closes #131 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Reworked Friend Comparison header/form layout structure
- Moved comparison form below heading for improved responsiveness
- Added responsive flex behavior for mobile and desktop layouts
- Prevented button overflow using proper width and shrink handling
- Improved spacing and alignment consistency across breakpoints

## How to Test

Steps for the reviewer to verify this works:

1. Open the dashboard page
2. Navigate to the Friend Comparison component
3. Resize the browser across desktop, tablet, and mobile widths
4. Verify the "Compare" button never overflows outside the card
5. Verify the input and button remain aligned and usable
6. Confirm there is no horizontal scrolling/layout breaking

## Screenshots (if UI change)

- Added before/after screenshots

**Before** 
<img width="537" height="677" alt="image" src="https://github.com/user-attachments/assets/03c57686-4f53-4c78-b489-0dd584c93fce" />
<img width="825" height="333" alt="image" src="https://github.com/user-attachments/assets/bb42be15-45e8-4dab-b435-f39e6fd0f555" />


**After**
<img width="420" height="651" alt="result mobile view" src="https://github.com/user-attachments/assets/c6247067-4231-49cb-b929-29fc5b47cd41" />
<img width="607" height="647" alt="result desktop view" src="https://github.com/user-attachments/assets/cef0e970-c76a-4efe-9efd-72d37fd3c441" />

- Added responsive behavior video recording

https://github.com/user-attachments/assets/18044244-767d-4948-b1db-3cc452d19ba0



## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable