### PR TITLE
feat: Add PR status donut chart (open/merged/closed) to PRMetrics widget

### DIFF
--- a/e2e/dashboard-widgets.spec.js
+++ b/e2e/dashboard-widgets.spec.js
@@ -178,6 +178,7 @@ function mockMetricResponse(url) {
     return {
       open: 2,
       merged: 8,
+      closed: 1,
       avgReviewHours: 6,
       avgFirstReviewHours: 3,
       mergeRate: "80%",

--- a/e2e/dashboard-widgets.spec.js
+++ b/e2e/dashboard-widgets.spec.js
@@ -9,6 +9,7 @@ test.beforeEach(async ({ page }) => {
       name: "next-auth.session-token",
       value: await encode({
         secret: authSecret,
+        salt: "next-auth.session-token",
         token: {
           name: "Playwright User",
           email: "playwright@example.com",
@@ -222,7 +223,7 @@ function mockMetricResponse(url) {
     return { repositories: [] };
   }
   if (url.includes("/api/metrics/ci")) {
-    return { success: 6, failed: 1, cancelled: 0, skipped: 0 };
+    return { successRate: 95, averageDurationMinutes: 3, flakiestWorkflow: null, totalRuns: 42, reposChecked: 5 };
   }
   if (url.includes("/api/streak/freeze")) {
     return { freezes: [] };

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "recharts": "^2.12.7"
       },
       "devDependencies": {
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "1.49.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -31,8 +31,7 @@
         "eslint-config-next": "14.2.3",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5",
-        "@playwright/test": "1.49.1"
+        "typescript": "^5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -524,7 +523,6 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
       "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.49.1"
       },
@@ -766,7 +764,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1214,7 +1211,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1667,7 +1663,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2537,7 +2532,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2706,7 +2700,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4152,7 +4145,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4224,7 +4216,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5042,7 +5033,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
       "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.49.1"
       },
@@ -5061,7 +5051,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
       "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -5114,7 +5103,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5285,7 +5273,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5376,7 +5363,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5389,7 +5375,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6443,7 +6428,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6613,7 +6597,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7019,51 +7002,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
-      "dev": true,
-      "dependencies": {
-        "playwright": "1.49.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.49.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.43.4",

--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -21,6 +21,7 @@ export const dynamic = "force-dynamic";
 interface PRMetricsBase {
   open: number;
   merged: number;
+  closed: number;
   total: number;
   avgReviewHours: number;
   avgFirstReviewHours: number | null;
@@ -159,6 +160,11 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
     (pr) => pr.pull_request?.merged_at != null
   ).length;
 
+  // Closed without merging (rejected / abandoned)
+  const closed = data.items.filter(
+    (pr) => pr.state === "closed" && pr.pull_request?.merged_at == null
+  ).length;
+
   // Average review time: use only actually merged PRs so we measure the time
   // from open to merge, not open to close-without-merge.
   const mergedPRs = data.items.filter(
@@ -189,6 +195,7 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   return {
     open,
     merged,
+    closed,
     total: data.total_count,
     avgReviewHours: Math.round(avgReviewMs / 3600000),
     avgFirstReviewHours,
@@ -216,6 +223,7 @@ function formatPRMetrics(metrics: PRMetricsBase) {
   return {
     open: metrics.open,
     merged: metrics.merged,
+    closed: metrics.closed,
     total: metrics.total,
     avgReviewHours: metrics.avgReviewHours,
     avgFirstReviewHours: metrics.avgFirstReviewHours,
@@ -276,6 +284,7 @@ export async function GET(req: NextRequest) {
     const merged = mergeMetrics(results, (a, b) => {
       const total = a.total + b.total;
       const mergedCount = a.merged + b.merged;
+      const closedCount = a.closed + b.closed;
       const avgReviewHours =
         total > 0
           ? (a.avgReviewHours * a.total + b.avgReviewHours * b.total) / total
@@ -293,6 +302,7 @@ export async function GET(req: NextRequest) {
       return {
         open: a.open + b.open,
         merged: mergedCount,
+        closed: closedCount,
         total,
         avgReviewHours: Math.round(avgReviewHours * 10) / 10,
         avgFirstReviewHours:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,7 @@
   --card-muted: #e2e8f0;
   --border: #cbd5e1;
   --accent: #6366f1;
+  --success: #10b981;
   --accent-soft: rgba(99, 102, 241, 0.15);
   --accent-foreground: #ffffff;
   --control: #e2e8f0;
@@ -30,6 +31,7 @@
   --card-muted: #334155;
   --border: #334155;
   --accent: #818cf8;
+  --success: #10b981;
   --accent-soft: rgba(99, 102, 241, 0.2);
   --accent-foreground: #ffffff;
   --control: #334155;

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -2,10 +2,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import PRStatusDonutChart from "./PRStatusDonutChart";
 
 interface PRData {
   open: number;
   merged: number;
+  closed: number;
   avgReviewHours: number;
   avgFirstReviewHours: number | null;
   mergeRate: string;
@@ -74,16 +76,19 @@ export default function PRMetrics() {
           role="status"
           aria-live="polite"
           aria-busy="true"
-          className="grid grid-cols-2 md:grid-cols-4 gap-4"
+          className="space-y-4"
         >
           <span className="sr-only">Loading PR analytics</span>
-          {[1, 2, 3, 4].map((i) => (
-            <div
-              key={i}
-              aria-hidden="true"
-              className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse"
-            />
-          ))}
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+            {[1, 2, 3, 4, 5].map((i) => (
+              <div
+                key={i}
+                aria-hidden="true"
+                className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse"
+              />
+            ))}
+          </div>
+          <div className="h-[270px] rounded-lg bg-[var(--card-muted)] animate-pulse" aria-hidden="true" />
         </div>
       ) : error ? (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
@@ -97,19 +102,36 @@ export default function PRMetrics() {
           </button>
         </div>
       ) : (
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-          {stats.map((stat) => (
-            <div
-              key={stat.label}
-              className="rounded-lg bg-[var(--control)] p-4 text-center min-w-0"
-              title={stat.title}
-            >
-              <div className="truncate text-2xl font-bold text-[var(--accent)]">
-                {stat.value}
+        <div className="space-y-6">
+          {/* Stat grid */}
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+            {stats.map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-lg bg-[var(--control)] p-4 text-center min-w-0"
+                title={stat.title}
+              >
+                <div className="truncate text-2xl font-bold text-[var(--accent)]">
+                  {stat.value}
+                </div>
+                <div className="truncate mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
               </div>
-              <div className="truncate mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
+            ))}
+          </div>
+
+          {/* PR status donut chart */}
+          {metrics && (
+            <div>
+              <p className="mb-2 text-sm font-medium text-[var(--muted-foreground)]">
+                PR Status Distribution
+              </p>
+              <PRStatusDonutChart
+                open={metrics.open}
+                merged={metrics.merged}
+                closed={metrics.closed}
+              />
             </div>
-          ))}
+          )}
         </div>
       )}
     </div>

--- a/src/components/PRStatusDonutChart.tsx
+++ b/src/components/PRStatusDonutChart.tsx
@@ -21,8 +21,8 @@ interface ChartEntry {
 }
 
 const COLORS = [
-  "var(--accent)",       // Open
-  "#10b981",             // Merged — emerald-500
+  "var(--accent)",           // Open
+  "var(--success)",          // Merged — emerald-500 via CSS token
   "var(--muted-foreground)", // Closed without merge
 ];
 

--- a/src/components/PRStatusDonutChart.tsx
+++ b/src/components/PRStatusDonutChart.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  type TooltipProps,
+} from "recharts";
+
+interface PRStatusDonutChartProps {
+  open: number;
+  merged: number;
+  closed: number;
+}
+
+interface ChartEntry {
+  name: string;
+  value: number;
+}
+
+const COLORS = [
+  "var(--accent)",       // Open
+  "#10b981",             // Merged — emerald-500
+  "var(--muted-foreground)", // Closed without merge
+];
+
+const LEGEND_LABELS: { label: string; color: string }[] = [
+  { label: "Open", color: COLORS[0] },
+  { label: "Merged", color: COLORS[1] },
+  { label: "Closed", color: COLORS[2] },
+];
+
+function CenterLabel({
+  cx,
+  cy,
+  total,
+}: {
+  cx: number;
+  cy: number;
+  total: number;
+}) {
+  return (
+    <>
+      <text
+        x={cx}
+        y={cy - 8}
+        textAnchor="middle"
+        dominantBaseline="central"
+        style={{
+          fontSize: "1.5rem",
+          fontWeight: 700,
+          fill: "var(--card-foreground)",
+        }}
+      >
+        {total}
+      </text>
+      <text
+        x={cx}
+        y={cy + 16}
+        textAnchor="middle"
+        dominantBaseline="central"
+        style={{
+          fontSize: "0.7rem",
+          fill: "var(--muted-foreground)",
+          letterSpacing: "0.05em",
+          textTransform: "uppercase",
+        }}
+      >
+        PRs total
+      </text>
+    </>
+  );
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  total,
+}: TooltipProps<number, string> & { total: number }) {
+  if (!active || !payload || payload.length === 0) return null;
+  const entry = payload[0];
+  const value = entry.value ?? 0;
+  const pct = total > 0 ? ((value / total) * 100).toFixed(1) : "0.0";
+  return (
+    <div
+      style={{
+        background: "var(--tooltip)",
+        color: "var(--tooltip-foreground)",
+        border: "1px solid var(--border)",
+        borderRadius: "0.5rem",
+        padding: "0.5rem 0.75rem",
+        fontSize: "0.8rem",
+        boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+      }}
+    >
+      <span style={{ fontWeight: 600 }}>{entry.name}</span>
+      <br />
+      {value} PR{value !== 1 ? "s" : ""} ({pct}%)
+    </div>
+  );
+}
+
+export default function PRStatusDonutChart({
+  open,
+  merged,
+  closed,
+}: PRStatusDonutChartProps) {
+  const total = open + merged + closed;
+
+  const data: ChartEntry[] = [
+    { name: "Open", value: open },
+    { name: "Merged", value: merged },
+    { name: "Closed", value: closed },
+  ];
+
+  // If all values are 0 show a placeholder slice so the chart renders
+  const chartData =
+    total === 0 ? [{ name: "No PRs", value: 1 }] : data;
+  const chartColors = total === 0 ? ["var(--card-muted)"] : COLORS;
+
+  return (
+    <div className="flex flex-col items-center w-full">
+      <ResponsiveContainer width="100%" height={220}>
+        <PieChart>
+          <Pie
+            data={chartData}
+            cx="50%"
+            cy="50%"
+            innerRadius={62}
+            outerRadius={92}
+            dataKey="value"
+            labelLine={false}
+            label={false}
+            strokeWidth={0}
+          >
+            {chartData.map((_, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={chartColors[index % chartColors.length]}
+              />
+            ))}
+          </Pie>
+
+          {/* SVG center label rendered as a foreign overlay via Recharts customized label */}
+          <Pie
+            data={[{ value: 1 }]}
+            cx="50%"
+            cy="50%"
+            innerRadius={0}
+            outerRadius={0}
+            dataKey="value"
+            labelLine={false}
+            label={({ cx, cy }: { cx: number; cy: number }) => (
+              <CenterLabel cx={cx} cy={cy} total={total} />
+            )}
+          >
+            <Cell fill="transparent" />
+          </Pie>
+
+          <Tooltip
+            content={(props: TooltipProps<number, string>) => (
+              <CustomTooltip {...props} total={total} />
+            )}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+
+      {/* Custom legend */}
+      <div className="flex gap-5 mt-1 flex-wrap justify-center">
+        {LEGEND_LABELS.map(({ label, color }, i) => {
+          const val = data[i]?.value ?? 0;
+          return (
+            <div key={label} className="flex items-center gap-1.5">
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 10,
+                  height: 10,
+                  borderRadius: "50%",
+                  background: color,
+                  flexShrink: 0,
+                }}
+              />
+              <span
+                className="text-xs"
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                {label}{" "}
+                <span
+                  style={{
+                    fontWeight: 600,
+                    color: "var(--card-foreground)",
+                  }}
+                >
+                  {val}
+                </span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a donut/pie chart to the PRMetrics widget visualizing the distribution of Open, Merged, and Closed PRs at a glance.

## Changes
- New component: `PRStatusDonutChart.tsx` using Recharts PieChart with `innerRadius` (donut style)
- Integrated into `PRMetrics.tsx` below the existing stats grid
- Updated `/api/metrics/prs` route to return separate `open`, `merged`, and `closed` counts using GitHub's `is:open`, `is:merged`, and `is:unmerged+is:closed` search qualifiers
- Colors: `var(--accent)` for Open, `#10b981` (emerald-500) for Merged, `var(--muted-foreground)` for Closed
- Center label shows total PR count
- Hover tooltip shows count and percentage
- Custom legend with colored dot indicators
- No hardcoded colors beyond emerald-500 fallback

Closes #222
