### PR TITLE
fix: encode username in badge URLs to handle special characters (#246)

### DIFF
--- a/src/components/BadgeSection.tsx
+++ b/src/components/BadgeSection.tsx
@@ -11,8 +11,9 @@ interface BadgeSectionProps {
  */
 export default function BadgeSection({ username }: BadgeSectionProps) {
   // Relative URLs for preview images — always correct regardless of env vars
-  const streakBadgePreviewUrl = `/api/badge/streak-shield?user=${username}`;
-  const commitsBadgePreviewUrl = `/api/badge/commits?user=${username}`;
+  const encodedUsername = encodeURIComponent(username);
+  const streakBadgePreviewUrl = `/api/badge/streak-shield?user=${encodedUsername}`;
+  const commitsBadgePreviewUrl = `/api/badge/commits?user=${encodedUsername}`;
 
   // Absolute URLs for copy markdown — resolved on client only to avoid hydration mismatch
   const [baseUrl, setBaseUrl] = useState("");
@@ -22,10 +23,10 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
   }, []);
 
   const streakBadgeUrl = baseUrl
-   ? `${baseUrl}/api/badge/streak-shield?user=${username}`
+    ? `${baseUrl}/api/badge/streak-shield?user=${encodedUsername}`
     : streakBadgePreviewUrl;
   const commitsBadgeUrl = baseUrl
-    ? `${baseUrl}/api/badge/commits?user=${username}`
+    ? `${baseUrl}/api/badge/commits?user=${encodedUsername}`
     : commitsBadgePreviewUrl;
 
   const streakMarkdown = `![DevTrack Streak](${streakBadgeUrl})`;


### PR DESCRIPTION
## Summary
Encodes the username parameter in badge URLs to handle special characters (dots, hyphens, underscores) that would otherwise break the badge preview and markdown output.
Closes #246

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made
- Added `encodeURIComponent()` for username in `BadgeSection.tsx` before building badge URLs
- Applied encoding to both streak and commits badge URLs

## How to Test
1. Create or use a GitHub account with special characters in the username (e.g. dots or double hyphens)
2. Navigate to the badge section on the dashboard
3. Verify the badge preview loads correctly without breaking
4. Verify the copied markdown URL is properly encoded

## Screenshots (if UI change)
N/A - No UI changes

## Checklist
- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable