### PR TITLE
Add public contributor leaderboard

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,230 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_API = "https://api.github.com";
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const RATE_LIMIT_REQUESTS = 20;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+type LeaderboardMetric = "streak" | "commits" | "prs";
+
+interface PublicUser {
+  id: string;
+  github_login: string;
+}
+
+interface LeaderboardEntry {
+  rank: number;
+  username: string;
+  avatarUrl: string;
+  profileUrl: string;
+  streak: number;
+  commits: number;
+  prs: number;
+  score: number;
+}
+
+interface LeaderboardPayload {
+  generatedAt: string;
+  refreshSeconds: number;
+  leaders: Record<LeaderboardMetric, LeaderboardEntry[]>;
+}
+
+let leaderboardCache: { expiresAt: number; payload: LeaderboardPayload } | null =
+  null;
+
+const ipRateLimits = new Map<string, { count: number; resetAt: number }>();
+
+function getRateLimitKey(req: NextRequest): string {
+  return (
+    req.ip ??
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown"
+  );
+}
+
+function checkRateLimit(ip: string): { allowed: boolean; retryAfter?: number } {
+  const now = Date.now();
+  const record = ipRateLimits.get(ip);
+
+  if (!record || now > record.resetAt) {
+    ipRateLimits.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { allowed: true };
+  }
+
+  if (record.count < RATE_LIMIT_REQUESTS) {
+    record.count += 1;
+    return { allowed: true };
+  }
+
+  return { allowed: false, retryAfter: Math.ceil((record.resetAt - now) / 1000) };
+}
+
+async function fetchGitHubJson<T>(path: string): Promise<T | null> {
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${GITHUB_API}${path}`, {
+    headers,
+    next: { revalidate: 3600 },
+  });
+
+  if (!res.ok) {
+    console.error("GitHub leaderboard request failed:", path, res.status);
+    return null;
+  }
+
+  return (await res.json()) as T;
+}
+
+function toDateStr(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function dateDiffDays(a: string, b: string): number {
+  return (new Date(b).getTime() - new Date(a).getTime()) / 86400000;
+}
+
+function calculateCurrentStreak(commitDates: string[]): number {
+  const days = Array.from(new Set(commitDates.map((date) => date.slice(0, 10)))).sort();
+  if (days.length === 0) {
+    return 0;
+  }
+
+  let runLength = 1;
+  const runs: { end: string; length: number }[] = [];
+  for (let i = 1; i < days.length; i += 1) {
+    if (dateDiffDays(days[i - 1], days[i]) === 1) {
+      runLength += 1;
+    } else {
+      runs.push({ end: days[i - 1], length: runLength });
+      runLength = 1;
+    }
+  }
+  runs.push({ end: days[days.length - 1], length: runLength });
+
+  const today = toDateStr(new Date());
+  const yesterday = toDateStr(new Date(Date.now() - 86400000));
+  const latest = runs[runs.length - 1];
+  return latest.end === today || latest.end === yesterday ? latest.length : 0;
+}
+
+async function fetchCommitStats(username: string, since: string) {
+  const query = new URLSearchParams({
+    q: `author:${username} author-date:>=${since}`,
+    per_page: "100",
+    sort: "author-date",
+    order: "desc",
+  });
+  return fetchGitHubJson<{
+    total_count: number;
+    items: Array<{ commit: { author: { date: string } } }>;
+  }>(`/search/commits?${query.toString()}`);
+}
+
+async function fetchPrCount(username: string, since: string): Promise<number> {
+  const query = new URLSearchParams({
+    q: `author:${username} type:pr created:>=${since}`,
+    per_page: "1",
+  });
+  const data = await fetchGitHubJson<{ total_count: number }>(
+    `/search/issues?${query.toString()}`
+  );
+  return data?.total_count ?? 0;
+}
+
+async function buildLeaderboard(): Promise<LeaderboardPayload> {
+  const { data: users, error } = await supabaseAdmin
+    .from("users")
+    .select("id, github_login")
+    .eq("is_public", true)
+    .eq("leaderboard_opt_in", true)
+    .limit(50);
+
+  if (error) {
+    console.error("Failed to fetch leaderboard users:", error);
+    throw new Error("Failed to load leaderboard users");
+  }
+
+  const now = new Date();
+  const monthStart = toDateStr(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)));
+  const streakStart = toDateStr(new Date(Date.now() - 90 * 86400000));
+
+  const rows = await Promise.all(
+    ((users ?? []) as PublicUser[]).map(async (user) => {
+      const [monthlyCommits, streakCommits, prs] = await Promise.all([
+        fetchCommitStats(user.github_login, monthStart),
+        fetchCommitStats(user.github_login, streakStart),
+        fetchPrCount(user.github_login, monthStart),
+      ]);
+
+      const streak = calculateCurrentStreak(
+        streakCommits?.items.map((item) => item.commit.author.date) ?? []
+      );
+      const commits = monthlyCommits?.total_count ?? 0;
+      const score = streak * 5 + commits + prs * 3;
+
+      return {
+        rank: 0,
+        username: user.github_login,
+        avatarUrl: `https://github.com/${user.github_login}.png?size=96`,
+        profileUrl: `/u/${user.github_login}`,
+        streak,
+        commits,
+        prs,
+        score,
+      };
+    })
+  );
+
+  const rankBy = (metric: LeaderboardMetric) =>
+    [...rows]
+      .sort((a, b) => b[metric] - a[metric] || b.score - a.score)
+      .slice(0, 50)
+      .map((entry, index) => ({ ...entry, rank: index + 1 }));
+
+  return {
+    generatedAt: now.toISOString(),
+    refreshSeconds: CACHE_TTL_MS / 1000,
+    leaders: {
+      streak: rankBy("streak"),
+      commits: rankBy("commits"),
+      prs: rankBy("prs"),
+    },
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const ip = getRateLimitKey(req);
+  const rateLimit = checkRateLimit(ip);
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded" },
+      { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
+    );
+  }
+
+  if (leaderboardCache && Date.now() < leaderboardCache.expiresAt) {
+    return NextResponse.json(leaderboardCache.payload);
+  }
+
+  try {
+    const payload = await buildLeaderboard();
+    leaderboardCache = { payload, expiresAt: Date.now() + CACHE_TTL_MS };
+    return NextResponse.json(payload);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to build leaderboard" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
-import { supabaseAdmin, updateUserPublicFlag } from "@/lib/supabase";
+import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +15,7 @@ export async function GET(req: NextRequest) {
   // Fetch user from Supabase
   const { data, error } = await supabaseAdmin
     .from("users")
-    .select("id, github_login, is_public")
+    .select("id, github_login, is_public, leaderboard_opt_in")
     .eq("github_id", session.githubId)
     .single();
 
@@ -53,7 +53,7 @@ export async function PATCH(req: NextRequest) {
   }
 
   // Parse request body
-  let body: { is_public?: boolean };
+  let body: { is_public?: boolean; leaderboard_opt_in?: boolean };
   try {
     body = await req.json();
   } catch {
@@ -63,19 +63,38 @@ export async function PATCH(req: NextRequest) {
     );
   }
 
-  const { is_public } = body;
+  const { is_public, leaderboard_opt_in } = body;
 
-  if (typeof is_public !== "boolean") {
+  if (
+    typeof is_public !== "boolean" &&
+    typeof leaderboard_opt_in !== "boolean"
+  ) {
     return NextResponse.json(
-      { error: "is_public must be a boolean" },
+      { error: "At least one boolean setting is required" },
       { status: 400 }
     );
   }
 
-  // Update user public flag
-  const updated = await updateUserPublicFlag(user.id, is_public);
+  const updates: { is_public?: boolean; leaderboard_opt_in?: boolean } = {};
+  if (typeof is_public === "boolean") {
+    updates.is_public = is_public;
+  }
+  if (typeof leaderboard_opt_in === "boolean") {
+    updates.leaderboard_opt_in = leaderboard_opt_in;
+    if (leaderboard_opt_in) {
+      updates.is_public = true;
+    }
+  }
 
-  if (!updated) {
+  const { data: updated, error: updateError } = await supabaseAdmin
+    .from("users")
+    .update(updates)
+    .eq("id", user.id)
+    .select("id, github_login, is_public, leaderboard_opt_in")
+    .single();
+
+  if (updateError || !updated) {
+    console.error("Error updating settings:", updateError);
     return NextResponse.json(
       { error: "Failed to update settings" },
       { status: 500 }
@@ -87,5 +106,6 @@ export async function PATCH(req: NextRequest) {
     id: updated.id,
     github_login: updated.github_login,
     is_public: updated.is_public,
+    leaderboard_opt_in: updated.leaderboard_opt_in ?? false,
   });
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -9,6 +9,7 @@ interface UserSettings {
   id: string;
   github_login: string;
   is_public: boolean;
+  leaderboard_opt_in: boolean;
 }
 
 interface LinkedAccount {
@@ -204,6 +205,30 @@ function SettingsPageContent() {
     }
   };
 
+  const handleToggleLeaderboard = async (value: boolean) => {
+    if (!settings) return;
+
+    setSaving(true);
+    try {
+      const res = await fetch("/api/user/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ leaderboard_opt_in: value }),
+      });
+
+      if (res.ok) {
+        const updated = await res.json();
+        setSettings(updated);
+      } else {
+        console.error("Failed to update leaderboard setting");
+      }
+    } catch (error) {
+      console.error("Error updating leaderboard setting:", error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const copyShareLink = () => {
     if (!settings) return;
     const link = `${window.location.origin}/u/${settings.github_login}`;
@@ -324,7 +349,7 @@ function SettingsPageContent() {
                   }`}
                 />
                 <div
-                  className={`absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition-transform ${
+                  className={`absolute left-1 top-1 h-4 w-4 rounded-full bg-[var(--card)] transition-transform ${
                     settings.is_public ? "translate-x-4" : ""
                   }`}
                 />
@@ -398,6 +423,51 @@ function SettingsPageContent() {
               </p>
             </div>
           )}
+        </div>
+
+        <div className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold text-[var(--card-foreground)]">
+                Public Leaderboard
+              </h2>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                Appear on the public leaderboard for streaks, commits, and pull
+                requests.
+              </p>
+            </div>
+
+            <label className="flex items-center cursor-pointer select-none">
+              <div className="relative">
+                <input
+                  type="checkbox"
+                  checked={settings.leaderboard_opt_in}
+                  onChange={(e) => handleToggleLeaderboard(e.target.checked)}
+                  disabled={saving}
+                  className="sr-only"
+                />
+                <div
+                  className={`block h-6 w-10 rounded-full transition-colors ${
+                    settings.leaderboard_opt_in
+                      ? "bg-[var(--accent)]"
+                      : "bg-[var(--control)]"
+                  }`}
+                />
+                <div
+                  className={`absolute left-1 top-1 h-4 w-4 rounded-full bg-[var(--card)] transition-transform ${
+                    settings.leaderboard_opt_in ? "translate-x-4" : ""
+                  }`}
+                />
+              </div>
+            </label>
+          </div>
+
+          <div className="mt-4 rounded-lg border border-[var(--border)] bg-[var(--control)] p-3">
+            <p className="text-sm text-[var(--muted-foreground)]">
+              Turning this on also enables your public profile so leaderboard
+              rows can link to your DevTrack stats.
+            </p>
+          </div>
         </div>
 
         <div className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,0 +1,183 @@
+import Link from "next/link";
+
+type LeaderboardTab = "streak" | "commits" | "prs";
+
+interface LeaderboardEntry {
+  rank: number;
+  username: string;
+  avatarUrl: string;
+  profileUrl: string;
+  streak: number;
+  commits: number;
+  prs: number;
+  score: number;
+}
+
+interface LeaderboardPayload {
+  generatedAt: string;
+  refreshSeconds: number;
+  leaders: Record<LeaderboardTab, LeaderboardEntry[]>;
+}
+
+const tabs: Array<{ id: LeaderboardTab; label: string; metric: string }> = [
+  { id: "streak", label: "Streak", metric: "days" },
+  { id: "commits", label: "Commits", metric: "this month" },
+  { id: "prs", label: "PRs", metric: "this month" },
+];
+
+async function fetchLeaderboard(): Promise<LeaderboardPayload | null> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    "http://localhost:3000";
+
+  try {
+    const res = await fetch(`${baseUrl}/api/leaderboard`, {
+      next: { revalidate: 3600 },
+    });
+
+    if (!res.ok) {
+      return null;
+    }
+
+    return (await res.json()) as LeaderboardPayload;
+  } catch (error) {
+    console.error("Failed to fetch leaderboard:", error);
+    return null;
+  }
+}
+
+function getMetricValue(entry: LeaderboardEntry, tab: LeaderboardTab): number {
+  if (tab === "streak") return entry.streak;
+  if (tab === "commits") return entry.commits;
+  return entry.prs;
+}
+
+export default async function LeaderboardPage({
+  searchParams,
+}: {
+  searchParams: { tab?: string };
+}) {
+  const activeTab = tabs.some((tab) => tab.id === searchParams.tab)
+    ? (searchParams.tab as LeaderboardTab)
+    : "streak";
+  const leaderboard = await fetchLeaderboard();
+  const activeMeta = tabs.find((tab) => tab.id === activeTab) ?? tabs[0];
+  const rows = leaderboard?.leaders[activeTab] ?? [];
+
+  return (
+    <main className="min-h-screen bg-[var(--background)] px-4 py-6 text-[var(--foreground)] md:px-8">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <Link
+              href="/"
+              className="text-sm font-medium text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            >
+              DevTrack
+            </Link>
+            <h1 className="mt-3 text-3xl font-bold text-[var(--foreground)] md:text-4xl">
+              Public Leaderboard
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm text-[var(--muted-foreground)] md:text-base">
+              Opted-in developers ranked by current streak, monthly commits,
+              and monthly pull request activity.
+            </p>
+          </div>
+
+          {leaderboard && (
+            <div className="text-sm text-[var(--muted-foreground)]">
+              Updated {new Date(leaderboard.generatedAt).toLocaleString()}
+            </div>
+          )}
+        </div>
+
+        <div className="mb-6 flex flex-wrap gap-2">
+          {tabs.map((tab) => {
+            const active = tab.id === activeTab;
+            return (
+              <Link
+                key={tab.id}
+                href={`/leaderboard?tab=${tab.id}`}
+                className={`rounded-lg border px-4 py-2 text-sm font-semibold transition-colors ${
+                  active
+                    ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-foreground)]"
+                    : "border-[var(--border)] bg-[var(--card)] text-[var(--card-foreground)] hover:bg-[var(--control)]"
+                }`}
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </div>
+
+        <section className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-sm">
+          <div className="grid grid-cols-[72px_1fr_110px_110px] border-b border-[var(--border)] bg-[var(--control)] px-4 py-3 text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)] md:grid-cols-[80px_1fr_140px_140px_120px]">
+            <div>Rank</div>
+            <div>Contributor</div>
+            <div>{activeMeta.label}</div>
+            <div className="hidden md:block">Score</div>
+            <div>Profile</div>
+          </div>
+
+          {!leaderboard ? (
+            <div className="px-4 py-12 text-center text-sm text-[var(--muted-foreground)]">
+              Leaderboard data is temporarily unavailable.
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="px-4 py-12 text-center text-sm text-[var(--muted-foreground)]">
+              No opted-in public profiles yet.
+            </div>
+          ) : (
+            rows.map((entry) => (
+              <div
+                key={`${activeTab}-${entry.username}`}
+                className="grid grid-cols-[72px_1fr_110px_110px] items-center border-b border-[var(--border)] px-4 py-4 last:border-b-0 md:grid-cols-[80px_1fr_140px_140px_120px]"
+              >
+                <div className="text-lg font-bold text-[var(--card-foreground)]">
+                  #{entry.rank}
+                </div>
+                <div className="flex min-w-0 items-center gap-3">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={entry.avatarUrl}
+                    alt=""
+                    className="h-10 w-10 rounded-full border border-[var(--border)]"
+                  />
+                  <div className="min-w-0">
+                    <div className="truncate font-semibold text-[var(--card-foreground)]">
+                      @{entry.username}
+                    </div>
+                    <div className="text-xs text-[var(--muted-foreground)]">
+                      {entry.commits} commits · {entry.prs} PRs · {entry.streak}d
+                      streak
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <div className="text-lg font-semibold text-[var(--card-foreground)]">
+                    {getMetricValue(entry, activeTab)}
+                  </div>
+                  <div className="text-xs text-[var(--muted-foreground)]">
+                    {activeMeta.metric}
+                  </div>
+                </div>
+                <div className="hidden text-sm font-medium text-[var(--card-foreground)] md:block">
+                  {entry.score}
+                </div>
+                <div>
+                  <Link
+                    href={entry.profileUrl}
+                    className="inline-flex rounded-lg border border-[var(--border)] px-3 py-2 text-sm font-medium text-[var(--card-foreground)] hover:bg-[var(--control)]"
+                  >
+                    View
+                  </Link>
+                </div>
+              </div>
+            ))
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -12,6 +12,7 @@ interface User {
   github_id: string;
   github_login: string;
   is_public: boolean;
+  leaderboard_opt_in: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -23,7 +24,7 @@ interface User {
 export async function getUserByUsername(username: string): Promise<User | null> {
   const { data, error } = await supabaseAdmin
     .from("users")
-    .select("id,github_id,github_login,is_public,created_at,updated_at")
+    .select("id,github_id,github_login,is_public,leaderboard_opt_in,created_at,updated_at")
     .eq("github_login", username)
     .eq("is_public", true)
     .single();
@@ -51,7 +52,7 @@ export async function updateUserPublicFlag(
     .from("users")
     .update({ is_public: isPublic })
     .eq("id", userId)
-    .select("id,github_id,github_login,is_public,created_at,updated_at")
+    .select("id,github_id,github_login,is_public,leaderboard_opt_in,created_at,updated_at")
     .single();
 
   if (error) {

--- a/supabase/migrations/20260519000000_add_leaderboard_opt_in.sql
+++ b/supabase/migrations/20260519000000_add_leaderboard_opt_in.sql
@@ -1,0 +1,7 @@
+-- Explicit opt-in for public leaderboard visibility.
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS leaderboard_opt_in boolean NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS users_leaderboard_opt_in_idx
+ON users(leaderboard_opt_in)
+WHERE leaderboard_opt_in = true;


### PR DESCRIPTION
## Summary
- add a public `/leaderboard` page with tabs for current streak, monthly commits, and monthly PRs
- add `/api/leaderboard` with hourly server-side caching, lightweight IP rate limiting, and GitHub-backed metric aggregation for opted-in public users
- add an explicit `leaderboard_opt_in` setting plus Supabase migration so leaderboard visibility is separate from simply having a public profile
- update settings so enabling leaderboard visibility also enables the public profile link used by leaderboard rows

Closes #259

## Testing
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/typescript/bin/tsc --noEmit` ✅
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/next/dist/bin/next lint` ✅ warnings only from pre-existing `BadgeSection` `<img>` usage and `CommitTimeChart` hook dependency
- `git diff --check` ✅
- `/Users/saurabhkumarbajpaiai/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/next/dist/bin/next build` ✅ compiled successfully, then stopped during page data collection because local `NEXT_PUBLIC_SUPABASE_URL` / Supabase env is not configured (`supabaseUrl is required`)

## GSSoC labels
Could you please add `gssoc:approved`, `level:advanced`, and `type:feature` if this matches the issue scope?