### PR TITLE
feat: persist contribution graph range selection

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -44,6 +44,31 @@ export default function ContributionGraph() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = localStorage.getItem("devtrack:contribution-range");
+        if (stored === "7" || stored === "30" || stored === "90" || stored === "365") {
+          setDays(Number(stored));
+        } else {
+          localStorage.setItem("devtrack:contribution-range", "30");
+          setDays(30);
+        }
+      } catch {
+        setDays(30);
+      }
+    }
+  }, []);
+
+  const handleRangeChange = (newDays: number) => {
+    setDays(newDays);
+    if (typeof window !== "undefined") {
+      try {
+        localStorage.setItem("devtrack:contribution-range", String(newDays));
+      } catch {}
+    }
+  };
+
+  useEffect(() => {
     setLoading(true);
     setError(null);
     const accountParam =
@@ -94,7 +119,7 @@ export default function ContributionGraph() {
             {RANGES.map((r) => (
               <button
                 key={r.days}
-                onClick={() => setDays(r.days)}
+                onClick={() => handleRangeChange(r.days)}
                 aria-label={`Show ${r.days}-day range`}
                 aria-pressed={days === r.days}
                 className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${days === r.days


### PR DESCRIPTION
## Summary

Added localStorage persistence for the `ContributionGraph` time range selection so users keep their preferred graph range across refreshes and sessions.

Closes #220

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added localStorage persistence for selected graph range
- Restored saved range on component mount
- Added validation for allowed range values
- Added fallback to default 30-day range for invalid values
- Added SSR-safe localStorage guards
- Prevented hydration/runtime errors in Next.js

## How to Test

Steps for the reviewer to verify this works:

1. Run the project locally using `npm run dev`
2. Open the dashboard page
3. Change the contribution graph range (7 / 30 / 90 / 365)
4. Refresh the page
5. Verify the selected range persists after refresh
6. Open DevTools → Application → Local Storage
7. Verify `devtrack:contribution-range` is stored correctly
8. Manually set an invalid localStorage value:
   ```js
   localStorage.setItem("devtrack:contribution-range", "999")