### PR TITLE
fix(security): bind link-github OAuth state to authenticated session

### DIFF
--- a/src/app/api/auth/link-github/callback/route.ts
+++ b/src/app/api/auth/link-github/callback/route.ts
@@ -44,6 +44,19 @@ export async function GET(req: NextRequest) {
     );
   }
 
+  // Verify the state was generated for this session's user.
+  // The state format is `<nonce>.<githubId>` (set in the initiation handler).
+  // Without this check, an attacker who places their state cookie on a
+  // victim's browser can trick the callback into linking the attacker's
+  // secondary GitHub account to the victim's devtrack profile.
+  const embeddedGithubId = state.split(".").slice(1).join(".");
+  if (!embeddedGithubId || embeddedGithubId !== session.githubId) {
+    return NextResponse.redirect(
+      buildSettingsRedirect("error", "invalid_state"),
+      { status: 302 }
+    );
+  }
+
   const redirectUri = `${process.env.NEXTAUTH_URL ?? ""}/api/auth/link-github/callback`;
 
   const tokenResponse = await fetch("https://github.com/login/oauth/access_token", {

--- a/src/app/api/auth/link-github/route.ts
+++ b/src/app/api/auth/link-github/route.ts
@@ -13,7 +13,14 @@ export async function GET() {
     );
   }
 
-  const state = randomBytes(32).toString("hex");
+  // Bind the random nonce to the authenticated session by appending the
+  // session user's GitHub ID. The callback verifies that the ID embedded
+  // in the state matches the session that completes the flow, so a
+  // state cookie placed on a different user's browser (e.g. via XSS or
+  // cookie tossing) cannot be used to link an attacker's GitHub account
+  // to the victim's devtrack profile.
+  const nonce = randomBytes(32).toString("hex");
+  const state = `${nonce}.${session.githubId}`;
   const baseUrl = process.env.NEXTAUTH_URL ?? "";
   const redirectUri = `${baseUrl}/api/auth/link-github/callback`;
 


### PR DESCRIPTION
Closes #341

## What was wrong

The OAuth \`state\` in \`/api/auth/link-github\` was a random nonce with no binding to the authenticated user's session. An attacker who places their state cookie on a victim's browser can redirect the victim to the callback URL with the attacker's OAuth code. The callback passes the cookie/state match check and links the attacker's secondary GitHub account to the victim's devtrack profile under the victim's session.

## What changed

**\`src/app/api/auth/link-github/route.ts\`**
- State is now \`<nonce>.<session.githubId>\` instead of just a random nonce
- The session user's GitHub ID is embedded so the callback can verify it

**\`src/app/api/auth/link-github/callback/route.ts\`**
- After the existing cookie/state match check, extracts the embedded githubId from the state
- Verifies the embedded ID equals \`session.githubId\`
- Rejects with \`invalid_state\` if they differ — a state generated for user A cannot complete the flow under user B's session

## Why this is safe

GitHub IDs are numeric integers and will never contain a \`.\`, so the \`<nonce>.<githubId>\` format parses unambiguously. The 32-byte random nonce prefix still prevents brute-force state guessing.

## Files changed

- \`src/app/api/auth/link-github/route.ts\`
- \`src/app/api/auth/link-github/callback/route.ts\`

## Type of change

- [x] Security fix
- [x] Bug fix