### PR TITLE
Fix commit search pagination in contributions metrics

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -65,6 +65,9 @@ async function fetchContributionsForAccount(
       let totalCount = 0;
       let page = 1;
 
+      // Note: this may issue up to 10 sequential GitHub Search API calls (max 1000 results).
+      // Authenticated GitHub Search rate limits are low (~30 req/min). We handle 429/403
+      // responses gracefully by returning partial results rather than failing the endpoint.
       while (page <= 10) {
         const searchRes = await fetch(
           `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&page=${page}&sort=author-date&order=desc`,
@@ -78,6 +81,17 @@ async function fetchContributionsForAccount(
         );
 
         if (!searchRes.ok) {
+          // If we're being rate limited or hit a secondary rate limit/permission error,
+          // return partial results collected so far instead of failing the whole request.
+          if (searchRes.status === 429 || searchRes.status === 403) {
+            if (allItems.length === 0) {
+              // If no items were retrieved at all, surface the error so callers know
+              // the request could not be fulfilled.
+              throw new Error(`GitHub API error: ${searchRes.status}`);
+            }
+            break;
+          }
+
           throw new Error("GitHub API error");
         }
 

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -41,33 +41,55 @@ async function fetchContributionsForAccount(
   since.setDate(since.getDate() - days);
   const sinceStr = toLocalDateStr(since);
 
-  const searchRes = await fetch(
-    `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-      },
-      cache: "no-store",
-    }
-  );
+  let allItems: Array<{ commit: { author: { date: string } } }> = [];
+  let totalCount = 0;
+  let page = 1;
 
-  if (!searchRes.ok) {
-    throw new Error("GitHub API error");
+  while (page <= 10) {
+    const searchRes = await fetch(
+      `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&page=${page}&sort=author-date&order=desc`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+        cache: "no-store",
+      }
+    );
+
+    if (!searchRes.ok) {
+      throw new Error("GitHub API error");
+    }
+
+    const data = (await searchRes.json()) as {
+      total_count: number;
+      items: Array<{ commit: { author: { date: string } } }>;
+    };
+
+    if (page === 1) {
+      totalCount = data.total_count;
+    }
+
+    allItems = allItems.concat(data.items);
+
+    if (data.items.length < 100) {
+      break;
+    }
+
+    if (allItems.length >= 1000 || allItems.length >= totalCount) {
+      break;
+    }
+
+    page += 1;
   }
 
-  const data = (await searchRes.json()) as {
-    total_count: number;
-    items: Array<{ commit: { author: { date: string } } }>;
-  };
-
   const commitsByDay: Record<string, number> = {};
-  for (const item of data.items) {
+  for (const item of allItems) {
     const date = item.commit.author.date.slice(0, 10);
     commitsByDay[date] = (commitsByDay[date] ?? 0) + 1;
   }
 
-  return { days, total: data.total_count, data: commitsByDay };
+  return { days, total: totalCount, data: commitsByDay };
 }
 
 export async function GET(req: NextRequest) {

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -49,55 +49,68 @@ async function fetchContributionsForAccount(
     githubLogin,
   });
 
-  let allItems: Array<{ commit: { author: { date: string } } }> = [];
-  let totalCount = 0;
-  let page = 1;
+  return withMetricsCache(
+    {
+      bypass: cacheContext.bypass,
+      key,
+      ttlSeconds: METRICS_CACHE_TTL_SECONDS.contributions,
+    },
+    async () => {
+      const since = new Date();
+      since.setDate(since.getDate() - days);
+      const sinceStr = toLocalDateStr(since);
 
-  while (page <= 10) {
-    const searchRes = await fetch(
-      `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&page=${page}&sort=author-date&order=desc`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-        },
-        cache: "no-store",
+      let allItems: Array<{ commit: { author: { date: string } } }> = [];
+      let totalCount = 0;
+      let page = 1;
+
+      while (page <= 10) {
+        const searchRes = await fetch(
+          `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&page=${page}&sort=author-date&order=desc`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "application/vnd.github+json",
+            },
+            cache: "no-store",
+          }
+        );
+
+        if (!searchRes.ok) {
+          throw new Error("GitHub API error");
+        }
+
+        const data = (await searchRes.json()) as {
+          total_count: number;
+          items: Array<{ commit: { author: { date: string } } }>;
+        };
+
+        if (page === 1) {
+          totalCount = data.total_count;
+        }
+
+        allItems = allItems.concat(data.items);
+
+        if (data.items.length < 100) {
+          break;
+        }
+
+        if (allItems.length >= 1000 || allItems.length >= totalCount) {
+          break;
+        }
+
+        page += 1;
       }
-    );
 
-    if (!searchRes.ok) {
-      throw new Error("GitHub API error");
+      const commitsByDay: Record<string, number> = {};
+      for (const item of allItems) {
+        const date = item.commit.author.date.slice(0, 10);
+        commitsByDay[date] = (commitsByDay[date] ?? 0) + 1;
+      }
+
+      return { days, total: totalCount, data: commitsByDay };
     }
-
-    const data = (await searchRes.json()) as {
-      total_count: number;
-      items: Array<{ commit: { author: { date: string } } }>;
-    };
-
-    if (page === 1) {
-      totalCount = data.total_count;
-    }
-
-    allItems = allItems.concat(data.items);
-
-    if (data.items.length < 100) {
-      break;
-    }
-
-    if (allItems.length >= 1000 || allItems.length >= totalCount) {
-      break;
-    }
-
-    page += 1;
-  }
-
-  const commitsByDay: Record<string, number> = {};
-  for (const item of allItems) {
-    const date = item.commit.author.date.slice(0, 10);
-    commitsByDay[date] = (commitsByDay[date] ?? 0) + 1;
-  }
-
-  return { days, total: totalCount, data: commitsByDay };
+  );
 }
 
 export async function GET(req: NextRequest) {


### PR DESCRIPTION
Fixed inaccurate contribution metrics in route.ts by properly paginating GitHub commit search results
Added support for fetching multiple pages (per_page=100&page=N) until all available results are retrieved, the reported total count is reached, or GitHub’s 1000-result search limit is hit
Aggregated commit data across all pages before calculating contribution statistics
Improved the accuracy of total commits, active contribution days, and related contribution metrics while keeping the existing API response shape unchanged

Closes [BUG] Paginate commit search results for high-activity users #301
