### PR TITLE
fixed toggle switch issue

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -218,7 +218,11 @@ export default function ContributionGraph() {
 
   useEffect(() => {
     const handleToggleChart = () => {
-      setChartType((prev) => (prev === "bar" ? "line" : "bar"));
+      setChartType((prev) => {
+        if (prev === "bar") return "line";
+        if (prev === "line") return "area";
+        return "bar";
+      });
     };
     window.addEventListener("toggleChart", handleToggleChart);
     return () => window.removeEventListener("toggleChart", handleToggleChart);


### PR DESCRIPTION
## Summary

Fix keyboard shortcut "B" to properly cycle through all three chart types (Bar → Line → Area → Bar) in the Contribution Graph component. Previously it only toggled between Bar and Line, skipping the Area chart option.

Closes #408 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Updated the `handleToggleChart` function in `ContributionGraph` component to cycle through all three chart types
- Changed logic from binary toggle (`bar` ↔ `line`) to sequential cycle (`bar` → `line` → `area` → `bar`)
- Area chart button now responds correctly to keyboard shortcut

## How to Test

1. Navigate to the dashboard page with the Contribution Graph component
2. Press the "B" key on your keyboard
3. Verify the chart cycles through:
   - Bar chart (first press)
   - Line chart (second press)
   - Area chart (third press)
   - Back to Bar chart (fourth press)
4. Also verify the UI buttons update to show the active chart type

## Screenshots (if UI change)

*No UI changes - only keyboard shortcut behavior fixed*

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable