### PR TITLE
feat: add share and download functionality to StreakTracker

### DIFF
--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -53,6 +53,25 @@ export default function StreakTracker() {
   const animatedLongest = useCountUp(data?.longest ?? 0);
   const animatedActiveDays = useCountUp(data?.totalActiveDays ?? 0);
 
+  const handleDownload = useCallback(async () => {
+    if (!containerRef.current) return;
+    try {
+      setIsDownloading(true);
+      const dataUrl = await toPng(containerRef.current, {
+        cacheBust: true,
+        style: { margin: "0" },
+      });
+      const link = document.createElement("a");
+      link.download = "devtrack-streak.png";
+      link.href = dataUrl;
+      link.click();
+    } catch (err) {
+      console.error("Failed to generate image", err);
+    } finally {
+      setIsDownloading(false);
+    }
+  }, []);
+
   const fetchStreak = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -352,25 +371,6 @@ export default function StreakTracker() {
     );
   };
 
-  const handleDownload = useCallback(async () => {
-    if (!containerRef.current) return;
-    try {
-      setIsDownloading(true);
-      const dataUrl = await toPng(containerRef.current, {
-        cacheBust: true,
-        style: { margin: "0" },
-      });
-      const link = document.createElement("a");
-      link.download = "devtrack-streak.png";
-      link.href = dataUrl;
-      link.click();
-    } catch (err) {
-      console.error("Failed to generate image", err);
-    } finally {
-      setIsDownloading(false);
-    }
-  }, []);
-
   return (
     <>
       {shouldShowBanner && currentMilestone && (
@@ -379,13 +379,9 @@ export default function StreakTracker() {
           onDismiss={handleDismissBanner}
         />
       )}
-      <div ref={containerRef} className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <div className="mb-4 flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
-          Commit Streaks
-        </h2>
+      <div className="relative">
         {data && (
-          <div className="flex items-center gap-2">
+          <div className="absolute top-6 right-6 flex items-center gap-2 z-10">
             <button
               type="button"
               onClick={handleCopy}
@@ -403,10 +399,10 @@ export default function StreakTracker() {
               onClick={handleDownload}
               disabled={isDownloading}
               className="cursor-pointer flex h-8 items-center justify-center rounded-md px-3 py-1.5 text-xs font-medium bg-[var(--accent)] text-[var(--accent-foreground)] hover:opacity-90 disabled:opacity-70 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-colors gap-1.5 shadow-sm"
-              aria-label="Share streak stats as image"
+              aria-label="Download streak stats as image"
             >
               {isDownloading ? (
-                <span className="w-4 h-4 rounded-full border-2 border-white/30 border-t-white animate-spin" />
+                <span className="w-4 h-4 rounded-full border-2 border-[var(--accent-foreground)]/30 border-t-[var(--accent-foreground)] animate-spin" />
               ) : (
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
               )}
@@ -414,8 +410,15 @@ export default function StreakTracker() {
             </button>
           </div>
         )}
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+
+        <div ref={containerRef} className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+              Commit Streaks
+            </h2>
+            {data && <div className="h-8 w-24" />}
+          </div>
+          <div className="grid grid-cols-2 gap-3">
         {stats.map((stat) => (
           <div
             key={stat.label}
@@ -592,6 +595,7 @@ export default function StreakTracker() {
           />
         </>
       ) : null}
+      </div>
     </div>
     </>
   );

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -402,7 +402,7 @@ export default function StreakTracker() {
               type="button"
               onClick={handleDownload}
               disabled={isDownloading}
-              className="cursor-pointer flex h-8 items-center justify-center rounded-md px-3 py-1.5 text-xs font-medium bg-[#5b6ef6] text-white hover:bg-[#4b5ee6] disabled:opacity-70 focus:outline-none focus:ring-2 focus:ring-[#5b6ef6]/50 transition-colors gap-1.5 shadow-sm"
+              className="cursor-pointer flex h-8 items-center justify-center rounded-md px-3 py-1.5 text-xs font-medium bg-[var(--accent)] text-[var(--accent-foreground)] hover:opacity-90 disabled:opacity-70 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-colors gap-1.5 shadow-sm"
               aria-label="Share streak stats as image"
             >
               {isDownloading ? (

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -1,10 +1,11 @@
 "use client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { useAccount } from "@/components/AccountContext";
 import { useCountUp } from "@/hooks/useCountUp";
 import StreakMilestoneBanner from "@/components/StreakMilestoneBanner";
 import { useHeatmapTheme } from "@/hooks/useHeatmapTheme";
 import { toast } from "sonner";
+import { toPng } from "html-to-image";
 
 const STREAK_MILESTONES = [7, 30, 50, 100, 200, 365];
 
@@ -44,6 +45,9 @@ export default function StreakTracker() {
   const [freezeLoading, setFreezeLoading] = useState(true);
   const [cancelling, setCancelling] = useState(false);
   const [confirmCancel, setConfirmCancel] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const animatedCurrent = useCountUp(data?.current ?? 0);
   const animatedLongest = useCountUp(data?.longest ?? 0);
@@ -348,6 +352,25 @@ export default function StreakTracker() {
     );
   };
 
+  const handleDownload = useCallback(async () => {
+    if (!containerRef.current) return;
+    try {
+      setIsDownloading(true);
+      const dataUrl = await toPng(containerRef.current, {
+        cacheBust: true,
+        style: { margin: "0" },
+      });
+      const link = document.createElement("a");
+      link.download = "devtrack-streak.png";
+      link.href = dataUrl;
+      link.click();
+    } catch (err) {
+      console.error("Failed to generate image", err);
+    } finally {
+      setIsDownloading(false);
+    }
+  }, []);
+
   return (
     <>
       {shouldShowBanner && currentMilestone && (
@@ -356,24 +379,40 @@ export default function StreakTracker() {
           onDismiss={handleDismissBanner}
         />
       )}
-    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <div ref={containerRef} className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
           Commit Streaks
         </h2>
         {data && (
-          <button
-            type="button"
-            onClick={handleCopy}
-            className="cursor-pointer flex h-8 items-center justify-center rounded-md px-2 text-sm text-[var(--muted-foreground)] hover:bg-[var(--control)] hover:text-[var(--card-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-colors"
-            aria-label="Copy streak stats to clipboard"
-          >
-            {copied ? (
-              <span className="text-xs font-medium text-[var(--success)]">Copied!</span>
-            ) : (
-              <span className="text-base opacity-80 hover:opacity-100">📋</span>
-            )}
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="cursor-pointer flex h-8 items-center justify-center rounded-md px-2 text-sm text-[var(--muted-foreground)] hover:bg-[var(--control)] hover:text-[var(--card-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition-colors"
+              aria-label="Copy streak stats to clipboard"
+            >
+              {copied ? (
+                <span className="text-xs font-medium text-[var(--success)]">Copied!</span>
+              ) : (
+                <span className="text-base opacity-80 hover:opacity-100">📋</span>
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={isDownloading}
+              className="cursor-pointer flex h-8 items-center justify-center rounded-md px-3 py-1.5 text-xs font-medium bg-[#5b6ef6] text-white hover:bg-[#4b5ee6] disabled:opacity-70 focus:outline-none focus:ring-2 focus:ring-[#5b6ef6]/50 transition-colors gap-1.5 shadow-sm"
+              aria-label="Share streak stats as image"
+            >
+              {isDownloading ? (
+                <span className="w-4 h-4 rounded-full border-2 border-white/30 border-t-white animate-spin" />
+              ) : (
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+              )}
+              <span>SHARE</span>
+            </button>
+          </div>
         )}
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">


### PR DESCRIPTION
## Summary

This PR adds a new "Share" feature to the `StreakTracker` widget, allowing users to effortlessly generate and download a high-quality PNG image of their coding streaks. This removes the friction of manually taking screenshots and helps users easily share their DevTrack stats on platforms like Twitter or LinkedIn!

Closes #<304>

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added a new stylish **SHARE** button with a download icon inside the StreakTracker header, positioned neatly next to the copy-to-clipboard button.
- Integrated `html-to-image` via `toPng` to capture the `StreakTracker` container programmatically.
- Implemented an `isDownloading` state that shows a smooth spinner animation inside the button while the image generates.
- Handled the automated download mechanism, saving the generated image cleanly as `devtrack-streak.png`.

## How to Test

Steps for the reviewer to verify this works:

1. Pull down the branch and run `npm install` to install `html-to-image`.
2. Start the server with `npm run dev` and navigate to a dashboard page with the StreakTracker widget.
3. Click the new blue "SHARE" button in the StreakTracker header.
4. Verify that the button shows a loading spinner briefly, and that a file named `devtrack-streak.png` is automatically downloaded.
5. Open the downloaded image to verify that the styling (Light/Dark mode) matches the live component exactly.

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
