### PR TITLE
Feat/aria live sync announcement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "recharts": "^2.12.7"
       },
       "devDependencies": {
+        "@playwright/test": "1.49.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -29,8 +30,7 @@
         "eslint-config-next": "14.2.3",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5",
-        "@playwright/test": "1.49.1"
+        "typescript": "^5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -517,6 +517,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "devOptional": true,
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -748,6 +764,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1186,6 +1203,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1638,6 +1656,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2507,6 +2526,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2675,6 +2695,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4120,6 +4141,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4191,6 +4213,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5003,6 +5026,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "devOptional": true,
+      "dependencies": {
+        "playwright-core": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "devOptional": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5033,6 +5086,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5203,6 +5257,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5293,6 +5348,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5305,6 +5361,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6358,6 +6415,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6527,6 +6585,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6926,51 +6985,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
-      "dev": true,
-      "dependencies": {
-        "playwright": "1.49.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.49.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     }
   }

--- a/src/components/CIAnalytics.tsx
+++ b/src/components/CIAnalytics.tsx
@@ -74,10 +74,17 @@ export default function CIAnalytics() {
       </div>
 
       {loading ? (
-        <div className="grid grid-cols-2 gap-4">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="grid grid-cols-2 gap-4"
+        >
+          <span className="sr-only">Loading CI analytics</span>
           {[1, 2, 3, 4].map((item) => (
             <div
               key={item}
+              aria-hidden="true"
               className="h-20 rounded-lg bg-[var(--card-muted)] animate-pulse"
             />
           ))}

--- a/src/components/CommitTimeChart.tsx
+++ b/src/components/CommitTimeChart.tsx
@@ -111,10 +111,17 @@ export default function CommitTimeChart() {
 
       <div className="flex-1 min-h-[250px]">
         {loading ? (
-          <div className="flex h-full flex-col justify-end space-y-3 pt-6 pb-2">
+          <div
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+            className="flex h-full flex-col justify-end space-y-3 pt-6 pb-2"
+          >
+            <span className="sr-only">Loading commit time chart</span>
             {[1, 2, 3, 4].map((i) => (
               <div
                 key={i}
+                aria-hidden="true"
                 className="h-10 rounded bg-[var(--card-muted)] animate-pulse"
               />
             ))}

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -326,7 +326,17 @@ export default function ContributionGraph() {
       </div>
 
       {loading ? (
-        <div className="h-[220px] rounded border border-[var(--border)] bg-[var(--background)] animate-pulse" />
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+        >
+          <span className="sr-only">Loading contribution graph</span>
+          <div
+            aria-hidden="true"
+            className="h-[220px] rounded border border-[var(--border)] bg-[var(--background)] animate-pulse"
+          />
+        </div>
       ) : error ? (
         <div className="flex h-[220px] items-center rounded-lg border border-[var(--border)] bg-[var(--background)] px-4">
           <p className="text-sm text-[var(--muted-foreground)]">

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -101,6 +101,7 @@ export default function DashboardHeader() {
               Share Profile
             </a>
           )}
+          
           <KeyboardShortcuts />
 
           {/* Sync button */}
@@ -113,7 +114,6 @@ export default function DashboardHeader() {
           >
             {syncing ? "Syncing..." : "Sync"}
           </button>
-
 
           <UserAvatar />
           <ThemeToggle />

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import AccountToggle from "@/components/AccountToggle";
 import SignOutButton from "@/components/SignOutButton";
@@ -10,7 +10,12 @@ import KeyboardShortcuts from "@/components/KeyboardShortcuts";
 
 export default function DashboardHeader() {
   const { data: session } = useSession();
+
   const [isPublic, setIsPublic] = useState<boolean | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [announcement, setAnnouncement] = useState("");
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
 
   useEffect(() => {
     if (!session) {
@@ -36,8 +41,43 @@ export default function DashboardHeader() {
     loadSettings();
   }, [session]);
 
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  async function handleSync() {
+    if (syncing) return;
+    setSyncing(true);
+    setAnnouncement("");
+
+    try {
+      const res = await fetch("/api/metrics/contributions?days=30");
+      if (!res.ok) throw new Error("Sync failed");
+      setAnnouncement("Metrics refreshed successfully");
+    } catch {
+      setAnnouncement("Sync failed. Please try again.");
+    } finally {
+      setSyncing(false);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setAnnouncement(""), 3000);
+    }
+  }
+
   return (
     <header className="mb-8 border-b border-[var(--border)] p-4 pb-6">
+      {/* Visually hidden aria-live region for screen readers */}
+      <span
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {announcement}
+      </span>
+
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl md:text-3xl font-bold text-[var(--foreground)]">
@@ -49,6 +89,7 @@ export default function DashboardHeader() {
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
+
           {isPublic === true && session?.githubLogin && (
             <a
               href={`/u/${session.githubLogin}`}
@@ -61,6 +102,19 @@ export default function DashboardHeader() {
             </a>
           )}
           <KeyboardShortcuts />
+
+          {/* Sync button */}
+          <button
+            type="button"
+            onClick={handleSync}
+            disabled={syncing}
+            aria-label="Sync metrics"
+            className="px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--control)] text-[var(--card-foreground)] text-sm font-medium hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)] transition-colors disabled:opacity-50"
+          >
+            {syncing ? "Syncing..." : "Sync"}
+          </button>
+
+
           <UserAvatar />
           <ThemeToggle />
           <SignOutButton />

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -152,13 +152,19 @@ export default function GoalTracker() {
   if (loading) {
     return (
       <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-        <div className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse" />
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="mb-4">
-            <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse mb-2" />
-            <div className="h-2 bg-[var(--card-muted)] rounded animate-pulse" />
-          </div>
-        ))}
+        <div role="status" aria-live="polite" aria-busy="true">
+          <span className="sr-only">Loading weekly goals</span>
+          <div
+            aria-hidden="true"
+            className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse"
+          />
+          {[1, 2, 3].map((i) => (
+            <div key={i} aria-hidden="true" className="mb-4">
+              <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse mb-2" />
+              <div className="h-2 bg-[var(--card-muted)] rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/src/components/IssueMetrics.tsx
+++ b/src/components/IssueMetrics.tsx
@@ -61,10 +61,17 @@ export default function IssueMetrics() {
         Issue Analytics
       </h2>
       {loading ? (
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="grid grid-cols-2 md:grid-cols-5 gap-4"
+        >
+          <span className="sr-only">Loading issue analytics</span>
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
+              aria-hidden="true"
               className="h-20 rounded-lg bg-[var(--card-muted)] p-4 animate-pulse"
             />
           ))}

--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -59,9 +59,18 @@ export default function LanguageBreakdown() {
       </h2>
 
       {loading ? (
-        <div className="space-y-3">
-          <div className="h-6 rounded-full bg-[var(--card-muted)] animate-pulse" />
-          <div className="grid grid-cols-2 gap-2 mt-3">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="space-y-3"
+        >
+          <span className="sr-only">Loading language breakdown</span>
+          <div
+            aria-hidden="true"
+            className="h-6 rounded-full bg-[var(--card-muted)] animate-pulse"
+          />
+          <div aria-hidden="true" className="grid grid-cols-2 gap-2 mt-3">
             {[1, 2, 3, 4].map((i) => (
               <div key={i} className="h-5 rounded bg-[var(--card-muted)] animate-pulse" />
             ))}

--- a/src/components/PRBreakdownChart.tsx
+++ b/src/components/PRBreakdownChart.tsx
@@ -49,8 +49,17 @@ export default function PRBreakdownChart() {
   if (loading) {
     return (
       <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-        <div className="mb-4 h-5 w-40 rounded bg-[var(--card-muted)] animate-pulse" />
-        <div className="h-[200px] rounded bg-[var(--card-muted)] animate-pulse" />
+        <div role="status" aria-live="polite" aria-busy="true">
+          <span className="sr-only">Loading PR breakdown</span>
+          <div
+            aria-hidden="true"
+            className="mb-4 h-5 w-40 rounded bg-[var(--card-muted)] animate-pulse"
+          />
+          <div
+            aria-hidden="true"
+            className="h-[200px] rounded bg-[var(--card-muted)] animate-pulse"
+          />
+        </div>
       </div>
     );
   }

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -70,10 +70,17 @@ export default function PRMetrics() {
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Analytics</h2>
       {loading ? (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="grid grid-cols-2 md:grid-cols-4 gap-4"
+        >
+          <span className="sr-only">Loading PR analytics</span>
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
+              aria-hidden="true"
               className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse"
             />
           ))}

--- a/src/components/PersonalRecords.tsx
+++ b/src/components/PersonalRecords.tsx
@@ -251,10 +251,17 @@ export default function PersonalRecords() {
         Personal Records
       </h2>
       {loading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 items-stretch">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 items-stretch"
+        >
+          <span className="sr-only">Loading personal records</span>
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
+              aria-hidden="true"
               className="h-32 rounded-lg bg-[var(--card-muted)] p-4 animate-pulse"
             />
           ))}

--- a/src/components/PinnedRepos.tsx
+++ b/src/components/PinnedRepos.tsx
@@ -44,9 +44,19 @@ export default function PinnedRepos() {
         Pinned Repositories
       </h2>
       {loading ? (
-        <div className="space-y-3">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="space-y-3"
+        >
+          <span className="sr-only">Loading pinned repositories</span>
           {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="h-24 rounded-lg bg-[var(--card-muted)] animate-pulse" />
+            <div
+              key={i}
+              aria-hidden="true"
+              className="h-24 rounded-lg bg-[var(--card-muted)] animate-pulse"
+            />
           ))}
         </div>
       ) : error ? (

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -137,11 +137,17 @@ export default function StreakTracker() {
   if (loading) {
     return (
       <div className="bg-[var(--card)] rounded-xl p-6">
-        <div className="h-6 w-36 bg-[var(--card-muted)] rounded animate-pulse mb-4" />
-        <div className="grid grid-cols-2 gap-4">
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="bg-[var(--card-muted)] rounded-lg h-28 animate-pulse" />
-          ))}
+        <div role="status" aria-live="polite" aria-busy="true">
+          <span className="sr-only">Loading streak tracker</span>
+          <div
+            aria-hidden="true"
+            className="h-6 w-36 bg-[var(--card-muted)] rounded animate-pulse mb-4"
+          />
+          <div aria-hidden="true" className="grid grid-cols-2 gap-4">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="bg-[var(--card-muted)] rounded-lg h-28 animate-pulse" />
+            ))}
+          </div>
         </div>
       </div>
     );

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -113,9 +113,19 @@ export default function TopRepos() {
         </select>
       </div>
       {loading ? (
-        <div className="space-y-3">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="space-y-3"
+        >
+          <span className="sr-only">Loading top repositories</span>
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-10 rounded bg-[var(--card-muted)] animate-pulse" />
+            <div
+              key={i}
+              aria-hidden="true"
+              className="h-10 rounded bg-[var(--card-muted)] animate-pulse"
+            />
           ))}
         </div>
       ) : error ? (

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -63,10 +63,17 @@ export default function WeeklySummaryCard() {
 
       {!isCollapsed &&
         (loading ? (
-          <div className="mt-4 space-y-3">
+          <div
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+            className="mt-4 space-y-3"
+          >
+            <span className="sr-only">Loading weekly summary</span>
             {[1, 2, 3, 4, 5].map((i) => (
               <div
                 key={i}
+                aria-hidden="true"
                 className="h-14 rounded-lg bg-[var(--card-muted)] animate-pulse"
               />
             ))}


### PR DESCRIPTION
## Summary

Added an accessible `aria-live="polite"` region in `DashboardHeader` to announce sync status updates for screen reader users after metrics refresh actions.

Closes #216 

## Type of Change

* [x] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Added a visually hidden live region using `aria-live="polite"` and `role="status"` in `DashboardHeader`
* Updated announcement text after sync success and failure responses
* Added timeout cleanup logic to clear announcements after 3 seconds
* Prevented stale timeout issues on component unmount

## How to Test

Steps for the reviewer to verify this works:

1. Open the dashboard page
2. Trigger the Sync button
3. Verify that screen readers announce:

   * "Metrics refreshed successfully" on success
   * "Sync failed. Please try again." on failure
4. Confirm the announcement clears automatically after 3 seconds

## Screenshots (after UI change)

<img width="1874" height="158" alt="Screenshot 2026-05-18 194032" src="https://github.com/user-attachments/assets/a30d4faa-8cc6-432f-b085-4f4d0472f2d8" />

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [ ] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable
