### PR TITLE
fix: add aria-label and error handling to copy profile URL button

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -203,11 +203,11 @@ function SettingsPageContent() {
 
   const copyShareLink = () => {
     if (!settings) return;
-
     const link = `${window.location.origin}/u/${settings.github_login}`;
-    navigator.clipboard.writeText(link);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    navigator.clipboard.writeText(link).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => { });
   };
 
   const handleRemoveAccount = async (githubId: string) => {
@@ -343,7 +343,9 @@ function SettingsPageContent() {
                   className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--control)] px-4 py-2 text-sm text-[var(--card-foreground)] focus:outline-none"
                 />
                 <button
+                  type="button"
                   onClick={copyShareLink}
+                  aria-label="Copy profile URL"
                   className="px-4 py-2 rounded-lg bg-[var(--accent)] text-[var(--accent-foreground)] text-sm font-medium hover:opacity-90 transition-opacity"
                 >
                   {copied ? "Copied!" : "Copy"}


### PR DESCRIPTION
## Summary
Adds `aria-label="Copy profile URL"` to the copy button in the settings page, and adds proper `.then().catch()` error handling to `navigator.clipboard.writeText()` so "Copied!" only shows when the copy actually succeeds.

Closes #218 

## Type of Change
- [x] Bug fix

## Changes Made
- Added `aria-label="Copy profile URL"` to the copy button for screen reader accessibility
- Added `type="button"` to prevent accidental form submission
- Wrapped `navigator.clipboard.writeText()` in `.then().catch()` so `setCopied(true)` only runs on success
- Added empty `.catch(() => {})` to silently handle clipboard failures

## How to Test
1. Go to `http://localhost:3000/dashboard/settings`
2. Find the Share Profile section with the profile URL
3. Click the **Copy** button — it should show **"Copied!"** for 2 seconds then revert to **"Copy"**
4. Open DevTools (F12) → Elements tab → inspect the button and confirm `aria-label="Copy profile URL"` is present
5. In DevTools Console, run `navigator.clipboard.writeText = () => Promise.reject('denied')` to simulate clipboard failure, then click Copy — button should NOT show "Copied!"

## Screenshots (if UI change)
No visual change — the button looks the same but is now accessible and reliable.

## Checklist
- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable