### PR TITLE
feat: add pie chart toggle to LanguageBreakdown widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -746,7 +746,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1185,7 +1184,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1638,7 +1636,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2508,7 +2505,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2677,7 +2673,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4118,7 +4113,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4190,7 +4184,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5033,7 +5026,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5204,7 +5196,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5295,7 +5286,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5308,7 +5298,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6362,7 +6351,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6532,7 +6520,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
 
 interface Language {
   name: string;
@@ -30,6 +31,7 @@ function getColor(name: string): string {
 export default function LanguageBreakdown() {
   const [languages, setLanguages] = useState<Language[]>([]);
   const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<"bar" | "pie">("pie");
 
   useEffect(() => {
     setLoading(true);
@@ -42,7 +44,7 @@ export default function LanguageBreakdown() {
 
   const totalPercentage = languages.reduce((sum, lang) => sum + lang.percentage, 0);
   const roundedTotal = Math.round(totalPercentage * 10) / 10;
-  
+
   const displayLanguages = [...languages];
   if (roundedTotal < 100 && languages.length > 0) {
     displayLanguages.push({
@@ -52,11 +54,43 @@ export default function LanguageBreakdown() {
     });
   }
 
+  const chartData = displayLanguages.map((lang) => ({
+    name: lang.name,
+    value: lang.percentage,
+    color: getColor(lang.name),
+  }));
+
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <h2 className="text-lg font-semibold text-[var(--card-foreground)] mb-4">
-        Language Breakdown
-      </h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+          Language Breakdown
+        </h2>
+        <div className="flex gap-1 rounded-lg border border-gray-600 p-1">
+          <button
+            type="button"
+            onClick={() => setView("pie")}
+            className={`px-3 py-1 text-xs rounded-md transition-colors ${
+              view === "pie"
+                ? "bg-indigo-500 text-white"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            Pie
+          </button>
+          <button
+            type="button"
+            onClick={() => setView("bar")}
+            className={`px-3 py-1 text-xs rounded-md transition-colors ${
+              view === "bar"
+                ? "bg-[var(--primary)] text-white"
+                : "text-[var(--muted-foreground)]"
+            }`}
+          >
+            Bar
+          </button>
+        </div>
+      </div>
 
       {loading ? (
         <div className="space-y-3">
@@ -71,9 +105,54 @@ export default function LanguageBreakdown() {
         <p className="text-sm text-[var(--muted-foreground)]">
           No language data available.
         </p>
+      ) : view === "pie" ? (
+        <>
+          <ResponsiveContainer width="100%" height={200}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={55}
+                outerRadius={80}
+                dataKey="value"
+                paddingAngle={2}
+              >
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
+              </Pie>
+              <Tooltip
+                contentStyle={{
+                  background: "var(--tooltip)",
+                  color: "var(--tooltip-foreground)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "8px",
+                  fontSize: "12px",
+                }}
+                formatter={(value: number) => [`${value}%`]}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+          <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2">
+            {displayLanguages.map((lang) => (
+              <div key={lang.name} className="flex items-center gap-2 text-sm">
+                <span
+                  className="inline-block h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: getColor(lang.name) }}
+                />
+                <span className="truncate text-[var(--card-foreground)]">
+                  {lang.name}
+                </span>
+                <span className="ml-auto shrink-0 text-[var(--muted-foreground)]">
+                  {lang.percentage}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
       ) : (
         <>
-          {/* Stacked bar */}
           <div className="flex h-6 w-full overflow-hidden rounded-full bg-[var(--control)]">
             {displayLanguages.map((lang) => (
               <div
@@ -81,21 +160,23 @@ export default function LanguageBreakdown() {
                 className="h-full transition-all duration-500 first:rounded-l-full last:rounded-r-full"
                 style={{
                   width: `${lang.percentage}%`,
-                  backgroundColor: lang.name === "Other" ? "var(--control)" : getColor(lang.name),
+                  backgroundColor:
+                    lang.name === "Other" ? "var(--control)" : getColor(lang.name),
                   minWidth: lang.percentage > 0 ? "4px" : "0px",
                 }}
                 title={`${lang.name}: ${lang.percentage}%`}
               />
             ))}
           </div>
-
-          {/* Legend */}
           <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2">
             {displayLanguages.map((lang) => (
               <div key={lang.name} className="flex items-center gap-2 text-sm">
                 <span
                   className="inline-block h-3 w-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: lang.name === "Other" ? "var(--control)" : getColor(lang.name) }}
+                  style={{
+                    backgroundColor:
+                      lang.name === "Other" ? "var(--control)" : getColor(lang.name),
+                  }}
                 />
                 <span className="truncate text-[var(--card-foreground)]">
                   {lang.name}


### PR DESCRIPTION
## Summary

Closes #224

The existing LanguageBreakdown widget only showed a stacked bar chart. 
This PR adds a pie chart view with a Pie/Bar toggle button, as mentioned 
in the issue (pie/bar chart requirement).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added pie chart using Recharts PieChart component
- Added Pie/Bar toggle buttons in the widget header
- Pie chart is set as the default view
- Bar chart kept as alternative view


## How to Test

Steps for the reviewer to verify this works:

1. Sign in to the dashboard
2. Scroll down to Language Breakdown widget
3. Click Pie button to see pie chart
4. Click Bar button to see stacked bar chart

## Screenshots 

### Pie Chart View (Default)

<img width="900" height="868" alt="image" src="https://github.com/user-attachments/assets/d07b7f34-a5b6-4e15-8e13-b0537d8d75a1" />

*New pie chart view showing language distribution with Pie/Bar toggle buttons*

### Bar Chart View

<img width="1264" height="503" alt="image" src="https://github.com/user-attachments/assets/b972dbc8-a4d1-4b83-9083-c483ba2682be" />


*Original stacked bar chart view — still accessible via toggle*

## Checklist

- [x] Linked issue in summary
- [ ] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
