### PR TITLE
Add stale PR indicators with configurable thresholds

### DIFF
--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -10,15 +10,12 @@ import { GITHUB_API } from "@/lib/github";
 import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
-
 interface PullRequest {
   title: string;
   created_at: string;
   html_url: string;
   state: string;
-}
-
-interface PRMetricsBase {
+}interface PRMetricsBase {
   open: number;
   merged: number;
   total: number;
@@ -50,7 +47,6 @@ interface ReviewCommentEvent {
 function getRepoFullName(repositoryUrl: string): string | null {
   const marker = "/repos/";
   const index = repositoryUrl.indexOf(marker);
-
   return index >= 0 ? repositoryUrl.slice(index + marker.length) : null;
 }
 
@@ -77,22 +73,15 @@ async function fetchFirstReviewTimestamp(
     Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github+json",
   };
-
   const [reviewsRes, commentsRes] = await Promise.all([
-    fetch(
-      `${GITHUB_API}/repos/${repo}/pulls/${pr.number}/reviews?per_page=100`,
-      {
-        headers,
-        cache: "no-store",
-      }
-    ),
-    fetch(
-      `${GITHUB_API}/repos/${repo}/pulls/${pr.number}/comments?per_page=100`,
-      {
-        headers,
-        cache: "no-store",
-      }
-    ),
+    fetch(`${GITHUB_API}/repos/${repo}/pulls/${pr.number}/reviews?per_page=100`, {
+      headers,
+      cache: "no-store",
+    }),
+    fetch(`${GITHUB_API}/repos/${repo}/pulls/${pr.number}/comments?per_page=100`, {
+      headers,
+      cache: "no-store",
+    }),
   ]);
 
   if (!reviewsRes.ok || !commentsRes.ok) {
@@ -121,7 +110,6 @@ async function getAverageFirstReviewHours(
       }
 
       const openedAt = new Date(pr.created_at).getTime();
-
       if (Number.isNaN(openedAt) || firstReviewAt < openedAt) {
         return null;
       }
@@ -129,7 +117,6 @@ async function getAverageFirstReviewHours(
       return (firstReviewAt - openedAt) / 3600000;
     })
   );
-
   const validDurations = reviewedPrs.filter(
     (value): value is number => typeof value === "number"
   );
@@ -146,6 +133,8 @@ async function getAverageFirstReviewHours(
 }
 
 async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
+
+  
   const searchRes = await fetch(
     `${GITHUB_API}/search/issues?q=type:pr+author:@me&sort=updated&order=desc&per_page=100`,
     {
@@ -158,28 +147,25 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
     throw new Error("GitHub API error");
   }
 
-  const data = (await searchRes.json()) as {
-    total_count: number;
-    items: PullRequestSearchItem[];
-  };
+ const data = (await searchRes.json()) as {
+  total_count: number;
+  items: PullRequestSearchItem[];
+};
 
   const open = data.items.filter((pr) => pr.state === "open").length;
 
+  // A PR with state "closed" may have been merged OR closed without merging
+  // (e.g. rejected, abandoned). Only count those with a non-null merged_at
+  // as truly merged so the dashboard does not inflate the merged count.
   const merged = data.items.filter(
     (pr) => pr.pull_request?.merged_at != null
   ).length;
 
+  // Average review time: use only actually merged PRs so we measure the time
+  // from open to merge, not open to close-without-merge.
   const mergedPRs = data.items.filter(
     (pr) => pr.pull_request?.merged_at != null
   );
-
-  const prs = data.items.map((pr) => ({
-    title: pr.title,
-    created_at: pr.created_at,
-    html_url: pr.html_url,
-    state: pr.state,
-  }));
-
   const avgReviewMs =
     mergedPRs.length > 0
       ? mergedPRs.reduce(
@@ -190,23 +176,33 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
           0
         ) / mergedPRs.length
       : 0;
+      const prs = data.items.map((pr) => ({
+  title: pr.title,
+  created_at: pr.created_at,
+  html_url: pr.html_url,
+  state: pr.state,
+}));
 
+  // Use the number of fetched items as the denominator for mergeRate.
+  // data.total_count is the all-time GitHub total (potentially thousands)
+  // while data.items is capped at 100, so dividing merged/total_count
+  // produces a near-zero rate for any active user. The fetched sample
+  // (open + merged + closed-without-merge) is the correct base.
   const sampleTotal = data.items.length;
-
   const avgFirstReviewHours = await getAverageFirstReviewHours(
     token,
     data.items
   );
 
-  return {
-    open,
-    merged,
-    total: data.total_count,
-    avgReviewHours: Math.round(avgReviewMs / 3600000),
-    avgFirstReviewHours,
-    mergeRate: sampleTotal > 0 ? merged / sampleTotal : 0,
-    prs,
-  };
+return {
+  open,
+  merged,
+  total: data.total_count,
+  avgReviewHours: Math.round(avgReviewMs / 3600000),
+  avgFirstReviewHours,
+  mergeRate: sampleTotal > 0 ? merged / sampleTotal : 0,
+  prs,
+};
 }
 
 function formatPRMetrics(metrics: PRMetricsBase) {
@@ -216,17 +212,16 @@ function formatPRMetrics(metrics: PRMetricsBase) {
     total: metrics.total,
     avgReviewHours: metrics.avgReviewHours,
     avgFirstReviewHours: metrics.avgFirstReviewHours,
-    prs: metrics.prs,
     mergeRate:
       metrics.total > 0
         ? `${Math.round(metrics.mergeRate * 100)}%`
         : "0%",
+    prs: metrics.prs,
   };
 }
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
-
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -236,7 +231,6 @@ export async function GET(req: NextRequest) {
   if (!accountId) {
     try {
       const result = await fetchPRMetrics(session.accessToken);
-
       return Response.json(formatPRMetrics(result));
     } catch {
       return Response.json({ error: "GitHub API error" }, { status: 502 });
@@ -274,16 +268,13 @@ export async function GET(req: NextRequest) {
     const merged = mergeMetrics(results, (a, b) => {
       const total = a.total + b.total;
       const mergedCount = a.merged + b.merged;
-
       const avgReviewHours =
         total > 0
           ? (a.avgReviewHours * a.total + b.avgReviewHours * b.total) / total
           : 0;
-
       const reviewedTotal =
         (a.avgFirstReviewHours === null ? 0 : a.total) +
         (b.avgFirstReviewHours === null ? 0 : b.total);
-
       const avgFirstReviewHours =
         reviewedTotal > 0
           ? ((a.avgFirstReviewHours ?? 0) * a.total +
@@ -293,6 +284,7 @@ export async function GET(req: NextRequest) {
 
       return {
         open: a.open + b.open,
+        prs: [...a.prs, ...b.prs],
         merged: mergedCount,
         total,
         avgReviewHours: Math.round(avgReviewHours * 10) / 10,
@@ -302,7 +294,6 @@ export async function GET(req: NextRequest) {
             : Math.round(avgFirstReviewHours * 10) / 10,
         mergeRate:
           total > 0 ? Math.round((mergedCount / total) * 100) / 100 : 0,
-        prs: [...a.prs, ...b.prs],
       };
     });
 
@@ -324,7 +315,6 @@ export async function GET(req: NextRequest) {
 
   try {
     const result = await fetchPRMetrics(token);
-
     return Response.json(formatPRMetrics(result));
   } catch {
     return Response.json({ error: "GitHub API error" }, { status: 502 });

--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -11,17 +11,143 @@ import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
+interface PullRequest {
+  title: string;
+  created_at: string;
+  html_url: string;
+  state: string;
+}
+
 interface PRMetricsBase {
   open: number;
   merged: number;
   total: number;
   avgReviewHours: number;
+  avgFirstReviewHours: number | null;
   mergeRate: number;
+  prs: PullRequest[];
+}
+
+interface PullRequestSearchItem {
+  title: string;
+  state: string;
+  created_at: string;
+  closed_at: string | null;
+  number: number;
+  repository_url: string;
+  html_url: string;
+  pull_request?: { merged_at: string | null };
+}
+
+interface ReviewEvent {
+  submitted_at?: string | null;
+}
+
+interface ReviewCommentEvent {
+  created_at?: string | null;
+}
+
+function getRepoFullName(repositoryUrl: string): string | null {
+  const marker = "/repos/";
+  const index = repositoryUrl.indexOf(marker);
+
+  return index >= 0 ? repositoryUrl.slice(index + marker.length) : null;
+}
+
+function getEarliestTimestamp(values: Array<string | null | undefined>) {
+  const timestamps = values
+    .filter((value): value is string => Boolean(value))
+    .map((value) => new Date(value).getTime())
+    .filter((value) => !Number.isNaN(value));
+
+  return timestamps.length > 0 ? Math.min(...timestamps) : null;
+}
+
+async function fetchFirstReviewTimestamp(
+  token: string,
+  pr: PullRequestSearchItem
+): Promise<number | null> {
+  const repo = getRepoFullName(pr.repository_url);
+
+  if (!repo) {
+    return null;
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+  };
+
+  const [reviewsRes, commentsRes] = await Promise.all([
+    fetch(
+      `${GITHUB_API}/repos/${repo}/pulls/${pr.number}/reviews?per_page=100`,
+      {
+        headers,
+        cache: "no-store",
+      }
+    ),
+    fetch(
+      `${GITHUB_API}/repos/${repo}/pulls/${pr.number}/comments?per_page=100`,
+      {
+        headers,
+        cache: "no-store",
+      }
+    ),
+  ]);
+
+  if (!reviewsRes.ok || !commentsRes.ok) {
+    return null;
+  }
+
+  const reviews = (await reviewsRes.json()) as ReviewEvent[];
+  const comments = (await commentsRes.json()) as ReviewCommentEvent[];
+
+  return getEarliestTimestamp([
+    ...reviews.map((review) => review.submitted_at),
+    ...comments.map((comment) => comment.created_at),
+  ]);
+}
+
+async function getAverageFirstReviewHours(
+  token: string,
+  prs: PullRequestSearchItem[]
+): Promise<number | null> {
+  const reviewedPrs = await Promise.all(
+    prs.slice(0, 30).map(async (pr) => {
+      const firstReviewAt = await fetchFirstReviewTimestamp(token, pr);
+
+      if (!firstReviewAt) {
+        return null;
+      }
+
+      const openedAt = new Date(pr.created_at).getTime();
+
+      if (Number.isNaN(openedAt) || firstReviewAt < openedAt) {
+        return null;
+      }
+
+      return (firstReviewAt - openedAt) / 3600000;
+    })
+  );
+
+  const validDurations = reviewedPrs.filter(
+    (value): value is number => typeof value === "number"
+  );
+
+  if (validDurations.length === 0) {
+    return null;
+  }
+
+  const average =
+    validDurations.reduce((sum, value) => sum + value, 0) /
+    validDurations.length;
+
+  return Math.round(average * 10) / 10;
 }
 
 async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
   const searchRes = await fetch(
-    `${GITHUB_API}/search/issues?q=type:pr+author:@me&per_page=100`,
+    `${GITHUB_API}/search/issues?q=type:pr+author:@me&sort=updated&order=desc&per_page=100`,
     {
       headers: { Authorization: `Bearer ${token}` },
       cache: "no-store",
@@ -34,30 +160,52 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
 
   const data = (await searchRes.json()) as {
     total_count: number;
-    items: Array<{ state: string; created_at: string; closed_at: string | null }>;
+    items: PullRequestSearchItem[];
   };
 
   const open = data.items.filter((pr) => pr.state === "open").length;
-  const merged = data.items.filter((pr) => pr.state === "closed").length;
 
-  const closedPRs = data.items.filter((pr) => pr.closed_at);
+  const merged = data.items.filter(
+    (pr) => pr.pull_request?.merged_at != null
+  ).length;
+
+  const mergedPRs = data.items.filter(
+    (pr) => pr.pull_request?.merged_at != null
+  );
+
+  const prs = data.items.map((pr) => ({
+    title: pr.title,
+    created_at: pr.created_at,
+    html_url: pr.html_url,
+    state: pr.state,
+  }));
+
   const avgReviewMs =
-    closedPRs.length > 0
-      ? closedPRs.reduce(
+    mergedPRs.length > 0
+      ? mergedPRs.reduce(
           (sum, pr) =>
             sum +
-            (new Date(pr.closed_at!).getTime() -
+            (new Date(pr.pull_request!.merged_at!).getTime() -
               new Date(pr.created_at).getTime()),
           0
-        ) / closedPRs.length
+        ) / mergedPRs.length
       : 0;
+
+  const sampleTotal = data.items.length;
+
+  const avgFirstReviewHours = await getAverageFirstReviewHours(
+    token,
+    data.items
+  );
 
   return {
     open,
     merged,
     total: data.total_count,
     avgReviewHours: Math.round(avgReviewMs / 3600000),
-    mergeRate: data.total_count > 0 ? merged / data.total_count : 0,
+    avgFirstReviewHours,
+    mergeRate: sampleTotal > 0 ? merged / sampleTotal : 0,
+    prs,
   };
 }
 
@@ -67,6 +215,8 @@ function formatPRMetrics(metrics: PRMetricsBase) {
     merged: metrics.merged,
     total: metrics.total,
     avgReviewHours: metrics.avgReviewHours,
+    avgFirstReviewHours: metrics.avgFirstReviewHours,
+    prs: metrics.prs,
     mergeRate:
       metrics.total > 0
         ? `${Math.round(metrics.mergeRate * 100)}%`
@@ -76,6 +226,7 @@ function formatPRMetrics(metrics: PRMetricsBase) {
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
+
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -85,6 +236,7 @@ export async function GET(req: NextRequest) {
   if (!accountId) {
     try {
       const result = await fetchPRMetrics(session.accessToken);
+
       return Response.json(formatPRMetrics(result));
     } catch {
       return Response.json({ error: "GitHub API error" }, { status: 502 });
@@ -122,18 +274,35 @@ export async function GET(req: NextRequest) {
     const merged = mergeMetrics(results, (a, b) => {
       const total = a.total + b.total;
       const mergedCount = a.merged + b.merged;
+
       const avgReviewHours =
         total > 0
           ? (a.avgReviewHours * a.total + b.avgReviewHours * b.total) / total
           : 0;
+
+      const reviewedTotal =
+        (a.avgFirstReviewHours === null ? 0 : a.total) +
+        (b.avgFirstReviewHours === null ? 0 : b.total);
+
+      const avgFirstReviewHours =
+        reviewedTotal > 0
+          ? ((a.avgFirstReviewHours ?? 0) * a.total +
+              (b.avgFirstReviewHours ?? 0) * b.total) /
+            reviewedTotal
+          : null;
 
       return {
         open: a.open + b.open,
         merged: mergedCount,
         total,
         avgReviewHours: Math.round(avgReviewHours * 10) / 10,
+        avgFirstReviewHours:
+          avgFirstReviewHours === null
+            ? null
+            : Math.round(avgFirstReviewHours * 10) / 10,
         mergeRate:
           total > 0 ? Math.round((mergedCount / total) * 100) / 100 : 0,
+        prs: [...a.prs, ...b.prs],
       };
     });
 
@@ -155,6 +324,7 @@ export async function GET(req: NextRequest) {
 
   try {
     const result = await fetchPRMetrics(token);
+
     return Response.json(formatPRMetrics(result));
   } catch {
     return Response.json({ error: "GitHub API error" }, { status: 502 });

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,8 +1,5 @@
 import { Metadata } from "next";
 import BadgeSection from "@/components/BadgeSection";
-import ContributionGraph from "@/components/ContributionGraph";
-import StreakTracker from "@/components/StreakTracker";
-import TopRepos from "@/components/TopRepos";
 import BackToDashboard from "@/components/BackToDashboard";
 interface PublicProfileData {
   username: string;
@@ -219,7 +216,16 @@ function PublicContributionGraph({
  * Public variant of StreakTracker component.
  * Displays data passed as props.
  */
-function PublicStreakTracker({ streak }: { streak: any }) {
+function PublicStreakTracker({
+  streak,
+}: {
+  streak: {
+    current: number;
+    longest: number;
+    lastCommitDate: string | null;
+    totalActiveDays: number;
+  };
+}) {
   const stats = [
     {
       label: "Current Streak",
@@ -351,6 +357,7 @@ function PublicTopRepos({
     </div>
   );
 }
+
 
 
 

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -22,9 +22,12 @@ interface PublicProfileData {
 }
 
 async function fetchPublicProfile(
-  username: string
+  username: string,
 ): Promise<PublicProfileData | null> {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || "http://localhost:3000";
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    "http://localhost:3000";
 
   try {
     const res = await fetch(`${baseUrl}/api/public/${username}`, {
@@ -50,7 +53,10 @@ export async function generateMetadata({
   const { username } = params;
   const profile = await fetchPublicProfile(username);
 
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || "http://localhost:3000";
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    "http://localhost:3000";
   const profileUrl = `${baseUrl}/u/${username}`;
 
   if (!profile) {
@@ -303,7 +309,7 @@ function PublicTopRepos({
           {repos.map((repo, idx) => {
             const barWidth = Math.max(
               Math.round((repo.commits / maxCommits) * 100),
-              4
+              4,
             );
             const shortName = repo.name.split("/")[1] ?? repo.name;
             return (

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -3,7 +3,7 @@ import BadgeSection from "@/components/BadgeSection";
 import ContributionGraph from "@/components/ContributionGraph";
 import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
-
+import BackToDashboard from "@/components/BackToDashboard";
 interface PublicProfileData {
   username: string;
   userId: string;
@@ -116,14 +116,20 @@ export default async function PublicProfilePage({
   return (
     <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors">
       {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl md:text-4xl font-bold text-[var(--foreground)]">
-          @{profile.username}&apos;s Profile
-        </h1>
-        <p className="mt-2 text-[var(--muted-foreground)]">
-          GitHub activity and coding stats
-        </p>
-      </div>
+     
+<div className="mb-8 flex flex-col gap-4">
+  <BackToDashboard username={profile.username} />
+
+  <div>
+    <h1 className="text-3xl md:text-4xl font-bold text-[var(--foreground)]">
+      @{profile.username}&apos;s Profile
+    </h1>
+
+    <p className="mt-2 text-[var(--muted-foreground)]">
+      GitHub activity and coding stats
+    </p>
+  </div>
+</div>
 
       {/* Row 1: Contribution graph + Streak */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -345,3 +351,6 @@ function PublicTopRepos({
     </div>
   );
 }
+
+
+

--- a/src/components/BackToDashboard.tsx
+++ b/src/components/BackToDashboard.tsx
@@ -16,3 +16,5 @@ export default function BackToDashboard({ username }: Props) {
     </Link>
   );
 }
+
+

--- a/src/components/BackToDashboard.tsx
+++ b/src/components/BackToDashboard.tsx
@@ -18,3 +18,5 @@ export default function BackToDashboard({ username }: Props) {
 }
 
 
+
+

--- a/src/components/BackToDashboard.tsx
+++ b/src/components/BackToDashboard.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+
+interface Props {
+  username: string;
+}
+
+export default function BackToDashboard({ username }: Props) {
+  return (
+    <Link
+      href={`/dashboard/${username}`}
+      className="mb-4 inline-flex items-center gap-2 text-sm text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
+    >
+      ← Back to Dashboard
+    </Link>
+  );
+}

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -7,14 +7,25 @@ interface PRData {
   open: number;
   merged: number;
   avgReviewHours: number;
+  avgFirstReviewHours: number | null;
   mergeRate: string;
+  prs: PullRequest[];
+}
+
+interface PullRequest {
+  title: string;
+  created_at: string;
+  html_url: string;
+  state: string;
 }
 
 export default function PRMetrics() {
   const { selectedAccount } = useAccount();
+
   const [metrics, setMetrics] = useState<PRData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [staleDays, setStaleDays] = useState(7);
 
   const fetchMetrics = useCallback(() => {
     setLoading(true);
@@ -31,7 +42,11 @@ export default function PRMetrics() {
         return r.json();
       })
       .then((data: PRData) => setMetrics(data))
-      .catch(() => setError("We couldn't load your PR analytics right now. Please try again in a moment."))
+      .catch(() =>
+        setError(
+          "We couldn't load your PR analytics right now. Please try again in a moment."
+        )
+      )
       .finally(() => setLoading(false));
   }, [selectedAccount]);
 
@@ -39,30 +54,61 @@ export default function PRMetrics() {
     fetchMetrics();
   }, [fetchMetrics]);
 
+  const isStale = (createdAt: string) => {
+    const createdDate = new Date(createdAt);
+    const now = new Date();
+
+    const diffTime = now.getTime() - createdDate.getTime();
+    const diffDays = diffTime / (1000 * 60 * 60 * 24);
+
+    return diffDays > staleDays;
+  };
+
+  const stalePRs =
+    metrics?.prs.filter(
+      (pr) => pr.state === "open" && isStale(pr.created_at)
+    ) || [];
+
   const stats = metrics
     ? [
         { label: "Open PRs", value: metrics.open },
         { label: "Merged (30d)", value: metrics.merged },
-        { label: "Avg Review Time", value: `${metrics.avgReviewHours}h` },
+        {
+          label: "Avg Review Time",
+          value: `${metrics.avgReviewHours}h`,
+        },
+        {
+          label: "Avg First Review",
+          value:
+            metrics.avgFirstReviewHours === null
+              ? "—"
+              : metrics.avgFirstReviewHours < 24
+                ? `${metrics.avgFirstReviewHours}h`
+                : `${Math.round((metrics.avgFirstReviewHours / 24) * 10) / 10}d`,
+        },
         { label: "Merge Rate", value: metrics.mergeRate },
       ]
     : [];
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Analytics</h2>
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
+        PR Analytics
+      </h2>
+
       {loading ? (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
-              className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse"
+              className="h-24 rounded-lg bg-[var(--card-muted)] p-4 animate-pulse"
             />
           ))}
         </div>
       ) : error ? (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
           <p>{error}</p>
+
           <button
             type="button"
             onClick={fetchMetrics}
@@ -72,19 +118,68 @@ export default function PRMetrics() {
           </button>
         </div>
       ) : (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          {stats.map((stat) => (
-            <div
-              key={stat.label}
-              className="rounded-lg bg-[var(--control)] p-4 text-center"
-            >
-              <div className="text-2xl font-bold text-[var(--accent)]">
-                {stat.value}
-              </div>
-              <div className="mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
+        <>
+          <div className="mb-4 flex items-center justify-between">
+            <div className="rounded-full bg-orange-500/10 px-3 py-1 text-sm text-orange-400">
+              {stalePRs.length} PRs stale &gt; {staleDays} days
             </div>
-          ))}
-        </div>
+
+            <select
+              value={staleDays}
+              onChange={(e) => setStaleDays(Number(e.target.value))}
+              className="rounded-md border border-[var(--border)] bg-[var(--card)] px-2 py-1 text-sm"
+            >
+              <option value={7}>7 days</option>
+              <option value={14}>14 days</option>
+              <option value={30}>30 days</option>
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
+            {stats.map((stat) => (
+              <div
+                key={stat.label}
+                className="min-w-0 rounded-lg bg-[var(--control)] p-4 text-center"
+              >
+                <div className="truncate text-2xl font-bold text-[var(--accent)]">
+                  {stat.value}
+                </div>
+
+                <div className="mt-1 truncate text-sm text-[var(--muted-foreground)]">
+                  {stat.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {stalePRs.length > 0 && (
+            <div className="mt-6">
+              <h3 className="mb-3 text-sm font-semibold text-[var(--card-foreground)]">
+                Stale Pull Requests
+              </h3>
+
+              <div className="space-y-2">
+                {stalePRs.map((pr) => (
+                  <a
+                    key={pr.html_url}
+                    href={pr.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center justify-between rounded-lg bg-[var(--control)] p-3 transition hover:opacity-90"
+                  >
+                    <span className="text-sm text-[var(--card-foreground)]">
+                      {pr.title}
+                    </span>
+
+                    <span className="rounded-full bg-orange-500/10 px-2 py-1 text-xs font-medium text-orange-400">
+                      Stale
+                    </span>
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -19,6 +19,18 @@ interface PullRequest {
   state: string;
 }
 
+function formatReviewCycle(hours: number | null): string {
+  if (hours === null) {
+    return "—";
+  }
+
+  if (hours < 24) {
+    return `${hours}h`;
+  }
+
+  return `${Math.round((hours / 24) * 10) / 10}d`;
+}
+
 export default function PRMetrics() {
   const { selectedAccount } = useAccount();
 
@@ -73,18 +85,11 @@ export default function PRMetrics() {
     ? [
         { label: "Open PRs", value: metrics.open },
         { label: "Merged (30d)", value: metrics.merged },
-        {
-          label: "Avg Review Time",
-          value: `${metrics.avgReviewHours}h`,
-        },
+        { label: "Avg Review Time", value: `${metrics.avgReviewHours}h` },
         {
           label: "Avg First Review",
-          value:
-            metrics.avgFirstReviewHours === null
-              ? "—"
-              : metrics.avgFirstReviewHours < 24
-                ? `${metrics.avgFirstReviewHours}h`
-                : `${Math.round((metrics.avgFirstReviewHours / 24) * 10) / 10}d`,
+          value: formatReviewCycle(metrics.avgFirstReviewHours),
+          title: "Average time from PR open to first review comment or approval",
         },
         { label: "Merge Rate", value: metrics.mergeRate },
       ]
@@ -140,6 +145,7 @@ export default function PRMetrics() {
               <div
                 key={stat.label}
                 className="min-w-0 rounded-lg bg-[var(--control)] p-4 text-center"
+                title={stat.title}
               >
                 <div className="truncate text-2xl font-bold text-[var(--accent)]">
                   {stat.value}

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -11,7 +11,6 @@ interface PRData {
   mergeRate: string;
   prs: PullRequest[];
 }
-
 interface PullRequest {
   title: string;
   created_at: string;
@@ -33,12 +32,10 @@ function formatReviewCycle(hours: number | null): string {
 
 export default function PRMetrics() {
   const { selectedAccount } = useAccount();
-
   const [metrics, setMetrics] = useState<PRData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [staleDays, setStaleDays] = useState(7);
-
+const [staleDays, setStaleDays] = useState(7);
   const fetchMetrics = useCallback(() => {
     setLoading(true);
     setError(null);
@@ -54,11 +51,7 @@ export default function PRMetrics() {
         return r.json();
       })
       .then((data: PRData) => setMetrics(data))
-      .catch(() =>
-        setError(
-          "We couldn't load your PR analytics right now. Please try again in a moment."
-        )
-      )
+      .catch(() => setError("We couldn't load your PR analytics right now. Please try again in a moment."))
       .finally(() => setLoading(false));
   }, [selectedAccount]);
 
@@ -67,19 +60,19 @@ export default function PRMetrics() {
   }, [fetchMetrics]);
 
   const isStale = (createdAt: string) => {
-    const createdDate = new Date(createdAt);
-    const now = new Date();
+  const createdDate = new Date(createdAt);
+  const now = new Date();
 
-    const diffTime = now.getTime() - createdDate.getTime();
-    const diffDays = diffTime / (1000 * 60 * 60 * 24);
+  const diffTime = now.getTime() - createdDate.getTime();
 
-    return diffDays > staleDays;
-  };
+  const diffDays = diffTime / (1000 * 60 * 60 * 24);
 
-  const stalePRs =
-    metrics?.prs.filter(
-      (pr) => pr.state === "open" && isStale(pr.created_at)
-    ) || [];
+  return diffDays > staleDays;
+};
+const stalePRs =
+  metrics?.prs.filter(
+    (pr) => pr.state === "open" && isStale(pr.created_at)
+  ) || [];
 
   const stats = metrics
     ? [
@@ -97,23 +90,20 @@ export default function PRMetrics() {
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
-        PR Analytics
-      </h2>
-
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Analytics</h2>
       {loading ? (
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
-              className="h-24 rounded-lg bg-[var(--card-muted)] p-4 animate-pulse"
+              className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse"
             />
           ))}
         </div>
       ) : error ? (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
           <p>{error}</p>
-
           <button
             type="button"
             onClick={fetchMetrics}
@@ -122,71 +112,71 @@ export default function PRMetrics() {
             Try again
           </button>
         </div>
-      ) : (
-        <>
-          <div className="mb-4 flex items-center justify-between">
-            <div className="rounded-full bg-orange-500/10 px-3 py-1 text-sm text-orange-400">
-              {stalePRs.length} PRs stale &gt; {staleDays} days
-            </div>
+) : (
+  <>
+    <div className="mb-4 flex items-center justify-between">
+      <div className="rounded-full bg-orange-500/10 px-3 py-1 text-sm text-orange-400">
+        {stalePRs.length} PRs stale &gt; {staleDays} days
+      </div>
 
-            <select
-              value={staleDays}
-              onChange={(e) => setStaleDays(Number(e.target.value))}
-              className="rounded-md border border-[var(--border)] bg-[var(--card)] px-2 py-1 text-sm"
+      <select
+        value={staleDays}
+        onChange={(e) => setStaleDays(Number(e.target.value))}
+        className="rounded-md border border-[var(--border)] bg-[var(--card)] px-2 py-1 text-sm"
+      >
+        <option value={7}>7 days</option>
+        <option value={14}>14 days</option>
+        <option value={30}>30 days</option>
+      </select>
+    </div>
+
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+      {stats.map((stat) => (
+        <div
+          key={stat.label}
+          className="rounded-lg bg-[var(--control)] p-4 text-center min-w-0"
+          title={stat.title}
+        >
+          <div className="truncate text-2xl font-bold text-[var(--accent)]">
+            {stat.value}
+          </div>
+
+          <div className="truncate mt-1 text-sm text-[var(--muted-foreground)]">
+            {stat.label}
+          </div>
+        </div>
+      ))}
+    </div>
+
+    {stalePRs.length > 0 && (
+      <div className="mt-6">
+        <h3 className="mb-3 text-sm font-semibold text-[var(--card-foreground)]">
+          Stale Pull Requests
+        </h3>
+
+        <div className="space-y-2">
+          {stalePRs.map((pr) => (
+            <a
+              key={pr.html_url}
+              href={pr.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between rounded-lg bg-[var(--control)] p-3 transition hover:opacity-90"
             >
-              <option value={7}>7 days</option>
-              <option value={14}>14 days</option>
-              <option value={30}>30 days</option>
-            </select>
-          </div>
+              <span className="text-sm text-[var(--card-foreground)]">
+                {pr.title}
+              </span>
 
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
-            {stats.map((stat) => (
-              <div
-                key={stat.label}
-                className="min-w-0 rounded-lg bg-[var(--control)] p-4 text-center"
-                title={stat.title}
-              >
-                <div className="truncate text-2xl font-bold text-[var(--accent)]">
-                  {stat.value}
-                </div>
-
-                <div className="mt-1 truncate text-sm text-[var(--muted-foreground)]">
-                  {stat.label}
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {stalePRs.length > 0 && (
-            <div className="mt-6">
-              <h3 className="mb-3 text-sm font-semibold text-[var(--card-foreground)]">
-                Stale Pull Requests
-              </h3>
-
-              <div className="space-y-2">
-                {stalePRs.map((pr) => (
-                  <a
-                    key={pr.html_url}
-                    href={pr.html_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center justify-between rounded-lg bg-[var(--control)] p-3 transition hover:opacity-90"
-                  >
-                    <span className="text-sm text-[var(--card-foreground)]">
-                      {pr.title}
-                    </span>
-
-                    <span className="rounded-full bg-orange-500/10 px-2 py-1 text-xs font-medium text-orange-400">
-                      Stale
-                    </span>
-                  </a>
-                ))}
-              </div>
-            </div>
-          )}
-        </>
-      )}
+              <span className="rounded-full bg-orange-500/10 px-2 py-1 text-xs font-medium text-orange-400">
+                Stale
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+    )}
+  </>
+)}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Added stale PR indicators in the PR Analytics section to help users quickly identify pull requests that have been open for too long.

Closes #257

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Added stale PR detection logic based on configurable thresholds
* Added threshold selector for 7 / 14 / 30 days
* Added stale PR count chip in the PR Analytics section
* Added stale PR list with orange "Stale" badges
* Added clickable links to open stale PRs directly
* Extended PR metrics API response to include PR metadata required for stale calculations

## How to Test

Steps for the reviewer to verify this works:

1. Open the dashboard page
2. Navigate to the PR Analytics section
3. Verify stale PR count appears above the metrics cards
4. Change the threshold dropdown between 7 / 14 / 30 days
5. Confirm stale PR count updates correctly
6. Verify stale PRs display orange "Stale" badges
7. Click a stale PR entry and verify it opens the corresponding GitHub PR link

## Screenshots (if UI change)
<img width="595" height="532" alt="Screenshot 2026-05-18 183221" src="https://github.com/user-attachments/assets/a3f80229-82e5-4976-b1ac-2d3b9b26f943" />
Add screenshots showing:

* stale PR count chip
* threshold selector
* stale PR list with badges

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable

