### PR TITLE
feat: add accessible keyboard shortcuts modal

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -73,6 +73,14 @@ export default function ContributionGraph() {
   }, [days, selectedAccount]);
 
   useEffect(() => {
+    const handleToggleChart = () => {
+      setChartType((prev) => (prev === "bar" ? "line" : "bar"));
+    };
+    window.addEventListener("toggleChart", handleToggleChart);
+    return () => window.removeEventListener("toggleChart", handleToggleChart);
+  }, []);
+
+  useEffect(() => {
     if (!lastUpdated) return;
     const interval = setInterval(() => {
       const diff = Math.floor((Date.now() - lastUpdated.getTime()) / 60000);

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -6,6 +6,7 @@ import AccountToggle from "@/components/AccountToggle";
 import SignOutButton from "@/components/SignOutButton";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserAvatar from "@/components/UserAvatar";
+import KeyboardShortcuts from "@/components/KeyboardShortcuts";
 
 interface UserSettings {
   is_public: boolean;
@@ -57,6 +58,7 @@ export default function DashboardHeader() {
               Share Profile
             </a>
           )}
+          <KeyboardShortcuts />
           <UserAvatar />
           <ThemeToggle />
           <SignOutButton />

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "@/components/ThemeContext";
+import ShortcutsModal from "./ShortcutsModal";
+
+export default function KeyboardShortcuts() {
+  const [isOpen, setIsOpen] = useState(false);
+  const { toggleTheme } = useTheme();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const activeElement = document.activeElement;
+      if (activeElement) {
+        const tagName = activeElement.tagName.toLowerCase();
+        if (tagName === "input" || tagName === "textarea" || tagName === "select") return;
+        if (activeElement.getAttribute("contenteditable") === "true") return;
+      }
+
+      if (e.key === "?") {
+        setIsOpen(true);
+        e.preventDefault();
+        return;
+      }
+
+      if (e.key.toLowerCase() === "d") {
+        toggleTheme();
+        e.preventDefault();
+        return;
+      }
+
+      if (e.key.toLowerCase() === "b") {
+        window.dispatchEvent(new Event("toggleChart"));
+        e.preventDefault();
+        return;
+      }
+
+      if (e.key.toLowerCase() === "r") {
+        window.location.reload();
+        e.preventDefault();
+        return;
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [toggleTheme]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="inline-flex h-10 items-center gap-1.5 rounded-full border border-[var(--border)] bg-[var(--card)] px-3 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--control)] hover:text-[var(--card-foreground)]"
+        aria-label="Show keyboard shortcuts"
+      >
+        <kbd className="rounded bg-[var(--control)] px-1.5 py-0.5 text-[10px] font-bold text-[var(--card-foreground)]">
+          ?
+        </kbd>
+        <span>Shortcuts</span>
+      </button>
+
+      <ShortcutsModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  );
+}

--- a/src/components/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface ShortcutsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface ShortcutItem {
+  key: string;
+  action: string;
+}
+
+const SHORTCUTS: ShortcutItem[] = [
+  { key: "D", action: "Toggle theme" },
+  { key: "B", action: "Toggle chart" },
+  { key: "R", action: "Reload data" },
+  { key: "?", action: "Show shortcuts" },
+];
+
+export default function ShortcutsModal({ isOpen, onClose }: ShortcutsModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (closeBtnRef.current) {
+      closeBtnRef.current.focus();
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (e.key === "Tab") {
+        if (!modalRef.current) return;
+
+        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm transition-opacity"
+      onClick={onClose}
+    >
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+        className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-xl transition-transform"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-[var(--border)] pb-4">
+          <h2 id="modal-title" className="text-lg font-semibold text-[var(--card-foreground)]">
+            Keyboard Shortcuts
+          </h2>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-1 text-[var(--muted-foreground)] hover:bg-[var(--control)] hover:text-[var(--card-foreground)] transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+            aria-label="Close modal"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          {SHORTCUTS.map((item) => (
+            <div key={item.key} className="flex items-center justify-between py-1.5 border-b border-[var(--border)]/50 last:border-0">
+              <span className="text-sm text-[var(--muted-foreground)]">{item.action}</span>
+              <kbd className="min-w-[28px] text-center rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-xs font-semibold text-[var(--card-foreground)] shadow-sm">
+                {item.key}
+              </kbd>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-6 pt-4 border-t border-[var(--border)] flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg bg-[var(--control)] px-4 py-2 text-sm font-medium text-[var(--card-foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+          >
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Added an accessible keyboard shortcuts modal that improves shortcut discoverability on the dashboard. Users can now press `?` to view all available shortcuts in a centered modal with keyboard navigation and accessibility support.

Closes #163

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added reusable `ShortcutsModal` component
- Added `?` keyboard shortcut to open the modal
- Added Escape key and outside-click close support
- Implemented focus trapping and accessibility attributes
- Prevented shortcut modal from opening inside inputs/textareas
- Added `? Shortcuts` hint text in dashboard header
- Added chart toggle handling for `B` shortcut

## How to Test

Steps for the reviewer to verify this works:

1. Run the project locally using `npm run dev`
2. Open the dashboard page
3. Press `?` and verify the shortcuts modal opens
4. Press `Escape` and verify the modal closes
5. Click outside the modal and verify it closes
6. Verify keyboard focus remains trapped inside the modal
7. Click inside an input/textarea and press `?` to verify the modal does not open
8. Verify:
   - `D` toggles theme
   - `B` toggles chart view
   - `R` reloads the page/data
9. Run `npm run lint`
10. Run `npm run type-check`

## Screenshots (if UI change)

<img width="461" height="413" alt="Screenshot 2026-05-17 123530" src="https://github.com/user-attachments/assets/46286e19-539b-4a22-aef6-ae48cf7e214a" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable