### PR TITLE
feat: add count-up animation to streak stats

### DIFF
--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { useCountUp } from "@/hooks/useCountUp";
 
 interface StreakData {
   current: number;
@@ -34,6 +35,10 @@ export default function StreakTracker() {
   const [freezeLoading, setFreezeLoading] = useState(true);
   const [cancelling, setCancelling] = useState(false);
   const [confirmCancel, setConfirmCancel] = useState(false);
+
+  const animatedCurrent = useCountUp(data?.current ?? 0);
+  const animatedLongest = useCountUp(data?.longest ?? 0);
+  const animatedActiveDays = useCountUp(data?.totalActiveDays ?? 0);
 
   const fetchStreak = useCallback(async () => {
     setLoading(true);
@@ -172,7 +177,7 @@ export default function StreakTracker() {
     ? [
         {
           label: "Current Streak",
-          value: data.current,
+          value: animatedCurrent,
           unit: "days",
           highlight: data.current > 0,
           icon: "🔥",
@@ -180,7 +185,7 @@ export default function StreakTracker() {
         },
         {
           label: "Longest Streak",
-          value: data.longest,
+          value: animatedLongest,
           unit: "days",
           highlight: false,
           icon: "🏆",
@@ -188,7 +193,7 @@ export default function StreakTracker() {
         },
         {
           label: "Active Days (90d)",
-          value: data.totalActiveDays,
+          value: animatedActiveDays,
           unit: "days",
           highlight: false,
           icon: "📅",

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+export function useCountUp(target: number, duration?: number): number {
+  const [count, setCount] = useState(0);
+  const hasAnimated = useRef(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (mediaQuery.matches) {
+      setCount(target);
+      return;
+    }
+
+    if (target === 0) {
+      setCount(0);
+      return;
+    }
+
+    if (hasAnimated.current) {
+      setCount(target);
+      return;
+    }
+
+    hasAnimated.current = true;
+
+    // Adaptive duration: smaller numbers animate slightly faster (500ms), larger numbers take up to 800ms
+    const actualDuration = duration ?? (target <= 10 ? 500 : target <= 50 ? 650 : 800);
+
+    let startTime: number | null = null;
+    let animationFrameId: number;
+
+    const animate = (currentTime: number) => {
+      if (startTime === null) {
+        startTime = currentTime;
+      }
+
+      const elapsed = currentTime - startTime;
+      const progress = Math.min(elapsed / actualDuration, 1);
+
+      // Quintic ease-out (1 - (1 - t)^5) provides an incredibly smooth, premium, soft settling effect
+      const easeOutQuint = 1 - Math.pow(1 - progress, 5);
+      const currentCount = Math.round(easeOutQuint * target);
+
+      setCount(currentCount);
+
+      if (progress < 1) {
+        animationFrame(animate);
+      } else {
+        setCount(target);
+      }
+    };
+
+    function animationFrame(callback: FrameRequestCallback) {
+      animationFrameId = requestAnimationFrame(callback);
+    }
+
+    animationFrame(animate);
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [target, duration]);
+
+  return count;
+}


### PR DESCRIPTION
## Summary

Added smooth count-up animations for streak statistics on dashboard load using a reusable `useCountUp` hook with `requestAnimationFrame`. The animation now smoothly counts from 0 to the final values for Current Streak, Longest Streak, and Active Days while supporting `prefers-reduced-motion`.

Closes #159

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added reusable `useCountUp` hook for animated number transitions
- Implemented smooth ease-out count-up animation for streak stats
- Added support for `prefers-reduced-motion`
- Ensured animation runs only on initial dashboard load
- Added proper cleanup using `cancelAnimationFrame`

## How to Test

Steps for the reviewer to verify this works:

1. Run the application locally using `npm run dev`
2. Open the dashboard page
3. Verify that Current Streak, Longest Streak, and Active Days animate from 0 to their final values
4. Refresh the page and confirm the animation runs smoothly
5. Enable `prefers-reduced-motion` in browser devtools and verify values appear instantly without animation
6. Run `npm run lint`
7. Run `npm run type-check`

## Screenshots (if UI change)

N/A

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable