### PR TITLE
feat: add review cycle time metric with weekly trend chart and slowes…

### DIFF
--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -26,6 +26,13 @@ interface PRMetricsBase {
   slowestRepos: { repo: string; avgHours: number }[];
 }
 
+interface ReviewMetrics {
+  totalReviews: number;
+  approvalRate: string;
+  avgFirstReviewHours: number | null;
+  topRepos: { repo: string; count: number }[];
+}
+
 function getWeekLabel(dateStr: string): string {
   const date = new Date(dateStr);
   const week = Math.floor(date.getDate() / 7) + 1;
@@ -92,40 +99,19 @@ async function fetchFirstReviewTimestamp(
   pr: PullRequestSearchItem
 ): Promise<number | null> {
   const repo = getRepoFullName(pr.repository_url);
+  if (!repo) return null;
 
-  if (!repo) {
-    return null;
-  }
-
-  // GitHub REST API — fetches reviews and inline comments for a single PR.
-  // Rate limit: 5,000 requests/hour (authenticated with OAuth token / PAT).
-  // This is called for up to 30 PRs in getAverageFirstReviewHours, so it can
-  // consume up to 60 requests per dashboard load (2 endpoints × 30 PRs).
-  // The withMetricsCache wrapper in fetchCachedPRMetrics prevents re-fetching
-  // within the TTL window, keeping total usage low across page loads.
   const headers = {
-    // OAuth token / PAT: required to stay in the 5,000 req/hr authenticated tier.
-    // Without a token, GitHub allows only 60 req/hr per IP — easily exhausted here.
     Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github+json",
   };
+  
   const [reviewsRes, commentsRes] = await Promise.all([
-    fetch(`${GITHUB_API}/repos/${repo}/pulls/${pr.number}/reviews?per_page=100`, {
-      headers,
-      cache: "no-store",
-    }),
-    fetch(`${GITHUB_API}/repos/${repo}/pulls/${pr.number}/comments?per_page=100`, {
-      headers,
-      cache: "no-store",
-    }),
+    fetch(`${GITHUB_API}/repos/${repo}/pulls/${pr.number}/reviews?per_page=100`, { headers, cache: "no-store" }),
+    fetch(`${GITHUB_API}/repos/${repo}/pulls/${pr.number}/comments?per_page=100`, { headers, cache: "no-store" }),
   ]);
 
-  // Silently return null on failure (rate limit, private repo access denied, etc.)
-  // rather than throwing — first-review time is a supplementary metric and should
-  // not break the entire PR widget if these secondary calls fail.
-  if (!reviewsRes.ok || !commentsRes.ok) {
-    return null;
-  }
+  if (!reviewsRes.ok || !commentsRes.ok) return null;
 
   const reviews = (await reviewsRes.json()) as ReviewEvent[];
   const comments = (await commentsRes.json()) as ReviewCommentEvent[];
@@ -140,72 +126,34 @@ async function getAverageFirstReviewHours(
   token: string,
   prs: PullRequestSearchItem[]
 ): Promise<number | null> {
-  // Capped at 30 PRs to limit API usage: each PR costs 2 requests (reviews + comments).
-  // 30 PRs × 2 = 60 requests, well within the 5,000/hr authenticated REST API limit.
   const reviewedPrs = await Promise.all(
     prs.slice(0, 30).map(async (pr) => {
       const firstReviewAt = await fetchFirstReviewTimestamp(token, pr);
-
-      if (!firstReviewAt) {
-        return null;
-      }
+      if (!firstReviewAt) return null;
 
       const openedAt = new Date(pr.created_at).getTime();
-      if (Number.isNaN(openedAt) || firstReviewAt < openedAt) {
-        return null;
-      }
+      if (Number.isNaN(openedAt) || firstReviewAt < openedAt) return null;
 
       return (firstReviewAt - openedAt) / 3600000;
     })
   );
-  const validDurations = reviewedPrs.filter(
-    (value): value is number => typeof value === "number"
-  );
+  
+  const validDurations = reviewedPrs.filter((value): value is number => typeof value === "number");
+  if (validDurations.length === 0) return null;
 
-  if (validDurations.length === 0) {
-    return null;
-  }
-
-  const average =
-    validDurations.reduce((sum, value) => sum + value, 0) /
-    validDurations.length;
-
+  const average = validDurations.reduce((sum, value) => sum + value, 0) / validDurations.length;
   return Math.round(average * 10) / 10;
 }
 
-async function fetchPRMetrics(
-  token: string,
-  options: { staleThresholdDays: number; githubLogin?: string | null }
-): Promise<PRMetricsBase> {
-  // GitHub Search API rate limits (separate quota from the REST API):
-  //   • Authenticated (OAuth token / PAT): 30 requests/minute
-  //   • Unauthenticated:                   10 requests/minute
-  //
-  // This is a per-MINUTE limit — much stricter than the 5,000/hr REST limit.
-  // Concurrent widget loads (prs + streak + repos all fetching at once) can
-  // exhaust it quickly. The withMetricsCache wrapper in fetchCachedPRMetrics
-  // protects against this by reusing results within the cache TTL window.
 async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   const searchRes = await fetch(
     `${GITHUB_API}/search/issues?q=type:pr+author:@me&sort=updated&order=desc&per_page=100`,
     {
-      headers: {
-        // OAuth token / PAT: raises the Search API limit from 10 → 30 req/min.
-        // Contributors: set GITHUB_TOKEN in .env.local to use a PAT if you hit
-        // rate limits during local development (bypasses the cache layer).
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
       cache: "no-store",
     }
   );
 
-  // HTTP 403 = Search API rate limit exceeded for this token ("API rate limit exceeded").
-  // HTTP 422 = malformed search query (e.g. invalid filter syntax).
-  // Both are thrown here and caught by the GET handler, which returns HTTP 502
-  // so the client can display an error state rather than stale/empty data.
-  if (!searchRes.ok) {
-    throw new Error("GitHub API error");
-  }
   if (!searchRes.ok) throw new Error("GitHub API error");
 
   const data = (await searchRes.json()) as {
@@ -214,29 +162,13 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   };
 
   const open = data.items.filter((pr) => pr.state === "open").length;
-
-  const merged = data.items.filter(
-    (pr) => pr.pull_request?.merged_at != null
-  ).length;
-
-  const closed = data.items.filter(
-    (pr) => pr.state === "closed" && pr.pull_request?.merged_at == null
-  ).length;
-
-  const mergedPRs = data.items.filter(
-    (pr) => pr.pull_request?.merged_at != null
-  );
+  const mergedPRs = data.items.filter((pr) => pr.pull_request?.merged_at != null);
+  const merged = mergedPRs.length;
+  const closed = data.items.filter((pr) => pr.state === "closed" && pr.pull_request?.merged_at == null).length;
   
-  const avgReviewMs =
-    mergedPRs.length > 0
-      ? mergedPRs.reduce(
-          (sum, pr) =>
-            sum +
-            (new Date(pr.closed_at!).getTime() -
-              new Date(pr.created_at).getTime()),
-          0
-        ) / mergedPRs.length
-      : 0;
+  const avgReviewMs = mergedPRs.length > 0
+    ? mergedPRs.reduce((sum, pr) => sum + (new Date(pr.closed_at!).getTime() - new Date(pr.created_at).getTime()), 0) / mergedPRs.length
+    : 0;
 
   const sampleTotal = data.items.length;
   const avgFirstReviewHours = await getAverageFirstReviewHours(token, data.items);
@@ -252,11 +184,7 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
         nodes {
           ... on PullRequest {
             createdAt
-            reviews(first: 1) {
-              nodes {
-                submittedAt
-              }
-            }
+            reviews(first: 1) { nodes { submittedAt } }
             repository { nameWithOwner }
           }
         }
@@ -277,27 +205,17 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   const gqlJson = (await gqlRes.json()) as GraphQLSearchResponse;
   const prs = gqlJson.data?.search?.nodes ?? [];
 
-  const reviewedPRs = prs.filter(
-    (pr) => pr.reviews?.nodes && pr.reviews.nodes.length > 0
-  );
+  const reviewedPRs = prs.filter((pr) => pr.reviews?.nodes && pr.reviews.nodes.length > 0);
 
   const cycleTimes = reviewedPRs.map((pr) => ({
-    hours: Math.round(
-      (new Date(pr.reviews.nodes[0].submittedAt).getTime() -
-        new Date(pr.createdAt).getTime()) /
-        3600000
-    ),
+    hours: Math.round((new Date(pr.reviews.nodes[0].submittedAt).getTime() - new Date(pr.createdAt).getTime()) / 3600000),
     week: getWeekLabel(pr.createdAt),
     repo: pr.repository.nameWithOwner,
   }));
 
-  const avgCycleTime =
-    cycleTimes.length > 0
-      ? Math.round(
-          cycleTimes.reduce((sum, ct) => sum + ct.hours, 0) /
-            cycleTimes.length
-        )
-      : 0;
+  const avgCycleTime = cycleTimes.length > 0
+    ? Math.round(cycleTimes.reduce((sum, ct) => sum + ct.hours, 0) / cycleTimes.length)
+    : 0;
 
   const weeklyMap: Record<string, number[]> = {};
   cycleTimes.forEach((ct) => {
@@ -307,9 +225,7 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   
   const weeklyTrend = Object.entries(weeklyMap).map(([week, times]) => ({
     week,
-    avgHours: Math.round(
-      times.reduce((a, b) => a + b, 0) / times.length
-    ),
+    avgHours: Math.round(times.reduce((a, b) => a + b, 0) / times.length),
   }));
 
   const repoMap: Record<string, number[]> = {};
@@ -319,12 +235,7 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   });
   
   const slowestRepos = Object.entries(repoMap)
-    .map(([repo, times]) => ({
-      repo,
-      avgHours: Math.round(
-        times.reduce((a, b) => a + b, 0) / times.length
-      ),
-    }))
+    .map(([repo, times]) => ({ repo, avgHours: Math.round(times.reduce((a, b) => a + b, 0) / times.length) }))
     .sort((a, b) => b.avgHours - a.avgHours)
     .slice(0, 3);
 
@@ -349,12 +260,6 @@ async function fetchGitLabMRMetrics(token: string): Promise<PRMetricsBase> {
   let totalCount: number | null = null;
   const items: GitLabMergeRequestItem[] = [];
 
-  // GitLab REST API — paginated fetch of all merge requests created by the user.
-  // GitLab rate limits differ from GitHub:
-  //   • Authenticated: 2,000 requests/minute (much more generous than GitHub Search)
-  //   • Unauthenticated: 500 requests/minute
-  // Pagination is driven by the x-next-page / x-total-pages response headers
-  // rather than GitHub's Link header style.
   while (page > 0) {
     const url = new URL("https://gitlab.com/api/v4/merge_requests");
     url.searchParams.set("scope", "created_by_me");
@@ -363,38 +268,26 @@ async function fetchGitLabMRMetrics(token: string): Promise<PRMetricsBase> {
     url.searchParams.set("page", String(page));
 
     const response = await fetch(url.toString(), {
-      headers: {
-        // GitLab personal access token or OAuth token passed as Bearer.
-        // Stored separately from the GitHub token in session.gitlabToken.
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
       cache: "no-store",
     });
 
-    if (!response.ok) {
-      throw new Error("GitLab API error");
-    }
+    if (!response.ok) throw new Error("GitLab API error");
 
     if (totalCount === null) {
       const totalHeader = response.headers.get("x-total");
       const parsedTotal = totalHeader ? Number(totalHeader) : NaN;
-      if (Number.isFinite(parsedTotal)) {
-        totalCount = parsedTotal;
-      }
+      if (Number.isFinite(parsedTotal)) totalCount = parsedTotal;
     }
 
     if (totalPages === null) {
       const totalPagesHeader = response.headers.get("x-total-pages");
       const parsedPages = totalPagesHeader ? Number(totalPagesHeader) : NaN;
-      if (Number.isFinite(parsedPages) && parsedPages > 0) {
-        totalPages = parsedPages;
-      }
+      if (Number.isFinite(parsedPages) && parsedPages > 0) totalPages = parsedPages;
     }
 
     const pageItems = (await response.json()) as GitLabMergeRequestItem[];
-    if (!Array.isArray(pageItems) || pageItems.length === 0) {
-      break;
-    }
+    if (!Array.isArray(pageItems) || pageItems.length === 0) break;
 
     items.push(...pageItems);
 
@@ -414,14 +307,11 @@ async function fetchGitLabMRMetrics(token: string): Promise<PRMetricsBase> {
       page += 1;
       continue;
     }
-
     break;
   }
 
   const open = items.filter((mr) => mr.state === "opened").length;
-  const mergedItems = items.filter(
-    (mr) => mr.state === "merged" && mr.merged_at
-  );
+  const mergedItems = items.filter((mr) => mr.state === "merged" && mr.merged_at);
   const merged = mergedItems.length;
   const closed = items.filter((mr) => mr.state === "closed").length;
 
@@ -429,18 +319,14 @@ async function fetchGitLabMRMetrics(token: string): Promise<PRMetricsBase> {
     .map((mr) => {
       const created = new Date(mr.created_at).getTime();
       const mergedAt = new Date(mr.merged_at!).getTime();
-      if (Number.isNaN(created) || Number.isNaN(mergedAt)) {
-        return null;
-      }
+      if (Number.isNaN(created) || Number.isNaN(mergedAt)) return null;
       return mergedAt - created;
     })
     .filter((value): value is number => typeof value === "number");
 
-  const avgReviewMs =
-    reviewDurations.length > 0
-      ? reviewDurations.reduce((sum, value) => sum + value, 0) /
-        reviewDurations.length
-      : 0;
+  const avgReviewMs = reviewDurations.length > 0
+    ? reviewDurations.reduce((sum, value) => sum + value, 0) / reviewDurations.length
+    : 0;
 
   const sampleTotal = items.length;
 
@@ -460,24 +346,14 @@ async function fetchGitLabMRMetrics(token: string): Promise<PRMetricsBase> {
 
 async function fetchCachedPRMetrics(
   token: string,
-  cacheContext: { bypass: boolean; userId: string }
+  cacheContext: { bypass: boolean; userId: string; staleThresholdDays?: number }
 ): Promise<PRMetricsBase> {
-  // Cache key is scoped per user + staleThresholdDays so different threshold
-  // settings don't return each other's cached results.
   const key = metricsCacheKey(cacheContext.userId, "prs", {
-    staleThresholdDays: cacheContext.staleThresholdDays,
+    staleThresholdDays: cacheContext.staleThresholdDays ?? 14,
   });
-  const key = metricsCacheKey(cacheContext.userId, "prs");
 
-  // withMetricsCache checks for a cached result first.
-  // If found and not bypassed, the GitHub Search API is never called —
-  // this is the primary defence against hitting the 30 req/min rate limit.
   return withMetricsCache(
-    {
-      bypass: cacheContext.bypass,
-      key,
-      ttlSeconds: METRICS_CACHE_TTL_SECONDS.prs,
-    },
+    { bypass: cacheContext.bypass, key, ttlSeconds: METRICS_CACHE_TTL_SECONDS.prs },
     () => fetchPRMetrics(token)
   );
 }
@@ -486,16 +362,10 @@ async function fetchCachedGitLabMRMetrics(
   token: string,
   cacheContext: { bypass: boolean; userId: string }
 ): Promise<PRMetricsBase> {
-  const key = metricsCacheKey(cacheContext.userId, "prs", {
-    source: "gitlab",
-  });
+  const key = metricsCacheKey(cacheContext.userId, "prs", { source: "gitlab" });
 
   return withMetricsCache(
-    {
-      bypass: cacheContext.bypass,
-      key,
-      ttlSeconds: METRICS_CACHE_TTL_SECONDS.prs,
-    },
+    { bypass: cacheContext.bypass, key, ttlSeconds: METRICS_CACHE_TTL_SECONDS.prs },
     () => fetchGitLabMRMetrics(token)
   );
 }
@@ -508,34 +378,22 @@ function formatPRMetrics(metrics: PRMetricsBase) {
     total: metrics.total,
     avgReviewHours: metrics.avgReviewHours,
     avgFirstReviewHours: metrics.avgFirstReviewHours,
-    mergeRate:
-      metrics.total > 0
-        ? `${Math.round(metrics.mergeRate * 100)}%`
-        : "0%",
+    mergeRate: metrics.total > 0 ? `${Math.round(metrics.mergeRate * 100)}%` : "0%",
     avgCycleTime: metrics.avgCycleTime,
     weeklyTrend: metrics.weeklyTrend,
     slowestRepos: metrics.slowestRepos,
   };
 }
 
-function formatPRMetricsResponse(
-  metrics: PRMetricsBase,
-  gitlab: PRMetricsBase | null
-) {
+function formatPRMetricsResponse(metrics: PRMetricsBase, gitlab: PRMetricsBase | null) {
   return {
     ...formatPRMetrics(metrics),
     ...(gitlab ? { gitlab: formatPRMetrics(gitlab) } : {}),
   };
 }
 
-async function getGitLabMetrics(
-  token: string | undefined,
-  cacheContext: { bypass: boolean; userId: string }
-) {
-  if (!token) {
-    return null;
-  }
-
+async function getGitLabMetrics(token: string | undefined, cacheContext: { bypass: boolean; userId: string }) {
+  if (!token) return null;
   try {
     return await fetchCachedGitLabMRMetrics(token, cacheContext);
   } catch {
@@ -553,11 +411,7 @@ async function fetchReviewMetrics(token: string): Promise<ReviewMetrics> {
               occurredAt
               pullRequestReview {
                 state
-                pullRequest {
-                  repository {
-                    nameWithOwner
-                  }
-                }
+                pullRequest { repository { nameWithOwner } }
               }
             }
           }
@@ -566,16 +420,9 @@ async function fetchReviewMetrics(token: string): Promise<ReviewMetrics> {
     }
   `;
 
-  // GitHub GraphQL API rate limits:
-  //   • Authenticated (OAuth token / PAT): 5,000 points/hour
-  //   • Unauthenticated:                   not supported — always requires a token
-  // GraphQL uses a "points" system where complex/nested queries cost more points.
-  // This query fetches up to 100 review contributions — a low-cost operation (~1 point).
   const res = await fetch("https://api.github.com/graphql", {
     method: "POST",
     headers: {
-      // Token is REQUIRED — GitHub rejects all unauthenticated GraphQL requests with 401.
-      // A PAT with `read:user` scope works as a drop-in for the OAuth token.
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
@@ -583,27 +430,17 @@ async function fetchReviewMetrics(token: string): Promise<ReviewMetrics> {
     cache: "no-store",
   });
 
-  // HTTP 403 = rate limit exceeded (5,000 points/hr exhausted).
-  // Note: GraphQL can also return HTTP 200 with an "errors" array for partial
-  // failures — not checked here since missing review data is non-critical and
-  // the .catch(() => null) in the GET handler silently swallows this error.
   if (!res.ok) throw new Error("GitHub GraphQL error");
 
   const json = await res.json();
-  const nodes =
-    json?.data?.viewer?.contributionsCollection
-      ?.pullRequestReviewContributions?.nodes ?? [];
+  const nodes = json?.data?.viewer?.contributionsCollection?.pullRequestReviewContributions?.nodes ?? [];
 
   const totalReviews = nodes.length;
   const approvals = nodes.filter(
-    (n: { pullRequestReview: { state: string } }) =>
-      n.pullRequestReview?.state === "APPROVED"
+    (n: { pullRequestReview: { state: string } }) => n.pullRequestReview?.state === "APPROVED"
   ).length;
 
-  const approvalRate =
-    totalReviews > 0
-      ? `${Math.round((approvals / totalReviews) * 100)}%`
-      : "0%";
+  const approvalRate = totalReviews > 0 ? `${Math.round((approvals / totalReviews) * 100)}%` : "0%";
 
   const repoCounts: Record<string, number> = {};
   for (const node of nodes) {
@@ -624,18 +461,16 @@ async function fetchReviewMetrics(token: string): Promise<ReviewMetrics> {
   };
 }
 
-
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const gitlabToken =
-    typeof session.gitlabToken === "string" ? session.gitlabToken : undefined;
-
+  const gitlabToken = typeof session.gitlabToken === "string" ? session.gitlabToken : undefined;
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
+  
   const gitlabCacheContext = {
     bypass,
     userId: session.githubId ?? session.githubLogin ?? "primary",
@@ -647,19 +482,14 @@ export async function GET(req: NextRequest) {
         bypass,
         userId: session.githubId ?? session.githubLogin ?? "primary",
       });
+      
       const [gitlab, reviews] = await Promise.all([
         getGitLabMetrics(gitlabToken, gitlabCacheContext),
-        // fetchReviewMetrics uses the GraphQL API (5,000 pts/hr limit).
-        // .catch(() => null) ensures a GraphQL rate limit error doesn't
-        // fail the entire PR metrics response — reviews are supplementary.
         fetchReviewMetrics(session.accessToken).catch(() => null),
       ]);
+      
       return Response.json({ ...formatPRMetricsResponse(result, gitlab), reviews });
-      const gitlab = await getGitLabMetrics(gitlabToken, gitlabCacheContext);
-      return Response.json(formatPRMetricsResponse(result, gitlab));
     } catch {
-      // Catches errors from fetchCachedPRMetrics (GitHub Search API failures).
-      // Returns 502 so the client knows the data is unavailable, not just empty.
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -669,7 +499,6 @@ export async function GET(req: NextRequest) {
   }
 
   const userRow = await resolveAppUser(session.githubId, session.githubLogin);
-
   if (!userRow) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -686,19 +515,6 @@ export async function GET(req: NextRequest) {
         return fetchCachedPRMetrics(token, { bypass, userId: acc.github_id });
       });
 
-    // Each account makes its own Search API call — N accounts = N requests
-    // against the 30 req/min Search API limit. Promise.allSettled is used so
-    // one account failing (e.g. expired token) doesn't block the others.
-    const results = await Promise.allSettled(
-      accounts.map((account) =>
-        fetchCachedPRMetrics(account.token, {
-          bypass,
-          githubLogin: account.githubLogin,
-          staleThresholdDays,
-          userId: account.githubId,
-        })
-      )
-    );
       const resultsRaw = await Promise.allSettled(metricsPromises);
       const results = resultsRaw
         .filter((r): r is PromiseFulfilledResult<PRMetricsBase> => r.status === "fulfilled" && r.value !== null)
@@ -733,6 +549,7 @@ export async function GET(req: NextRequest) {
           weeklyTrendsMap[wt.week].push(wt.avgHours);
         });
       });
+      
       const combinedWeeklyTrend = Object.entries(weeklyTrendsMap).map(([week, hoursArray]) => ({
         week,
         avgHours: Math.round(hoursArray.reduce((a, b) => a + b, 0) / hoursArray.length)
@@ -756,29 +573,35 @@ export async function GET(req: NextRequest) {
         slowestRepos: combinedSlowest
       };
 
-      const gitlab = await getGitLabMetrics(gitlabToken, gitlabCacheContext);
-      return Response.json(formatPRMetricsResponse(combinedMetrics, gitlab));
+      const [gitlab, reviews] = await Promise.all([
+        getGitLabMetrics(gitlabToken, gitlabCacheContext),
+        fetchReviewMetrics(session.accessToken).catch(() => null),
+      ]);
+      
+      return Response.json({ ...formatPRMetricsResponse(combinedMetrics, gitlab), reviews });
     } catch {
       return Response.json({ error: "Failed to compile combined profile metrics" }, { status: 502 });
     }
   }
 
-  const token =
-    !accountId || accountId === session.githubId
+  const token = !accountId || accountId === session.githubId
       ? session.accessToken
       : await getAccountToken(userRow.id, accountId);
 
-  if (!token) {
-    return Response.json({ error: "Account not found" }, { status: 404 });
-  }
+  if (!token) return Response.json({ error: "Account not found" }, { status: 404 });
 
   try {
     const result = await fetchCachedPRMetrics(token, {
       bypass,
       userId: accountId === session.githubId ? session.githubId : accountId,
     });
-    const gitlab = await getGitLabMetrics(gitlabToken, gitlabCacheContext);
-    return Response.json(formatPRMetricsResponse(result, gitlab));
+    
+    const [gitlab, reviews] = await Promise.all([
+      getGitLabMetrics(gitlabToken, gitlabCacheContext),
+      fetchReviewMetrics(session.accessToken).catch(() => null),
+    ]);
+    
+    return Response.json({ ...formatPRMetricsResponse(result, gitlab), reviews });
   } catch {
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }

--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -1,10 +1,7 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
-import {
-  getAllAccounts,
-  mergeMetrics,
-} from "@/lib/github-accounts";
+import { getAccountToken, getAllAccounts } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
 import {
   isMetricsCacheBypassed,
@@ -12,20 +9,9 @@ import {
   metricsCacheKey,
   withMetricsCache,
 } from "@/lib/metrics-cache";
-import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
-
-const STALE_THRESHOLD_OPTIONS = [7, 14, 30] as const;
-const DEFAULT_STALE_THRESHOLD_DAYS = 7;
-
-interface ReviewMetrics {
-  totalReviews: number;
-  approvalRate: string;
-  avgFirstReviewHours: number | null;
-  topRepos: { repo: string; count: number }[];
-}
 
 interface PRMetricsBase {
   open: number;
@@ -35,9 +21,15 @@ interface PRMetricsBase {
   avgReviewHours: number;
   avgFirstReviewHours: number | null;
   mergeRate: number;
-  staleCount: number;
-  staleThresholdDays: number;
-  staleSearchUrl: string | null;
+  avgCycleTime: number;
+  weeklyTrend: { week: string; avgHours: number }[];
+  slowestRepos: { repo: string; avgHours: number }[];
+}
+
+function getWeekLabel(dateStr: string): string {
+  const date = new Date(dateStr);
+  const week = Math.floor(date.getDate() / 7) + 1;
+  return `${date.toLocaleString("default", { month: "short" })} W${week}`;
 }
 
 interface PullRequestSearchItem {
@@ -55,6 +47,22 @@ interface ReviewEvent {
 
 interface ReviewCommentEvent {
   created_at?: string | null;
+}
+
+interface GraphQLPullRequestNode {
+  createdAt: string;
+  reviews: {
+    nodes: { submittedAt: string }[];
+  };
+  repository: { nameWithOwner: string };
+}
+
+interface GraphQLSearchResponse {
+  data?: {
+    search?: {
+      nodes?: GraphQLPullRequestNode[];
+    };
+  };
 }
 
 interface GitLabMergeRequestItem {
@@ -77,35 +85,6 @@ function getEarliestTimestamp(values: Array<string | null | undefined>) {
     .filter((value) => !Number.isNaN(value));
 
   return timestamps.length > 0 ? Math.min(...timestamps) : null;
-}
-
-function getStaleThresholdDays(req: NextRequest): number {
-  const requestedThreshold = Number(
-    req.nextUrl.searchParams.get("staleThresholdDays") ??
-      DEFAULT_STALE_THRESHOLD_DAYS
-  );
-
-  return STALE_THRESHOLD_OPTIONS.includes(
-    requestedThreshold as (typeof STALE_THRESHOLD_OPTIONS)[number]
-  )
-    ? requestedThreshold
-    : DEFAULT_STALE_THRESHOLD_DAYS;
-}
-
-function getStaleSearchUrl(
-  githubLogin: string | null | undefined,
-  staleCutoffMs: number
-): string | null {
-  if (!githubLogin) {
-    return null;
-  }
-
-  const cutoffDate = new Date(staleCutoffMs).toISOString().slice(0, 10);
-  const params = new URLSearchParams({
-    q: `is:pr is:open author:${githubLogin} created:<${cutoffDate}`,
-  });
-
-  return `https://github.com/pulls?${params.toString()}`;
 }
 
 async function fetchFirstReviewTimestamp(
@@ -206,6 +185,7 @@ async function fetchPRMetrics(
   // Concurrent widget loads (prs + streak + repos all fetching at once) can
   // exhaust it quickly. The withMetricsCache wrapper in fetchCachedPRMetrics
   // protects against this by reusing results within the cache TTL window.
+async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   const searchRes = await fetch(
     `${GITHUB_API}/search/issues?q=type:pr+author:@me&sort=updated&order=desc&per_page=100`,
     {
@@ -226,6 +206,7 @@ async function fetchPRMetrics(
   if (!searchRes.ok) {
     throw new Error("GitHub API error");
   }
+  if (!searchRes.ok) throw new Error("GitHub API error");
 
   const data = (await searchRes.json()) as {
     total_count: number;
@@ -233,55 +214,119 @@ async function fetchPRMetrics(
   };
 
   const open = data.items.filter((pr) => pr.state === "open").length;
-  const staleCutoffMs =
-    Date.now() - options.staleThresholdDays * 24 * 60 * 60 * 1000;
-  const staleCount = data.items.filter((pr) => {
-    if (pr.state !== "open") {
-      return false;
-    }
 
-    const createdAt = new Date(pr.created_at).getTime();
-    return !Number.isNaN(createdAt) && createdAt < staleCutoffMs;
-  }).length;
-
-  // A PR with state "closed" may have been merged OR closed without merging
-  // (e.g. rejected, abandoned). Only count those with a non-null merged_at
-  // as truly merged so the dashboard does not inflate the merged count.
   const merged = data.items.filter(
     (pr) => pr.pull_request?.merged_at != null
   ).length;
 
-  // Closed without merging (rejected / abandoned)
   const closed = data.items.filter(
     (pr) => pr.state === "closed" && pr.pull_request?.merged_at == null
   ).length;
 
-  // Average review time: use only actually merged PRs so we measure the time
-  // from open to merge, not open to close-without-merge.
   const mergedPRs = data.items.filter(
     (pr) => pr.pull_request?.merged_at != null
   );
+  
   const avgReviewMs =
     mergedPRs.length > 0
       ? mergedPRs.reduce(
           (sum, pr) =>
             sum +
-            (new Date(pr.pull_request!.merged_at!).getTime() -
+            (new Date(pr.closed_at!).getTime() -
               new Date(pr.created_at).getTime()),
           0
         ) / mergedPRs.length
       : 0;
 
-  // Use the number of fetched items as the denominator for mergeRate.
-  // data.total_count is the all-time GitHub total (potentially thousands)
-  // while data.items is capped at 100, so dividing merged/total_count
-  // produces a near-zero rate for any active user. The fetched sample
-  // (open + merged + closed-without-merge) is the correct base.
   const sampleTotal = data.items.length;
-  const avgFirstReviewHours = await getAverageFirstReviewHours(
-    token,
-    data.items
+  const avgFirstReviewHours = await getAverageFirstReviewHours(token, data.items);
+
+  // GraphQL for review cycle time
+  const ninetyDaysAgo = new Date();
+  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+  const since = ninetyDaysAgo.toISOString().split("T")[0];
+
+  const query = `
+    query {
+      search(query: "type:pr reviewed-by:@me created:>${since}", type: ISSUE, first: 100) {
+        nodes {
+          ... on PullRequest {
+            createdAt
+            reviews(first: 1) {
+              nodes {
+                submittedAt
+              }
+            }
+            repository { nameWithOwner }
+          }
+        }
+      }
+    }
+  `;
+
+  const gqlRes = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query }),
+    cache: "no-store",
+  });
+
+  const gqlJson = (await gqlRes.json()) as GraphQLSearchResponse;
+  const prs = gqlJson.data?.search?.nodes ?? [];
+
+  const reviewedPRs = prs.filter(
+    (pr) => pr.reviews?.nodes && pr.reviews.nodes.length > 0
   );
+
+  const cycleTimes = reviewedPRs.map((pr) => ({
+    hours: Math.round(
+      (new Date(pr.reviews.nodes[0].submittedAt).getTime() -
+        new Date(pr.createdAt).getTime()) /
+        3600000
+    ),
+    week: getWeekLabel(pr.createdAt),
+    repo: pr.repository.nameWithOwner,
+  }));
+
+  const avgCycleTime =
+    cycleTimes.length > 0
+      ? Math.round(
+          cycleTimes.reduce((sum, ct) => sum + ct.hours, 0) /
+            cycleTimes.length
+        )
+      : 0;
+
+  const weeklyMap: Record<string, number[]> = {};
+  cycleTimes.forEach((ct) => {
+    if (!weeklyMap[ct.week]) weeklyMap[ct.week] = [];
+    weeklyMap[ct.week].push(ct.hours);
+  });
+  
+  const weeklyTrend = Object.entries(weeklyMap).map(([week, times]) => ({
+    week,
+    avgHours: Math.round(
+      times.reduce((a, b) => a + b, 0) / times.length
+    ),
+  }));
+
+  const repoMap: Record<string, number[]> = {};
+  cycleTimes.forEach((ct) => {
+    if (!repoMap[ct.repo]) repoMap[ct.repo] = [];
+    repoMap[ct.repo].push(ct.hours);
+  });
+  
+  const slowestRepos = Object.entries(repoMap)
+    .map(([repo, times]) => ({
+      repo,
+      avgHours: Math.round(
+        times.reduce((a, b) => a + b, 0) / times.length
+      ),
+    }))
+    .sort((a, b) => b.avgHours - a.avgHours)
+    .slice(0, 3);
 
   return {
     open,
@@ -291,9 +336,9 @@ async function fetchPRMetrics(
     avgReviewHours: Math.round(avgReviewMs / 3600000),
     avgFirstReviewHours,
     mergeRate: sampleTotal > 0 ? merged / sampleTotal : 0,
-    staleCount,
-    staleThresholdDays: options.staleThresholdDays,
-    staleSearchUrl: getStaleSearchUrl(options.githubLogin, staleCutoffMs),
+    avgCycleTime,
+    weeklyTrend,
+    slowestRepos,
   };
 }
 
@@ -407,26 +452,22 @@ async function fetchGitLabMRMetrics(token: string): Promise<PRMetricsBase> {
     avgReviewHours: Math.round(avgReviewMs / 3600000),
     avgFirstReviewHours: null,
     mergeRate: sampleTotal > 0 ? merged / sampleTotal : 0,
-    staleCount: 0,
-    staleThresholdDays: DEFAULT_STALE_THRESHOLD_DAYS,
-    staleSearchUrl: null,
+    avgCycleTime: 0,
+    weeklyTrend: [],
+    slowestRepos: [],
   };
 }
 
 async function fetchCachedPRMetrics(
   token: string,
-  cacheContext: {
-    bypass: boolean;
-    githubLogin?: string | null;
-    staleThresholdDays: number;
-    userId: string;
-  }
+  cacheContext: { bypass: boolean; userId: string }
 ): Promise<PRMetricsBase> {
   // Cache key is scoped per user + staleThresholdDays so different threshold
   // settings don't return each other's cached results.
   const key = metricsCacheKey(cacheContext.userId, "prs", {
     staleThresholdDays: cacheContext.staleThresholdDays,
   });
+  const key = metricsCacheKey(cacheContext.userId, "prs");
 
   // withMetricsCache checks for a cached result first.
   // If found and not bypassed, the GitHub Search API is never called —
@@ -437,11 +478,7 @@ async function fetchCachedPRMetrics(
       key,
       ttlSeconds: METRICS_CACHE_TTL_SECONDS.prs,
     },
-    () =>
-      fetchPRMetrics(token, {
-        githubLogin: cacheContext.githubLogin,
-        staleThresholdDays: cacheContext.staleThresholdDays,
-      })
+    () => fetchPRMetrics(token)
   );
 }
 
@@ -471,13 +508,13 @@ function formatPRMetrics(metrics: PRMetricsBase) {
     total: metrics.total,
     avgReviewHours: metrics.avgReviewHours,
     avgFirstReviewHours: metrics.avgFirstReviewHours,
-    staleCount: metrics.staleCount,
-    staleThresholdDays: metrics.staleThresholdDays,
-    staleSearchUrl: metrics.staleSearchUrl,
     mergeRate:
       metrics.total > 0
         ? `${Math.round(metrics.mergeRate * 100)}%`
         : "0%",
+    avgCycleTime: metrics.avgCycleTime,
+    weeklyTrend: metrics.weeklyTrend,
+    slowestRepos: metrics.slowestRepos,
   };
 }
 
@@ -587,6 +624,7 @@ async function fetchReviewMetrics(token: string): Promise<ReviewMetrics> {
   };
 }
 
+
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken) {
@@ -598,7 +636,6 @@ export async function GET(req: NextRequest) {
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
-  const staleThresholdDays = getStaleThresholdDays(req);
   const gitlabCacheContext = {
     bypass,
     userId: session.githubId ?? session.githubLogin ?? "primary",
@@ -608,8 +645,6 @@ export async function GET(req: NextRequest) {
     try {
       const result = await fetchCachedPRMetrics(session.accessToken, {
         bypass,
-        githubLogin: session.githubLogin,
-        staleThresholdDays,
         userId: session.githubId ?? session.githubLogin ?? "primary",
       });
       const [gitlab, reviews] = await Promise.all([
@@ -620,6 +655,8 @@ export async function GET(req: NextRequest) {
         fetchReviewMetrics(session.accessToken).catch(() => null),
       ]);
       return Response.json({ ...formatPRMetricsResponse(result, gitlab), reviews });
+      const gitlab = await getGitLabMetrics(gitlabToken, gitlabCacheContext);
+      return Response.json(formatPRMetricsResponse(result, gitlab));
     } catch {
       // Catches errors from fetchCachedPRMetrics (GitHub Search API failures).
       // Returns 502 so the client knows the data is unavailable, not just empty.
@@ -638,14 +675,16 @@ export async function GET(req: NextRequest) {
   }
 
   if (accountId === "combined") {
-    const accounts = await getAllAccounts(
-      {
-        token: session.accessToken,
-        githubId: session.githubId,
-        githubLogin: session.githubLogin,
-      },
-      userRow.id
-    );
+    try {
+      const allAccounts = await getAllAccounts(userRow.id);
+      
+      const metricsPromises = allAccounts.map(async (acc) => {
+        const token = acc.github_id === session.githubId
+          ? session.accessToken
+          : await getAccountToken(userRow.id, acc.github_id);
+        if (!token) return null;
+        return fetchCachedPRMetrics(token, { bypass, userId: acc.github_id });
+      });
 
     // Each account makes its own Search API call — N accounts = N requests
     // against the 30 req/min Search API limit. Promise.allSettled is used so
@@ -660,81 +699,86 @@ export async function GET(req: NextRequest) {
         })
       )
     );
+      const resultsRaw = await Promise.allSettled(metricsPromises);
+      const results = resultsRaw
+        .filter((r): r is PromiseFulfilledResult<PRMetricsBase> => r.status === "fulfilled" && r.value !== null)
+        .map(r => r.value);
 
-    const merged = mergeMetrics(results, (a, b) => {
-      const total = a.total + b.total;
-      const mergedCount = a.merged + b.merged;
-      const closedCount = a.closed + b.closed;
-      const avgReviewHours =
-        total > 0
-          ? (a.avgReviewHours * a.total + b.avgReviewHours * b.total) / total
-          : 0;
-      const reviewedTotal =
-        (a.avgFirstReviewHours === null ? 0 : a.total) +
-        (b.avgFirstReviewHours === null ? 0 : b.total);
-      const avgFirstReviewHours =
-        reviewedTotal > 0
-          ? ((a.avgFirstReviewHours ?? 0) * a.total +
-              (b.avgFirstReviewHours ?? 0) * b.total) /
-            reviewedTotal
-          : null;
+      if (results.length === 0) {
+        return Response.json({ error: "No accounts found" }, { status: 404 });
+      }
 
-      return {
-        open: a.open + b.open,
-        merged: mergedCount,
-        closed: closedCount,
-        total,
+      const combinedTotal = results.reduce((sum, r) => sum + r.total, 0);
+      const combinedMerged = results.reduce((sum, r) => sum + r.merged, 0);
+      const combinedClosed = results.reduce((sum, r) => sum + r.closed, 0);
+      const combinedOpen = results.reduce((sum, r) => sum + r.open, 0);
+
+      const avgReviewHours = combinedTotal > 0
+        ? results.reduce((sum, r) => sum + (r.avgReviewHours * r.total), 0) / combinedTotal
+        : 0;
+
+      const reviewedTotal = results.reduce((sum, r) => sum + (r.avgFirstReviewHours === null ? 0 : r.total), 0);
+      const avgFirstReviewHours = reviewedTotal > 0
+        ? results.reduce((sum, r) => sum + ((r.avgFirstReviewHours ?? 0) * r.total), 0) / reviewedTotal
+        : null;
+
+      const combinedCycleTime = results.length > 0
+        ? Math.round(results.reduce((sum, r) => sum + r.avgCycleTime, 0) / results.length)
+        : 0;
+
+      const weeklyTrendsMap: Record<string, number[]> = {};
+      results.forEach(r => {
+        r.weeklyTrend.forEach(wt => {
+          if (!weeklyTrendsMap[wt.week]) weeklyTrendsMap[wt.week] = [];
+          weeklyTrendsMap[wt.week].push(wt.avgHours);
+        });
+      });
+      const combinedWeeklyTrend = Object.entries(weeklyTrendsMap).map(([week, hoursArray]) => ({
+        week,
+        avgHours: Math.round(hoursArray.reduce((a, b) => a + b, 0) / hoursArray.length)
+      }));
+
+      const combinedSlowest = results
+        .flatMap(r => r.slowestRepos)
+        .sort((a, b) => b.avgHours - a.avgHours)
+        .slice(0, 3);
+
+      const combinedMetrics: PRMetricsBase = {
+        open: combinedOpen,
+        merged: combinedMerged,
+        closed: combinedClosed,
+        total: combinedTotal,
         avgReviewHours: Math.round(avgReviewHours * 10) / 10,
-        avgFirstReviewHours:
-          avgFirstReviewHours === null
-            ? null
-            : Math.round(avgFirstReviewHours * 10) / 10,
-        staleCount: a.staleCount + b.staleCount,
-        staleThresholdDays,
-        staleSearchUrl: null,
-        mergeRate:
-          total > 0 ? Math.round((mergedCount / total) * 100) / 100 : 0,
+        avgFirstReviewHours: avgFirstReviewHours === null ? null : Math.round(avgFirstReviewHours * 10) / 10,
+        mergeRate: combinedTotal > 0 ? combinedMerged / combinedTotal : 0,
+        avgCycleTime: combinedCycleTime,
+        weeklyTrend: combinedWeeklyTrend,
+        slowestRepos: combinedSlowest
       };
-    });
 
-    if (!merged) {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+      const gitlab = await getGitLabMetrics(gitlabToken, gitlabCacheContext);
+      return Response.json(formatPRMetricsResponse(combinedMetrics, gitlab));
+    } catch {
+      return Response.json({ error: "Failed to compile combined profile metrics" }, { status: 502 });
     }
-    const [gitlab, reviews] = await Promise.all([
-      getGitLabMetrics(gitlabToken, gitlabCacheContext),
-      fetchReviewMetrics(session.accessToken).catch(() => null),
-    ]);
-    return Response.json({ ...formatPRMetricsResponse(merged, gitlab), reviews });
   }
 
-  const accounts = await getAllAccounts(
-    {
-      token: session.accessToken,
-      githubId: session.githubId,
-      githubLogin: session.githubLogin,
-    },
-    userRow.id
-  );
-  const selectedAccount = accounts.find(
-    (account) => account.githubId === accountId
-  );
+  const token =
+    !accountId || accountId === session.githubId
+      ? session.accessToken
+      : await getAccountToken(userRow.id, accountId);
 
-  if (!selectedAccount) {
+  if (!token) {
     return Response.json({ error: "Account not found" }, { status: 404 });
   }
 
   try {
-    const result = await fetchCachedPRMetrics(selectedAccount.token, {
+    const result = await fetchCachedPRMetrics(token, {
       bypass,
-      githubLogin: selectedAccount.githubLogin,
-      staleThresholdDays,
-      userId: selectedAccount.githubId,
+      userId: accountId === session.githubId ? session.githubId : accountId,
     });
-    const [gitlab, reviews] = await Promise.all([
-      getGitLabMetrics(gitlabToken, gitlabCacheContext),
-      fetchReviewMetrics(selectedAccount.token).catch(() => null),
-    ]);
-    return Response.json({ ...formatPRMetricsResponse(result, gitlab), reviews });
+    const gitlab = await getGitLabMetrics(gitlabToken, gitlabCacheContext);
+    return Response.json(formatPRMetricsResponse(result, gitlab));
   } catch {
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -3,77 +3,67 @@ import SectionHeader from "./SectionHeader";
 
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import PRStatusDonutChart from "./PRStatusDonutChart";
 import MiniPRTrendChart from "./MiniPRTrendChart";
-
-interface ReviewMetrics {
-  totalReviews: number;
-  approvalRate: string;
-  avgFirstReviewHours: number | null;
-  topRepos: { repo: string; count: number }[];
-}
 
 interface PRMetricsSummary {
   open: number;
   merged: number;
   closed: number;
+  total: number;
   avgReviewHours: number;
   avgFirstReviewHours: number | null;
   mergeRate: string;
-  staleCount: number;
-  staleThresholdDays: number;
-  staleSearchUrl: string | null;
+  avgCycleTime?: number;
+  weeklyTrend?: { week: string; avgHours: number }[];
+  slowestRepos?: { repo: string; avgHours: number }[];
+}
+
+interface PRData extends PRMetricsSummary {
+  gitlab?: PRMetricsSummary;
+  reviews?: {
+    totalReviews: number;
+    approvalRate: string;
+    topRepos: { repo: string; count: number }[];
+  };
 }
 
 interface PRStat {
   label: string;
   value: string | number;
-  href?: string | null;
   title?: string;
   warning?: boolean;
-}
-
-interface PRData extends PRMetricsSummary {
-  gitlab?: PRMetricsSummary;
-  reviews?: ReviewMetrics;
+  href?: string;
 }
 
 function formatReviewCycle(hours: number | null): string {
-  if (hours === null) {
-    return "--";
-  }
-
-  if (hours < 24) {
-    return `${hours}h`;
-  }
-
+  if (hours === null) return "—";
+  if (hours < 24) return `${hours}h`;
   return `${Math.round((hours / 24) * 10) / 10}d`;
 }
 
 export default function PRMetrics() {
   const { selectedAccount } = useAccount();
   const [metrics, setMetrics] = useState<PRData | null>(null);
-  const [staleThresholdDays, setStaleThresholdDays] = useState(7);
   const [loading, setLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"authored" | "reviews">("authored");
   const [prFilter, setPrFilter] = useState<"all" | "merged" | "open">("all");
+  const [staleThresholdDays, setStaleThresholdDays] = useState(14);
 
   const fetchMetrics = useCallback(() => {
     setLoading(true);
     setError(null);
 
-    const params = new URLSearchParams({
-      staleThresholdDays: String(staleThresholdDays),
-    });
+    const url =
+      selectedAccount !== null
+        ? `/api/metrics/prs?accountId=${encodeURIComponent(selectedAccount)}`
+        : "/api/metrics/prs";
 
-    if (selectedAccount !== null) {
-      params.set("accountId", selectedAccount);
-    }
-
-    fetch(`/api/metrics/prs?${params.toString()}`)
+    fetch(url)
       .then((r) => {
         if (!r.ok) throw new Error("API error");
         return r.json();
@@ -85,22 +75,18 @@ export default function PRMetrics() {
       })
       .catch(() => setError("We couldn't load your PR analytics right now. Please try again in a moment."))
       .finally(() => setLoading(false));
-  }, [selectedAccount, staleThresholdDays]);
+  }, [selectedAccount]);
 
   useEffect(() => {
     fetchMetrics();
   }, [fetchMetrics]);
 
   useEffect(() => {
-    if (!lastUpdated) {
-      return;
-    }
-
+    if (!lastUpdated) return;
     const interval = setInterval(() => {
       const diff = Math.floor((Date.now() - lastUpdated.getTime()) / 60000);
       setMinutesAgo(diff);
     }, 60000);
-
     return () => clearInterval(interval);
   }, [lastUpdated]);
 
@@ -112,44 +98,36 @@ export default function PRMetrics() {
       avgReview: string;
       avgFirstReview: string;
       mergeRate: string;
-      stale?: string;
-    },
-    options: { includeStale?: boolean } = {}
-  ): PRStat[] => [
-    { label: labels.open, value: source.open },
-    ...(options.includeStale
-      ? [
-          {
-            label: labels.stale ?? `Stale > ${source.staleThresholdDays}d`,
-            value: source.staleCount,
-            href: source.staleSearchUrl,
-            title: `${source.staleCount} open PRs are older than ${source.staleThresholdDays} days`,
-            warning: source.staleCount > 0,
-          },
-        ]
-      : []),
-    { label: labels.merged, value: source.merged },
-    { label: labels.avgReview, value: `${source.avgReviewHours}h` },
-    {
-      label: labels.avgFirstReview,
-      value: formatReviewCycle(source.avgFirstReviewHours),
-      title: "Average time from PR open to first review comment or approval",
-    },
-    { label: labels.mergeRate, value: source.mergeRate },
-  ];
+      avgCycleTime?: string;
+    }
+  ) => {
+    const baseStats: PRStat[] = [
+      { label: labels.open, value: source.open },
+      { label: labels.merged, value: source.merged },
+      { label: labels.avgReview, value: `${source.avgReviewHours}h` },
+      {
+        label: labels.avgFirstReview,
+        value: formatReviewCycle(source.avgFirstReviewHours),
+        title: "Average time from PR open to first review comment or approval",
+      },
+      { label: labels.mergeRate, value: source.mergeRate },
+    ];
+
+    if (labels.avgCycleTime && source.avgCycleTime !== undefined) {
+      baseStats.push({ label: labels.avgCycleTime, value: `${source.avgCycleTime}h` });
+    }
+    return baseStats;
+  };
 
   const githubStats = metrics
-    ? buildStats(
-        metrics,
-        {
-          open: "Open PRs",
-          merged: "Merged (30d)",
-          avgReview: "Avg Review Time",
-          avgFirstReview: "Avg First Review",
-          mergeRate: "Merge Rate",
-        },
-        { includeStale: true }
-      )
+    ? buildStats(metrics, {
+        open: "Open PRs",
+        merged: "Merged (30d)",
+        avgReview: "Avg Review Time",
+        avgFirstReview: "Avg First Review",
+        mergeRate: "Merge Rate",
+        avgCycleTime: "Avg Cycle Time",
+      })
     : [];
 
   const gitlabStats = metrics?.gitlab
@@ -165,11 +143,7 @@ export default function PRMetrics() {
   const renderStat = (stat: PRStat) => {
     const content = (
       <>
-        <div
-          className={`truncate text-2xl font-bold ${
-            stat.warning ? "text-orange-300" : "text-[var(--accent)]"
-          }`}
-        >
+        <div className={`truncate text-2xl font-bold ${stat.warning ? "text-orange-300" : "text-[var(--accent)]"}`}>
           {stat.value}
         </div>
         <div className="truncate mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
@@ -183,18 +157,10 @@ export default function PRMetrics() {
     }`;
 
     return stat.href ? (
-      <a
-        key={stat.label}
-        href={stat.href}
-        target="_blank"
-        rel="noreferrer"
-        className={className}
-        title={stat.title}
-      >
+      <a key={stat.label} href={stat.href} target="_blank" rel="noreferrer" className={className} title={stat.title}>
         {content}
       </a>
     ) : (
-      // 🎯 Fixed: Changed opening tag to match closing tag correctly
       <div key={stat.label} className={className} title={stat.title}>
         {content}
       </div>
@@ -202,29 +168,23 @@ export default function PRMetrics() {
   };
 
   return (
-    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm space-y-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between mb-4">
         <SectionHeader title="PR Analytics" />
         <div className="flex flex-wrap items-center gap-2">
           <div className="flex gap-2">
             <button
-              type="button"
               onClick={() => setActiveTab("authored")}
               className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                activeTab === "authored"
-                  ? "bg-[var(--accent)] text-white"
-                  : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+                activeTab === "authored" ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
               }`}
             >
               PRs Authored
             </button>
             <button
-              type="button"
               onClick={() => setActiveTab("reviews")}
               className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                activeTab === "reviews"
-                  ? "bg-[var(--accent)] text-white"
-                  : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+                activeTab === "reviews" ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
               }`}
             >
               Reviews Given
@@ -234,50 +194,35 @@ export default function PRMetrics() {
             Stale after
             <select
               value={staleThresholdDays}
-              onChange={(event) => setStaleThresholdDays(Number(event.target.value))}
-              className="rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--accent)]"
+              onChange={(e) => setStaleThresholdDays(Number(e.target.value))}
+              className="rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--foreground)] outline-none"
             >
               {[7, 14, 30].map((days) => (
-                <option key={days} value={days}>
-                  {days} days
-                </option>
+                <option key={days} value={days}>{days} days</option>
               ))}
             </select>
           </label>
         </div>
       </div>
+
       {loading ? (
-        <div
-          role="status"
-          aria-live="polite"
-          aria-busy="true"
-          className="space-y-4"
-        >
-          <span className="sr-only">Loading PR analytics</span>
+        <div className="space-y-4">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4">
             {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div
-                key={i}
-                aria-hidden="true"
-                className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse"
-              />
+              <div key={i} className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse" />
             ))}
           </div>
-          <div className="h-[270px] rounded-lg bg-[var(--card-muted)] animate-pulse" aria-hidden="true" />
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-[var(--destructive-muted-border)] bg-[var(--destructive-muted)] p-4 text-sm text-[var(--destructive)]">
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
           <p>{error}</p>
-          <button
-            type="button"
-            onClick={fetchMetrics}
-            className="mt-3 rounded-md border border-[var(--destructive-muted-border)] px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive-muted)]"
-          >
+          <button onClick={fetchMetrics} className="mt-3 rounded-md px-3 py-1.5 text-xs text-red-300 hover:bg-red-500/10 border border-red-500/30">
             Try again
           </button>
         </div>
       ) : activeTab === "authored" ? (
         <div className="space-y-6">
+          {/* GitHub Stats */}
           <div>
             <div className="flex flex-wrap items-center justify-between mb-4">
               <p className="text-sm font-medium text-[var(--muted-foreground)]">GitHub PRs</p>
@@ -287,9 +232,7 @@ export default function PRMetrics() {
                     key={filter}
                     onClick={() => setPrFilter(filter)}
                     className={`rounded-full px-4 py-1.5 text-xs font-semibold capitalize transition-colors ${
-                      prFilter === filter
-                        ? "bg-[var(--accent)] text-white"
-                        : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+                      prFilter === filter ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)]"
                     }`}
                   >
                     {filter}
@@ -297,7 +240,6 @@ export default function PRMetrics() {
                 ))}
               </div>
             </div>
-            
             <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4">
               {githubStats
                 .filter((stat) => {
@@ -312,11 +254,10 @@ export default function PRMetrics() {
             {prFilter !== "open" && <MiniPRTrendChart />}
           </div>
 
+          {/* PR Status Donut Chart */}
           {metrics && (
             <div>
-              <p className="mb-2 text-sm font-medium text-[var(--muted-foreground)]">
-                PR Status Distribution
-              </p>
+              <p className="mb-2 text-sm font-medium text-[var(--muted-foreground)]">PR Status Distribution</p>
               <PRStatusDonutChart
                 open={prFilter === "merged" ? 0 : (metrics.open || 0)}
                 merged={prFilter === "open" ? 0 : (metrics.merged || 0)}
@@ -325,10 +266,42 @@ export default function PRMetrics() {
             </div>
           )}
 
+          {/* Cycle Time Features */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {metrics?.weeklyTrend && metrics.weeklyTrend.length > 0 && (
+              <div className="rounded-lg bg-[var(--control)] p-4">
+                <h3 className="text-sm font-semibold text-[var(--card-foreground)] mb-3">Review Cycle Trend</h3>
+                <ResponsiveContainer width="100%" height={200}>
+                  <LineChart data={metrics.weeklyTrend}>
+                    <XAxis dataKey="week" tick={{ fontSize: 11 }} />
+                    <YAxis tick={{ fontSize: 11 }} unit="h" />
+                    <Tooltip formatter={(val) => [`${val}h`, "Avg Cycle Time"]} />
+                    <Line type="monotone" dataKey="avgHours" stroke="var(--accent)" strokeWidth={2} dot={{ r: 4 }} />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+
+            {metrics?.slowestRepos && metrics.slowestRepos.length > 0 && (
+              <div className="rounded-lg bg-[var(--control)] p-4">
+                <h3 className="text-sm font-semibold text-[var(--card-foreground)] mb-3">Slowest Review Repos</h3>
+                <div className="space-y-2">
+                  {metrics.slowestRepos.map((r) => (
+                    <div key={r.repo} className="flex justify-between items-center bg-[var(--card)] p-2 rounded">
+                      <span className="text-sm text-[var(--muted-foreground)] truncate">{r.repo}</span>
+                      <span className="text-sm font-bold text-[var(--accent)]">{r.avgHours}h</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* GitLab MRs Section */}
           {metrics?.gitlab && (
             <div className="space-y-4 border-t border-[var(--border)] pt-4">
               <p className="text-sm font-medium text-[var(--muted-foreground)]">GitLab MRs</p>
-              <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
                 {gitlabStats
                   .filter((stat) => {
                     if (prFilter === "all") return true;
@@ -338,16 +311,6 @@ export default function PRMetrics() {
                     return true;
                   })
                   .map(renderStat)}
-              </div>
-              <div>
-                <p className="mb-2 text-sm font-medium text-[var(--muted-foreground)]">
-                  MR Status Distribution
-                </p>
-                <PRStatusDonutChart
-                  open={prFilter === "merged" ? 0 : (metrics.gitlab.open || 0)}
-                  merged={prFilter === "open" ? 0 : (metrics.gitlab.merged || 0)}
-                  closed={prFilter === "all" ? (metrics.gitlab.closed || 0) : 0}
-                />
               </div>
             </div>
           )}
@@ -359,35 +322,15 @@ export default function PRMetrics() {
               { label: "Total Reviews Given", value: metrics?.reviews?.totalReviews ?? 0 },
               { label: "Approval Rate", value: metrics?.reviews?.approvalRate ?? "0%" },
             ].map((stat) => (
-              <div 
-                key={stat.label} 
-                className="rounded-lg bg-[var(--control)] border border-transparent p-4 text-center transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-md hover:bg-[var(--control-hover)] hover:border-[var(--border)]"
-              >
+              <div key={stat.label} className="rounded-lg bg-[var(--control)] p-4 text-center">
                 <div className="text-2xl font-bold text-[var(--accent)]">{stat.value}</div>
                 <div className="mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
               </div>
             ))}
           </div>
-          {metrics?.reviews?.topRepos && metrics.reviews.topRepos.length > 0 && (
-            <div>
-              <p className="mb-3 text-sm font-medium text-[var(--muted-foreground)]">Most Reviewed Repos</p>
-              <div className="space-y-2">
-                {metrics.reviews.topRepos.map((item) => (
-                  <div key={item.repo} className="flex items-center justify-between rounded-lg bg-[var(--control)] px-4 py-2">
-                    <span className="truncate text-sm text-[var(--card-foreground)]">{item.repo}</span>
-                    <span className="ml-4 shrink-0 text-sm font-semibold text-[var(--accent)]">
-                      {item.count} review{item.count !== 1 ? "s" : ""}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-          {(metrics?.reviews?.totalReviews ?? 0) === 0 && (
-            <p className="text-sm text-[var(--muted-foreground)]">No reviews found for this period.</p>
-          )}
         </div>
       )}
+      
       {lastUpdated && (
         <p className="text-xs text-[var(--muted-foreground)] mt-2 text-right">
           {minutesAgo === 0 ? "Updated just now" : `Updated ${minutesAgo} min ago`}


### PR DESCRIPTION
## Summary
Added review cycle time metric to PR Analytics — tracks how long PRs sit before getting their first review (DORA metric).

Closes #255

## Type of Change
- [x] New feature

## Changes Made
- GitHub GraphQL query to fetch PR reviews with `submittedAt`
- Compute `first_review_at - created_at` per PR
- Filter: only PRs where user is NOT the author + last 90 days
- Added `avgCycleTime` stat card in PRMetrics component
- Weekly trend chart using recharts (LineChart)
- Top 3 slowest repos highlighted

## How to Test
1. Login to DevTrack with GitHub
2. Navigate to PR Analytics section
3. Verify "Avg Cycle Time" stat card appears
4. Verify weekly trend chart renders
5. Verify slowest repos section shows

## Checklist
- [x] Linked issue in summary
- [x] No TypeScript errors
- [x] Self-reviewed the diff