### PR TITLE
feat: merge gitlab commits into contribution graph

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -5,6 +5,54 @@ import { authOptions } from "@/lib/auth";
 export const dynamic = "force-dynamic";
 
 const GITHUB_API = "https://api.github.com";
+const GITLAB_API = "https://gitlab.com/api/v4";
+
+interface GitHubCommitSearchResponse {
+  total_count: number;
+  items: Array<{ commit: { author: { date: string } } }>;
+}
+
+interface GitLabEvent {
+  created_at: string;
+  push_data?: { commit_count?: number };
+}
+
+interface TimeBlocks {
+  morning: number;
+  afternoon: number;
+  evening: number;
+  night: number;
+}
+
+function incrementDay(
+  target: Record<string, number>,
+  date: string,
+  count: number
+) {
+  target[date] = (target[date] ?? 0) + count;
+}
+
+function incrementTimeBlocks(
+  blocks: TimeBlocks,
+  rawDate: string,
+  count: number
+) {
+  const parsed = new Date(rawDate);
+  if (Number.isNaN(parsed.getTime()) || count <= 0) {
+    return;
+  }
+
+  const hour = parsed.getHours();
+  if (hour >= 6 && hour < 12) {
+    blocks.morning += count;
+  } else if (hour >= 12 && hour < 18) {
+    blocks.afternoon += count;
+  } else if (hour >= 18 && hour < 22) {
+    blocks.evening += count;
+  } else {
+    blocks.night += count;
+  }
+}
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -17,6 +65,7 @@ export async function GET(req: NextRequest) {
   const since = new Date();
   since.setDate(since.getDate() - days);
   const sinceStr = since.toISOString().slice(0, 10);
+  const sinceMs = since.getTime();
 
   // Commits search API captures all commits authored by the user —
   // including web UI commits, merge commits, PRs — unlike the events API
@@ -36,13 +85,12 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 
-  const data = (await searchRes.json()) as {
-    total_count: number;
-    items: Array<{ commit: { author: { date: string } } }>;
-  };
+  const data = (await searchRes.json()) as GitHubCommitSearchResponse;
 
+  const githubCommitsByDay: Record<string, number> = {};
+  const gitlabCommitsByDay: Record<string, number> = {};
   const commitsByDay: Record<string, number> = {};
-  const timeBlocks = {
+  const timeBlocks: TimeBlocks = {
     morning: 0, // 6-11
     afternoon: 0, // 12-17
     evening: 0, // 18-21
@@ -52,24 +100,67 @@ export async function GET(req: NextRequest) {
   for (const item of data.items) {
     const rawDate = item.commit.author.date;
     const date = rawDate.slice(0, 10);
-    commitsByDay[date] = (commitsByDay[date] ?? 0) + 1;
+    incrementDay(githubCommitsByDay, date, 1);
+    incrementDay(commitsByDay, date, 1);
+    incrementTimeBlocks(timeBlocks, rawDate, 1);
+  }
 
-    const hour = new Date(rawDate).getHours();
-    if (hour >= 6 && hour < 12) {
-      timeBlocks.morning++;
-    } else if (hour >= 12 && hour < 18) {
-      timeBlocks.afternoon++;
-    } else if (hour >= 18 && hour < 22) {
-      timeBlocks.evening++;
-    } else {
-      timeBlocks.night++;
+  let gitlabTotal = 0;
+  const gitlabToken =
+    typeof session.gitlabToken === "string" ? session.gitlabToken : null;
+
+  if (gitlabToken) {
+    try {
+      const gitlabRes = await fetch(
+        `${GITLAB_API}/events?action=pushed&per_page=100`,
+        {
+          headers: { Authorization: `Bearer ${gitlabToken}` },
+          cache: "no-store",
+        }
+      );
+
+      if (gitlabRes.ok) {
+        const events = (await gitlabRes.json()) as GitLabEvent[];
+        for (const event of events) {
+          if (!event.created_at) {
+            continue;
+          }
+
+          const createdAtMs = Date.parse(event.created_at);
+          if (Number.isNaN(createdAtMs) || createdAtMs < sinceMs) {
+            continue;
+          }
+
+          const commitCountRaw = event.push_data?.commit_count;
+          const commitCount =
+            typeof commitCountRaw === "number" && Number.isFinite(commitCountRaw)
+              ? commitCountRaw
+              : 1;
+
+          if (commitCount <= 0) {
+            continue;
+          }
+
+          const date = event.created_at.slice(0, 10);
+          incrementDay(gitlabCommitsByDay, date, commitCount);
+          incrementDay(commitsByDay, date, commitCount);
+          incrementTimeBlocks(timeBlocks, event.created_at, commitCount);
+          gitlabTotal += commitCount;
+        }
+      }
+    } catch {
+      // Non-fatal: fall back to GitHub-only data if GitLab fails.
     }
   }
 
   return Response.json({
     days,
-    total: data.total_count,
+    total: data.total_count + gitlabTotal,
     data: commitsByDay,
     timeBlocks,
+    sources: {
+      github: { total: data.total_count, data: githubCommitsByDay },
+      gitlab: gitlabToken ? { total: gitlabTotal, data: gitlabCommitsByDay } : null,
+    },
   });
 }

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -18,6 +18,39 @@ interface DayData {
   commits: number;
 }
 
+interface ContributionSourceData {
+  data?: Record<string, number>;
+}
+
+interface ContributionResponse {
+  data?: Record<string, number>;
+  sources?: {
+    github?: ContributionSourceData;
+    gitlab?: ContributionSourceData | null;
+  };
+}
+
+function mergeContributionSources(
+  response: ContributionResponse
+): Record<string, number> {
+  if (!response.sources) {
+    return response.data ?? {};
+  }
+
+  const merged: Record<string, number> = {};
+  const sources = [response.sources.github?.data, response.sources.gitlab?.data];
+  for (const source of sources) {
+    if (!source) continue;
+    for (const [day, commits] of Object.entries(source)) {
+      const count = typeof commits === "number" ? commits : Number(commits);
+      if (!Number.isFinite(count) || count <= 0) continue;
+      merged[day] = (merged[day] ?? 0) + count;
+    }
+  }
+
+  return merged;
+}
+
 type ViewMode = "bar" | "line";
 
 const RANGES = [
@@ -49,8 +82,9 @@ export default function ContributionGraph() {
         if (!r.ok) throw new Error("API error");
         return r.json();
       })
-      .then((res: { data: Record<string, number> }) => {
-        const sorted = Object.entries(res.data ?? {})
+      .then((res: ContributionResponse) => {
+        const merged = mergeContributionSources(res);
+        const sorted = Object.entries(merged)
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([day, commits]) => ({ day, commits }));
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -69,6 +69,8 @@ export const authOptions: NextAuthOptions = {
         session.githubId = token.githubId;
       if (typeof token.githubLogin === "string")
         session.githubLogin = token.githubLogin;
+      if (typeof token.gitlabToken === "string")
+        session.gitlabToken = token.gitlabToken;
       return session;
     },
   },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -5,6 +5,7 @@ declare module "next-auth" {
     accessToken?: string;
     githubId?: string;
     githubLogin?: string;
+    gitlabToken?: string;
     user?: DefaultSession["user"];
   }
 }
@@ -14,5 +15,6 @@ declare module "next-auth/jwt" {
     accessToken?: string;
     githubId?: string;
     githubLogin?: string;
+    gitlabToken?: string;
   }
 }


### PR DESCRIPTION
## Summary

Brief description of what this PR does.

Closes #10
## Type of Change

- [ ] Bug fix
- [ ..] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Fetch GitLab push events when session.gitlabToken exists and merge counts with GitHub commits.

- Return combined totals plus per‑source breakdown in the contributions response.

- Update ContributionGraph to merge source data for a unified chart.

## How to Test

Steps for the reviewer to verify this works:

1. Sign in and ensure session.gitlabToken is set.
2. Open the dashboard → verify ContributionGraph shows combined GitHub + GitLab activity.
3. Call GET /api/metrics/contributions?days=30 and confirm combined data + sources block.
4. Repeat without a GitLab token and confirm GitHub‑only behavior.


## Checklist

- [ ..] Linked issue in summary
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ..] Self-reviewed the diff
- [ ] Added/updated tests if applicable
