### PR TITLE
enforce backend auth truth and prevent stale sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "recharts": "^2.12.7"
       },
       "devDependencies": {
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "1.49.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -31,8 +31,7 @@
         "eslint-config-next": "14.2.3",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5",
-        "@playwright/test": "1.49.1"
+        "typescript": "^5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -524,7 +523,6 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
       "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.49.1"
       },
@@ -766,7 +764,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1214,7 +1211,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1667,7 +1663,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2537,7 +2532,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2706,7 +2700,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4152,7 +4145,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4224,7 +4216,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5042,7 +5033,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
       "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.49.1"
       },
@@ -5061,7 +5051,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
       "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -5114,7 +5103,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5285,7 +5273,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5376,7 +5363,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5389,7 +5375,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6443,7 +6428,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6613,7 +6597,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7019,51 +7002,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
-      "dev": true,
-      "dependencies": {
-        "playwright": "1.49.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.49.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     }
   }

--- a/src/app/api/auth/link-github/callback/route.ts
+++ b/src/app/api/auth/link-github/callback/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { encryptToken } from "@/lib/crypto";
 import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 interface GitHubTokenResponse {
   access_token?: string;
@@ -107,13 +108,8 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  const { data: user, error: userError } = await supabaseAdmin
-    .from("users")
-    .select("id")
-    .eq("github_id", session.githubId)
-    .single();
-
-  if (userError || !user) {
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
     return NextResponse.redirect(
       buildSettingsRedirect("error", "user_not_found"),
       { status: 302 }

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,28 @@
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { resolveAppUser } from "@/lib/resolve-user";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.githubId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    user: {
+      id: user.id,
+      githubId: session.githubId,
+      githubLogin: session.githubLogin ?? null,
+    },
+  });
+}

--- a/src/app/api/metrics/ci/route.ts
+++ b/src/app/api/metrics/ci/route.ts
@@ -9,6 +9,7 @@ import {
 import { GITHUB_API } from "@/lib/github";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
+import { GitHubApiError, toGitHubErrorResponse } from "@/lib/github-error";
 
 export const dynamic = "force-dynamic";
 
@@ -35,34 +36,6 @@ interface CIAnalyticsResponse {
   flakiestWorkflow: string | null;
   totalRuns: number;
   reposChecked: number;
-}
-
-class GitHubApiError extends Error {
-  status: number;
-  endpoint: string;
-  details: string;
-
-  constructor(endpoint: string, status: number, details: string) {
-    super("GitHub API failed");
-    this.status = status;
-    this.endpoint = endpoint;
-    this.details = details;
-  }
-}
-
-function toGitHubErrorResponse(error: unknown) {
-  if (error instanceof GitHubApiError) {
-    return Response.json(
-      {
-        error: "GitHub API failed",
-        endpoint: error.endpoint,
-        status: error.status,
-        details: error.details,
-      },
-      { status: error.status }
-    );
-  }
-  return Response.json({ error: "GitHub API error" }, { status: 502 });
 }
 
 function toIsoDate(daysAgo: number): string {

--- a/src/app/api/metrics/ci/route.ts
+++ b/src/app/api/metrics/ci/route.ts
@@ -238,7 +238,7 @@ export async function GET(req: NextRequest) {
   }
 
   if (!session.githubId) {
-    return Response.json({ error: "User not found" }, { status: 404 });
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const userRow = await resolveAppUser(session.githubId, session.githubLogin);

--- a/src/app/api/metrics/ci/route.ts
+++ b/src/app/api/metrics/ci/route.ts
@@ -37,6 +37,34 @@ interface CIAnalyticsResponse {
   reposChecked: number;
 }
 
+class GitHubApiError extends Error {
+  status: number;
+  endpoint: string;
+  details: string;
+
+  constructor(endpoint: string, status: number, details: string) {
+    super("GitHub API failed");
+    this.status = status;
+    this.endpoint = endpoint;
+    this.details = details;
+  }
+}
+
+function toGitHubErrorResponse(error: unknown) {
+  if (error instanceof GitHubApiError) {
+    return Response.json(
+      {
+        error: "GitHub API failed",
+        endpoint: error.endpoint,
+        status: error.status,
+        details: error.details,
+      },
+      { status: error.status }
+    );
+  }
+  return Response.json({ error: "GitHub API error" }, { status: 502 });
+}
+
 function toIsoDate(daysAgo: number): string {
   const date = new Date();
   date.setDate(date.getDate() - daysAgo);
@@ -83,19 +111,23 @@ async function fetchTopRepos(
   githubLogin: string
 ): Promise<TopRepo[]> {
   const since = toIsoDate(30);
-  const searchRes = await fetch(
-    `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${since}&per_page=100&sort=author-date&order=desc`,
-    {
+  const endpoint = `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${since}&per_page=100&sort=author-date&order=desc`;
+  const searchRes = await fetch(endpoint, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
       cache: "no-store",
-    }
-  );
+    });
 
   if (!searchRes.ok) {
-    throw new Error("GitHub API error");
+    const body = await searchRes.text();
+    console.error("GitHub API failed", {
+      endpoint,
+      status: searchRes.status,
+      body,
+    });
+    throw new GitHubApiError(endpoint, searchRes.status, body);
   }
 
   const data = (await searchRes.json()) as {
@@ -123,23 +155,27 @@ async function fetchWorkflowRuns(
     per_page: "100",
     created: `>=${created}`,
   });
-  const res = await fetch(
-    `${GITHUB_API}/repos/${repo}/actions/runs?${params.toString()}`,
-    {
+  const endpoint = `${GITHUB_API}/repos/${repo}/actions/runs?${params.toString()}`;
+  const res = await fetch(endpoint, {
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
       cache: "no-store",
-    }
-  );
+    });
 
   if (res.status === 404 || res.status === 403) {
     return [];
   }
 
   if (!res.ok) {
-    throw new Error("GitHub API error");
+    const body = await res.text();
+    console.error("GitHub API failed", {
+      endpoint,
+      status: res.status,
+      body,
+    });
+    throw new GitHubApiError(endpoint, res.status, body);
   }
 
   const data = (await res.json()) as { workflow_runs?: WorkflowRun[] };
@@ -223,13 +259,13 @@ export async function GET(req: NextRequest) {
         session.githubLogin
       );
       return Response.json(result);
-    } catch {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    } catch (error) {
+      return toGitHubErrorResponse(error);
     }
   }
 
   if (!session.githubId) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+    return Response.json({ error: "User not found" }, { status: 404 });
   }
 
   const userRow = await resolveAppUser(session.githubId, session.githubLogin);
@@ -268,8 +304,8 @@ export async function GET(req: NextRequest) {
         session.githubLogin
       );
       return Response.json(result);
-    } catch {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    } catch (error) {
+      return toGitHubErrorResponse(error);
     }
   }
 
