### PR TITLE
Feat/repo contribution distribution chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out/
 # Environment files — NEVER commit these
 .env
 .env.local
+.env.local*
 .env.production
 .env.*.local
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -78,6 +78,14 @@ const ContributionHeatmap = dynamic(
   { ssr: false, loading: () => <SkeletonCard /> },
 );
 
+const RepoContributionDistribution = dynamic(
+  () => import("@/components/RepoContributionDistribution"),
+  {
+    ssr: false,
+    loading: () => <SkeletonCard />,
+  },
+);
+
 const PRMetrics = dynamic(() => import("@/components/PRMetrics"), {
   ssr: false,
   loading: () => <PRMetricsSkeleton />,
@@ -173,6 +181,9 @@ export default async function DashboardPage() {
               <div className="w-full overflow-x-auto pb-2">
                 <ContributionHeatmap />
               </div>
+              <LazyWidget fallback={<SkeletonCard />}>
+                <RepoContributionDistribution />
+              </LazyWidget>
               <LazyWidget fallback={<SkeletonCard />}>
                 <ActivityRingChart />
               </LazyWidget>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,13 @@
   --destructive-foreground: #ffffff;
   --shadow-soft: 0 12px 30px -20px rgba(37, 99, 235, 0.35);
   --shadow-medium: 0 18px 35px -24px rgba(37, 99, 235, 0.4);
+  --chart-2: #22c55e;
+  --chart-3: #f97316;
+  --chart-4: #06b6d4;
+  --chart-5: #ec4899;
+  --chart-6: #eab308;
+  --chart-7: #8b5cf6;
+  --chart-8: #14b8a6;
 }
 
 .dark {
@@ -61,6 +68,13 @@
   --destructive-foreground: #ffffff;
   --shadow-soft: 0 16px 34px -24px rgba(2, 6, 23, 0.8);
   --shadow-medium: 0 24px 45px -28px rgba(2, 6, 23, 0.85);
+  --chart-2: #4ade80;
+  --chart-3: #fb923c;
+  --chart-4: #22d3ee;
+  --chart-5: #f472b6;
+  --chart-6: #facc15;
+  --chart-7: #a78bfa;
+  --chart-8: #2dd4bf;
 }
 
 html, body {
@@ -138,12 +152,32 @@ body {
   scrollbar-width: thin;
   scrollbar-color: var(--muted-foreground) transparent;
 }
-.scrollbar-thin::-webkit-scrollbar { width: 6px; height: 6px; }
-.scrollbar-thin::-webkit-scrollbar-track { background: transparent; }
-.scrollbar-thin::-webkit-scrollbar-thumb { background: var(--muted-foreground); border-radius: 9999px; }
-.scrollbar-thin::-webkit-scrollbar-thumb:hover { background: var(--muted-foreground); }
-.dark .scrollbar-thin::-webkit-scrollbar-thumb { background: var(--muted-foreground); }
-.dark .scrollbar-thin::-webkit-scrollbar-thumb:hover { background: var(--muted-foreground); }
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background: var(--muted-foreground);
+  border-radius: 9999px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground);
+}
+
+.dark .scrollbar-thin::-webkit-scrollbar-thumb {
+  background: var(--muted-foreground);
+}
+
+.dark .scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground);
+}
 
 @keyframes fadeUp {
   from {

--- a/src/components/RepoContributionDistribution.tsx
+++ b/src/components/RepoContributionDistribution.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useTheme } from "./ThemeContext";
 import {
   Bar,
   BarChart,
@@ -27,19 +28,7 @@ type ChartTooltipPayload = {
   value?: number;
 };
 
-// First color follows the active theme accent.
-// Remaining colors are chart-specific categorical hues used to distinguish repositories;
-// there are no matching project semantic tokens for every chart slice/bar.
-const COLORS = [
-  "var(--accent)",
-  "#22c55e",
-  "#f97316",
-  "#06b6d4",
-  "#ec4899",
-  "#eab308",
-  "#8b5cf6",
-  "#14b8a6",
-];
+
 
 function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
@@ -151,6 +140,35 @@ function ChartTooltip({
 }
 
 export default function RepoContributionDistribution({ days = 365 }: { days?: number }) {
+  const { theme } = useTheme();
+  const [colors, setColors] = useState<string[]>([]);
+
+  useEffect(() => {
+    const style = getComputedStyle(document.documentElement);
+    const resolvedColors = [
+      style.getPropertyValue("--accent").trim() || "var(--accent)",
+      style.getPropertyValue("--chart-2").trim() || "var(--chart-2)",
+      style.getPropertyValue("--chart-3").trim() || "var(--chart-3)",
+      style.getPropertyValue("--chart-4").trim() || "var(--chart-4)",
+      style.getPropertyValue("--chart-5").trim() || "var(--chart-5)",
+      style.getPropertyValue("--chart-6").trim() || "var(--chart-6)",
+      style.getPropertyValue("--chart-7").trim() || "var(--chart-7)",
+      style.getPropertyValue("--chart-8").trim() || "var(--chart-8)",
+    ];
+    setColors(resolvedColors);
+  }, [theme]);
+
+  const activeColors = colors.length > 0 ? colors : [
+    "var(--accent)",
+    "var(--chart-2)",
+    "var(--chart-3)",
+    "var(--chart-4)",
+    "var(--chart-5)",
+    "var(--chart-6)",
+    "var(--chart-7)",
+    "var(--chart-8)",
+  ];
+
   const [data, setData] = useState<RepoChartItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -282,7 +300,7 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
                     label={renderPieLabel}
                   >
                     {data.map((_, index) => (
-                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                      <Cell key={`cell-${index}`} fill={activeColors[index % activeColors.length]} />
                     ))}
                   </Pie>
                   <Tooltip content={<ChartTooltip />} />
@@ -302,7 +320,7 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
                   <Tooltip content={<ChartTooltip />} />
                   <Bar dataKey="commits" radius={[6, 6, 0, 0]}>
                     {data.map((_, index) => (
-                      <Cell key={`bar-${index}`} fill={COLORS[index % COLORS.length]} />
+                      <Cell key={`bar-${index}`} fill={activeColors[index % activeColors.length]} />
                     ))}
                   </Bar>
                 </BarChart>

--- a/src/components/RepoContributionDistribution.tsx
+++ b/src/components/RepoContributionDistribution.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+type RepoChartItem = {
+  name: string;
+  commits: number;
+  percentage: number;
+};
+
+type ChartType = "pie" | "bar";
+
+const COLORS = [
+  "#6366f1",
+  "#22c55e",
+  "#f97316",
+  "#06b6d4",
+  "#ec4899",
+  "#eab308",
+  "#8b5cf6",
+  "#14b8a6",
+];
+
+function normalizeRepos(payload: any): RepoChartItem[] {
+  const repos = Array.isArray(payload) ? payload : payload?.repos || payload?.data || [];
+
+  const mapped = repos
+    .map((repo: any) => {
+      const name =
+        repo.name ||
+        repo.repo ||
+        repo.repository ||
+        repo.full_name ||
+        repo.fullName ||
+        "Unknown repository";
+
+      const commits =
+        Number(
+          repo.commits ??
+            repo.commitCount ??
+            repo.contributions ??
+            repo.count ??
+            repo.totalCommits ??
+            0
+        ) || 0;
+
+      return { name, commits };
+    })
+    .filter((repo: { commits: number }) => repo.commits > 0)
+    .sort((a: { commits: number }, b: { commits: number }) => b.commits - a.commits)
+    .slice(0, 8);
+
+  const total = mapped.reduce((sum: number, repo: { commits: number }) => sum + repo.commits, 0);
+
+  return mapped.map((repo: { name: string; commits: number }) => ({
+    ...repo,
+    percentage: total > 0 ? Number(((repo.commits / total) * 100).toFixed(1)) : 0,
+  }));
+}
+
+export default function RepoContributionDistribution({ days = 365 }: { days?: number }) {
+  const [data, setData] = useState<RepoChartItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [chartType, setChartType] = useState<ChartType>("pie");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadRepos() {
+      try {
+        setLoading(true);
+        setError("");
+
+        const res = await fetch(`/api/metrics/repos?days=${days}`);
+
+        if (!res.ok) {
+          throw new Error("Failed to fetch repository metrics.");
+        }
+
+        const payload = await res.json();
+        const normalized = normalizeRepos(payload);
+
+        if (!cancelled) {
+          setData(normalized);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load repository chart.");
+          setData([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadRepos();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [days]);
+
+  const totalCommits = useMemo(
+    () => data.reduce((sum, repo) => sum + repo.commits, 0),
+    [data]
+  );
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-sm backdrop-blur">
+      <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Repository Contribution Distribution</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Repo-wise contribution share based on recent commit activity.
+          </p>
+        </div>
+
+        <div className="flex w-fit rounded-lg border border-white/10 bg-black/10 p-1 text-sm">
+          <button
+            type="button"
+            onClick={() => setChartType("pie")}
+            className={`rounded-md px-3 py-1 transition ${
+              chartType === "pie" ? "bg-primary text-primary-foreground" : "text-muted-foreground"
+            }`}
+          >
+            Pie
+          </button>
+          <button
+            type="button"
+            onClick={() => setChartType("bar")}
+            className={`rounded-md px-3 py-1 transition ${
+              chartType === "bar" ? "bg-primary text-primary-foreground" : "text-muted-foreground"
+            }`}
+          >
+            Bar
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex h-72 items-center justify-center rounded-xl border border-dashed border-white/10 text-sm text-muted-foreground">
+          Loading repository distribution...
+        </div>
+      ) : error ? (
+        <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-300">
+          {error}
+        </div>
+      ) : data.length === 0 ? (
+        <div className="flex h-72 items-center justify-center rounded-xl border border-dashed border-white/10 text-sm text-muted-foreground">
+          No repository contribution data available yet.
+        </div>
+      ) : (
+        <>
+          <div className="mb-4 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-xl border border-white/10 bg-black/10 p-3">
+              <p className="text-xs text-muted-foreground">Repositories</p>
+              <p className="text-xl font-semibold">{data.length}</p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-black/10 p-3">
+              <p className="text-xs text-muted-foreground">Total commits</p>
+              <p className="text-xl font-semibold">{totalCommits}</p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-black/10 p-3">
+              <p className="text-xs text-muted-foreground">Top repo</p>
+              <p className="truncate text-xl font-semibold">{data[0]?.name}</p>
+            </div>
+          </div>
+
+          <div className="h-80 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              {chartType === "pie" ? (
+                <PieChart>
+                  <Pie
+                    data={data}
+                    dataKey="commits"
+                    nameKey="name"
+                    innerRadius={60}
+                    outerRadius={105}
+                    paddingAngle={2}
+                    label={({ percentage }) => `${percentage}%`}
+                  >
+                    {data.map((_, index) => (
+                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(value: number, _name, props: any) => [
+                      `${value} commits (${props.payload.percentage}%)`,
+                      props.payload.name,
+                    ]}
+                  />
+                </PieChart>
+              ) : (
+                <BarChart data={data}>
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fontSize: 12 }}
+                    interval={0}
+                    angle={-20}
+                    textAnchor="end"
+                    height={70}
+                  />
+                  <YAxis allowDecimals={false} />
+                  <Tooltip
+                    formatter={(value: number, _name, props: any) => [
+                      `${value} commits (${props.payload.percentage}%)`,
+                      props.payload.name,
+                    ]}
+                  />
+                  <Bar dataKey="commits" radius={[6, 6, 0, 0]}>
+                    {data.map((_, index) => (
+                      <Cell key={`bar-${index}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              )}
+            </ResponsiveContainer>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/RepoContributionDistribution.tsx
+++ b/src/components/RepoContributionDistribution.tsx
@@ -22,8 +22,13 @@ type RepoChartItem = {
 
 type ChartType = "pie" | "bar";
 
+type ChartTooltipPayload = {
+  payload?: RepoChartItem;
+  value?: number;
+};
+
 const COLORS = [
-  "#6366f1",
+  "var(--accent)",
   "#22c55e",
   "#f97316",
   "#06b6d4",
@@ -40,23 +45,28 @@ function asRecord(value: unknown): Record<string, unknown> {
 function getStringValue(record: Record<string, unknown>, keys: string[], fallback: string) {
   for (const key of keys) {
     const value = record[key];
+
     if (typeof value === "string" && value.trim().length > 0) {
       return value;
     }
   }
+
   return fallback;
 }
 
 function getNumberValue(record: Record<string, unknown>, keys: string[]) {
   for (const key of keys) {
     const value = record[key];
+
     if (typeof value === "number" && Number.isFinite(value)) {
       return value;
     }
+
     if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) {
       return Number(value);
     }
   }
+
   return 0;
 }
 
@@ -107,8 +117,34 @@ function normalizeRepos(payload: unknown): RepoChartItem[] {
   }));
 }
 
-function renderPieLabel(props: { payload?: RepoChartItem }) {
-  return props.payload ? `${props.payload.percentage}%` : "";
+function renderPieLabel(props: unknown) {
+  const record = asRecord(props);
+  const payload = asRecord(record.payload);
+  const percentage = payload.percentage;
+
+  return typeof percentage === "number" ? `${percentage}%` : "";
+}
+
+function ChartTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: ChartTooltipPayload[];
+}) {
+  if (!active || !payload?.length || !payload[0]?.payload) {
+    return null;
+  }
+
+  const repo = payload[0].payload;
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-3 text-sm shadow-lg">
+      <p className="font-medium text-[var(--card-foreground)]">{repo.name}</p>
+      <p className="text-[var(--muted-foreground)]">{repo.commits} commits</p>
+      <p className="text-[var(--muted-foreground)]">{repo.percentage}% contribution</p>
+    </div>
+  );
 }
 
 export default function RepoContributionDistribution({ days = 365 }: { days?: number }) {
@@ -159,21 +195,25 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
   const totalCommits = useMemo(() => data.reduce((sum, repo) => sum + repo.commits, 0), [data]);
 
   return (
-    <section className="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-sm backdrop-blur">
+    <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm">
       <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-lg font-semibold">Repository Contribution Distribution</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            Repository Contribution Distribution
+          </h2>
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">
             Repo-wise contribution share based on recent commit activity.
           </p>
         </div>
 
-        <div className="flex w-fit rounded-lg border border-white/10 bg-black/10 p-1 text-sm">
+        <div className="flex w-fit rounded-lg border border-[var(--border)] bg-[var(--control)] p-1 text-sm">
           <button
             type="button"
             onClick={() => setChartType("pie")}
             className={`rounded-md px-3 py-1 transition ${
-              chartType === "pie" ? "bg-primary text-primary-foreground" : "text-muted-foreground"
+              chartType === "pie"
+                ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                : "text-[var(--muted-foreground)]"
             }`}
           >
             Pie
@@ -182,7 +222,9 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
             type="button"
             onClick={() => setChartType("bar")}
             className={`rounded-md px-3 py-1 transition ${
-              chartType === "bar" ? "bg-primary text-primary-foreground" : "text-muted-foreground"
+              chartType === "bar"
+                ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
+                : "text-[var(--muted-foreground)]"
             }`}
           >
             Bar
@@ -191,7 +233,7 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
       </div>
 
       {loading ? (
-        <div className="flex h-72 items-center justify-center rounded-xl border border-dashed border-white/10 text-sm text-muted-foreground">
+        <div className="flex h-72 items-center justify-center rounded-xl border border-dashed border-[var(--border)] text-sm text-[var(--muted-foreground)]">
           Loading repository distribution...
         </div>
       ) : error ? (
@@ -199,23 +241,27 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
           {error}
         </div>
       ) : data.length === 0 ? (
-        <div className="flex h-72 items-center justify-center rounded-xl border border-dashed border-white/10 text-sm text-muted-foreground">
+        <div className="flex h-72 items-center justify-center rounded-xl border border-dashed border-[var(--border)] text-sm text-[var(--muted-foreground)]">
           No repository contribution data available yet.
         </div>
       ) : (
         <>
           <div className="mb-4 grid gap-3 sm:grid-cols-3">
-            <div className="rounded-xl border border-white/10 bg-black/10 p-3">
-              <p className="text-xs text-muted-foreground">Repositories</p>
-              <p className="text-xl font-semibold">{data.length}</p>
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-3">
+              <p className="text-xs text-[var(--muted-foreground)]">Repositories</p>
+              <p className="text-xl font-semibold text-[var(--card-foreground)]">{data.length}</p>
             </div>
-            <div className="rounded-xl border border-white/10 bg-black/10 p-3">
-              <p className="text-xs text-muted-foreground">Total commits</p>
-              <p className="text-xl font-semibold">{totalCommits}</p>
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-3">
+              <p className="text-xs text-[var(--muted-foreground)]">Total commits</p>
+              <p className="text-xl font-semibold text-[var(--card-foreground)]">
+                {totalCommits}
+              </p>
             </div>
-            <div className="rounded-xl border border-white/10 bg-black/10 p-3">
-              <p className="text-xs text-muted-foreground">Top repo</p>
-              <p className="truncate text-xl font-semibold">{data[0]?.name}</p>
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-3">
+              <p className="text-xs text-[var(--muted-foreground)]">Top repo</p>
+              <p className="truncate text-xl font-semibold text-[var(--card-foreground)]">
+                {data[0]?.name}
+              </p>
             </div>
           </div>
 
@@ -236,12 +282,7 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
                       <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                     ))}
                   </Pie>
-                  <Tooltip
-                    formatter={(value, _name, item) => {
-                      const payload = item.payload as RepoChartItem;
-                      return [`${value} commits (${payload.percentage}%)`, payload.name];
-                    }}
-                  />
+                  <Tooltip content={<ChartTooltip />} />
                 </PieChart>
               ) : (
                 <BarChart data={data}>
@@ -255,12 +296,7 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
                     height={70}
                   />
                   <YAxis allowDecimals={false} />
-                  <Tooltip
-                    formatter={(value, _name, item) => {
-                      const payload = item.payload as RepoChartItem;
-                      return [`${value} commits (${payload.percentage}%)`, payload.name];
-                    }}
-                  />
+                  <Tooltip content={<ChartTooltip />} />
                   <Bar dataKey="commits" radius={[6, 6, 0, 0]}>
                     {data.map((_, index) => (
                       <Cell key={`bar-${index}`} fill={COLORS[index % COLORS.length]} />

--- a/src/components/RepoContributionDistribution.tsx
+++ b/src/components/RepoContributionDistribution.tsx
@@ -240,7 +240,7 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
           Loading repository distribution...
         </div>
       ) : error ? (
-        <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-[var(--destructive)]">
+        <div className="rounded-xl border border-[var(--destructive)] bg-[var(--card)] p-4 text-sm text-[var(--destructive)]">
           {error}
         </div>
       ) : data.length === 0 ? (

--- a/src/components/RepoContributionDistribution.tsx
+++ b/src/components/RepoContributionDistribution.tsx
@@ -33,41 +33,82 @@ const COLORS = [
   "#14b8a6",
 ];
 
-function normalizeRepos(payload: any): RepoChartItem[] {
-  const repos = Array.isArray(payload) ? payload : payload?.repos || payload?.data || [];
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function getStringValue(record: Record<string, unknown>, keys: string[], fallback: string) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return fallback;
+}
+
+function getNumberValue(record: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) {
+      return Number(value);
+    }
+  }
+  return 0;
+}
+
+function getRepoArray(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+
+  const record = asRecord(payload);
+
+  if (Array.isArray(record.repos)) return record.repos;
+  if (Array.isArray(record.data)) return record.data;
+  if (Array.isArray(record.repositories)) return record.repositories;
+
+  return [];
+}
+
+function normalizeRepos(payload: unknown): RepoChartItem[] {
+  const repos = getRepoArray(payload);
 
   const mapped = repos
-    .map((repo: any) => {
-      const name =
-        repo.name ||
-        repo.repo ||
-        repo.repository ||
-        repo.full_name ||
-        repo.fullName ||
-        "Unknown repository";
+    .map((item) => {
+      const repo = asRecord(item);
 
-      const commits =
-        Number(
-          repo.commits ??
-            repo.commitCount ??
-            repo.contributions ??
-            repo.count ??
-            repo.totalCommits ??
-            0
-        ) || 0;
+      const name = getStringValue(
+        repo,
+        ["name", "repo", "repository", "full_name", "fullName"],
+        "Unknown repository"
+      );
+
+      const commits = getNumberValue(repo, [
+        "commits",
+        "commitCount",
+        "contributions",
+        "count",
+        "totalCommits",
+      ]);
 
       return { name, commits };
     })
-    .filter((repo: { commits: number }) => repo.commits > 0)
-    .sort((a: { commits: number }, b: { commits: number }) => b.commits - a.commits)
+    .filter((repo) => repo.commits > 0)
+    .sort((a, b) => b.commits - a.commits)
     .slice(0, 8);
 
-  const total = mapped.reduce((sum: number, repo: { commits: number }) => sum + repo.commits, 0);
+  const total = mapped.reduce((sum, repo) => sum + repo.commits, 0);
 
-  return mapped.map((repo: { name: string; commits: number }) => ({
+  return mapped.map((repo) => ({
     ...repo,
     percentage: total > 0 ? Number(((repo.commits / total) * 100).toFixed(1)) : 0,
   }));
+}
+
+function renderPieLabel(props: { payload?: RepoChartItem }) {
+  return props.payload ? `${props.payload.percentage}%` : "";
 }
 
 export default function RepoContributionDistribution({ days = 365 }: { days?: number }) {
@@ -84,13 +125,13 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
         setLoading(true);
         setError("");
 
-        const res = await fetch(`/api/metrics/repos?days=${days}`);
+        const response = await fetch(`/api/metrics/repos?days=${days}`);
 
-        if (!res.ok) {
+        if (!response.ok) {
           throw new Error("Failed to fetch repository metrics.");
         }
 
-        const payload = await res.json();
+        const payload: unknown = await response.json();
         const normalized = normalizeRepos(payload);
 
         if (!cancelled) {
@@ -108,17 +149,14 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
       }
     }
 
-    loadRepos();
+    void loadRepos();
 
     return () => {
       cancelled = true;
     };
   }, [days]);
 
-  const totalCommits = useMemo(
-    () => data.reduce((sum, repo) => sum + repo.commits, 0),
-    [data]
-  );
+  const totalCommits = useMemo(() => data.reduce((sum, repo) => sum + repo.commits, 0), [data]);
 
   return (
     <section className="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-sm backdrop-blur">
@@ -192,17 +230,17 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
                     innerRadius={60}
                     outerRadius={105}
                     paddingAngle={2}
-                    label={({ percentage }) => `${percentage}%`}
+                    label={renderPieLabel}
                   >
                     {data.map((_, index) => (
                       <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                     ))}
                   </Pie>
                   <Tooltip
-                    formatter={(value: number, _name, props: any) => [
-                      `${value} commits (${props.payload.percentage}%)`,
-                      props.payload.name,
-                    ]}
+                    formatter={(value, _name, item) => {
+                      const payload = item.payload as RepoChartItem;
+                      return [`${value} commits (${payload.percentage}%)`, payload.name];
+                    }}
                   />
                 </PieChart>
               ) : (
@@ -218,10 +256,10 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
                   />
                   <YAxis allowDecimals={false} />
                   <Tooltip
-                    formatter={(value: number, _name, props: any) => [
-                      `${value} commits (${props.payload.percentage}%)`,
-                      props.payload.name,
-                    ]}
+                    formatter={(value, _name, item) => {
+                      const payload = item.payload as RepoChartItem;
+                      return [`${value} commits (${payload.percentage}%)`, payload.name];
+                    }}
                   />
                   <Bar dataKey="commits" radius={[6, 6, 0, 0]}>
                     {data.map((_, index) => (

--- a/src/components/RepoContributionDistribution.tsx
+++ b/src/components/RepoContributionDistribution.tsx
@@ -27,6 +27,9 @@ type ChartTooltipPayload = {
   value?: number;
 };
 
+// First color follows the active theme accent.
+// Remaining colors are chart-specific categorical hues used to distinguish repositories;
+// there are no matching project semantic tokens for every chart slice/bar.
 const COLORS = [
   "var(--accent)",
   "#22c55e",
@@ -237,7 +240,7 @@ export default function RepoContributionDistribution({ days = 365 }: { days?: nu
           Loading repository distribution...
         </div>
       ) : error ? (
-        <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-300">
+        <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-[var(--destructive)]">
           {error}
         </div>
       ) : data.length === 0 ? (


### PR DESCRIPTION
## Summary

Added a **Repository Contribution Distribution Chart** below the Contribution Heatmap section on the dashboard.

This chart helps users understand which repositories they contribute to the most by showing repository-wise commit distribution, percentage contribution, and hover tooltip details.

The chart uses real GitHub contribution data from the existing backend endpoint:

```txt
/api/metrics/repos?days=365
```

So it displays repository data for the logged-in GitHub user instead of using sample/static data.

Closes #308

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added a new `RepoContributionDistribution` component.
- Placed the chart below the **Contribution Heatmap** section on the dashboard.
- Used the existing `/api/metrics/repos?days=365` endpoint to fetch real repository metrics.
- Added repository-wise commit count display.
- Added percentage contribution calculation per repository.
- Added Pie chart view for contribution share.
- Added Bar chart view for repository comparison.
- Added toggle support between Pie and Bar chart modes.
- Added hover tooltips showing:
  - Repository name
  - Commit count
  - Percentage contribution
- Added loading state while data is being fetched.
- Added empty state when no repository contribution data is available.
- Added error state if repository metrics fail to load.
- Updated chart styling to support both light and dark mode.
- Replaced hardcoded theme-breaking UI colors with CSS variables where applicable.
- Used `var(--accent)` for the first chart color.
- Added a comment explaining that the remaining chart colors are intentional categorical hues for distinguishing repositories.
- Replaced hardcoded error text color with `text-[var(--destructive)]`.
- Removed the accidentally committed `.env.localø` file.
- Added `.env.local*` to `.gitignore` so local environment files are not tracked.
- Ensured `RepoContributionDistribution.tsx` ends with a newline.

## How to Test

Steps for the reviewer to verify this works:

1. Pull this branch locally.

2. Install dependencies:

```bash
npm install
```

3. Add the required environment variables in `.env.local`:

```env
NEXT_PUBLIC_SUPABASE_URL=
NEXT_PUBLIC_SUPABASE_ANON_KEY=
SUPABASE_SERVICE_ROLE_KEY=

NEXTAUTH_SECRET=
NEXTAUTH_URL=http://localhost:3000

GITHUB_CLIENT_ID=
GITHUB_CLIENT_SECRET=
```

4. Start the development server:

```bash
npm run dev
```

5. Open the dashboard:

```txt
http://localhost:3000/dashboard
```

6. Log in using GitHub.

7. Scroll below the **Contribution Heatmap** section.

8. Verify that the **Repository Contribution Distribution Chart** is visible.

9. Verify that the chart displays real repository contribution data from the logged-in user.

10. Test both chart modes:
    - Pie chart
    - Bar chart

11. Hover over chart items and verify that the tooltip displays:
    - Repository name
    - Commit count
    - Percentage contribution

12. Verify all UI states:
    - Loading state
    - Empty state
    - Error state
    - Success state

13. Switch between light and dark mode and verify that the chart container, text, controls, and error state remain readable.

## Screenshots (if UI change)

Add screenshots here:

- Dashboard with Repository Contribution Distribution Chart
- Pie chart view
- Bar chart view
- Tooltip hover state
- Light mode view
- Dark mode view

## Checklist

- [x] Linked issue in summary
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Removed accidentally committed env file
- [x] Added `.env.local*` to `.gitignore`
- [x] Replaced hardcoded theme-breaking UI colors with CSS variables where applicable
- [x] Documented intentional chart-specific categorical colors
- [x] Ensured `RepoContributionDistribution.tsx` ends with a newline
- [ ] Added/updated tests if applicable