### PR TITLE
feat: Add repo pinning — pin up to 3 repos in TopRepos #221

### DIFF
--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
-import { supabaseAdmin, updateUserPublicFlag } from "@/lib/supabase";
+import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
@@ -12,22 +12,23 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Fetch user from Supabase
   const { data, error } = await supabaseAdmin
     .from("users")
-    .select("id, github_login, is_public")
+    .select("id, github_login, is_public, pinned_repos")
     .eq("github_id", session.githubId)
     .single();
 
   if (error) {
     console.error("Error fetching user:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch user settings" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to fetch user settings" }, { status: 500 });
   }
 
-  return NextResponse.json(data);
+  return NextResponse.json({
+    id: data.id,
+    github_login: data.github_login,
+    is_public: data.is_public,
+    pinned_repos: data.pinned_repos || [],
+  });
 }
 
 export async function PATCH(req: NextRequest) {
@@ -37,7 +38,6 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Get user ID from Supabase
   const { data: user, error: fetchError } = await supabaseAdmin
     .from("users")
     .select("id")
@@ -45,47 +45,50 @@ export async function PATCH(req: NextRequest) {
     .single();
 
   if (fetchError || !user) {
-    console.error("Error fetching user:", fetchError);
-    return NextResponse.json(
-      { error: "User not found" },
-      { status: 404 }
-    );
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
 
-  // Parse request body
-  let body: { is_public?: boolean };
+  let body: { is_public?: boolean; pinned_repos?: string[] };
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json(
-      { error: "Invalid request body" },
-      { status: 400 }
-    );
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const { is_public } = body;
+  const { is_public, pinned_repos } = body;
+  const updates: Record<string, any> = {};
 
-  if (typeof is_public !== "boolean") {
-    return NextResponse.json(
-      { error: "is_public must be a boolean" },
-      { status: 400 }
-    );
+  if (typeof is_public === "boolean") {
+    updates.is_public = is_public;
   }
 
-  // Update user public flag
-  const updated = await updateUserPublicFlag(user.id, is_public);
-
-  if (!updated) {
-    return NextResponse.json(
-      { error: "Failed to update settings" },
-      { status: 500 }
-    );
+  if (Array.isArray(pinned_repos)) {
+    if (pinned_repos.length > 3) {
+      return NextResponse.json({ error: "Maximum 3 pins allowed" }, { status: 400 });
+    }
+    updates.pinned_repos = pinned_repos;
   }
 
-  // Return updated user (only safe fields)
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "No updates provided" }, { status: 400 });
+  }
+
+  const { data: updated, error: updateError } = await supabaseAdmin
+    .from("users")
+    .update(updates)
+    .eq("id", user.id)
+    .select("id, github_login, is_public, pinned_repos")
+    .single();
+
+  if (updateError || !updated) {
+    console.error("Update error:", updateError);
+    return NextResponse.json({ error: "Failed to update settings" }, { status: 500 });
+  }
+
   return NextResponse.json({
     id: updated.id,
     github_login: updated.github_login,
     is_public: updated.is_public,
+    pinned_repos: updated.pinned_repos || [],
   });
 }

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -56,7 +56,7 @@ export async function PATCH(req: NextRequest) {
   }
 
   const { is_public, pinned_repos } = body;
-  const updates: Record<string, any> = {};
+  const updates: { is_public?: boolean; pinned_repos?: string[] } = {};
 
   if (typeof is_public === "boolean") {
     updates.is_public = is_public;

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -22,6 +22,46 @@ export default function TopRepos() {
   const [healthLoading, setHealthLoading] = useState(true);
   const [sortColumn, setSortColumn] = useState<"commits" | "name">("commits");
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
+  const [pinnedRepos, setPinnedRepos] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch("/api/user/settings")
+      .then((r) => r.json())
+      .then((d) => setPinnedRepos(d.pinned_repos || []))
+      .catch((err) => console.error("Failed to load pinned repos", err));
+  }, []);
+
+  const togglePin = async (repoFullName: string) => {
+    const isPinned = pinnedRepos.includes(repoFullName);
+    let newPinsArray: string[];
+    
+    if (isPinned) {
+      newPinsArray = pinnedRepos.filter(name => name !== repoFullName);
+    } else {
+      if (pinnedRepos.length >= 3) {
+        alert("Maximum 3 pins allowed");
+        return;
+      }
+      newPinsArray = [...pinnedRepos, repoFullName];
+    }
+
+    const prevPins = [...pinnedRepos];
+    setPinnedRepos(newPinsArray);
+
+    try {
+      const res = await fetch("/api/user/settings", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ pinned_repos: newPinsArray }),
+      });
+      if (!res.ok) throw new Error("Failed to update pins");
+    } catch (err) {
+      console.error(err);
+      setPinnedRepos(prevPins);
+    }
+  };
 
   const fetchRepos = useCallback(() => {
     setLoading(true);
@@ -67,11 +107,11 @@ export default function TopRepos() {
     return () => clearInterval(interval);
   }, [lastUpdated]);
 
-
   useEffect(() => {
     fetchRepos();
     fetchHealthScores();
   }, [fetchRepos, fetchHealthScores, selectedAccount]);
+
   // toggle sort: same column flips direction, new column resets to desc
   const handleSort = (column: "commits" | "name") => {
     if (sortColumn === column) {
@@ -81,8 +121,9 @@ export default function TopRepos() {
       setSortDirection("desc");
     }
   };
+
   // sort repos based on selected column and direction before rendering
-  const sortedRepos = [...repos].sort((a, b) => {
+  const baseSortedRepos = [...repos].sort((a, b) => {
     if (sortColumn === "name") {
       const nameA = (a.name.split("/")[1] ?? a.name).toLowerCase();
       const nameB = (b.name.split("/")[1] ?? b.name).toLowerCase();
@@ -95,7 +136,12 @@ export default function TopRepos() {
       : b.commits - a.commits;
   });
 
-  const maxCommits = sortedRepos[0]?.commits ?? 1;
+  const sortedRepos = [
+    ...pinnedRepos.map(pin => repos.find(r => r.name === pin)).filter(Boolean) as Repo[],
+    ...baseSortedRepos.filter(r => !pinnedRepos.includes(r.name))
+  ];
+
+  const maxCommits = repos.reduce((max, r) => Math.max(max, r.commits), 1);
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
@@ -130,10 +176,8 @@ export default function TopRepos() {
           </button>
         </div>
       ) : repos.length === 0 ? (
-        
         <p className="text-sm text-[var(--muted-foreground)]">No commits in the last {days} days.</p>
       ) : (
-      /* column headers — clicking sorts the list */
       <>
         <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)] mb-2 px-0">
           <button
@@ -161,6 +205,7 @@ export default function TopRepos() {
         </div>
         <ul className="space-y-3">
           {sortedRepos.map((repo, idx) => {
+            const isPinned = pinnedRepos.includes(repo.name);
             const barWidth = Math.max(
               Math.round((repo.commits / maxCommits) * 100),
               4
@@ -193,6 +238,11 @@ export default function TopRepos() {
                   >
                     <span className="mr-1 text-[var(--muted-foreground)]">#{idx + 1}</span>
                     {shortName}
+                    {isPinned && (
+                      <span className="ml-2 inline-flex items-center rounded-md bg-[color-mix(in_srgb,var(--accent)_10%,transparent)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--accent)] ring-1 ring-inset ring-[color-mix(in_srgb,var(--accent)_20%,transparent)] align-middle">
+                        Pinned
+                      </span>
+                    )}
                   </a>
                   <span className="shrink-0 flex items-center gap-2">
                     {healthLoading ? (
@@ -215,6 +265,29 @@ export default function TopRepos() {
                     <span className="text-[var(--muted-foreground)]">
                       {repo.commits} commit{repo.commits !== 1 ? "s" : ""}
                     </span>
+                    <button
+                      type="button"
+                      onClick={() => togglePin(repo.name)}
+                      className="ml-1 p-1 hover:bg-[var(--card-muted)] rounded-md transition-colors"
+                      title={isPinned ? "Unpin repository" : "Pin repository"}
+                      aria-label={isPinned ? `Unpin ${repo.name}` : `Pin ${repo.name}`}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill={isPinned ? "currentColor" : "none"}
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className={isPinned ? "text-[var(--accent)]" : "text-[var(--muted-foreground)]"}
+                      >
+                        <path d="M12 17v5" />
+                        <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+                      </svg>
+                    </button>
                   </span>
                 </div>
                 <div className="h-1.5 overflow-hidden rounded-full bg-[var(--control)]">
@@ -227,7 +300,7 @@ export default function TopRepos() {
             );
           })}
         </ul>
-        </>
+      </>
       )}
       {lastUpdated && (
         <p className="text-xs text-[var(--muted-foreground)] mt-2 text-right">

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -23,6 +23,7 @@ export default function TopRepos() {
   const [sortColumn, setSortColumn] = useState<"commits" | "name">("commits");
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
   const [pinnedRepos, setPinnedRepos] = useState<string[]>([]);
+  const [pinError, setPinError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/user/settings")
@@ -39,11 +40,13 @@ export default function TopRepos() {
       newPinsArray = pinnedRepos.filter(name => name !== repoFullName);
     } else {
       if (pinnedRepos.length >= 3) {
-        alert("Maximum 3 pins allowed");
+        setPinError("Maximum 3 pins allowed");
         return;
       }
       newPinsArray = [...pinnedRepos, repoFullName];
     }
+    
+    setPinError(null);
 
     const prevPins = [...pinnedRepos];
     setPinnedRepos(newPinsArray);
@@ -146,7 +149,12 @@ export default function TopRepos() {
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-[var(--card-foreground)]">Top Repositories</h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">Top Repositories</h2>
+          {pinError && (
+            <p className="text-xs text-[var(--destructive)]">{pinError}</p>
+          )}
+        </div>
         <select
           value={days}
           onChange={(e) => setDays(Number(e.target.value))}

--- a/supabase/migrations/20260518000000_add_pinned_repos_to_users.sql
+++ b/supabase/migrations/20260518000000_add_pinned_repos_to_users.sql
@@ -1,0 +1,10 @@
+-- Migration: Add pinned_repos column to users table
+-- Stores up to 3 pinned repository full_names (e.g. "owner/repo")
+
+alter table users
+  add column if not exists pinned_repos text[] not null default '{}';
+
+-- Optional: enforce the 3-pin limit at the DB level as a safety net
+alter table users
+  add constraint pinned_repos_max_3
+    check (array_length(pinned_repos, 1) is null or array_length(pinned_repos, 1) <= 3);


### PR DESCRIPTION
## Summary

Resolves #221 
This PR implements the "Repo Pinning" feature in the `TopRepos` widget, allowing users to pin up to 3 of their repositories so they always appear at the top of the list for permanent visibility.

Closes #221 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- **Frontend (`TopRepos.tsx`)**: 
  - Added a `pinnedRepos` state hooked up to `/api/user/settings` via `GET` to load existing pins.
  - Injected an interactive pin icon on each repository row with optimistic UI updates for pinning/unpinning.
  - Enforced a max 3-pin limit via a frontend alert.
  - Dynamically sorted the rendered list so pinned repositories naturally stay at the top in the exact order they were pinned, while unpinned repos retain their current sort order.
- **Backend (`route.ts`)**: 
  - Updated the `/api/user/settings` `GET` endpoint to include the `pinned_repos` column.
  - Refactored the `PATCH` endpoint to use a dynamic update payload, successfully processing updates for `pinned_repos` and `is_public` independently. Added validation for the 3-pin limit on the backend.
- **Database**:
  - Created a Supabase migration script (`20260518000000_add_pinned_repos_to_users.sql`) to add the `pinned_repos` `text[]` column to the `users` table, including a DB-level constraint to ensure a maximum of 3 pins.

## How to Test

Steps for the reviewer to verify this works:

1. Apply the new Supabase migration locally to add the `pinned_repos` column to your database.
2. Run the application and log in. Navigate to the dashboard where the `TopRepos` widget is displayed.
3. Click the pin icon on any repository. It should instantly jump to the top of the list and turn blue.
4. Pin 3 repositories. Try to pin a 4th — you should get an alert preventing you from doing so.
5. Refresh the page to verify that the pins persist correctly and remain at the top.

## Screenshots (if UI change)

Dark Mode:
<img width="1208" height="6923" alt="localhost_3000_dashboard (1)" src="https://github.com/user-attachments/assets/36638df5-e824-44a7-b9ea-104604259577" />
<img width="610" height="552" alt="Screenshot 2026-05-18 010410" src="https://github.com/user-attachments/assets/d73689e5-e1b1-409b-adf6-0c0ebcf5a3e2" />
<img width="622" height="547" alt="Screenshot 2026-05-18 010422" src="https://github.com/user-attachments/assets/7816f203-d106-4ce0-a958-c5b955207ea7" />

Max Alert:
<img width="1912" height="973" alt="image" src="https://github.com/user-attachments/assets/ea2e14e2-009d-47a7-acf2-900713a5a4bd" />

Light Mode:
<img width="1208" height="6923" alt="localhost_3000_dashboard" src="https://github.com/user-attachments/assets/6e01373b-afef-42f2-a32d-78753afdef59" />
<img width="628" height="559" alt="Screenshot 2026-05-18 010443" src="https://github.com/user-attachments/assets/aa70a13d-a16c-4603-92c1-13b67e2e4354" />
<img width="616" height="554" alt="Screenshot 2026-05-18 010433" src="https://github.com/user-attachments/assets/4a7aed54-8507-4e2b-bb76-8020bbbd6743" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable

