### PR TITLE
fix: add missing .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# -------------------------------------------------------
+# Supabase
+# Project Settings → API → Project URL
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+
+# Project Settings → API → anon / public key
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# Project Settings → API → service_role secret (server-side only — never expose client-side)
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+
+# -------------------------------------------------------
+# NextAuth
+# The URL your app is running on
+NEXTAUTH_URL=http://localhost:3000
+
+# Generate with: openssl rand -base64 32
+NEXTAUTH_SECRET=your_nextauth_secret
+
+# -------------------------------------------------------
+# GitHub OAuth App
+# github.com/settings/applications/new → Client ID
+GITHUB_ID=your_github_oauth_client_id
+
+# github.com/settings/applications/new → Client Secret
+GITHUB_SECRET=your_github_oauth_client_secret
+
+# -------------------------------------------------------
+# GitHub Webhook (optional — enables real-time metric refresh on push)
+# Generate with: openssl rand -hex 32
+GITHUB_WEBHOOK_SECRET=your_github_webhook_secret
+
+# -------------------------------------------------------
+# GitHub Personal Access Token (optional — increases API rate limits)
+# github.com/settings/tokens → Fine-grained or classic PAT
+GITHUB_TOKEN=your_github_personal_access_token

--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,15 @@ GITHUB_WEBHOOK_SECRET=your_github_webhook_secret
 # GitHub Personal Access Token (optional — increases API rate limits)
 # github.com/settings/tokens → Fine-grained or classic PAT
 GITHUB_TOKEN=your_github_personal_access_token
+
+# -------------------------------------------------------
+# Encryption key — required for OAuth token encryption in src/lib/crypto.ts
+# Without this the app crashes on first OAuth callback
+# Generate with: openssl rand -hex 32
+ENCRYPTION_KEY=your_32_byte_hex_encryption_key
+
+# -------------------------------------------------------
+# Upstash Redis (optional — used for caching; app degrades gracefully without it)
+# upstash.com → Create Database → REST API
+UPSTASH_REDIS_REST_URL=your_upstash_redis_rest_url
+UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token


### PR DESCRIPTION
## Summary
README.md (step 4) and DEVELOPMENT.md (step 4) both instruct contributors to run `cp .env.example .env.local`, but `.env.example` did not exist anywhere in the repository. Any first-time contributor following the quickstart would immediately hit a `No such file or directory` error before even starting the dev server.

This PR creates `.env.example` in the repo root with clearly documented placeholder values for every required (and optional) environment variable.

## Changes
- Added `.env.example` to the repo root

## Environment variables covered

| Variable | Required | Source |
|---|---|---|
| `NEXT_PUBLIC_SUPABASE_URL` | ✅ | Supabase → Project Settings → API |
| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | ✅ | Supabase → Project Settings → API |
| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | Supabase → Project Settings → API |
| `NEXTAUTH_URL` | ✅ | Your app's base URL |
| `NEXTAUTH_SECRET` | ✅ | `openssl rand -base64 32` |
| `GITHUB_ID` | ✅ | GitHub OAuth App → Client ID |
| `GITHUB_SECRET` | ✅ | GitHub OAuth App → Client Secret |
| `GITHUB_WEBHOOK_SECRET` | Optional | For real-time metric refresh on push |
| `GITHUB_TOKEN` | Optional | For higher GitHub API rate limits |

## Notes
- `.env.example` contains only placeholder values — no secrets. It is safe and intentional to commit.
- `.env.local` (real secrets) remains gitignored — no changes to `.gitignore` were needed.
- `GITHUB_WEBHOOK_SECRET` and `GITHUB_TOKEN` are marked optional since the app runs without them locally.

## Testing
- [x] Ran `cp .env.example .env.local` — succeeds without error
- [x] Confirmed `.env.example` is not listed in `.gitignore`
- [x] Confirmed `.env.local` remains gitignored

Please add the appropriate labels so that I can get points for GSSoC