### PR TITLE
feat : added PR review time trend chart

### DIFF
--- a/src/app/api/metrics/pr-review-time/route.ts
+++ b/src/app/api/metrics/pr-review-time/route.ts
@@ -1,0 +1,310 @@
+import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
+import { authOptions } from "@/lib/auth";
+import {
+  getAccountToken,
+  getAllAccounts,
+  mergeMetrics,
+} from "@/lib/github-accounts";
+import { GITHUB_API } from "@/lib/github";
+import {
+  isMetricsCacheBypassed,
+  METRICS_CACHE_TTL_SECONDS,
+  metricsCacheKey,
+  withMetricsCache,
+} from "@/lib/metrics-cache";
+import { resolveAppUser } from "@/lib/resolve-user";
+
+export const dynamic = "force-dynamic";
+
+interface PullRequestSearchItem {
+  created_at: string;
+  pull_request?: { merged_at: string | null };
+}
+
+interface TrendWeek {
+  weekStart: string;
+  label: string;
+  avgReviewDays: number | null;
+  mergedCount: number;
+  totalDays: number;
+}
+
+interface TrendBucket {
+  totalDays: number;
+  mergedCount: number;
+}
+
+function addDaysUtc(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+function getUtcWeekStart(date: Date): Date {
+  const result = new Date(date);
+  const dayOfWeek = result.getUTCDay();
+  const daysSinceMonday = (dayOfWeek + 6) % 7;
+
+  result.setUTCDate(result.getUTCDate() - daysSinceMonday);
+  result.setUTCHours(0, 0, 0, 0);
+
+  return result;
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function formatWeekLabel(start: Date): string {
+  const end = addDaysUtc(start, 6);
+  const startLabel = start.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+  const endLabel = end.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+  return `${startLabel} - ${endLabel}`;
+}
+
+function buildTrendWeeks(): TrendWeek[] {
+  const currentWeekStart = getUtcWeekStart(new Date());
+  const oldestWeekStart = addDaysUtc(currentWeekStart, -21);
+
+  return Array.from({ length: 4 }, (_, index) => {
+    const weekStart = addDaysUtc(oldestWeekStart, index * 7);
+
+    return {
+      weekStart: toDateKey(weekStart),
+      label: formatWeekLabel(weekStart),
+      avgReviewDays: null,
+      mergedCount: 0,
+      totalDays: 0,
+    };
+  });
+}
+
+function emptyTrend(): TrendWeek[] {
+  return buildTrendWeeks();
+}
+
+async function fetchPRReviewTrendForAccount(
+  token: string,
+  cacheContext: { bypass: boolean; userId: string }
+): Promise<TrendWeek[]> {
+  const key = metricsCacheKey(cacheContext.userId, "pr-review-time", {
+    weeks: 4,
+  });
+
+  return withMetricsCache(
+    {
+      bypass: cacheContext.bypass,
+      key,
+      ttlSeconds: METRICS_CACHE_TTL_SECONDS.prs,
+    },
+    async () => {
+      const trendWeeks = emptyTrend();
+      const bucketMap = new Map<string, TrendBucket>(
+        trendWeeks.map((week) => [week.weekStart, { totalDays: 0, mergedCount: 0 }])
+      );
+
+      const oldestWeekStart = new Date(`${trendWeeks[0].weekStart}T00:00:00.000Z`);
+      const since = oldestWeekStart.toISOString().slice(0, 10);
+
+      const mergedRes = await fetch(
+        `${GITHUB_API}/search/issues?q=type:pr+author:@me+merged:>=${since}&sort=updated&order=desc&per_page=100`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+          },
+          cache: "no-store",
+        }
+      );
+
+      if (!mergedRes.ok) {
+        throw new Error("GitHub API error");
+      }
+
+      const data = (await mergedRes.json()) as {
+        items: PullRequestSearchItem[];
+      };
+
+      for (const pr of data.items) {
+        const mergedAt = pr.pull_request?.merged_at;
+
+        if (!mergedAt) {
+          continue;
+        }
+
+        const openedAt = new Date(pr.created_at).getTime();
+        const mergedAtMs = new Date(mergedAt).getTime();
+
+        if (
+          Number.isNaN(openedAt) ||
+          Number.isNaN(mergedAtMs) ||
+          mergedAtMs < openedAt
+        ) {
+          continue;
+        }
+
+        const weekStart = getUtcWeekStart(new Date(mergedAt));
+        const weekKey = toDateKey(weekStart);
+        const bucket = bucketMap.get(weekKey);
+
+        if (!bucket) {
+          continue;
+        }
+
+        bucket.totalDays += (mergedAtMs - openedAt) / 86400000;
+        bucket.mergedCount += 1;
+      }
+
+      return trendWeeks.map((week) => {
+        const bucket = bucketMap.get(week.weekStart);
+        const avgReviewDays =
+          bucket && bucket.mergedCount > 0
+            ? Math.round((bucket.totalDays / bucket.mergedCount) * 100) / 100
+            : null;
+
+        return {
+          ...week,
+          avgReviewDays,
+          mergedCount: bucket?.mergedCount ?? 0,
+          totalDays: bucket?.totalDays ?? 0,
+        };
+      });
+    }
+  );
+}
+
+function mergeTrendWeeks(a: TrendWeek[], b: TrendWeek[]): TrendWeek[] {
+  const bucketMap = new Map<string, TrendBucket>(
+    a.map((week) => [week.weekStart, { totalDays: 0, mergedCount: 0 }])
+  );
+
+  for (const week of a) {
+    const bucket = bucketMap.get(week.weekStart);
+    if (!bucket || week.avgReviewDays === null || week.mergedCount === 0) {
+      continue;
+    }
+
+    bucket.totalDays += week.totalDays;
+    bucket.mergedCount += week.mergedCount;
+  }
+
+  for (const week of b) {
+    const bucket = bucketMap.get(week.weekStart);
+    if (!bucket || week.avgReviewDays === null || week.mergedCount === 0) {
+      continue;
+    }
+
+    bucket.totalDays += week.totalDays;
+    bucket.mergedCount += week.mergedCount;
+  }
+
+  return a.map((week) => {
+    const bucket = bucketMap.get(week.weekStart);
+
+    return {
+      ...week,
+      avgReviewDays:
+        bucket && bucket.mergedCount > 0
+          ? Math.round((bucket.totalDays / bucket.mergedCount) * 100) / 100
+          : null,
+      mergedCount: bucket?.mergedCount ?? 0,
+      totalDays: bucket?.totalDays ?? 0,
+    };
+  });
+}
+
+function formatTrendWeeks(weeks: TrendWeek[]) {
+  return { weeks };
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.accessToken) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const accountId = req.nextUrl.searchParams.get("accountId");
+  const bypass = isMetricsCacheBypassed(req);
+
+  if (!accountId) {
+    try {
+      const result = await fetchPRReviewTrendForAccount(session.accessToken, {
+        bypass,
+        userId: session.githubId ?? session.githubLogin ?? "primary",
+      });
+
+      return Response.json(formatTrendWeeks(result));
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  if (!session.githubId || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
+
+  if (!userRow) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (accountId === "combined") {
+    const accounts = await getAllAccounts(
+      {
+        token: session.accessToken,
+        githubId: session.githubId,
+        githubLogin: session.githubLogin,
+      },
+      userRow.id
+    );
+
+    const results = await Promise.allSettled(
+      accounts.map((account) =>
+        fetchPRReviewTrendForAccount(account.token, {
+          bypass,
+          userId: account.githubId,
+        })
+      )
+    );
+
+    const merged = mergeMetrics(results, mergeTrendWeeks);
+
+    if (!merged) {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+
+    return Response.json(formatTrendWeeks(merged));
+  }
+
+  const token =
+    accountId === session.githubId
+      ? session.accessToken
+      : await getAccountToken(userRow.id, accountId);
+
+  if (!token) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  try {
+    const result = await fetchPRReviewTrendForAccount(token, {
+      bypass,
+      userId: accountId === session.githubId ? session.githubId : accountId,
+    });
+
+    return Response.json(formatTrendWeeks(result));
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import TopRepos from "@/components/TopRepos";
 import PinnedRepos from "@/components/PinnedRepos";
 import LanguageBreakdown from "@/components/LanguageBreakdown";
 import CommitTimeChart from "@/components/CommitTimeChart";
+import PRReviewTrendChart from "@/components/PRReviewTrendChart";
 import CIAnalytics from "@/components/CIAnalytics";
 import IssueMetrics from "@/components/IssueMetrics";
 import StreakAtRiskBanner from "@/components/StreakAtRiskBanner";
@@ -76,6 +77,10 @@ export default async function DashboardPage() {
         <PRMetrics />
         <PRBreakdownChart />
         <CommitTimeChart />
+      </div>
+
+      <div className="mt-6">
+        <PRReviewTrendChart />
       </div>
 
       {/* Row 3: Issue metrics + CI analytics */}

--- a/src/components/PRReviewTrendChart.tsx
+++ b/src/components/PRReviewTrendChart.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAccount } from "@/components/AccountContext";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+interface PRReviewTrendPoint {
+  weekStart: string;
+  label: string;
+  avgReviewDays: number | null;
+  mergedCount: number;
+}
+
+interface PRReviewTrendResponse {
+  weeks: PRReviewTrendPoint[];
+}
+
+function formatDays(value: number | null | undefined) {
+  if (value === null || value === undefined) return "No data";
+  if (value < 1) return `${(value * 24).toFixed(1)}h`;
+  return `${value.toFixed(2)}d`;
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: any[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const point = payload[0]?.payload as PRReviewTrendPoint;
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-4 py-3 shadow-lg">
+      <p className="text-sm font-semibold text-[var(--card-foreground)]">
+        {label}
+      </p>
+
+      {point.avgReviewDays === null ? (
+        <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+          No merged PRs this week
+        </p>
+      ) : (
+        <>
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+            Avg merge time:{" "}
+            <span className="font-semibold text-[var(--card-foreground)]">
+              {formatDays(point.avgReviewDays)}
+            </span>
+          </p>
+          <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+            Based on {point.mergedCount} merged PR
+            {point.mergedCount === 1 ? "" : "s"}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function PRReviewTrendChart() {
+  const { selectedAccount } = useAccount();
+
+  const [data, setData] = useState<PRReviewTrendPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTrend = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    const url =
+      selectedAccount !== null
+        ? `/api/metrics/pr-review-time?accountId=${encodeURIComponent(
+            selectedAccount
+          )}`
+        : "/api/metrics/pr-review-time";
+
+    fetch(url)
+      .then((r) => {
+        if (!r.ok) throw new Error("API error");
+        return r.json();
+      })
+      .then((res: PRReviewTrendResponse) => {
+        setData(res.weeks ?? []);
+      })
+      .catch(() => {
+        setError(
+          "We couldn't load your PR review trend right now. Please try again."
+        );
+      })
+      .finally(() => setLoading(false));
+  }, [selectedAccount]);
+
+  useEffect(() => {
+    fetchTrend();
+  }, [fetchTrend]);
+
+  const stats = useMemo(() => {
+    const validWeeks = data.filter((week) => week.avgReviewDays !== null);
+    const totalMerged = data.reduce((sum, week) => sum + week.mergedCount, 0);
+
+    const overallAvg =
+      validWeeks.length > 0
+        ? validWeeks.reduce(
+            (sum, week) => sum + (week.avgReviewDays ?? 0),
+            0
+          ) / validWeeks.length
+        : null;
+
+    const latestValid = [...data]
+      .reverse()
+      .find((week) => week.avgReviewDays !== null);
+
+    const previousValid = [...data]
+      .reverse()
+      .filter((week) => week.avgReviewDays !== null)[1];
+
+    let trendText = "Not enough data";
+    if (latestValid && previousValid) {
+      const diff =
+        (latestValid.avgReviewDays ?? 0) - (previousValid.avgReviewDays ?? 0);
+
+      if (Math.abs(diff) < 0.01) {
+        trendText = "No major change";
+      } else if (diff < 0) {
+        trendText = `${Math.abs(diff).toFixed(2)}d faster`;
+      } else {
+        trendText = `${diff.toFixed(2)}d slower`;
+      }
+    }
+
+    return {
+      totalMerged,
+      overallAvg,
+      latestAvg: latestValid?.avgReviewDays ?? null,
+      trendText,
+    };
+  }, [data]);
+
+  const hasData = data.some((week) => week.avgReviewDays !== null);
+
+  return (
+    <div className="flex h-full flex-col rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            PR Review Time Trend
+          </h2>
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+            Average time from PR open to merge over the last 4 weeks.
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-5">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="h-20 animate-pulse rounded-lg bg-[var(--card-muted)]"
+              />
+            ))}
+          </div>
+          <div className="h-[280px] animate-pulse rounded-lg bg-[var(--card-muted)]" />
+        </div>
+      ) : error ? (
+        <div className="flex h-[360px] items-center justify-center">
+          <div className="max-w-sm rounded-lg border border-red-500/20 bg-red-500/10 p-5 text-center">
+            <p className="text-sm text-red-300">{error}</p>
+            <button
+              type="button"
+              onClick={fetchTrend}
+              className="mt-4 rounded-md border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      ) : !hasData ? (
+        <div className="flex h-[360px] items-center justify-center rounded-lg border border-dashed border-[var(--border)]">
+          <div className="text-center">
+            <p className="text-sm font-medium text-[var(--card-foreground)]">
+              No merged PRs found
+            </p>
+            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+              Merged PRs are required to calculate review time.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="mb-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-4">
+              <p className="text-xs text-[var(--muted-foreground)]">
+                Overall avg
+              </p>
+              <p className="mt-1 text-xl font-semibold text-[var(--card-foreground)]">
+                {formatDays(stats.overallAvg)}
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-4">
+              <p className="text-xs text-[var(--muted-foreground)]">
+                Latest week
+              </p>
+              <p className="mt-1 text-xl font-semibold text-[var(--card-foreground)]">
+                {formatDays(stats.latestAvg)}
+              </p>
+            </div>
+
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-4">
+              <p className="text-xs text-[var(--muted-foreground)]">
+                Merged PRs
+              </p>
+              <p className="mt-1 text-xl font-semibold text-[var(--card-foreground)]">
+                {stats.totalMerged}
+              </p>
+              <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                {stats.trendText}
+              </p>
+            </div>
+          </div>
+
+          <div className="h-[300px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={data}
+                margin={{ top: 16, right: 24, left: 4, bottom: 10 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="4 4"
+                  stroke="var(--border)"
+                  opacity={0.45}
+                />
+
+                <XAxis
+                  dataKey="label"
+                  axisLine={false}
+                  tickLine={false}
+                  tickMargin={12}
+                  interval={0}
+                  style={{
+                    fill: "var(--muted-foreground)",
+                    fontSize: "0.8rem",
+                  }}
+                />
+
+                <YAxis
+                  axisLine={false}
+                  tickLine={false}
+                  tickMargin={10}
+                  width={48}
+                  domain={[0, "dataMax + 0.5"]}
+                  allowDecimals
+                  tickFormatter={(value: number) => `${value}d`}
+                  style={{
+                    fill: "var(--muted-foreground)",
+                    fontSize: "0.8rem",
+                  }}
+                />
+
+                <Tooltip content={<CustomTooltip />} />
+
+                <Line
+                  type="monotone"
+                  dataKey="avgReviewDays"
+                  stroke="var(--accent)"
+                  strokeWidth={3}
+                  connectNulls={false}
+                  dot={(props: any) => {
+                    const point = props.payload as PRReviewTrendPoint;
+
+                    if (point.avgReviewDays === null) {
+                      return (
+                        <circle
+                          cx={props.cx}
+                          cy={props.cy}
+                          r={4}
+                          fill="var(--muted-foreground)"
+                          opacity={0.35}
+                        />
+                      );
+                    }
+
+                    return (
+                      <circle
+                        cx={props.cx}
+                        cy={props.cy}
+                        r={5}
+                        fill="var(--accent)"
+                        stroke="var(--card)"
+                        strokeWidth={2}
+                      />
+                    );
+                  }}
+                  activeDot={{
+                    r: 7,
+                    stroke: "var(--card)",
+                    strokeWidth: 2,
+                  }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-4">
+            {data.map((week) => (
+              <div
+                key={week.weekStart}
+                className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2"
+              >
+                <p className="text-xs font-medium text-[var(--card-foreground)]">
+                  {week.label}
+                </p>
+                <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                  {week.avgReviewDays === null
+                    ? "No merged PRs"
+                    : `${formatDays(week.avgReviewDays)} · ${
+                        week.mergedCount
+                      } PR${week.mergedCount === 1 ? "" : "s"}`}
+                </p>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -5,6 +5,7 @@ export const METRICS_CACHE_TTL_SECONDS = {
   contributions: 5 * 60,
   repos: 10 * 60,
   prs: 10 * 60,
+  "pr-review-time": 10 * 60,
   streak: 2 * 60,
 } as const;
 


### PR DESCRIPTION
## Summary

Add a new PR review time trend chart to the dashboard, backed by a new `/api/metrics/pr-review-time` endpoint. The chart shows average days from PR open to merge over the last 4 weeks, with merged only PRs included in the calculation and unmerged PRs excluded.

Closes #60 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added a new PR review time metrics endpoint that groups merged PRs by merge week and calculates average open-to-merge time.
- Added `PRReviewTrendChart.tsx` using Recharts line chart with tooltip, loading skeleton, empty state, and error state.
- Wired the chart into the dashboard.

## How to Test

Steps for the reviewer to verify this works:

1. Open the dashboard and confirm the new PR Review Time Trend card renders.
2. Verify the chart shows the last 4 weeks with week labels on the x-axis and average days on the y-axis.
3. Hover a point to confirm the tooltip shows the exact average value.
4. Confirm PRs that were never merged do not affect the average.
5. Check the loading state and retry behavior by throttling or temporarily breaking the API call.

## Screenshots (if UI change)
<img width="1777" height="757" alt="image" src="https://github.com/user-attachments/assets/dfd174af-993a-4de1-8879-ff2267875a46" />

- 

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable