### PR TITLE
feat: add monthly active-day trend comparison

### DIFF
--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -173,6 +173,7 @@ export default function StreakTracker() {
 
   const badge = MILESTONES.find((m) => (data?.current ?? 0) >= m.days);
   const activeDayData = calculateActiveDayInsights(contributionData?.data);
+  const monthlyTrend = calculateMonthlyTrend(contributionData);
 
   const stats = data
     ? [
@@ -283,6 +284,16 @@ export default function StreakTracker() {
           </div>
         ))}
       </div>
+      {monthlyTrend.isValid && (
+        <div className="mt-3 flex items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--card)] px-4 py-2.5 text-xs shadow-sm">
+          <span className="text-[var(--muted-foreground)]">
+            This month: <strong className="font-semibold text-[var(--card-foreground)]">{monthlyTrend.thisMonth} active days</strong>
+          </span>
+          <span className={monthlyTrend.colorClass}>
+            ({monthlyTrend.text})
+          </span>
+        </div>
+      )}
       {badge && (
         <div className="mt-3 flex items-center justify-center gap-2 rounded-lg border border-[var(--accent)]/30 bg-[var(--accent)]/10 px-3 py-2">
           <span>{badge.emoji}</span>
@@ -592,4 +603,75 @@ function calculateActiveDayInsights(data: Record<string, number> | undefined | n
   const peakDay = tiedDays.length > 0 ? tiedDays[0] : null;
 
   return { insights, peakDay, isValid: true };
+}
+
+interface MonthlyTrendResult {
+  isValid: boolean;
+  thisMonth: number;
+  lastMonth: number;
+  text: string;
+  colorClass: string;
+}
+
+function calculateMonthlyTrend(contrib: ContributionData | undefined | null): MonthlyTrendResult {
+  if (!contrib || !contrib.data) {
+    return { isValid: false, thisMonth: 0, lastMonth: 0, text: "", colorClass: "" };
+  }
+
+  if (contrib.days < 30) {
+    return { isValid: false, thisMonth: 0, lastMonth: 0, text: "", colorClass: "" };
+  }
+
+  const data = contrib.data;
+
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
+
+  const prevDate = new Date(currentYear, currentMonth - 1, 1);
+  const prevYear = prevDate.getFullYear();
+  const prevMonth = prevDate.getMonth();
+
+  let thisMonth = 0;
+  let lastMonth = 0;
+
+  for (const [dateStr, count] of Object.entries(data)) {
+    if (count > 0) {
+      const parts = dateStr.split("-").map(Number);
+      if (parts.length === 3 && !isNaN(parts[0]) && !isNaN(parts[1]) && !isNaN(parts[2])) {
+        const d = new Date(parts[0], parts[1] - 1, parts[2]);
+        if (!isNaN(d.getTime())) {
+          if (d.getFullYear() === currentYear && d.getMonth() === currentMonth) {
+            thisMonth++;
+          } else if (d.getFullYear() === prevYear && d.getMonth() === prevMonth) {
+            lastMonth++;
+          }
+        }
+      }
+    }
+  }
+
+  let text = "";
+  let colorClass = "";
+
+  if (lastMonth === 0) {
+    text = "First month tracked!";
+    colorClass = "text-[var(--accent)] font-medium";
+  } else {
+    const deltaCalc = ((thisMonth - lastMonth) / lastMonth) * 100;
+    const formatted = deltaCalc.toFixed(0);
+
+    if (deltaCalc > 0) {
+      text = `↑${formatted}% vs last month`;
+      colorClass = "text-green-500 font-medium";
+    } else if (deltaCalc < 0) {
+      text = `↓${Math.abs(deltaCalc).toFixed(0)}% vs last month`;
+      colorClass = "text-red-500 font-medium";
+    } else {
+      text = `=0% vs last month`;
+      colorClass = "text-[var(--muted-foreground)] font-medium";
+    }
+  }
+
+  return { isValid: true, thisMonth, lastMonth, text, colorClass };
 }


### PR DESCRIPTION
## Summary

Added a monthly active-day trend comparison section to the `StreakTracker` component that compares the current month's active days with the previous month and displays a percentage-based delta indicator with proper trend styling and edge-case handling.

Closes #189

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added monthly active-day comparison logic using existing contribution data
- Added percentage delta calculation for current vs previous month
- Added positive, negative, and neutral trend indicators
- Added edge-case handling for first tracked month
- Added conditional rendering when at least 30 days of data exist
- Integrated comparison callout below streak stat cards

## How to Test

Steps for the reviewer to verify this works:

1. Run the project locally using `npm run dev`
2. Open the dashboard page
3. Navigate to the `StreakTracker` section
4. Verify the monthly comparison section appears below the streak cards
5. Verify:
   - Positive trends show green `↑`
   - Negative trends show red `↓`
   - Equal trends show neutral `=`
6. Verify the edge case:
   - `First month tracked!`
   appears when the previous month has 0 active days
7. Verify the section hides when insufficient contribution data exists
8. Run `npm run lint`
9. Run `npm run type-check`

## Screenshots (if UI change)

<img width="606" height="491" alt="Screenshot 2026-05-17 125246" src="https://github.com/user-attachments/assets/a84af1b2-9da6-4d9a-9ee1-9f9c89de5320" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable