### PR TITLE
fix(metrics): correct merged PR count and merge rate calculation

### DIFF
--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -34,30 +34,55 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
 
   const data = (await searchRes.json()) as {
     total_count: number;
-    items: Array<{ state: string; created_at: string; closed_at: string | null }>;
+    items: Array<{
+      state: string;
+      created_at: string;
+      closed_at: string | null;
+      // GitHub Search API includes a pull_request object on PR items.
+      // merged_at is non-null only when the PR was actually merged, as
+      // opposed to closed without merging.
+      pull_request?: { merged_at: string | null };
+    }>;
   };
 
   const open = data.items.filter((pr) => pr.state === "open").length;
-  const merged = data.items.filter((pr) => pr.state === "closed").length;
 
-  const closedPRs = data.items.filter((pr) => pr.closed_at);
+  // A PR with state "closed" may have been merged OR closed without merging
+  // (e.g. rejected, abandoned). Only count those with a non-null merged_at
+  // as truly merged so the dashboard does not inflate the merged count.
+  const merged = data.items.filter(
+    (pr) => pr.pull_request?.merged_at != null
+  ).length;
+
+  // Average review time: use only actually merged PRs so we measure the time
+  // from open to merge, not open to close-without-merge.
+  const mergedPRs = data.items.filter(
+    (pr) => pr.pull_request?.merged_at != null
+  );
   const avgReviewMs =
-    closedPRs.length > 0
-      ? closedPRs.reduce(
+    mergedPRs.length > 0
+      ? mergedPRs.reduce(
           (sum, pr) =>
             sum +
-            (new Date(pr.closed_at!).getTime() -
+            (new Date(pr.pull_request!.merged_at!).getTime() -
               new Date(pr.created_at).getTime()),
           0
-        ) / closedPRs.length
+        ) / mergedPRs.length
       : 0;
+
+  // Use the number of fetched items as the denominator for mergeRate.
+  // data.total_count is the all-time GitHub total (potentially thousands)
+  // while data.items is capped at 100, so dividing merged/total_count
+  // produces a near-zero rate for any active user. The fetched sample
+  // (open + merged + closed-without-merge) is the correct base.
+  const sampleTotal = data.items.length;
 
   return {
     open,
     merged,
     total: data.total_count,
     avgReviewHours: Math.round(avgReviewMs / 3600000),
-    mergeRate: data.total_count > 0 ? merged / data.total_count : 0,
+    mergeRate: sampleTotal > 0 ? merged / sampleTotal : 0,
   };
 }
 


### PR DESCRIPTION
Closes #339

## What was wrong

Two bugs in \`fetchPRMetrics()\` in \`src/app/api/metrics/prs/route.ts\` caused incorrect data for all users.

**Bug 1 — Wrong merged count:**
The GitHub Search API returns \`state: "closed"\` for both merged PRs and PRs closed without merging. The old code counted all closed PRs as merged. Fixed by checking \`pull_request.merged_at\`, which is non-null only for actually merged PRs.

**Bug 2 — Wrong merge rate denominator:**
\`mergeRate\` was computed as \`merged / data.total_count\` where \`total_count\` is the user's all-time PR count (potentially thousands) while \`merged\` was derived from \`data.items\`, capped at 100. This produced a near-zero rate for any active user. Fixed by using \`data.items.length\` (the fetched sample size) as the denominator.

**Bug 3 — avgReviewHours used wrong end timestamp:**
Average review time now uses \`pull_request.merged_at\` instead of \`closed_at\` and only counts actually merged PRs, giving a meaningful time-to-merge metric.

## Files changed

- \`src/app/api/metrics/prs/route.ts\` — \`fetchPRMetrics()\` function only

## Type of change

- [x] Bug fix
- [x] Data integrity improvement