### PR TITLE
fix: remove dead revalidate config conflicting with force-dynamic

### DIFF
--- a/src/app/api/metrics/issues/route.ts
+++ b/src/app/api/metrics/issues/route.ts
@@ -3,7 +3,7 @@ import { authOptions } from "@/lib/auth";
 import { fetchIssuesMetrics } from "@/lib/github";
 
 export const dynamic = "force-dynamic";
-export const revalidate=300;
+
 
 export async function GET() {
   const session = await getServerSession(authOptions);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary

Removes the dead `revalidate = 300` config from `src/app/api/metrics/issues/route.ts` 
that was conflicting with `force-dynamic`. Since `force-dynamic` opts out of caching 
entirely, `revalidate` had no effect and was dead code.

 Follow-up fix from review comment on #254

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup

## Changes Made

- Removed `export const revalidate = 300` from `issues/route.ts` as it conflicts with `force-dynamic`
- `tsconfig.json` jsx set to `preserve` (auto-updated by Next.js)

## How to Test

Steps for the reviewer to verify this works:
1. Run `npm run dev`
2. Check that GitHub metrics still load on the dashboard
3. Verify no caching conflicts in the API route


## Screenshots (if UI change)
N/A

## Checklist

- [ ] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
