### PR TITLE
fix(TopRepos): show repo description as native tooltip on name hover (#214)

### DIFF
--- a/src/app/api/metrics/repos/route.ts
+++ b/src/app/api/metrics/repos/route.ts
@@ -21,6 +21,7 @@ export const dynamic = "force-dynamic";
 interface RepoSummary {
   name: string;
   commits: number;
+  description: string | null;
 }
 
 interface RepoResponse {
@@ -29,15 +30,19 @@ interface RepoResponse {
 }
 
 function mergeRepoCommits(
-  a: Array<{ name: string; commits: number }>,
-  b: Array<{ name: string; commits: number }>
-): Array<{ name: string; commits: number }> {
-  const map = new Map<string, number>();
+  a: Array<{ name: string; commits: number; description: string | null }>,
+  b: Array<{ name: string; commits: number; description: string | null }>
+): Array<{ name: string; commits: number; description: string | null }> {
+  const map = new Map<string, { commits: number; description: string | null }>();
   for (const repo of [...a, ...b]) {
-    map.set(repo.name, (map.get(repo.name) ?? 0) + repo.commits);
+    const existing = map.get(repo.name);
+    map.set(repo.name, {
+      commits: (existing?.commits ?? 0) + repo.commits,
+      description: existing?.description ?? repo.description,
+    });
   }
   return Array.from(map.entries())
-    .map(([name, commits]) => ({ name, commits }))
+    .map(([name, { commits, description }]) => ({ name, commits, description }))
     .sort((x, y) => y.commits - x.commits);
 }
 
@@ -80,19 +85,22 @@ async function fetchReposForAccount(
 
       const data = (await searchRes.json()) as {
         items: Array<{
-          repository: { full_name: string; html_url: string };
+          repository: { full_name: string; html_url: string; description: string | null };
           commit: { author: { date: string } };
         }>;
       };
 
-      const repoMap: Record<string, number> = {};
+      const repoMap: Record<string, { commits: number; description: string | null }> = {};
       for (const item of data.items) {
         const name = item.repository.full_name;
-        repoMap[name] = (repoMap[name] ?? 0) + 1;
+        repoMap[name] = {
+          commits: (repoMap[name]?.commits ?? 0) + 1,
+          description: item.repository.description,
+        };
       }
 
       const repos = Object.entries(repoMap)
-        .map(([name, commits]) => ({ name, commits }))
+        .map(([name, { commits, description }]) => ({ name, commits, description }))
         .sort((a, b) => b.commits - a.commits)
         .slice(0, 6);
 

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -8,6 +8,7 @@ interface Repo {
   name: string;
   commits: number;
   url: string;
+  description: string | null;
 }
 
 export default function TopRepos() {
@@ -198,7 +199,7 @@ export default function TopRepos() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="max-w-[60%] sm:max-w-[70%] truncate text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)]"
-                    title={repo.name}
+                    title={repo.description || undefined}
                   >
                     <span className="mr-1 text-[var(--muted-foreground)]">#{idx + 1}</span>
                     {shortName}


### PR DESCRIPTION
## Summary

Fixes #214 — `TopRepos` listed repository names but never surfaced the
description the GitHub API already returns. Hovering a repo name now shows
its description as a native browser tooltip. Repos with no description
(`null` or `""`) correctly show no tooltip at all.

## Changes

- **`src/components/TopRepos.tsx`** — added `description: string | null` to
  the `Repo` type; set the repo name link's
  `title={repo.description || undefined}`.
- **`src/app/api/metrics/repos/route.ts`** — threaded `description` through
  the GitHub search response type, the `repoMap` projection, the
  `RepoSummary` type, and the multi-account `mergeRepoCommits` merge. The
  field was being dropped at every step of the API → component pipeline.

Using `|| undefined` (not `""`) makes React omit the `title` attribute
entirely when there is no description, so no empty tooltip renders.

## Verification

Confirmed against the live GitHub API that `search/commits` returns
`repository.description`, and verified end-to-end on the dashboard that a
repo with a description shows the tooltip while a repo with a `null`
description shows none.

**Tooltip shows on hover (repo with a description):**

<img width="629" height="317" alt="Screenshot 2026-05-20 021225" src="https://github.com/user-attachments/assets/9cca794c-f507-49b1-b6c1-4ef43d182feb" />


**No tooltip (repo with null/empty description):**

<img width="620" height="314" alt="Screenshot 2026-05-20 021557" src="https://github.com/user-attachments/assets/40d5eeb3-027f-402c-ab68-b16aff91d073" />


## Note

The repo name link previously had `title={repo.name}` (full `org/repo`
path on hover). An element can carry only one `title`, and the issue
explicitly specifies `title={repo.description || undefined}` on the name
element, so that prior tooltip is now replaced by the description — this is
the behaviour the issue asks for.

Closes #214
