### PR TITLE
fix(auth): centralize user resolution utility to eliminate OAuth dashboard race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -748,6 +748,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1186,6 +1187,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1638,6 +1640,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2507,6 +2510,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2675,6 +2679,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4120,6 +4125,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4191,6 +4197,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5033,6 +5040,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5203,6 +5211,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5293,6 +5302,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5305,6 +5315,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6358,6 +6369,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6527,6 +6539,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -13,12 +14,7 @@ export async function DELETE(
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: user } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
-
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
   // Only delete if the goal belongs to the authenticated user

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -1,8 +1,21 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
+
+interface Goal {
+  id: string;
+  user_id: string;
+  title: string;
+  target: number;
+  current: number;
+  unit: string;
+  recurrence: string;
+  period_start: string | null;
+  created_at: string;
+}
 
 type Recurrence = "none" | "weekly" | "monthly";
 
@@ -34,12 +47,7 @@ export async function GET() {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: user } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
-
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
   const { data: goals } = await supabaseAdmin
@@ -50,7 +58,7 @@ export async function GET() {
 
   // Reset progress if we're in a new period
   const processedGoals = await Promise.all(
-    (goals ?? []).map(async (goal) => {
+    (goals ?? []).map(async (goal: Goal) => {
       if (goal.recurrence === "none") return goal;
 
       const periodStart = new Date(getPeriodStart(goal.recurrence as Recurrence));
@@ -114,12 +122,7 @@ export async function POST(req: Request) {
     return Response.json({ error: "Invalid recurrence value" }, { status: 400 });
   }
 
-  const { data: user } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
-
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
   const { data: goal, error } = await supabaseAdmin

--- a/src/app/api/metrics/ci/route.ts
+++ b/src/app/api/metrics/ci/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -231,11 +232,7 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: userRow } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
 
   if (!userRow) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -111,11 +112,7 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: userRow } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
 
   if (!userRow) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -224,11 +225,7 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: userRow } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
 
   if (!userRow) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/metrics/repos/route.ts
+++ b/src/app/api/metrics/repos/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -105,11 +106,7 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: userRow } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
 
   if (!userRow) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/metrics/streak/route.ts
+++ b/src/app/api/metrics/streak/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { getAccountToken, getAllAccounts } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -139,28 +140,11 @@ export async function GET(req: NextRequest) {
   const accountId = req.nextUrl.searchParams.get("accountId");
   let appUserId: string | null = null;
 
-  if (accountId) {
-    const { data: userRow } = await supabaseAdmin
-      .from("users")
-      .select("id")
-      .eq("github_id", session.githubId)
-      .single();
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
+  appUserId = userRow?.id ?? null;
 
-    if (!userRow) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    appUserId = userRow.id;
-  } else {
-    const { data: dbUser } = await supabaseAdmin
-      .from("users")
-      .select("id")
-      .eq("github_id", session.githubId)
-      .single();
-
-    if (dbUser) {
-      appUserId = dbUser.id;
-    }
+  if (accountId && !appUserId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const since = new Date();

--- a/src/app/api/streak/freeze/route.ts
+++ b/src/app/api/streak/freeze/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -16,12 +17,7 @@ export async function GET() {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: user } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
-
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
   const today = todayStr();
@@ -46,12 +42,7 @@ export async function POST() {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: user } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
-
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
   const today = todayStr();
@@ -83,12 +74,7 @@ export async function DELETE() {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: user } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
-
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
   const { error } = await supabaseAdmin

--- a/src/app/api/user/github-accounts/[githubId]/route.ts
+++ b/src/app/api/user/github-accounts/[githubId]/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -15,11 +16,7 @@ export async function DELETE(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: userRow } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
 
   if (!userRow) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/user/github-accounts/route.ts
+++ b/src/app/api/user/github-accounts/route.ts
@@ -2,8 +2,16 @@ import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
+
+interface LinkedAccount {
+  id: string;
+  github_id: string;
+  github_login: string;
+  added_at: string;
+}
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -12,11 +20,7 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: userRow } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
 
   if (!userRow) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -36,7 +40,7 @@ export async function GET() {
   }
 
   return NextResponse.json({
-    accounts: (accounts ?? []).map((account) => ({
+    accounts: (accounts ?? []).map((account: LinkedAccount) => ({
       id: account.id,
       githubId: account.github_id,
       githubLogin: account.github_login,

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -12,11 +13,19 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
+    return NextResponse.json(
+      { error: "Failed to fetch user settings" },
+      { status: 500 }
+    );
+  }
+
   // Fetch user from Supabase
   const { data, error } = await supabaseAdmin
     .from("users")
     .select("id, github_login, is_public, leaderboard_opt_in")
-    .eq("github_id", session.githubId)
+    .eq("id", user.id)
     .single();
 
   if (error) {
@@ -38,14 +47,9 @@ export async function PATCH(req: NextRequest) {
   }
 
   // Get user ID from Supabase
-  const { data: user, error: fetchError } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
 
-  if (fetchError || !user) {
-    console.error("Error fetching user:", fetchError);
+  if (!user) {
     return NextResponse.json(
       { error: "User not found" },
       { status: 404 }

--- a/src/lib/resolve-user.ts
+++ b/src/lib/resolve-user.ts
@@ -1,0 +1,33 @@
+import { supabaseAdmin } from "@/lib/supabase";
+
+export interface AppUser {
+  id: string;
+}
+
+export async function resolveAppUser(
+  githubId: string,
+  githubLogin?: string
+): Promise<AppUser | null> {
+  const { data: existing } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", githubId)
+    .single();
+
+  if (existing) return existing;
+
+  const { data: upserted } = await supabaseAdmin
+    .from("users")
+    .upsert(
+      {
+        github_id: githubId,
+        github_login: githubLogin,
+        updated_at: new Date().toISOString()
+      },
+      { onConflict: "github_id" }
+    )
+    .select("id")
+    .single();
+
+  return upserted ?? null;
+}


### PR DESCRIPTION
### Overview
Resolves **Issue #348**. This PR eliminates a severe authentication race condition where fast early dashboard API requests fired before a newly created GitHub OAuth user's database entry was fully written, resulting in silent 401/404 lockouts.

### Changes Executed
- **Gateway Abstraction:** Created a centralized `resolveAppUser(githubId, githubLogin)` interface inside `src/lib/resolve-user.ts`. It utilizes a high-performance path lookup with a safe upsert fallback mechanism to handle un-indexed user creation on demand.
- **Code De-duplication:** Refactored 12 separate API routes (including `goals`, `settings`, `streak/freeze`, and `metrics/*`) to use this singular gateway, stripping away repetitive, copy-pasted query lookups.

### Verification Matrix
- Simulated high-concurrency unindexed authentications; race condition safely mitigated via the upsert boundary.
- `npm run type-check` passes cleanly.