### PR TITLE
feat(toprepos): add sortable columns with asc/desc toggle

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -20,6 +20,8 @@ export default function TopRepos() {
   const [minutesAgo, setMinutesAgo] = useState(0);
   const [healthScores, setHealthScores] = useState<Record<string, RepoHealthScore>>({});
   const [healthLoading, setHealthLoading] = useState(true);
+  const [sortColumn, setSortColumn] = useState<"commits" | "name">("commits");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
 
   const fetchRepos = useCallback(() => {
     setLoading(true);
@@ -70,8 +72,30 @@ export default function TopRepos() {
     fetchRepos();
     fetchHealthScores();
   }, [fetchRepos, fetchHealthScores, selectedAccount]);
+  // toggle sort: same column flips direction, new column resets to desc
+  const handleSort = (column: "commits" | "name") => {
+    if (sortColumn === column) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortColumn(column);
+      setSortDirection("desc");
+    }
+  };
+  // sort repos based on selected column and direction before rendering
+  const sortedRepos = [...repos].sort((a, b) => {
+    if (sortColumn === "name") {
+      const nameA = (a.name.split("/")[1] ?? a.name).toLowerCase();
+      const nameB = (b.name.split("/")[1] ?? b.name).toLowerCase();
+      return sortDirection === "asc"
+        ? nameA.localeCompare(nameB)
+        : nameB.localeCompare(nameA);
+    }
+    return sortDirection === "asc"
+      ? a.commits - b.commits
+      : b.commits - a.commits;
+  });
 
-  const maxCommits = repos[0]?.commits ?? 1;
+  const maxCommits = sortedRepos[0]?.commits ?? 1;
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
@@ -106,10 +130,37 @@ export default function TopRepos() {
           </button>
         </div>
       ) : repos.length === 0 ? (
+        
         <p className="text-sm text-[var(--muted-foreground)]">No commits in the last {days} days.</p>
       ) : (
+      /* column headers — clicking sorts the list */
+      <>
+        <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)] mb-2 px-0">
+          <button
+            type="button"
+            onClick={() => handleSort("name")}
+            className="flex items-center gap-1 hover:text-[var(--card-foreground)] transition-colors"
+            aria-label="Sort by repository name"
+          >
+            Repository
+            <span aria-hidden="true">
+              {sortColumn === "name" ? (sortDirection === "asc" ? "↑" : "↓") : "↕"}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => handleSort("commits")}
+            className="flex items-center gap-1 hover:text-[var(--card-foreground)] transition-colors"
+            aria-label="Sort by commit count"
+          >
+            Commits
+            <span aria-hidden="true">
+              {sortColumn === "commits" ? (sortDirection === "asc" ? "↑" : "↓") : "↕"}
+            </span>
+          </button>
+        </div>
         <ul className="space-y-3">
-          {repos.map((repo, idx) => {
+          {sortedRepos.map((repo, idx) => {
             const barWidth = Math.max(
               Math.round((repo.commits / maxCommits) * 100),
               4
@@ -168,6 +219,7 @@ export default function TopRepos() {
             );
           })}
         </ul>
+        </>
       )}
       {lastUpdated && (
         <p className="text-xs text-[var(--muted-foreground)] mt-2 text-right">


### PR DESCRIPTION
## What does this PR do?
Adds clickable column headers to the TopRepos widget so users can sort repositories by name or commit count in ascending or descending order.

## Related issue
Closes #226

## Changes made
- Added `sortColumn` and `sortDirection` state to TopRepos component
- Added `handleSort` function that toggles direction on same column, resets to desc on new column
- Added column header buttons with ↑ ↓ ↕ arrow indicators
- Changed render to use `sortedRepos` instead of raw `repos` array
- Added `aria-label` on sort buttons for accessibility

## How to test
1. Sign in and go to the dashboard
2. Find the Top Repositories widget
3. Click "Repository" header — list sorts A→Z
4. Click "Repository" again — reverses to Z→A
5. Click "Commits" header — sorts by commit count high→low
6. Arrow indicators update to reflect current sort direction

## Screenshots
<img width="1896" height="682" alt="Screenshot 2026-05-18 012136" src="https://github.com/user-attachments/assets/ce8c8f18-19a7-43aa-9a3a-e6564ac3e67d" />