@@ -284,7 +320,7 @@ export async function GET(req: NextRequest) {
     .select("github_login")
     .eq("user_id", userRow.id)
     .eq("github_id", accountId)
-    .single();
+    .maybeSingle();
 
   if (!accountRow?.github_login) {
     return Response.json({ error: "Account not found" }, { status: 404 });
@@ -296,7 +332,7 @@ export async function GET(req: NextRequest) {
       accountRow.github_login
     );
     return Response.json(result);
-  } catch {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  } catch (error) {
+    return toGitHubErrorResponse(error);
   }
 }

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -226,4 +226,4 @@ export async function GET(req: NextRequest) {
   } catch (error) {
     return toGitHubErrorResponse(error);
   }
-}
+}

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -24,6 +24,34 @@ interface ContributionResponse {
   data: Record<string, number>;
 }
 
+class GitHubApiError extends Error {
+  status: number;
+  endpoint: string;
+  details: string;
+
+  constructor(endpoint: string, status: number, details: string) {
+    super("GitHub API failed");
+    this.status = status;
+    this.endpoint = endpoint;
+    this.details = details;
+  }
+}
+
+function toGitHubErrorResponse(error: unknown) {
+  if (error instanceof GitHubApiError) {
+    return Response.json(
+      {
+        error: "GitHub API failed",
+        endpoint: error.endpoint,
+        status: error.status,
+        details: error.details,
+      },
+      { status: error.status }
+    );
+  }
+  return Response.json({ error: "GitHub API error" }, { status: 502 });
+}
+
 function toLocalDateStr(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
@@ -61,19 +89,23 @@ async function fetchContributionsForAccount(
       since.setDate(since.getDate() - days);
       const sinceStr = toLocalDateStr(since);
 
-      const searchRes = await fetch(
-        `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
-        {
+      const endpoint = `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`;
+      const searchRes = await fetch(endpoint, {
           headers: {
             Authorization: `Bearer ${token}`,
             Accept: "application/vnd.github+json",
           },
           cache: "no-store",
-        }
-      );
+        });
 
       if (!searchRes.ok) {
-        throw new Error("GitHub API error");
+        const body = await searchRes.text();
+        console.error("GitHub API failed", {
+          endpoint,
+          status: searchRes.status,
+          body,
+        });
+        throw new GitHubApiError(endpoint, searchRes.status, body);
       }
 
       const data = (await searchRes.json()) as {
@@ -113,8 +145,8 @@ export async function GET(req: NextRequest) {
         { bypass, userId: session.githubId ?? session.githubLogin }
       );
       return Response.json(result);
-    } catch {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    } catch (error) {
+      return toGitHubErrorResponse(error);
     }
   }
 
@@ -127,13 +159,13 @@ export async function GET(req: NextRequest) {
         { bypass, userId: session.githubId ?? session.githubLogin }
       );
       return Response.json(result);
-    } catch {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    } catch (error) {
+      return toGitHubErrorResponse(error);
     }
   }
 
   if (!session.githubId) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+    return Response.json({ error: "User not found" }, { status: 404 });
   }
 
   const userRow = await resolveAppUser(session.githubId, session.githubLogin);
@@ -199,7 +231,7 @@ export async function GET(req: NextRequest) {
     .select("github_login")
     .eq("user_id", userRow.id)
     .eq("github_id", accountId)
-    .single();
+    .maybeSingle();
 
   if (!accountRow?.github_login) {
     return Response.json({ error: "Account not found" }, { status: 404 });
@@ -213,7 +245,7 @@ export async function GET(req: NextRequest) {
       { bypass, userId: accountId }
     );
     return Response.json(result);
-  } catch {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  } catch (error) {
+    return toGitHubErrorResponse(error);
   }
 }

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/metrics-cache";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
+import { GitHubApiError, toGitHubErrorResponse } from "@/lib/github-error";
 
 export const dynamic = "force-dynamic";
 
@@ -22,34 +23,6 @@ interface ContributionResponse {
   days: number;
   total: number;
   data: Record<string, number>;
-}
-
-class GitHubApiError extends Error {
-  status: number;
-  endpoint: string;
-  details: string;
-
-  constructor(endpoint: string, status: number, details: string) {
-    super("GitHub API failed");
-    this.status = status;
-    this.endpoint = endpoint;
-    this.details = details;
-  }
-}
-
-function toGitHubErrorResponse(error: unknown) {
-  if (error instanceof GitHubApiError) {
-    return Response.json(
-      {
-        error: "GitHub API failed",
-        endpoint: error.endpoint,
-        status: error.status,
-        details: error.details,
-      },
-      { status: error.status }
-    );
-  }
-  return Response.json({ error: "GitHub API error" }, { status: 502 });
 }
 
 function toLocalDateStr(d: Date): string {
@@ -91,12 +64,12 @@ async function fetchContributionsForAccount(
 
       const endpoint = `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`;
       const searchRes = await fetch(endpoint, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: "application/vnd.github+json",
-          },
-          cache: "no-store",
-        });
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+        cache: "no-store",
+      });
 
       if (!searchRes.ok) {
         const body = await searchRes.text();
@@ -165,7 +138,7 @@ export async function GET(req: NextRequest) {
   }
 
   if (!session.githubId) {
-    return Response.json({ error: "User not found" }, { status: 404 });
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const userRow = await resolveAppUser(session.githubId, session.githubLogin);
@@ -175,35 +148,40 @@ export async function GET(req: NextRequest) {
   }
 
   if (accountId === "combined") {
-    const accounts = await getAllAccounts(
-      {
-        token: session.accessToken,
-        githubId: session.githubId,
-        githubLogin: session.githubLogin,
-      },
-      userRow.id
-    );
+    try {
+      const accounts = await getAllAccounts(
+        {
+          token: session.accessToken,
+          githubId: session.githubId,
+          githubLogin: session.githubLogin,
+        },
+        userRow.id
+      );
 
-    const results = await Promise.allSettled(
-      accounts.map((account) =>
-        fetchContributionsForAccount(account.token, account.githubLogin, days, {
-          bypass,
-          userId: account.githubId,
-        })
-      )
-    );
+      const results = await Promise.allSettled(
+        accounts.map((account) =>
+          fetchContributionsForAccount(account.token, account.githubLogin, days, {
+            bypass,
+            userId: account.githubId,
+          })
+        )
+      );
 
-    const merged = mergeMetrics(results, (a, b) => ({
-      days: a.days,
-      total: a.total + b.total,
-      data: mergeContributionDays(a.data, b.data),
-    }));
+      const merged = mergeMetrics(results, (a, b) => ({
+        days: a.days,
+        total: a.total + b.total,
+        data: mergeContributionDays(a.data, b.data),
+      }));
 
-    if (!merged) {
-      return Response.json({ error: "All accounts failed" }, { status: 502 });
+      if (!merged) {
+        return Response.json({ error: "All accounts failed" }, { status: 502 });
+      }
+
+      return Response.json(merged);
+    } catch (error) {
+      console.error("Failed to fetch combined contributions:", error);
+      return Response.json({ error: "Failed to fetch accounts" }, { status: 500 });
     }
-
-    return Response.json(merged);
   }
 
   if (accountId === session.githubId) {
@@ -215,8 +193,8 @@ export async function GET(req: NextRequest) {
         { bypass, userId: session.githubId }
       );
       return Response.json(result);
-    } catch {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    } catch (error) {
+      return toGitHubErrorResponse(error);
     }
   }
 

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -319,29 +319,32 @@ export async function GET(req: NextRequest) {
         )
       );
 
-    const merged = mergeMetrics(results, (a, b) => ({
-      days: a.days,
-      total: a.total + b.total,
-      data: mergeContributionDays(a.data, b.data),
-      commits: [...a.commits, ...b.commits].sort(
-        (c, d) => d.date.localeCompare(c.date) || d.sha.localeCompare(c.sha)
-      ),
-    }));
+      const merged = mergeMetrics(results, (a, b) => ({
+        days: a.days,
+        total: a.total + b.total,
+        data: mergeContributionDays(a.data, b.data),
+        commits: [...a.commits, ...b.commits].sort(
+          (c, d) => d.date.localeCompare(c.date) || d.sha.localeCompare(c.sha)
+        ),
+      }));
 
       if (!merged) {
         return Response.json({ error: "All accounts failed" }, { status: 502 });
       }
 
-    if (!gitlabToken) {
-      return Response.json(merged);
+      if (!gitlabToken) {
+        return Response.json(merged);
+      }
+
+      const combined = await mergeGitLabContributions(merged, gitlabToken, days, {
+        bypass,
+        userId: session.githubId,
+      });
+
+      return Response.json(combined);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
-
-    const combined = await mergeGitLabContributions(merged, gitlabToken, days, {
-      bypass,
-      userId: session.githubId,
-    });
-
-    return Response.json(combined);
   }
 
   if (accountId === session.githubId) {

--- a/src/app/api/metrics/repos/route.ts
+++ b/src/app/api/metrics/repos/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/metrics-cache";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
+import { GitHubApiError, toGitHubErrorResponse } from "@/lib/github-error";
 
 export const dynamic = "force-dynamic";
 
@@ -29,33 +30,7 @@ interface RepoResponse {
   days: number;
 }
 
-class GitHubApiError extends Error {
-  status: number;
-  endpoint: string;
-  details: string;
 
-  constructor(endpoint: string, status: number, details: string) {
-    super("GitHub API failed");
-    this.status = status;
-    this.endpoint = endpoint;
-    this.details = details;
-  }
-}
-
-function toGitHubErrorResponse(error: unknown) {
-  if (error instanceof GitHubApiError) {
-    return Response.json(
-      {
-        error: "GitHub API failed",
-        endpoint: error.endpoint,
-        status: error.status,
-        details: error.details,
-      },
-      { status: error.status }
-    );
-  }
-  return Response.json({ error: "GitHub API error" }, { status: 502 });
-}
 
 function mergeRepoCommits(
   a: Array<{ name: string; commits: number; description: string | null }>,
@@ -166,7 +141,7 @@ export async function GET(req: NextRequest) {
   }
 
   if (!session.githubId) {
-    return Response.json({ error: "User not found" }, { status: 404 });
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const userRow = await resolveAppUser(session.githubId, session.githubLogin);

--- a/src/app/api/metrics/repos/route.ts
+++ b/src/app/api/metrics/repos/route.ts
@@ -28,6 +28,34 @@ interface RepoResponse {
   days: number;
 }
 
+class GitHubApiError extends Error {
+  status: number;
+  endpoint: string;
+  details: string;
+
+  constructor(endpoint: string, status: number, details: string) {
+    super("GitHub API failed");
+    this.status = status;
+    this.endpoint = endpoint;
+    this.details = details;
+  }
+}
+
+function toGitHubErrorResponse(error: unknown) {
+  if (error instanceof GitHubApiError) {
+    return Response.json(
+      {
+        error: "GitHub API failed",
+        endpoint: error.endpoint,
+        status: error.status,
+        details: error.details,
+      },
+      { status: error.status }
+    );
+  }
+  return Response.json({ error: "GitHub API error" }, { status: 502 });
+}
+
 function mergeRepoCommits(
   a: Array<{ name: string; commits: number }>,
   b: Array<{ name: string; commits: number }>
@@ -63,19 +91,23 @@ async function fetchReposForAccount(
       since.setDate(since.getDate() - days);
       const sinceStr = since.toISOString().slice(0, 10);
 
-      const searchRes = await fetch(
-        `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
-        {
+      const endpoint = `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`;
+      const searchRes = await fetch(endpoint, {
           headers: {
             Authorization: `Bearer ${token}`,
             Accept: "application/vnd.github+json",
           },
           cache: "no-store",
-        }
-      );
+        });
 
       if (!searchRes.ok) {
-        throw new Error("GitHub API error");
+        const body = await searchRes.text();
+        console.error("GitHub API failed", {
+          endpoint,
+          status: searchRes.status,
+          body,
+        });
+        throw new GitHubApiError(endpoint, searchRes.status, body);
       }
 
       const data = (await searchRes.json()) as {
@@ -120,13 +152,13 @@ export async function GET(req: NextRequest) {
         { bypass, userId: session.githubId ?? session.githubLogin }
       );
       return Response.json(result);
-    } catch {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    } catch (error) {
+      return toGitHubErrorResponse(error);
     }
   }
 
   if (!session.githubId) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+    return Response.json({ error: "User not found" }, { status: 404 });
   }
 
   const userRow = await resolveAppUser(session.githubId, session.githubLogin);
