### PR TITLE
fix : added finite number handling to repository health scoring

### DIFF
--- a/src/lib/repo-health.ts
+++ b/src/lib/repo-health.ts
@@ -1,6 +1,10 @@
 import type { RepoHealthScore, RepoHealthSignals } from "@/types/repo-health";
 
 function clamp(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) {
+    return min;
+  }
+
   return Math.min(max, Math.max(min, n));
 }
 
@@ -65,4 +69,3 @@ export function computeHealthScore(
     grade: gradeForScore(rounded),
   };
 }
-


### PR DESCRIPTION
Closes #446.

Summary of What Has Been Done:
Repository health scoring now handles non-finite numeric inputs before applying score bounds.

Changes Made:
Updated src/lib/repo-health.ts so the shared clamp helper returns the minimum bound when it receives NaN, Infinity, or -Infinity, while preserving the existing scoring weights and grade thresholds.

Impact it Made:
Health score responses stay numeric and bounded even when upstream metric calculations produce non-finite values. Verification completed with npm run type-check.