### PR TITLE
a11y: add ARIA loading feedback to skeletons

### DIFF
--- a/src/components/CIAnalytics.tsx
+++ b/src/components/CIAnalytics.tsx
@@ -74,10 +74,17 @@ export default function CIAnalytics() {
       </div>
 
       {loading ? (
-        <div className="grid grid-cols-2 gap-4">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="grid grid-cols-2 gap-4"
+        >
+          <span className="sr-only">Loading CI analytics</span>
           {[1, 2, 3, 4].map((item) => (
             <div
               key={item}
+              aria-hidden="true"
               className="h-20 rounded-lg bg-[var(--card-muted)] animate-pulse"
             />
           ))}

--- a/src/components/CommitTimeChart.tsx
+++ b/src/components/CommitTimeChart.tsx
@@ -111,10 +111,17 @@ export default function CommitTimeChart() {
 
       <div className="flex-1 min-h-[250px]">
         {loading ? (
-          <div className="flex h-full flex-col justify-end space-y-3 pt-6 pb-2">
+          <div
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+            className="flex h-full flex-col justify-end space-y-3 pt-6 pb-2"
+          >
+            <span className="sr-only">Loading commit time chart</span>
             {[1, 2, 3, 4].map((i) => (
               <div
                 key={i}
+                aria-hidden="true"
                 className="h-10 rounded bg-[var(--card-muted)] animate-pulse"
               />
             ))}

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -326,7 +326,17 @@ export default function ContributionGraph() {
       </div>
 
       {loading ? (
-        <div className="h-[220px] rounded border border-[var(--border)] bg-[var(--background)] animate-pulse" />
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+        >
+          <span className="sr-only">Loading contribution graph</span>
+          <div
+            aria-hidden="true"
+            className="h-[220px] rounded border border-[var(--border)] bg-[var(--background)] animate-pulse"
+          />
+        </div>
       ) : error ? (
         <div className="flex h-[220px] items-center rounded-lg border border-[var(--border)] bg-[var(--background)] px-4">
           <p className="text-sm text-[var(--muted-foreground)]">

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -152,13 +152,19 @@ export default function GoalTracker() {
   if (loading) {
     return (
       <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-        <div className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse" />
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="mb-4">
-            <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse mb-2" />
-            <div className="h-2 bg-[var(--card-muted)] rounded animate-pulse" />
-          </div>
-        ))}
+        <div role="status" aria-live="polite" aria-busy="true">
+          <span className="sr-only">Loading weekly goals</span>
+          <div
+            aria-hidden="true"
+            className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse"
+          />
+          {[1, 2, 3].map((i) => (
+            <div key={i} aria-hidden="true" className="mb-4">
+              <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse mb-2" />
+              <div className="h-2 bg-[var(--card-muted)] rounded animate-pulse" />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/src/components/IssueMetrics.tsx
+++ b/src/components/IssueMetrics.tsx
@@ -61,10 +61,17 @@ export default function IssueMetrics() {
         Issue Analytics
       </h2>
       {loading ? (
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="grid grid-cols-2 md:grid-cols-5 gap-4"
+        >
+          <span className="sr-only">Loading issue analytics</span>
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
+              aria-hidden="true"
               className="h-20 rounded-lg bg-[var(--card-muted)] p-4 animate-pulse"
             />
           ))}

--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -59,9 +59,18 @@ export default function LanguageBreakdown() {
       </h2>
 
       {loading ? (
-        <div className="space-y-3">
-          <div className="h-6 rounded-full bg-[var(--card-muted)] animate-pulse" />
-          <div className="grid grid-cols-2 gap-2 mt-3">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="space-y-3"
+        >
+          <span className="sr-only">Loading language breakdown</span>
+          <div
+            aria-hidden="true"
+            className="h-6 rounded-full bg-[var(--card-muted)] animate-pulse"
+          />
+          <div aria-hidden="true" className="grid grid-cols-2 gap-2 mt-3">
             {[1, 2, 3, 4].map((i) => (
               <div key={i} className="h-5 rounded bg-[var(--card-muted)] animate-pulse" />
             ))}

--- a/src/components/PRBreakdownChart.tsx
+++ b/src/components/PRBreakdownChart.tsx
@@ -49,8 +49,17 @@ export default function PRBreakdownChart() {
   if (loading) {
     return (
       <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-        <div className="mb-4 h-5 w-40 rounded bg-[var(--card-muted)] animate-pulse" />
-        <div className="h-[200px] rounded bg-[var(--card-muted)] animate-pulse" />
+        <div role="status" aria-live="polite" aria-busy="true">
+          <span className="sr-only">Loading PR breakdown</span>
+          <div
+            aria-hidden="true"
+            className="mb-4 h-5 w-40 rounded bg-[var(--card-muted)] animate-pulse"
+          />
+          <div
+            aria-hidden="true"
+            className="h-[200px] rounded bg-[var(--card-muted)] animate-pulse"
+          />
+        </div>
       </div>
     );
   }

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -70,10 +70,17 @@ export default function PRMetrics() {
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Analytics</h2>
       {loading ? (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="grid grid-cols-2 md:grid-cols-4 gap-4"
+        >
+          <span className="sr-only">Loading PR analytics</span>
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
+              aria-hidden="true"
               className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse"
             />
           ))}

--- a/src/components/PersonalRecords.tsx
+++ b/src/components/PersonalRecords.tsx
@@ -251,10 +251,17 @@ export default function PersonalRecords() {
         Personal Records
       </h2>
       {loading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 items-stretch">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 items-stretch"
+        >
+          <span className="sr-only">Loading personal records</span>
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
+              aria-hidden="true"
               className="h-32 rounded-lg bg-[var(--card-muted)] p-4 animate-pulse"
             />
           ))}

--- a/src/components/PinnedRepos.tsx
+++ b/src/components/PinnedRepos.tsx
@@ -44,9 +44,19 @@ export default function PinnedRepos() {
         Pinned Repositories
       </h2>
       {loading ? (
-        <div className="space-y-3">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="space-y-3"
+        >
+          <span className="sr-only">Loading pinned repositories</span>
           {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="h-24 rounded-lg bg-[var(--card-muted)] animate-pulse" />
+            <div
+              key={i}
+              aria-hidden="true"
+              className="h-24 rounded-lg bg-[var(--card-muted)] animate-pulse"
+            />
           ))}
         </div>
       ) : error ? (

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -137,11 +137,17 @@ export default function StreakTracker() {
   if (loading) {
     return (
       <div className="bg-[var(--card)] rounded-xl p-6">
-        <div className="h-6 w-36 bg-[var(--card-muted)] rounded animate-pulse mb-4" />
-        <div className="grid grid-cols-2 gap-4">
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="bg-[var(--card-muted)] rounded-lg h-28 animate-pulse" />
-          ))}
+        <div role="status" aria-live="polite" aria-busy="true">
+          <span className="sr-only">Loading streak tracker</span>
+          <div
+            aria-hidden="true"
+            className="h-6 w-36 bg-[var(--card-muted)] rounded animate-pulse mb-4"
+          />
+          <div aria-hidden="true" className="grid grid-cols-2 gap-4">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="bg-[var(--card-muted)] rounded-lg h-28 animate-pulse" />
+            ))}
+          </div>
         </div>
       </div>
     );

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -113,9 +113,19 @@ export default function TopRepos() {
         </select>
       </div>
       {loading ? (
-        <div className="space-y-3">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="space-y-3"
+        >
+          <span className="sr-only">Loading top repositories</span>
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-10 rounded bg-[var(--card-muted)] animate-pulse" />
+            <div
+              key={i}
+              aria-hidden="true"
+              className="h-10 rounded bg-[var(--card-muted)] animate-pulse"
+            />
           ))}
         </div>
       ) : error ? (

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -63,10 +63,17 @@ export default function WeeklySummaryCard() {
 
       {!isCollapsed &&
         (loading ? (
-          <div className="mt-4 space-y-3">
+          <div
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+            className="mt-4 space-y-3"
+          >
+            <span className="sr-only">Loading weekly summary</span>
             {[1, 2, 3, 4, 5].map((i) => (
               <div
                 key={i}
+                aria-hidden="true"
                 className="h-14 rounded-lg bg-[var(--card-muted)] animate-pulse"
               />
             ))}


### PR DESCRIPTION
## Summary
Skeleton loaders on the dashboard were silent for screen-reader users — no loading announcement, no completion signal. This PR adds purely additive ARIA semantics so assistive tech announces "Loading [widget]" while each widget fetches and falls quiet when its real content renders.

## Changes
- Wrapped each widget's skeleton block in `role="status"` + `aria-live="polite"` + `aria-busy="true"`.
- Added a visually hidden `<span className="sr-only">Loading …</span>` label inside each wrapper, using Tailwind's built-in `sr-only` utility (consistent with existing usage in `src/app/dashboard/settings/page.tsx`).
- Marked every decorative pulse `<div>` with `aria-hidden="true"` so screen readers don't enumerate the placeholders.
- Files touched (13, all in `src/components/`): `CIAnalytics`, `CommitTimeChart`, `ContributionGraph`, `GoalTracker`, `IssueMetrics`, `LanguageBreakdown`, `PRBreakdownChart`, `PRMetrics`, `PersonalRecords`, `PinnedRepos`, `StreakTracker`, `TopRepos`, `WeeklySummaryCard`.

No visual change. No data-flow change. No new components or dependencies.

## Accessibility impact
Previously, dashboard skeleton state was invisible to assistive tech. Now:
- **During load:** each loading widget emits a polite "Loading [widget]" announcement via its `role="status"` region.
- **On completion:** the status region unmounts; AT goes quiet and the user can navigate to the real content via its existing heading. Completion is communicated implicitly (no explicit "loaded" announcement) to avoid a cascade of overlapping messages as the 13 independent widgets finish at different times.
- Decorative pulse blocks are now `aria-hidden`, so only the single status message per widget is announced — not each placeholder shape.

Per-widget live regions were chosen over a single dashboard-root live region because each widget owns an independent `loading` state — there is no centralised loading signal that a root region could meaningfully announce.

## Testing
- `npm run lint` — clean; no new `jsx-a11y` warnings.
- `npm run build` — TypeScript compiles cleanly (`✓ Compiled successfully`).
- DOM inspected in DevTools: every skeleton wrapper carries `role="status"`, `aria-live="polite"`, `aria-busy="true"`, contains an `sr-only` "Loading …" span, and every pulse child has `aria-hidden="true"`.
- Expected screen-reader behavior (NVDA / VoiceOver): "Loading PR analytics", "Loading top repositories", etc. announced once per widget while fetching; silent after content arrives.
- No visual diff vs `main`; keyboard tab order unchanged (the live region is non-interactive and not focusable).

Closes #324.