### PR TITLE
feat: add confetti celebration for completed goals

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 
 type Recurrence = "none" | "weekly" | "monthly";
 
@@ -33,6 +33,10 @@ export default function GoalTracker() {
   const [createError, setCreateError] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const [activeConfettiGoalId, setActiveConfettiGoalId] = useState<string | null>(null);
+  const prevGoalsRef = useRef<Map<string, boolean>>(new Map());
+  const initialLoadDoneRef = useRef<boolean>(false);
 
   const loadGoals = useCallback(async () => {
     const response = await fetch("/api/goals");
@@ -107,6 +111,36 @@ export default function GoalTracker() {
   }
 
   useEffect(() => {
+    if (goals.length === 0) return;
+
+    if (!initialLoadDoneRef.current) {
+      const map = new Map<string, boolean>();
+      for (const g of goals) {
+        map.set(g.id, g.current >= g.target);
+      }
+      prevGoalsRef.current = map;
+      initialLoadDoneRef.current = true;
+      return;
+    }
+
+    for (const g of goals) {
+      const isCompleted = g.current >= g.target;
+      const wasCompleted = prevGoalsRef.current.get(g.id);
+
+      if (wasCompleted === false && isCompleted) {
+        if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+          setActiveConfettiGoalId(g.id);
+          setTimeout(() => {
+            setActiveConfettiGoalId((curr) => (curr === g.id ? null : curr));
+          }, 2500);
+        }
+      }
+
+      prevGoalsRef.current.set(g.id, isCompleted);
+    }
+  }, [goals]);
+
+  useEffect(() => {
     if (!lastUpdated) return;
     const interval = setInterval(() => {
       const diff = Math.floor((Date.now() - lastUpdated.getTime()) / 60000);
@@ -147,7 +181,8 @@ export default function GoalTracker() {
             const completionLabel = getCompletionLabel(goal);
 
             return (
-              <li key={goal.id}>
+              <li key={goal.id} className="relative">
+                {activeConfettiGoalId === goal.id && <ConfettiBurst />}
                 <div className="flex justify-between items-center text-sm mb-1">
                   <div className="flex flex-col gap-0.5">
                     <div className="flex items-center gap-2">
@@ -328,3 +363,60 @@ export default function GoalTracker() {
     </div>
   );
 }
+
+function ConfettiBurst() {
+  const [particles, setParticles] = useState<Array<{ id: number; x: number; y: number; color: string; rot: number; scale: number; speed: number }>>([]);
+
+  useEffect(() => {
+    const colors = ["var(--accent)", "#10B981", "#F59E0B", "#EF4444", "#8B5CF6", "#EC4899"];
+    const newParticles = [];
+    for (let i = 0; i < 35; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const distance = 30 + Math.random() * 140;
+      newParticles.push({
+        id: i,
+        x: Math.cos(angle) * distance,
+        y: Math.sin(angle) * distance - 20,
+        color: colors[Math.random() * colors.length | 0],
+        rot: Math.random() * 360 + 180,
+        scale: 0.5 + Math.random() * 0.7,
+        speed: 0.8 + Math.random() * 0.6,
+      });
+    }
+    setParticles(newParticles);
+  }, []);
+
+  return (
+    <div className="absolute inset-0 pointer-events-none z-50 flex items-center justify-center overflow-visible">
+      <style>{`
+        @keyframes confettiBurstAnim {
+          0% {
+            transform: translate(0, 0) rotate(0deg) scale(0);
+            opacity: 1;
+          }
+          50% {
+            opacity: 1;
+          }
+          100% {
+            transform: translate(var(--tx), var(--ty)) rotate(var(--rot)) scale(var(--scale));
+            opacity: 0;
+          }
+        }
+      `}</style>
+      {particles.map((p) => (
+        <div
+          key={p.id}
+          className="absolute w-2.5 h-2.5 rounded-sm"
+          style={{
+            backgroundColor: p.color,
+            ["--tx" as string]: `${p.x}px`,
+            ["--ty" as string]: `${p.y}px`,
+            ["--rot" as string]: `${p.rot}deg`,
+            ["--scale" as string]: p.scale,
+            animation: `confettiBurstAnim ${p.speed}s cubic-bezier(0.25, 1, 0.5, 1) forwards`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Added a lightweight confetti celebration to `GoalTracker` that triggers when a goal transitions from incomplete to completed, making goal completion feel more rewarding while respecting reduced motion accessibility preferences.

Closes #219

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added goal completion transition detection using refs
- Triggered confetti only when a goal changes from incomplete to completed
- Prevented confetti from replaying on re-renders or refreshes
- Added reduced motion accessibility support
- Implemented lightweight custom particle burst animation
- Added automatic animation cleanup after completion

## How to Test

Steps for the reviewer to verify this works:

1. Run the project locally using `npm run dev`
2. Open the dashboard and navigate to the `GoalTracker` section
3. Update a goal so `current >= target`
4. Verify a confetti burst appears when the goal becomes completed
5. Refresh the page and verify confetti does not replay for already completed goals
6. Complete multiple goals and verify each triggers independently
7. Enable `prefers-reduced-motion` in browser devtools and verify no confetti animation plays
8. Open browser console and verify there are no warnings or errors
9. Run `npm run lint`
10. Run `npm run type-check`

## Screenshots (if UI change)

NA

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable