### PR TITLE
fix(security): prevent rate limit bypass via X-Forwarded-For spoofing

### DIFF
--- a/src/app/api/public/[username]/route.ts
+++ b/src/app/api/public/[username]/route.ts
@@ -19,12 +19,15 @@ const RATE_LIMIT_REQUESTS = 30;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
 
 function getRateLimitKey(req: NextRequest): string {
-  return (
-    req.headers.get("x-forwarded-for") ||
-    req.headers.get("x-real-ip") ||
-    req.ip ||
-    "unknown"
-  );
+  // req.ip is populated by the Next.js / Vercel runtime from the verified
+  // network-layer source address and cannot be spoofed by the caller.
+  //
+  // x-forwarded-for is intentionally excluded here: it is a plain request
+  // header that any client can set to an arbitrary value. Trusting it as the
+  // primary key allows an attacker to rotate the header on every request,
+  // bypass the per-IP limit entirely, and exhaust the shared GITHUB_TOKEN
+  // quota (5 000 req/hr), making the endpoint unavailable for all users.
+  return req.ip || req.headers.get("x-real-ip") || "unknown";
 }
 
 function checkRateLimit(ip: string): { allowed: boolean; retryAfter?: number } {


### PR DESCRIPTION
Closes #337

## What was wrong

`getRateLimitKey()` in `src/app/api/public/[username]/route.ts` used `x-forwarded-for` as the primary source for the rate limit key. This header is a plain HTTP request header — any caller can set it to an arbitrary value on every request. This made the 30 req/min in-memory rate limiter completely ineffective against anyone who rotated the header, allowing unbounded requests to the public profile endpoint and full exhaustion of the shared `GITHUB_TOKEN` quota (5,000 req/hr).

## What changed

- Removed `x-forwarded-for` from the rate limit key lookup chain
- `req.ip` is now the primary key — the Next.js/Vercel runtime populates this from the verified network-layer source address, which cannot be set by the caller
- `x-real-ip` is kept as a fallback for non-Vercel self-hosted deployments
- Added an explanatory comment in the function so the intentional exclusion of `x-forwarded-for` is clear to future contributors

## Files changed

- `src/app/api/public/[username]/route.ts` — `getRateLimitKey()` function only

## Testing

The fix can be verified locally by running the endpoint with a custom `X-Forwarded-For` header after more than 30 requests — the 429 response should now trigger based on the actual connection IP regardless of the header value.

## Type of change

- [x] Bug fix
- [x] Security improvement