### PR TITLE
feat: add custom date range picker to ContributionGraph

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -43,7 +43,9 @@ async function fetchContributionsForAccount(
   token: string,
   githubLogin: string,
   days: number,
-  cacheContext: { bypass: boolean; userId: string }
+  cacheContext: { bypass: boolean; userId: string },
+  fromDate?: string
+
 ): Promise<ContributionResponse> {
   const key = metricsCacheKey(cacheContext.userId, "contributions", {
     days,
@@ -59,7 +61,7 @@ async function fetchContributionsForAccount(
     async () => {
       const since = new Date();
       since.setDate(since.getDate() - days);
-      const sinceStr = toLocalDateStr(since);
+      const sinceStr = fromDate ?? toLocalDateStr(since);
 
       const searchRes = await fetch(
         `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
@@ -98,7 +100,22 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const days = Number(req.nextUrl.searchParams.get("days")) || 30;
+  const fromParam = req.nextUrl.searchParams.get("from");
+  const toParam = req.nextUrl.searchParams.get("to");
+
+  let days: number;
+  let fromDate: string | undefined;
+
+  if (fromParam && toParam) {
+    fromDate = fromParam;
+    const msPerDay = 1000 * 60 * 60 * 24;
+    days = Math.ceil(
+      (new Date(toParam).getTime() - new Date(fromParam).getTime()) / msPerDay
+    ) + 1;
+  } else {
+    days = Number(req.nextUrl.searchParams.get("days")) || 30;
+  }
+
   const accountId = req.nextUrl.searchParams.get("accountId");
   const username = req.nextUrl.searchParams.get("username")?.trim();
   const bypass = isMetricsCacheBypassed(req);
@@ -110,7 +127,8 @@ export async function GET(req: NextRequest) {
         session.accessToken,
         username,
         days,
-        { bypass, userId: session.githubId ?? session.githubLogin }
+        { bypass, userId: session.githubId ?? session.githubLogin },
+        fromDate
       );
       return Response.json(result);
     } catch {
@@ -124,7 +142,8 @@ export async function GET(req: NextRequest) {
         session.accessToken,
         session.githubLogin,
         days,
-        { bypass, userId: session.githubId ?? session.githubLogin }
+        { bypass, userId: session.githubId ?? session.githubLogin },
+        fromDate
       );
       return Response.json(result);
     } catch {
@@ -157,7 +176,8 @@ export async function GET(req: NextRequest) {
         fetchContributionsForAccount(account.token, account.githubLogin, days, {
           bypass,
           userId: account.githubId,
-        })
+
+        }, fromDate)
       )
     );
 
@@ -180,7 +200,8 @@ export async function GET(req: NextRequest) {
         session.accessToken,
         session.githubLogin,
         days,
-        { bypass, userId: session.githubId }
+        { bypass, userId: session.githubId },
+        fromDate
       );
       return Response.json(result);
     } catch {
@@ -210,7 +231,8 @@ export async function GET(req: NextRequest) {
       accountToken,
       accountRow.github_login,
       days,
-      { bypass, userId: accountId }
+      { bypass, userId: accountId },
+      fromDate
     );
     return Response.json(result);
   } catch {

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
 import {
   BarChart,
@@ -92,6 +92,14 @@ export default function ContributionGraph() {
   const [compareLoading, setCompareLoading] = useState(false);
   const [compareRequestId, setCompareRequestId] = useState(0);
 
+  // Custom range state
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState("");
+  const [showPopover, setShowPopover] = useState(false);
+  const [customLabel, setCustomLabel] = useState<string | null>(null);
+  const [customError, setCustomError] = useState<string | null>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
   // Fetch my data
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -137,7 +145,12 @@ export default function ContributionGraph() {
       selectedAccount !== null
         ? `&accountId=${encodeURIComponent(selectedAccount)}`
         : "";
-    fetch(`/api/metrics/contributions?days=${days}${accountParam}`)
+    const url =
+      customLabel && customFrom && customTo
+        ? `/api/metrics/contributions?from=${customFrom}&to=${customTo}${accountParam}`
+        : `/api/metrics/contributions?days=${days}${accountParam}`;
+
+    fetch(url)
       .then((r) => {
         if (!r.ok) throw new Error("API error");
         return r.json();
@@ -156,7 +169,7 @@ export default function ContributionGraph() {
         setLastUpdated(new Date());
         setMinutesAgo(0);
       });
-  }, [days, selectedAccount]);
+    }, [days, selectedAccount, customFrom, customTo, customLabel]);
 
   // Fetch friend data when compare mode is on and compareUser changes
   useEffect(() => {
@@ -233,12 +246,63 @@ export default function ContributionGraph() {
     return () => clearInterval(interval);
   }, [lastUpdated]);
 
+  useEffect(() => {
+    if (!showPopover) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setShowPopover(false);
+    };
+    const handleClick = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        setShowPopover(false);
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    document.addEventListener("mousedown", handleClick);
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      document.removeEventListener("mousedown", handleClick);
+    };
+  }, [showPopover]);
+
   const handleClearCompare = () => {
     window.dispatchEvent(new Event("devtrack:clear-compare-user"));
     setCompareMode(false);
     setCompareUser(null);
     setFriendData([]);
     setCompareError(null);
+  };
+
+  const handleCustomApply = () => {
+    setCustomError(null);
+    const today = new Date().toISOString().slice(0, 10);
+
+    if (!customFrom || !customTo) {
+      setCustomError("Please select both dates.");
+      return;
+    }
+    if (customFrom > customTo) {
+      setCustomError("Start date must be before end date.");
+      return;
+    }
+    if (customTo > today) {
+      setCustomError("End date can't be in the future.");
+      return;
+    }
+    const msPerDay = 1000 * 60 * 60 * 24;
+    const diff =
+      (new Date(customTo).getTime() - new Date(customFrom).getTime()) / msPerDay;
+    if (diff > 365 * 2) {
+      setCustomError("Max range is 2 years.");
+      return;
+    }
+
+    const fmt = (d: string) =>
+      new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
+    setCustomLabel(`${fmt(customFrom)} – ${fmt(customTo)}`);
+    setShowPopover(false);
   };
 
   const mergedData =
@@ -288,6 +352,59 @@ export default function ContributionGraph() {
             ))}
           </div>
 
+          {/* Custom date range */}
+          <div className="relative" ref={popoverRef}>
+            <button
+              onClick={() => setShowPopover((v) => !v)}
+              className={`px-3 py-1 rounded-md text-sm font-medium transition-colors border border-[var(--border)] ${
+                customLabel
+                  ? "bg-[var(--accent)] text-[var(--background)]"
+                  : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+              }`}
+            >
+              {customLabel ?? "Custom…"}
+            </button>
+
+            {showPopover && (
+              <div className="absolute right-0 top-10 z-50 w-72 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-lg">
+                <p className="text-sm font-medium text-[var(--foreground)] mb-3">
+                  Custom range
+                </p>
+                <div className="flex flex-col gap-2">
+                  <label className="text-xs text-[var(--muted-foreground)]">
+                    Start date
+                    <input
+                      type="date"
+                      value={customFrom}
+                      max={new Date().toISOString().slice(0, 10)}
+                      onChange={(e) => setCustomFrom(e.target.value)}
+                      className="mt-1 w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+                    />
+                  </label>
+                  <label className="text-xs text-[var(--muted-foreground)]">
+                    End date
+                    <input
+                      type="date"
+                      value={customTo}
+                      max={new Date().toISOString().slice(0, 10)}
+                      onChange={(e) => setCustomTo(e.target.value)}
+                      className="mt-1 w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+                    />
+                  </label>
+                  {customError && (
+                    <p className="text-xs text-red-500">{customError}</p>
+                  )}
+                  <button
+                    onClick={handleCustomApply}
+                    className="mt-1 w-full rounded-md bg-[var(--accent)] py-1.5 text-sm font-medium text-[var(--background)] hover:opacity-90 transition-opacity"
+                  >
+                    Apply
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+          
           {/* Chart Toggle Buttons */}
           {displayData.length > 0 && !error && (
             <div

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -131,6 +131,9 @@ export default function ContributionGraph() {
 
   const handleRangeChange = (newDays: number) => {
     setDays(newDays);
+    setCustomLabel(null);
+    setCustomFrom("");
+    setCustomTo("");
     if (typeof window !== "undefined") {
       try {
         localStorage.setItem("devtrack:contribution-range", String(newDays));
@@ -296,11 +299,13 @@ export default function ContributionGraph() {
       return;
     }
 
-    const fmt = (d: string) =>
-      new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+    const fmt = (d: string) => {
+      const [year, month, day] = d.split("-").map(Number);
+      return new Date(year, month - 1, day).toLocaleDateString("en-US", {
         month: "short",
         day: "numeric",
       });
+      };
     setCustomLabel(`${fmt(customFrom)} – ${fmt(customTo)}`);
     setShowPopover(false);
   };
@@ -340,9 +345,9 @@ export default function ContributionGraph() {
                 key={r.days}
                 onClick={() => handleRangeChange(r.days)}
                 aria-label={`Show ${r.days}-day range`}
-                aria-pressed={days === r.days}
+                aria-pressed={days === r.days && !customLabel}
                 className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${
-                  days === r.days
+                  days === r.days && !customLabel
                     ? "bg-[var(--accent)] text-[var(--background)]"
                     : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
                 }`}
@@ -377,7 +382,12 @@ export default function ContributionGraph() {
                       type="date"
                       value={customFrom}
                       max={new Date().toISOString().slice(0, 10)}
-                      onChange={(e) => setCustomFrom(e.target.value)}
+                      onChange={(e) => {
+                        setCustomFrom(e.target.value);
+                        if (!customTo) {
+                          setCustomTo(new Date().toISOString().slice(0, 10));
+                        }
+                      }}
                       className="mt-1 w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
                     />
                   </label>
@@ -392,7 +402,21 @@ export default function ContributionGraph() {
                     />
                   </label>
                   {customError && (
-                    <p className="text-xs text-red-500">{customError}</p>
+                    <p className="text-xs text-[var(--destructive)]">{customError}</p>
+                  )}
+                  {customLabel && (
+                    <button
+                      onClick={() => {
+                        setCustomLabel(null);
+                        setCustomFrom("");
+                        setCustomTo("");
+                        setCustomError(null);
+                        setShowPopover(false);
+                      }}
+                      className="w-full rounded-md border border-[var(--border)] py-1.5 text-sm font-medium text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                    >
+                      Clear
+                    </button>
                   )}
                   <button
                     onClick={handleCustomApply}
@@ -404,7 +428,7 @@ export default function ContributionGraph() {
               </div>
             )}
           </div>
-          
+
           {/* Chart Toggle Buttons */}
           {displayData.length > 0 && !error && (
             <div


### PR DESCRIPTION
## Summary
Adds a Custom… button next to the existing range presets in ContributionGraph.
Clicking opens a date-range popover with native date inputs, validation, and 
dismisses on Escape or outside click. Also updates the contributions API route 
to accept `from` and `to` params alongside the existing `days` param.

Closes #166 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made
- Added Custom… button next to 7d/30d/90d range presets
- Built date-range popover using native <input type="date"> elements
- Added validation: start ≤ end, end ≤ today, max 2-year range
- Popover dismisses on Escape key or outside click
- Selected range shown as formatted label e.g. "May 1 – May 17"
- Updated route.ts to accept `from` and `to` query params as alternative to `days`

## How to Test
1. Run the app locally with `npm run dev`
2. Go to the dashboard and find the Contribution Graph
3. Click the Custom… button - popover should open
4. Select a start and end date and click Apply
5. Graph should update to show commits for that range
6. Label on the button should update e.g. "May 1 – May 17"
7. Press Escape or click outside - popover should close
8. Try invalid ranges (end before start, future date, >2 years) - error messages should appear

## Screenshots (if UI change)
<img width="1215" height="496" alt="image" src="https://github.com/user-attachments/assets/9b6ccdd5-4b20-4a33-9924-7fb311d282b6" />
<img width="1214" height="512" alt="image" src="https://github.com/user-attachments/assets/74abda38-dda3-431e-9daa-54ec07d1c57f" />


## Checklist
- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
