### PR TITLE
Feat(activity): add Recent Activity component to display GitHub events

### DIFF
--- a/src/app/api/metrics/activity/route.ts
+++ b/src/app/api/metrics/activity/route.ts
@@ -1,0 +1,325 @@
+import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
+import { authOptions } from "@/lib/auth";
+import {
+  getAccountToken,
+  getAllAccounts,
+} from "@/lib/github-accounts";
+import { GITHUB_API, fetchUserEvents } from "@/lib/github";
+import { supabaseAdmin } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+
+type ActivityType =
+  | "push"
+  | "pull_request"
+  | "issue"
+  | "release"
+  | "other";
+
+interface ActivityItem {
+  id: string;
+  type: ActivityType;
+  createdAt: string;
+  title: string;
+  subtitle: string;
+  repo: string;
+  url: string;
+}
+
+interface RawEvent {
+  id: string;
+  type: string;
+  created_at: string;
+  repo?: { name?: string };
+  payload?: {
+    ref?: string;
+    head?: string;
+    action?: string;
+    commits?: Array<{ sha?: string }>;
+    pull_request?: {
+      html_url?: string;
+      number?: number;
+      title?: string;
+      merged?: boolean;
+    };
+    issue?: {
+      html_url?: string;
+      number?: number;
+      title?: string;
+    };
+    release?: {
+      html_url?: string;
+      tag_name?: string;
+      name?: string;
+    };
+  };
+}
+
+const SUPPORTED_EVENT_TYPES = new Set([
+  "PushEvent",
+  "PullRequestEvent",
+  "IssuesEvent",
+  "ReleaseEvent",
+]);
+
+function getRepoUrl(repoName: string): string {
+  return `https://github.com/${repoName}`;
+}
+
+function capitalize(value: string): string {
+  return value.length > 0
+    ? value[0].toUpperCase() + value.slice(1)
+    : "Updated";
+}
+
+function formatActivity(event: RawEvent): ActivityItem | null {
+  const repoName = event.repo?.name;
+
+  if (!repoName || !SUPPORTED_EVENT_TYPES.has(event.type)) {
+    return null;
+  }
+
+  if (event.type === "PushEvent") {
+    const commitCount = event.payload?.commits?.length ?? 0;
+    const rawRef = event.payload?.ref ?? "";
+    const branch = rawRef.replace("refs/heads/", "") || "default branch";
+    const plural = commitCount === 1 ? "" : "s";
+
+    return {
+      id: event.id,
+      type: "push",
+      createdAt: event.created_at,
+      title: `Pushed ${commitCount} commit${plural} to ${branch}`,
+      subtitle: repoName,
+      repo: repoName,
+      url: event.payload?.head
+        ? `https://github.com/${repoName}/commit/${event.payload.head}`
+        : getRepoUrl(repoName),
+    };
+  }
+
+  if (event.type === "PullRequestEvent") {
+    const action = event.payload?.action ?? "updated";
+    const pr = event.payload?.pull_request;
+    const number = pr?.number ? `#${pr.number}` : "PR";
+    const wasMerged = action === "closed" && pr?.merged === true;
+    const actionText = wasMerged ? "Merged" : capitalize(action);
+
+    return {
+      id: event.id,
+      type: "pull_request",
+      createdAt: event.created_at,
+      title: `${actionText} pull request ${number}`,
+      subtitle: pr?.title ?? repoName,
+      repo: repoName,
+      url: pr?.html_url ?? getRepoUrl(repoName),
+    };
+  }
+
+  if (event.type === "IssuesEvent") {
+    const action = event.payload?.action ?? "updated";
+    const issue = event.payload?.issue;
+    const number = issue?.number ? `#${issue.number}` : "Issue";
+    const actionText = capitalize(action);
+
+    return {
+      id: event.id,
+      type: "issue",
+      createdAt: event.created_at,
+      title: `${actionText} issue ${number}`,
+      subtitle: issue?.title ?? repoName,
+      repo: repoName,
+      url: issue?.html_url ?? getRepoUrl(repoName),
+    };
+  }
+
+  if (event.type === "ReleaseEvent") {
+    const action = event.payload?.action ?? "published";
+    const release = event.payload?.release;
+    const tag = release?.tag_name ?? "release";
+    const actionText = capitalize(action);
+
+    return {
+      id: event.id,
+      type: "release",
+      createdAt: event.created_at,
+      title: `${actionText} ${tag}`,
+      subtitle: release?.name ?? repoName,
+      repo: repoName,
+      url: release?.html_url ?? getRepoUrl(repoName),
+    };
+  }
+
+  return null;
+}
+
+async function fetchFormattedActivity(token: string): Promise<ActivityItem[]> {
+  const events = (await fetchUserEvents(token)) as RawEvent[];
+
+  return events
+    .map(formatActivity)
+    .filter((item): item is ActivityItem => item !== null)
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+}
+
+async function fetchPublicEvents(
+  token: string,
+  githubLogin: string
+): Promise<RawEvent[]> {
+  const response = await fetch(
+    `${GITHUB_API}/users/${encodeURIComponent(githubLogin)}/events/public?per_page=100`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      cache: "no-store",
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error("GitHub API error");
+  }
+
+  return (await response.json()) as RawEvent[];
+}
+
+async function fetchFormattedActivityWithFallback(
+  token: string,
+  githubLogin?: string
+): Promise<ActivityItem[]> {
+  try {
+    return await fetchFormattedActivity(token);
+  } catch {
+    if (!githubLogin) {
+      throw new Error("GitHub API error");
+    }
+
+    const events = await fetchPublicEvents(token, githubLogin);
+
+    return events
+      .map(formatActivity)
+      .filter((item): item is ActivityItem => item !== null)
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.accessToken) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const accountId = req.nextUrl.searchParams.get("accountId");
+
+  if (!accountId) {
+    try {
+      const items = await fetchFormattedActivityWithFallback(
+        session.accessToken,
+        session.githubLogin
+      );
+      return Response.json({ items: items.slice(0, 15) });
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  if (!session.githubId || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: userRow } = await supabaseAdmin
+    .from("users")
+    .select("id")
+    .eq("github_id", session.githubId)
+    .single();
+
+  if (!userRow) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (accountId === "combined") {
+    const accounts = await getAllAccounts(
+      {
+        token: session.accessToken,
+        githubId: session.githubId,
+        githubLogin: session.githubLogin,
+      },
+      userRow.id
+    );
+
+    const results = await Promise.allSettled(
+      accounts.map((account) =>
+        fetchFormattedActivityWithFallback(account.token, account.githubLogin)
+      )
+    );
+
+    const merged = results
+      .filter(
+        (result): result is PromiseFulfilledResult<ActivityItem[]> =>
+          result.status === "fulfilled"
+      )
+      .flatMap((result) => result.value)
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      )
+      .slice(0, 15);
+
+    if (merged.length === 0 && results.length > 0) {
+      const allFailed = results.every((result) => result.status === "rejected");
+      if (allFailed) {
+        return Response.json({ error: "GitHub API error" }, { status: 502 });
+      }
+    }
+
+    return Response.json({ items: merged });
+  }
+
+  if (accountId === session.githubId) {
+    try {
+      const items = await fetchFormattedActivityWithFallback(
+        session.accessToken,
+        session.githubLogin
+      );
+      return Response.json({ items: items.slice(0, 15) });
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  const token = await getAccountToken(userRow.id, accountId);
+
+  if (!token) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  const { data: accountRow } = await supabaseAdmin
+    .from("user_github_accounts")
+    .select("github_login")
+    .eq("user_id", userRow.id)
+    .eq("github_id", accountId)
+    .single();
+
+  if (!accountRow?.github_login) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  try {
+    const items = await fetchFormattedActivityWithFallback(
+      token,
+      accountRow.github_login
+    );
+    return Response.json({ items: items.slice(0, 15) });
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+}

--- a/src/app/api/metrics/activity/route.ts
+++ b/src/app/api/metrics/activity/route.ts
@@ -323,3 +323,4 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }
+

--- a/src/app/api/metrics/activity/route.ts
+++ b/src/app/api/metrics/activity/route.ts
@@ -6,7 +6,14 @@ import {
   getAllAccounts,
 } from "@/lib/github-accounts";
 import { GITHUB_API, fetchUserEvents } from "@/lib/github";
+import {
+  isMetricsCacheBypassed,
+  METRICS_CACHE_TTL_SECONDS,
+  metricsCacheKey,
+  withMetricsCache,
+} from "@/lib/metrics-cache";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
@@ -211,20 +218,43 @@ async function fetchFormattedActivityWithFallback(
   }
 }
 
+async function fetchActivityForAccount(
+  token: string,
+  githubLogin: string,
+  cacheContext: { bypass: boolean; userId: string }
+): Promise<ActivityItem[]> {
+  const key = metricsCacheKey(cacheContext.userId, "activity", {
+    githubLogin,
+  });
+
+  return withMetricsCache(
+    {
+      bypass: cacheContext.bypass,
+      key,
+      ttlSeconds: METRICS_CACHE_TTL_SECONDS.activity,
+    },
+    async () => {
+      return fetchFormattedActivityWithFallback(token, githubLogin);
+    }
+  );
+}
+
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
 
-  if (!session?.accessToken) {
+  if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
+  const bypass = isMetricsCacheBypassed(req);
 
   if (!accountId) {
     try {
-      const items = await fetchFormattedActivityWithFallback(
+      const items = await fetchActivityForAccount(
         session.accessToken,
-        session.githubLogin
+        session.githubLogin,
+        { bypass, userId: session.githubId ?? session.githubLogin }
       );
       return Response.json({ items: items.slice(0, 15) });
     } catch {
@@ -232,15 +262,11 @@ export async function GET(req: NextRequest) {
     }
   }
 
-  if (!session.githubId || !session.githubLogin) {
+  if (!session.githubId) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: userRow } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
 
   if (!userRow) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
@@ -258,7 +284,10 @@ export async function GET(req: NextRequest) {
 
     const results = await Promise.allSettled(
       accounts.map((account) =>
-        fetchFormattedActivityWithFallback(account.token, account.githubLogin)
+        fetchActivityForAccount(account.token, account.githubLogin, {
+          bypass,
+          userId: account.githubId,
+        })
       )
     );
 
@@ -286,9 +315,10 @@ export async function GET(req: NextRequest) {
 
   if (accountId === session.githubId) {
     try {
-      const items = await fetchFormattedActivityWithFallback(
+      const items = await fetchActivityForAccount(
         session.accessToken,
-        session.githubLogin
+        session.githubLogin,
+        { bypass, userId: session.githubId }
       );
       return Response.json({ items: items.slice(0, 15) });
     } catch {
@@ -314,13 +344,13 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const items = await fetchFormattedActivityWithFallback(
+    const items = await fetchActivityForAccount(
       token,
-      accountRow.github_login
+      accountRow.github_login,
+      { bypass, userId: accountId }
     );
     return Response.json({ items: items.slice(0, 15) });
   } catch {
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }
-

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import ExportButton from "@/components/ExportButton";
 import Link from "next/link";
 import PersonalRecords from "@/components/PersonalRecords";
 import LocalCodingTime from "@/components/LocalCodingTime";
+import RecentActivity from "@/components/RecentActivity";
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
@@ -96,6 +97,11 @@ export default async function DashboardPage() {
         <TopRepos />
         <LanguageBreakdown />
         <GoalTracker />
+      </div>
+
+      {/* Row 6: Recent GitHub activity */}
+      <div className="mt-6">
+        <RecentActivity />
       </div>
     </div>
   );

--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { useAccount } from "@/components/AccountContext";
+
+type ActivityType =
+  | "push"
+  | "pull_request"
+  | "issue"
+  | "release"
+  | "other";
+
+interface ActivityItem {
+  id: string;
+  type: ActivityType;
+  createdAt: string;
+  title: string;
+  subtitle: string;
+  repo: string;
+  url: string;
+}
+
+function getTypeBadge(type: ActivityType): string {
+  if (type === "push") return "Push";
+  if (type === "pull_request") return "PR";
+  if (type === "issue") return "Issue";
+  if (type === "release") return "Release";
+  return "Event";
+}
+
+function getTypeIcon(type: ActivityType): ReactNode {
+  if (type === "push") {
+    return (
+      <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
+        <path
+          d="M5 2v8M5 10l-2-2M5 10l2-2M11 14V6M11 6l-2 2M11 6l2 2"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+
+  if (type === "pull_request") {
+    return (
+      <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
+        <path
+          d="M4 3a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0ZM4 13a1.5 1.5 0 1 1-3 0a1.5 1.5 0 0 1 3 0ZM10 3a1.5 1.5 0 1 1 3 0a1.5 1.5 0 0 1-3 0Z"
+          fill="currentColor"
+        />
+        <path
+          d="M2.5 4.5v7M4 3h4.5a2.5 2.5 0 0 1 2.5 2.5v0"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+
+  if (type === "issue") {
+    return (
+      <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
+        <circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <circle cx="8" cy="5" r="1" fill="currentColor" />
+        <path d="M8 7.5v3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  if (type === "release") {
+    return (
+      <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
+        <path
+          d="M8 2l1.6 3.2L13 6l-2.5 2.4L11 12l-3-1.6L5 12l.5-3.6L3 6l3.4-.8L8 2Z"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+
+  return null;
+}
+
+function formatEventTime(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown time";
+  }
+
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / 60000);
+
+  if (diffMinutes < 1) return "Just now";
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function RecentActivity() {
+  const { selectedAccount } = useAccount();
+  const [items, setItems] = useState<ActivityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchActivity = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    const query =
+      selectedAccount !== null
+        ? `?accountId=${encodeURIComponent(selectedAccount)}`
+        : "";
+
+    fetch(`/api/metrics/activity${query}`)
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error("API error");
+        }
+        return res.json();
+      })
+      .then((payload: { items?: ActivityItem[] }) =>
+        setItems(payload.items ?? [])
+      )
+      .catch(() =>
+        setError(
+          "We couldn't load your recent activity right now. Please try again in a moment."
+        )
+      )
+      .finally(() => setLoading(false));
+  }, [selectedAccount]);
+
+  useEffect(() => {
+    fetchActivity();
+  }, [fetchActivity]);
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            Recent Activity
+          </h2>
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+            Your latest GitHub events
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={fetchActivity}
+          className="rounded-md border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--control)]"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-16 rounded-lg bg-[var(--card-muted)] animate-pulse"
+            />
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchActivity}
+            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+          >
+            Try again
+          </button>
+        </div>
+      ) : items.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--card-muted)] p-4 text-sm text-[var(--muted-foreground)]">
+          No recent GitHub activity yet.
+        </p>
+      ) : (
+        <ul className="space-y-3 border-l border-[var(--border)] pl-4">
+          {items.map((item) => (
+            <li key={item.id} className="relative">
+              <span
+                aria-hidden="true"
+                className="absolute -left-[21px] top-6 h-2.5 w-2.5 rounded-full border border-[var(--border)] bg-[var(--card)]"
+              />
+              <a
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block rounded-lg border border-[var(--border)] bg-[var(--control)] p-4 transition-colors hover:border-[var(--accent)]"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] bg-[var(--card)] px-2 py-0.5 text-xs font-medium text-[var(--muted-foreground)]">
+                    {getTypeIcon(item.type)}
+                    {getTypeBadge(item.type)}
+                  </span>
+                  <span
+                    className="shrink-0 text-xs text-[var(--muted-foreground)]"
+                    title={new Date(item.createdAt).toLocaleString()}
+                  >
+                    {formatEventTime(item.createdAt)}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm font-medium text-[var(--card-foreground)]">
+                  {item.title}
+                </p>
+                <p className="mt-1 truncate text-xs text-[var(--muted-foreground)]">
+                  {item.subtitle}
+                </p>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -183,12 +183,12 @@ export default function RecentActivity() {
           ))}
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchActivity}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>
@@ -237,3 +237,4 @@ export default function RecentActivity() {
     </div>
   );
 }
+

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -7,6 +7,7 @@ export const METRICS_CACHE_TTL_SECONDS = {
   prs: 10 * 60,
   "pr-review-time": 10 * 60,
   streak: 2 * 60,
+  activity: 5 * 60,
 } as const;
 
 type MetricsCacheEndpoint = keyof typeof METRICS_CACHE_TTL_SECONDS;


### PR DESCRIPTION
This PR introduces a "Recent Activity" widget to the dashboard, providing users with a live, chronological feed of their latest GitHub events. This
  transforms the dashboard from a static reporting tool into a dynamic productivity hub.

  Closes #364 

  Type of Change

   - [ ] Bug fix
   - [x] New feature
   - [ ] Documentation update
   - [ ] Refactor / code cleanup

  Changes Made

   - API Route: Implemented /api/metrics/activity to fetch, filter, and format GitHub events (Push, Pull Request, Issues, and Release events).
   - Recent Activity Component: Created a new RecentActivity.tsx component featuring a vertical timeline, custom event icons, and human-readable time
     formatting (e.g., "2h ago").
   - Multi-Account Support: Integrated with AccountContext to support filtering activity by specific linked GitHub accounts or a combined view.
   - Fallback Logic: Added fallback to public events API to ensure the widget remains functional if private event tokens hit limits or specific errors
     occur.
   - Dashboard Integration: Added the widget as a full-width section at the bottom of the main dashboard.
   - Loading & Empty States: Implemented polished skeleton loaders and clear empty/error state handling.

  How to Test

   1. Sign in to the application and navigate to the Dashboard.
   2. Scroll to the bottom of the page to find the Recent Activity widget.
   3. Verify that your latest GitHub actions (commits, PRs, etc.) are listed with correct titles and timestamps.
   4. Click an item: Ensure it opens the corresponding repository or event on GitHub in a new tab.
   5. Switch accounts: Use the account toggle to verify that the activity list filters correctly for different linked accounts.
   6. Refresh: Click the "Refresh" button to manually trigger an update of the feed.

  Screenshots 
<img width="1900" height="922" alt="image" src="https://github.com/user-attachments/assets/3b80c35b-f7b5-4665-b13e-e3ff2dfa00ea" />


  Checklist

   - [x] Linked issue in summary
   - [x] npm run lint passes locally
   - [x] No TypeScript errors (npm run type-check)
   - [x] Self-reviewed the diff
   - [ ] Added/updated tests if applicable 