### PR TITLE
Make TopRepos clickable with GitHub links

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -143,15 +143,6 @@ export default function TopRepos() {
                       aria-label="Open on GitHub"
                       title={repo.name}
                       className="inline-block truncate text-[var(--card-foreground)] transition-colors hover:underline hover:text-[var(--accent)] cursor-pointer z-10"
-                      onClick={(e) => {
-                        // fallback open in case something stops the default navigation
-                        try {
-                          e.stopPropagation();
-                          window.open(repoHref, "_blank", "noopener,noreferrer");
-                        } catch {
-                          /* ignore */
-                        }
-                      }}
                     >
                       {shortName}
                     </a>

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -109,14 +109,12 @@ export default function TopRepos() {
         <p className="text-sm text-[var(--muted-foreground)]">No commits in the last {days} days.</p>
       ) : (
         <ul className="space-y-3">
-            {repos.map((repo, idx) => {
+          {repos.map((repo, idx) => {
             const barWidth = Math.max(
               Math.round((repo.commits / maxCommits) * 100),
               4
             );
             const shortName = repo.name.split("/")[1] ?? repo.name;
-            // Safe href: use repo.url if present, otherwise fall back to github.com/<owner/repo>
-            const repoHref = repo.url && repo.url.trim() !== "" ? repo.url : `https://github.com/${repo.name}`;
             const health = healthScores[repo.name];
             const badgeTitle = health
               ? `Commits: ${health.signals.commitFrequency} | PR Merge Rate: ${Math.round(
@@ -134,19 +132,16 @@ export default function TopRepos() {
             return (
               <li key={repo.name}>
                 <div className="flex items-center justify-between text-sm mb-1">
-                  <div className="max-w-[70%] truncate">
+                  <a
+                    href={repo.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="max-w-[70%] truncate text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)]"
+                    title={repo.name}
+                  >
                     <span className="mr-1 text-[var(--muted-foreground)]">#{idx + 1}</span>
-                    <a
-                      href={repoHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label="Open on GitHub"
-                      title={repo.name}
-                      className="inline-block truncate text-[var(--card-foreground)] transition-colors hover:underline hover:text-[var(--accent)] cursor-pointer z-10"
-                    >
-                      {shortName}
-                    </a>
-                  </div>
+                    {shortName}
+                  </a>
                   <span className="shrink-0 flex items-center gap-2">
                     {healthLoading ? (
                       <div className="h-5 w-9 rounded bg-[var(--card-muted)] animate-pulse" />

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -109,12 +109,14 @@ export default function TopRepos() {
         <p className="text-sm text-[var(--muted-foreground)]">No commits in the last {days} days.</p>
       ) : (
         <ul className="space-y-3">
-          {repos.map((repo, idx) => {
+            {repos.map((repo, idx) => {
             const barWidth = Math.max(
               Math.round((repo.commits / maxCommits) * 100),
               4
             );
             const shortName = repo.name.split("/")[1] ?? repo.name;
+            // Safe href: use repo.url if present, otherwise fall back to github.com/<owner/repo>
+            const repoHref = repo.url && repo.url.trim() !== "" ? repo.url : `https://github.com/${repo.name}`;
             const health = healthScores[repo.name];
             const badgeTitle = health
               ? `Commits: ${health.signals.commitFrequency} | PR Merge Rate: ${Math.round(
@@ -132,16 +134,28 @@ export default function TopRepos() {
             return (
               <li key={repo.name}>
                 <div className="flex items-center justify-between text-sm mb-1">
-                  <a
-                    href={repo.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="max-w-[70%] truncate text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)]"
-                    title={repo.name}
-                  >
+                  <div className="max-w-[70%] truncate">
                     <span className="mr-1 text-[var(--muted-foreground)]">#{idx + 1}</span>
-                    {shortName}
-                  </a>
+                    <a
+                      href={repoHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="Open on GitHub"
+                      title={repo.name}
+                      className="inline-block truncate text-[var(--card-foreground)] transition-colors hover:underline hover:text-[var(--accent)] cursor-pointer z-10"
+                      onClick={(e) => {
+                        // fallback open in case something stops the default navigation
+                        try {
+                          e.stopPropagation();
+                          window.open(repoHref, "_blank", "noopener,noreferrer");
+                        } catch {
+                          /* ignore */
+                        }
+                      }}
+                    >
+                      {shortName}
+                    </a>
+                  </div>
                   <span className="shrink-0 flex items-center gap-2">
                     {healthLoading ? (
                       <div className="h-5 w-9 rounded bg-[var(--card-muted)] animate-pulse" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,13 +14,30 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "client", "server"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "client",
+    "server"
+  ]
 }


### PR DESCRIPTION
## Summary

This PR improves the TopRepos widget by making each repository name directly clickable.
Each repo now links to its corresponding GitHub repository page and opens in a new tab.

Closes #291

---

## Type of Change

* [x] New feature

---

## Changes Made

* Wrapped repository name in an anchor (`<a>`) tag

``` 
<a
  href={repoHref}
  target="_blank"
  rel="noopener noreferrer"
  aria-label="Open on GitHub"
  title={repo.name}
  className="inline-block truncate text-[var(--card-foreground)] transition-colors hover:underline hover:text-[var(--accent)] cursor-pointer z-10"
  onClick={(e) => {
    try {
      e.stopPropagation();
      window.open(repoHref, "_blank", "noopener,noreferrer");
    } catch {}
  }}
>
  {shortName}
</a> 
```


* Added `href={repo.url}` to link directly to GitHub repository
* Added `target="_blank"` to open links in a new tab
* Added `rel="noopener noreferrer"` for security best practices
* Added `aria-label="Open on GitHub"` for accessibility
* Ensured no changes to commit count or layout structure
* Preserved existing UI design and styling

---

## How to Test

1. Run the project using `npm run dev`
2. Go to the dashboard page
3. Locate the TopRepos widget
4. Click on any repository name
5. Verify:

   * It opens the correct GitHub repository
   * It opens in a new tab
   * Layout and styling remain unchanged

---

## Screenshots (if UI change)

<img width="1912" height="962" alt="Screenshot 2026-05-17 214556" src="https://github.com/user-attachments/assets/f62096a7-c7b0-4544-a3aa-af6c29974847" />
<img width="1905" height="980" alt="Screenshot 2026-05-17 214610" src="https://github.com/user-attachments/assets/7e0f6b84-25ed-4fd4-8e7e-53d59f060448" />


---

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [x] No layout or UI regression

