### PR TITLE
fix: add aria-label to repo links in TopRepos widget

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -136,7 +136,8 @@ export default function TopRepos() {
                     href={repo.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="max-w-[70%] truncate text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)]"
+                    aria-label="Open on GitHub"
+                    className="max-w-[70%] truncate text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)] hover:underline"
                     title={repo.name}
                   >
                     <span className="mr-1 text-[var(--muted-foreground)]">#{idx + 1}</span>


### PR DESCRIPTION
Fixes: #[158]
What changed:
Added aria-label="Open on GitHub" to the repo <a> tag in TopRepos.tsx and added hover:underline for clearer hover feedback.
Acceptance criteria checklist:

 href={repo.url} already present
 target="_blank"  already present
 rel="noopener noreferrer" already present
 Hover accent colour  already present
 aria-label="Open on GitHub" added in this PR
 No change to commit count or bar layout 