@@ -175,8 +207,8 @@ export async function GET(req: NextRequest) {
         { bypass, userId: session.githubId }
       );
       return Response.json(result);
-    } catch {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    } catch (error) {
+      return toGitHubErrorResponse(error);
     }
   }
 
@@ -191,7 +223,7 @@ export async function GET(req: NextRequest) {
     .select("github_login")
     .eq("user_id", userRow.id)
     .eq("github_id", accountId)
-    .single();
+    .maybeSingle();
 
   if (!accountRow?.github_login) {
     return Response.json({ error: "Account not found" }, { status: 404 });
@@ -205,7 +237,7 @@ export async function GET(req: NextRequest) {
       { bypass, userId: accountId }
     );
     return Response.json(result);
-  } catch {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  } catch (error) {
+    return toGitHubErrorResponse(error);
   }
 }

--- a/src/app/api/metrics/streak/route.ts
+++ b/src/app/api/metrics/streak/route.ts
@@ -14,6 +14,34 @@ import { resolveAppUser } from "@/lib/resolve-user";
 
 export const dynamic = "force-dynamic";
 
+class GitHubApiError extends Error {
+  status: number;
+  endpoint: string;
+  details: string;
+
+  constructor(endpoint: string, status: number, details: string) {
+    super("GitHub API failed");
+    this.status = status;
+    this.endpoint = endpoint;
+    this.details = details;
+  }
+}
+
+function toGitHubErrorResponse(error: unknown) {
+  if (error instanceof GitHubApiError) {
+    return Response.json(
+      {
+        error: "GitHub API failed",
+        endpoint: error.endpoint,
+        status: error.status,
+        details: error.details,
+      },
+      { status: error.status }
+    );
+  }
+  return Response.json({ error: "GitHub API error" }, { status: 502 });
+}
+
 function dateDiffDays(a: string, b: string): number {
   return (
     (new Date(b).getTime() - new Date(a).getTime()) / (1000 * 60 * 60 * 24)
@@ -44,19 +72,23 @@ async function fetchActiveDates(
       const activeDates = new Set<string>();
       let page = 1;
       while (true) {
-        const searchRes = await fetch(
-          `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&page=${page}&sort=author-date&order=desc`,
-          {
+        const endpoint = `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&page=${page}&sort=author-date&order=desc`;
+        const searchRes = await fetch(endpoint, {
             headers: {
               Authorization: `Bearer ${token}`,
               Accept: "application/vnd.github+json",
             },
             cache: "no-store",
-          }
-        );
+          });
 
         if (!searchRes.ok) {
-          throw new Error("GitHub API error");
+          const body = await searchRes.text();
+          console.error("GitHub API failed", {
+            endpoint,
+            status: searchRes.status,
+            body,
+          });
+          throw new GitHubApiError(endpoint, searchRes.status, body);
         }
 
         const data = (await searchRes.json()) as {
@@ -188,8 +220,8 @@ export async function GET(req: NextRequest) {
       return Response.json(
         calculateStreakFromDates(activeDates, freezeDates)
       );
-    } catch {
-      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    } catch (error) {
+      return toGitHubErrorResponse(error);
     }
   }
 
@@ -241,7 +273,7 @@ export async function GET(req: NextRequest) {
       .select("github_login")
       .eq("user_id", appUserId)
       .eq("github_id", accountId)
-      .single();
+      .maybeSingle();
 
     if (!accountRow?.github_login) {
       return Response.json({ error: "Account not found" }, { status: 404 });
@@ -257,7 +289,7 @@ export async function GET(req: NextRequest) {
       userId: accountId,
     });
     return Response.json(calculateStreakFromDates(activeDates, freezeDates));
-  } catch {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  } catch (error) {
+    return toGitHubErrorResponse(error);
   }
 }

--- a/src/app/api/metrics/streak/route.ts
+++ b/src/app/api/metrics/streak/route.ts
@@ -11,36 +11,11 @@ import {
 } from "@/lib/metrics-cache";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
+import { GitHubApiError, toGitHubErrorResponse } from "@/lib/github-error";
 
 export const dynamic = "force-dynamic";
 
-class GitHubApiError extends Error {
-  status: number;
-  endpoint: string;
-  details: string;
 
-  constructor(endpoint: string, status: number, details: string) {
-    super("GitHub API failed");
-    this.status = status;
-    this.endpoint = endpoint;
-    this.details = details;
-  }
-}
-
-function toGitHubErrorResponse(error: unknown) {
-  if (error instanceof GitHubApiError) {
-    return Response.json(
-      {
-        error: "GitHub API failed",
-        endpoint: error.endpoint,
-        status: error.status,
-        details: error.details,
-      },
-      { status: error.status }
-    );
-  }
-  return Response.json({ error: "GitHub API error" }, { status: 502 });
-}
 
 function dateDiffDays(a: string, b: string): number {
   return (

--- a/src/app/api/user/github-accounts/route.ts
+++ b/src/app/api/user/github-accounts/route.ts
@@ -33,6 +33,10 @@ export async function GET() {
     .order("added_at", { ascending: true });
 
   if (error) {
+    // Backward compatibility: table may not exist before migration.
+    if (error.code === "42P01") {
+      return NextResponse.json({ accounts: [] });
+    }
     return NextResponse.json(
       { error: "Failed to fetch accounts" },
       { status: 500 }

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -16,17 +16,30 @@ export async function GET(req: NextRequest) {
   const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) {
     return NextResponse.json(
-      { error: "Failed to fetch user settings" },
-      { status: 500 }
+      { error: "User not found" },
+      { status: 404 }
     );
   }
 
   // Fetch user from Supabase
-  const { data, error } = await supabaseAdmin
+  let { data, error } = await supabaseAdmin
     .from("users")
     .select("id, github_login, is_public, leaderboard_opt_in")
     .eq("id", user.id)
-    .single();
+    .maybeSingle();
+
+  // Backward compatibility: older DBs may not have leaderboard_opt_in yet.
+  if (error?.code === "42703") {
+    const fallback = await supabaseAdmin
+      .from("users")
+      .select("id, github_login, is_public")
+      .eq("id", user.id)
+      .maybeSingle();
+    data = fallback.data
+      ? { ...fallback.data, leaderboard_opt_in: false }
+      : null;
+    error = fallback.error;
+  }
 
   if (error) {
     console.error("Error fetching user:", error);
@@ -34,6 +47,9 @@ export async function GET(req: NextRequest) {
       { error: "Failed to fetch user settings" },
       { status: 500 }
     );
+  }
+  if (!data) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
 
   return NextResponse.json(data);
@@ -90,12 +106,35 @@ export async function PATCH(req: NextRequest) {
     }
   }
 
-  const { data: updated, error: updateError } = await supabaseAdmin
+  let { data: updated, error: updateError } = await supabaseAdmin
     .from("users")
     .update(updates)
     .eq("id", user.id)
     .select("id, github_login, is_public, leaderboard_opt_in")
-    .single();
+    .maybeSingle();
+
+  // Backward compatibility: older DBs may not have leaderboard_opt_in yet.
+  if (
+    updateError?.code === "42703" &&
+    Object.prototype.hasOwnProperty.call(updates, "leaderboard_opt_in")
+  ) {
+    const fallbackUpdates: { is_public?: boolean } = {};
+    if (typeof updates.is_public === "boolean") {
+      fallbackUpdates.is_public = updates.is_public;
+    }
+
+    const fallback = await supabaseAdmin
+      .from("users")
+      .update(fallbackUpdates)
+      .eq("id", user.id)
+      .select("id, github_login, is_public")
+      .maybeSingle();
+
+    updated = fallback.data
+      ? { ...fallback.data, leaderboard_opt_in: false }
+      : null;
+    updateError = fallback.error;
+  }
 
   if (updateError || !updated) {
     console.error("Error updating settings:", updateError);

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -312,7 +312,7 @@ function SettingsPageContent() {
             className={`mb-6 rounded-xl border p-4 text-sm ${
               statusMessage.kind === "success"
                 ? "border-green-500/30 bg-green-500/10 text-green-400"
-                : "border-red-500/30 bg-red-500/10 text-red-400"
+                : "border-[var(--destructive)]/30 bg-[var(--destructive)]/10 text-[var(--destructive)]"
             }`}
           >
             {statusMessage.message}
@@ -491,7 +491,7 @@ function SettingsPageContent() {
           </div>
 
           {removeError && (
-            <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400">
+            <div className="mt-4 rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 p-3 text-sm text-[var(--destructive)]">
               {removeError}
             </div>
           )}
@@ -531,7 +531,7 @@ function SettingsPageContent() {
                       onClick={() => handleRemoveAccount(account.githubId)}
                       aria-label={`Remove ${account.githubLogin}`}
                       disabled={removingAccountId === account.githubId}
-                      className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--card-foreground)] transition-colors hover:bg-red-500/10 hover:text-red-400 disabled:opacity-60"
+                      className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm font-medium text-[var(--card-foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)] disabled:opacity-60"
                     >
                       {removingAccountId === account.githubId
                         ? "Removing..."

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,10 +4,12 @@ import type { ReactNode } from "react";
 import { SessionProvider } from "next-auth/react";
 import { AccountProvider } from "@/components/AccountContext";
 import { ThemeProvider } from "@/components/ThemeContext";
+import AuthSessionValidator from "@/components/AuthSessionValidator";
 
 export default function Providers({ children }: { children: ReactNode }) {
   return (
     <SessionProvider>
+      <AuthSessionValidator />
       <AccountProvider>
         <ThemeProvider>
           {children}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -15,6 +15,16 @@ export default function Providers({ children }: { children: ReactNode }) {
         <ThemeProvider>
           {children}
           <BackToTopButton />
+          <style dangerouslySetInnerHTML={{ __html: `
+            :root {
+              --destructive: #ef4444;
+              --destructive-rgb: 239, 68, 68;
+            }
+            .dark {
+              --destructive: #f87171;
+              --destructive-rgb: 248, 113, 113;
+            }
+          `}} />
         </ThemeProvider>
       </AccountProvider>
     </SessionProvider>

--- a/src/components/AuthSessionValidator.tsx
+++ b/src/components/AuthSessionValidator.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { signOut, useSession } from "next-auth/react";
+
+export default function AuthSessionValidator() {
+  const { status } = useSession();
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+
+    let active = true;
+
+    const validateUser = async () => {
+      try {
+        const res = await fetch("/api/auth/me", { cache: "no-store" });
+        if (!res.ok && active) {
+          await signOut({ callbackUrl: "/" });
+        }
+      } catch {
+        if (active) {
+          await signOut({ callbackUrl: "/" });
+        }
+      }
+    };
+
+    validateUser();
+
+    return () => {
+      active = false;
+    };
+  }, [status]);
+
+  return null;
+}

--- a/src/components/AuthSessionValidator.tsx
+++ b/src/components/AuthSessionValidator.tsx
@@ -14,13 +14,12 @@ export default function AuthSessionValidator() {
     const validateUser = async () => {
       try {
         const res = await fetch("/api/auth/me", { cache: "no-store" });
-        if (!res.ok && active) {
+        // Only sign out on authentication errors (401) or missing resource (404)
+        if ((res.status === 401 || res.status === 404) && active) {
           await signOut({ callbackUrl: "/" });
         }
       } catch {
-        if (active) {
-          await signOut({ callbackUrl: "/" });
-        }
+        // Transient network errors should not trigger sign out
       }
     };
 

--- a/src/components/CIAnalytics.tsx
+++ b/src/components/CIAnalytics.tsx
@@ -90,12 +90,12 @@ export default function CIAnalytics() {
           ))}
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchCIAnalytics}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>

--- a/src/components/CommitTimeChart.tsx
+++ b/src/components/CommitTimeChart.tsx
@@ -128,12 +128,12 @@ export default function CommitTimeChart() {
           </div>
         ) : error ? (
           <div className="flex h-full items-center justify-center">
-            <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400 text-center">
+            <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)] text-center">
               <p>{error}</p>
               <button
                 type="button"
                 onClick={fetchContributions}
-                className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+                className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
               >
                 Try again
               </button>

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -257,9 +257,33 @@ export default function ContributionGraph() {
     >
       <div className="flex flex-wrap items-center justify-between mb-4 gap-2">
         <div className="min-w-0">
-          <h2 className="text-lg font-semibold text-[var(--foreground)]">
-            {compareMode && compareUser ? `You vs ${compareUser}` : "Your Commits"}
-          </h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-[var(--foreground)]">
+              {compareMode && compareUser ? `You vs ${compareUser}` : "Your Commits"}
+            </h2>
+            {!compareMode && (
+              <button
+                onClick={() => setData([])}
+                title="Remove"
+                aria-label="Remove Your Commits section"
+                className="p-1 rounded-md text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--background)] transition-colors"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            )}
+          </div>
           {compareMode && compareError && (
             <p className="mt-1 text-xs text-[var(--muted-foreground)]">{compareError}</p>
           )}

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -554,4 +554,4 @@ export default function ContributionGraph() {
       )}
     </div>
   );
-}
+}

--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -220,13 +220,13 @@ export default function ContributionHeatmap({
       {loading ? (
         <div className="h-[180px] animate-pulse rounded-lg bg-[var(--card-muted)]" />
       ) : error ? (
-        <div className="flex h-[180px] items-center justify-between gap-3 rounded-lg border border-red-500/30 bg-red-500/10 px-4">
-          <p className="text-sm text-red-400">{error} Please try again.</p>
+        <div className="flex h-[180px] items-center justify-between gap-3 rounded-lg border border-[rgba(var(--destructive-rgb),0.3)] bg-[rgba(var(--destructive-rgb),0.1)] px-4">
+          <p className="text-sm text-[var(--destructive)]">{error} Please try again.</p>
           <button
             type="button"
             onClick={() => setReloadKey((key) => key + 1)}
             disabled={loading}
-            className="rounded-md border border-red-400/40 bg-red-500/20 px-3 py-1 text-xs text-red-200 transition hover:bg-red-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md border border-[rgba(var(--destructive-rgb),0.4)] bg-[rgba(var(--destructive-rgb),0.2)] px-3 py-1 text-xs text-[rgba(var(--destructive-rgb),0.9)] transition hover:bg-[rgba(var(--destructive-rgb),0.3)] disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading ? "Reloading..." : "Reload"}
           </button>

--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -76,6 +76,7 @@ export default function ContributionHeatmap({ days = DEFAULT_DAYS }: Contributio
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     let active = true;
@@ -108,7 +109,7 @@ export default function ContributionHeatmap({ days = DEFAULT_DAYS }: Contributio
     return () => {
       active = false;
     };
-  }, [days]);
+  }, [days, reloadKey]);
 
   useEffect(() => {
     if (!lastUpdated) return;
@@ -209,8 +210,16 @@ export default function ContributionHeatmap({ days = DEFAULT_DAYS }: Contributio
       {loading ? (
         <div className="h-[180px] rounded-lg bg-[var(--card-muted)] animate-pulse" />
       ) : error ? (
-        <div className="flex h-[180px] items-center rounded-lg border border-red-500/30 bg-red-500/10 px-4">
-          <p className="text-sm text-red-400">{error} Please try refreshing.</p>
+        <div className="flex h-[180px] items-center justify-between gap-3 rounded-lg border border-red-500/30 bg-red-500/10 px-4">
+          <p className="text-sm text-red-400">{error} Please try again.</p>
+          <button
+            type="button"
+            onClick={() => setReloadKey((key) => key + 1)}
+            disabled={loading}
+            className="rounded-md border border-red-400/40 bg-red-500/20 px-3 py-1 text-xs text-red-200 transition hover:bg-red-500/30 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {loading ? "Reloading..." : "Reload"}
+          </button>
         </div>
       ) : (
         <>
@@ -285,7 +294,17 @@ export default function ContributionHeatmap({ days = DEFAULT_DAYS }: Contributio
             <p>
               {cells.filter((cell) => cell.inRange).reduce((total, cell) => total + cell.count, 0)} commits shown across {days} days.
             </p>
-            {lastUpdated && <p>{minutesAgo === 0 ? "Updated just now" : `Updated ${minutesAgo} min ago`}</p>}
+            <div className="flex items-center gap-3">
+              {lastUpdated && <p>{minutesAgo === 0 ? "Updated just now" : `Updated ${minutesAgo} min ago`}</p>}
+              <button
+                type="button"
+                onClick={() => setReloadKey((key) => key + 1)}
+                disabled={loading}
+                className="rounded-md border border-[var(--border)] px-2 py-1 text-[11px] text-[var(--muted-foreground)] transition hover:bg-[var(--card-muted)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loading ? "Reloading..." : "Reload"}
+              </button>
+            </div>
           </div>
         </>
       )}

--- a/src/components/FriendComparison.tsx
+++ b/src/components/FriendComparison.tsx
@@ -116,7 +116,7 @@ export default function FriendComparison() {
     </div>
 
       {error && (
-        <div className="p-4 mb-4 rounded-md border border-red-500/30 bg-red-500/10 text-red-500 text-sm flex justify-between items-center">
+        <div className="p-4 mb-4 rounded-md border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 text-[var(--destructive)] text-sm flex justify-between items-center">
           <span>{error}</span>
           <button onClick={() => setError("")} className="hover:underline">Dismiss</button>
         </div>
@@ -169,7 +169,7 @@ export default function FriendComparison() {
             </a>
             <button
               onClick={clearComparison}
-              className="rounded-full bg-[var(--control)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-red-500/10 hover:text-red-500"
+              className="rounded-full bg-[var(--control)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)]"
             >
               Clear Comparison
             </button>

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -221,7 +221,7 @@ export default function GoalTracker() {
                         <button
                           onClick={() => handleDelete(goal.id)}
                           disabled={isDeleting}
-                          className="text-red-400 hover:text-red-300 font-semibold transition-colors disabled:opacity-50"
+                          className="text-[var(--destructive)] hover:text-[var(--destructive)] font-semibold transition-colors disabled:opacity-50"
                           aria-label={`Confirm delete goal: ${goal.title}`}
                         >
                           Yes
@@ -239,7 +239,7 @@ export default function GoalTracker() {
                       <button
                         onClick={() => setConfirmingId(goal.id)}
                         disabled={isDeleting}
-                        className="text-[var(--muted-foreground)] hover:text-red-400 transition-colors disabled:opacity-50"
+                        className="text-[var(--muted-foreground)] hover:text-[var(--destructive)] transition-colors disabled:opacity-50"
                         aria-label={`Delete goal: ${goal.title}`}
                         title="Delete goal"
                       >
@@ -363,7 +363,7 @@ export default function GoalTracker() {
         </button>
 
         {createError && (
-          <p className="text-sm text-red-500">{createError}</p>
+          <p className="text-sm text-[var(--destructive)]">{createError}</p>
         )}
       </form>
     </div>
@@ -425,4 +425,4 @@ function ConfettiBurst() {
       ))}
     </div>
   );
-}
+}

--- a/src/components/IssueMetrics.tsx
+++ b/src/components/IssueMetrics.tsx
@@ -53,7 +53,8 @@ export default function IssueMetrics() {
       : null;
 
   const trendColor =
-    metrics && metrics.trend > 0 ? "text-green-400" : "text-red-400";
+    metrics && metrics.trend > 0 ? "text-[var(--success)]" : "text-[var(--destructive)]";
+
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
@@ -77,12 +78,12 @@ export default function IssueMetrics() {
           ))}
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchMetrics}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>

--- a/src/components/PRBreakdownChart.tsx
+++ b/src/components/PRBreakdownChart.tsx
@@ -68,12 +68,12 @@ export default function PRBreakdownChart() {
     return (
       <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">PR Breakdown</h2>
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchBreakdown}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -91,12 +91,12 @@ export default function PRMetrics() {
           <div className="h-[270px] rounded-lg bg-[var(--card-muted)] animate-pulse" aria-hidden="true" />
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchMetrics}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>

--- a/src/components/PRReviewTrendChart.tsx
+++ b/src/components/PRReviewTrendChart.tsx
@@ -179,12 +179,12 @@ export default function PRReviewTrendChart() {
         </div>
       ) : error ? (
         <div className="flex h-[360px] items-center justify-center">
-          <div className="max-w-sm rounded-lg border border-red-500/20 bg-red-500/10 p-5 text-center">
-            <p className="text-sm text-red-300">{error}</p>
+          <div className="max-w-sm rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-5 text-center">
+            <p className="text-sm text-[var(--destructive)]">{error}</p>
             <button
               type="button"
               onClick={fetchTrend}
-              className="mt-4 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+              className="mt-4 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
             >
               Try again
             </button>

--- a/src/components/PersonalRecords.tsx
+++ b/src/components/PersonalRecords.tsx
@@ -238,12 +238,12 @@ export default function PersonalRecords() {
           ))}
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchRecords}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>

--- a/src/components/PinnedRepos.tsx
+++ b/src/components/PinnedRepos.tsx
@@ -60,12 +60,12 @@ export default function PinnedRepos() {
           ))}
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchPinnedRepos}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -21,7 +21,7 @@ export default function SignOutButton() {
             type="button"
             disabled={signingOut}
             onClick={handleSignOut}
-            className="inline-flex h-10 items-center gap-2 rounded-full border border-red-600/50 bg-red-600/80 px-4 text-sm font-semibold text-white transition-colors hover:bg-red-600 disabled:cursor-not-allowed disabled:opacity-70">
+            className="inline-flex h-10 items-center gap-2 rounded-full border border-[var(--destructive)]/50 bg-[var(--destructive)]/80 px-4 text-sm font-semibold text-white transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-70">
             {signingOut && (
                 <svg className="h-4 w-4 animate-spin text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
@@ -32,4 +32,3 @@ export default function SignOutButton() {
         </button>
     );
 }
-

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -184,12 +184,12 @@ export default function StreakTracker() {
     return (
       <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Commit Streaks</h2>
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchStreak}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>
@@ -493,7 +493,7 @@ export default function StreakTracker() {
                 type="button"
                 onClick={handleCancelFreeze}
                 disabled={cancelling}
-                className="rounded-md bg-red-500/10 px-2.5 py-1 text-xs font-medium text-red-400 transition hover:bg-red-500/20 disabled:opacity-60"
+                className="rounded-md bg-[var(--destructive)]/10 px-2.5 py-1 text-xs font-medium text-[var(--destructive)] transition hover:bg-[var(--destructive)]/20 disabled:opacity-60"
               >
                 {cancelling ? "Removing..." : "Yes, remove"}
               </button>
@@ -790,7 +790,7 @@ function calculateMonthlyTrend(contrib: ContributionData | undefined | null): Mo
       colorClass = "text-green-500 font-medium";
     } else if (deltaCalc < 0) {
       text = `↓${Math.abs(deltaCalc).toFixed(0)}% vs last month`;
-      colorClass = "text-red-500 font-medium";
+      colorClass = "text-[var(--destructive)] font-medium";
     } else {
       text = `=0% vs last month`;
       colorClass = "text-[var(--muted-foreground)] font-medium";

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -189,12 +189,12 @@ export default function TopRepos() {
           ))}
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           <p>{error}</p>
           <button
             type="button"
             onClick={fetchRepos}
-            className="mt-3 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
           >
             Try again
           </button>
@@ -249,7 +249,7 @@ export default function TopRepos() {
                 ? "bg-green-500/15 text-green-300 border border-green-500/25"
                 : health?.grade === "yellow"
                   ? "bg-yellow-500/15 text-yellow-300 border border-yellow-500/25"
-                  : "bg-red-500/15 text-red-300 border border-red-500/25";
+                  : "bg-[var(--destructive)]/15 text-[var(--destructive)] border border-[var(--destructive)]/25";
             const visibleLanguages = repo.languages ? getVisibleLanguages(repo.languages) : [];
             return (
               <li key={repo.name}>

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -79,7 +79,7 @@ export default function WeeklySummaryCard() {
             ))}
           </div>
         ) : error ? (
-          <div className="mt-4 rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
+          <div className="mt-4 rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
             {error}
           </div>
         ) : summary ? (
@@ -93,12 +93,12 @@ export default function WeeklySummaryCard() {
                   {summary.commits.current}
                 </span>
                 {summary.commits.trend === "up" && (
-                  <span className="text-sm font-medium text-green-400">
+                  <span className="text-sm font-medium text-[var(--success)]">
                     + {summary.commits.delta}
                   </span>
                 )}
                 {summary.commits.trend === "down" && (
-                  <span className="text-sm font-medium text-red-400">
+                  <span className="text-sm font-medium text-[var(--destructive)]">
                     - {Math.abs(summary.commits.delta)}
                   </span>
                 )}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -42,7 +42,7 @@ export const authOptions: NextAuthOptions = {
     async signIn({ account, profile }) {
       if (account?.provider === "github" && profile) {
         const p = profile as { id: number; login: string };
-        await supabaseAdmin.from("users").upsert(
+        const { error } = await supabaseAdmin.from("users").upsert(
           {
             github_id: String(p.id),
             github_login: p.login,
@@ -50,6 +50,14 @@ export const authOptions: NextAuthOptions = {
           },
           { onConflict: "github_id" }
         );
+        if (error) {
+          console.error("Failed to upsert user during GitHub sign in", {
+            githubId: String(p.id),
+            githubLogin: p.login,
+            error,
+          });
+          return false;
+        }
       }
       return true;
     },

--- a/src/lib/github-accounts.ts
+++ b/src/lib/github-accounts.ts
@@ -145,7 +145,7 @@ export async function getAccountToken(
     .select("access_token_encrypted, access_token_iv")
     .eq("user_id", userId)
     .eq("github_id", accountGithubId)
-    .single();
+    .maybeSingle();
 
   if (error || !data) {
     return null;

--- a/src/lib/github-accounts.ts
+++ b/src/lib/github-accounts.ts
@@ -193,4 +193,4 @@ export function mergeMetrics<T>(
   return fulfilled
     .slice(1)
     .reduce((acc, result) => merge(acc, result.value), fulfilled[0].value);
-}
+}

--- a/src/lib/github-accounts.ts
+++ b/src/lib/github-accounts.ts
@@ -193,4 +193,4 @@ export function mergeMetrics<T>(
   return fulfilled
     .slice(1)
     .reduce((acc, result) => merge(acc, result.value), fulfilled[0].value);
-}
+}

--- a/src/lib/github-error.ts
+++ b/src/lib/github-error.ts
@@ -1,0 +1,27 @@
+export class GitHubApiError extends Error {
+  status: number;
+  endpoint: string;
+  details: string;
+
+  constructor(endpoint: string, status: number, details: string) {
+    super("GitHub API failed");
+    this.status = status;
+    this.endpoint = endpoint;
+    this.details = details;
+  }
+}
+
+export function toGitHubErrorResponse(error: unknown) {
+  if (error instanceof GitHubApiError) {
+    return Response.json(
+      {
+        error: "GitHub API failed",
+        endpoint: error.endpoint,
+        status: error.status,
+        details: error.details,
+      },
+      { status: error.status }
+    );
+  }
+  return Response.json({ error: "GitHub API error" }, { status: 502 });
+}

--- a/src/lib/resolve-user.ts
+++ b/src/lib/resolve-user.ts
@@ -8,15 +8,23 @@ export async function resolveAppUser(
   githubId: string,
   githubLogin?: string
 ): Promise<AppUser | null> {
-  const { data: existing } = await supabaseAdmin
+  const { data: existing, error: existingError } = await supabaseAdmin
     .from("users")
     .select("id")
     .eq("github_id", githubId)
-    .single();
+    .maybeSingle();
+
+  if (existingError) {
+    console.error("Failed to resolve existing user", {
+      githubId,
+      error: existingError,
+    });
+    return null;
+  }
 
   if (existing) return existing;
 
-  const { data: upserted } = await supabaseAdmin
+  const { data: upserted, error: upsertError } = await supabaseAdmin
     .from("users")
     .upsert(
       {
@@ -27,7 +35,16 @@ export async function resolveAppUser(
       { onConflict: "github_id" }
     )
     .select("id")
-    .single();
+    .maybeSingle();
+
+  if (upsertError) {
+    console.error("Failed to upsert user", {
+      githubId,
+      githubLogin,
+      error: upsertError,
+    });
+    return null;
+  }
 
   return upserted ?? null;
 }


### PR DESCRIPTION
## Summary

Adds backend-backed auth session validation to prevent stale or mismatched authenticated states in the client.

This PR introduces a new `/api/auth/me` endpoint to verify session-user mapping, adds startup auth validation with automatic sign-out for invalid sessions, improves GitHub account token lookup reliability, and adds reload buttons for better recovery UX.

Closes #348 

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / code cleanup

## Changes Made

* Added `/api/auth/me` endpoint to validate authenticated sessions against backend user records
* Ensures invalid or missing user mappings return proper `401` / `404` responses
* Added `AuthSessionValidator` component for startup auth verification
* Mounted validator globally in `providers.tsx`
* Automatically signs out users with stale or invalid auth sessions
* Replaced brittle `.single()` usage with `.maybeSingle()` in GitHub account token lookup
* Reduced `PGRST116`-style cascading failures from missing user rows
* Added reload buttons for easier recovery and improved user experience during auth/data mismatch states

## How to Test

Steps for the reviewer to verify this works:

1. Sign in normally and verify authenticated flows still work
2. Delete or invalidate the corresponding backend user record/session mapping
3. Refresh the application
4. Verify the client automatically signs out instead of remaining falsely authenticated
5. Verify `/api/auth/me` returns proper `401` or `404` responses for invalid states
6. Test GitHub account token retrieval and confirm missing rows no longer throw `.single()` errors
7. Verify reload buttons properly refresh/recover affected UI states

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable
