### PR TITLE
fix: prevent session crashes caused by token decryption failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -523,6 +523,7 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
       "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "playwright": "1.49.1"
       },
@@ -764,6 +765,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1211,6 +1213,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1663,6 +1666,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2532,6 +2536,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2700,6 +2705,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4145,6 +4151,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4216,6 +4223,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5103,6 +5111,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5273,6 +5282,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5363,6 +5373,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5375,6 +5386,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6428,6 +6440,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6597,6 +6610,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -46,24 +46,35 @@ export function encryptToken(plaintext: string): {
   };
 }
 
-export function decryptToken(encrypted: string, iv: string): string {
-  const key = getEncryptionKey();
-  const encryptedBuffer = Buffer.from(encrypted, "hex");
-  const ivBuffer = Buffer.from(iv, "hex");
 
-  const ciphertext = encryptedBuffer.subarray(
-    0,
-    encryptedBuffer.length - AUTH_TAG_LENGTH
-  );
-  const authTag = encryptedBuffer.subarray(
-    encryptedBuffer.length - AUTH_TAG_LENGTH
-  );
+export function decryptToken(
+  encrypted: string,
+  iv: string
+): string | null {
+  try {
+    const key = getEncryptionKey();
+    const encryptedBuffer = Buffer.from(encrypted, "hex");
+    const ivBuffer = Buffer.from(iv, "hex");
 
-  const decipher = createDecipheriv(ALGORITHM, key, ivBuffer);
-  decipher.setAuthTag(authTag);
+    const ciphertext = encryptedBuffer.subarray(
+      0,
+      encryptedBuffer.length - AUTH_TAG_LENGTH
+    );
 
-  return Buffer.concat([
-    decipher.update(ciphertext),
-    decipher.final(),
-  ]).toString("utf8");
+    const authTag = encryptedBuffer.subarray(
+      encryptedBuffer.length - AUTH_TAG_LENGTH
+    );
+
+    const decipher = createDecipheriv(ALGORITHM, key, ivBuffer);
+
+    decipher.setAuthTag(authTag);
+
+    return Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]).toString("utf8");
+  } catch (error) {
+    console.error("Token decryption failed:", error);
+    return null;
+  }
 }

--- a/src/lib/github-accounts.ts
+++ b/src/lib/github-accounts.ts
@@ -34,9 +34,11 @@ export async function getLinkedTokens(userId: string): Promise<string[]> {
 
   const rows = (data ?? []) as UserGitHubAccountRow[];
 
-  return rows.map((row) =>
-    decryptToken(row.access_token_encrypted, row.access_token_iv)
-  );
+  return rows
+    .map((row) =>
+      decryptToken(row.access_token_encrypted, row.access_token_iv)
+    )
+    .filter((token): token is string => token !== null);
 }
 
 export async function getRateLimitRemaining(token: string): Promise<number> {
@@ -87,6 +89,7 @@ export async function getAllTokens(
   userId: string
 ): Promise<string[]> {
   const linkedTokens = await getLinkedTokens(userId);
+
   const dedupedLinkedTokens = linkedTokens.filter(
     (token) => token !== primaryToken
   );
@@ -110,11 +113,24 @@ export async function getLinkedAccounts(
 
   const rows = (data ?? []) as UserGitHubAccountRow[];
 
-  return rows.map((row) => ({
-    githubId: row.github_id ?? "",
-    githubLogin: row.github_login ?? "",
-    token: decryptToken(row.access_token_encrypted, row.access_token_iv),
-  }));
+  return rows
+    .map((row) => {
+      const token = decryptToken(
+        row.access_token_encrypted,
+        row.access_token_iv
+      );
+
+      if (!token) {
+        return null;
+      }
+
+      return {
+        githubId: row.github_id ?? "",
+        githubLogin: row.github_login ?? "",
+        token,
+      };
+    })
+    .filter((account): account is LinkedAccount => account !== null);
 }
 
 export async function getAllAccounts(
@@ -122,6 +138,7 @@ export async function getAllAccounts(
   userId: string
 ): Promise<LinkedAccount[]> {
   const linkedAccounts = await getLinkedAccounts(userId);
+
   const filteredLinkedAccounts = linkedAccounts.filter(
     (account) => account.githubId !== primary.githubId
   );


### PR DESCRIPTION
## Summary

Added safe fallback handling for token decryption failures to prevent dashboard crashes and API 500/502 errors after page refresh or invalid token states.

Closes #427

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added try-catch handling inside `decryptToken`
- Prevented server crashes caused by invalid/corrupted encrypted tokens
- Added null-safe token filtering in linked account utilities
- Improved reliability of token handling during dashboard refresh

## How to Test

1. Run the project locally using `npm run dev`
2. Login through GitHub authentication
3. Refresh the dashboard page
4. Verify application no longer crashes on invalid token states
5. Check API routes return safe fallback behavior instead of 500/502 crashes

## Screenshots (if UI change)

N/A

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable