### PR TITLE
fix : added flexible metrics cache bypass parsing

### DIFF
--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -13,6 +13,14 @@ type CacheParamValue = boolean | number | string | null | undefined;
 
 let redisClient: Redis | null | undefined;
 
+function isTruthyCacheBypass(value: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
 function getRedisClient(): Redis | null {
   if (redisClient !== undefined) {
     return redisClient;
@@ -37,7 +45,7 @@ export function isMetricsCacheBypassed(req: NextRequest): boolean {
     req.nextUrl.searchParams.get("sync");
   const bypassHeader = req.headers.get("x-devtrack-cache-bypass");
 
-  return bypassParam === "1" || bypassParam === "true" || bypassHeader === "1";
+  return isTruthyCacheBypass(bypassParam) || isTruthyCacheBypass(bypassHeader);
 }
 
 export function metricsCacheKey(


### PR DESCRIPTION
Closes #444.

Summary of What Has Been Done:
Metrics cache bypass parsing now normalizes query parameter and header values before deciding whether to skip cached metric responses.

Changes Made:
Updated src/lib/metrics-cache.ts with an isTruthyCacheBypass helper that trims and lowercases values, then accepts 1, true, yes, and on for both query parameters and the x-devtrack-cache-bypass header.

Impact it Made:
Manual metric refreshes are more forgiving and consistent across request surfaces without changing default cached behavior. Verification completed with npm run type-check.