### PR TITLE
Add GitLab contributions merge

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -156,7 +156,7 @@ async function fetchGitLabContributions(
           const eventDate = new Date(event.created_at);
           if (eventDate < since) {
             reachedCutoff = true;
-            continue;
+            break;
           }
 
           const count = event.push_data?.commit_count ?? 0;
@@ -181,6 +181,35 @@ async function fetchGitLabContributions(
       };
     }
   );
+}
+
+async function mergeGitLabContributions(
+  result: ContributionResponse,
+  token: string,
+  days: number,
+  cacheContext: { bypass: boolean; userId: string }
+): Promise<ContributionResponse> {
+  const gitlabResult = await fetchGitLabContributions(
+    token,
+    days,
+    cacheContext
+  ).catch(() => null);
+
+  if (!gitlabResult) {
+    return result;
+  }
+
+  const combinedData = mergeContributionDays(result.data, gitlabResult.data);
+
+  return {
+    days: result.days,
+    total: sumContributionDays(combinedData),
+    data: combinedData,
+    sources: {
+      github: result.data,
+      gitlab: gitlabResult.data,
+    },
+  };
 }
 
 export async function GET(req: NextRequest) {
@@ -224,30 +253,12 @@ export async function GET(req: NextRequest) {
         return Response.json(result);
       }
 
-      const gitlabResult = await fetchGitLabContributions(
-        gitlabToken,
-        days,
-        { bypass, userId: session.githubId ?? session.githubLogin }
-      ).catch(() => null);
-
-      if (!gitlabResult) {
-        return Response.json(result);
-      }
-
-      const combinedData = mergeContributionDays(
-        result.data,
-        gitlabResult.data
-      );
-
-      return Response.json({
-        days: result.days,
-        total: sumContributionDays(combinedData),
-        data: combinedData,
-        sources: {
-          github: result.data,
-          gitlab: gitlabResult.data,
-        },
+      const merged = await mergeGitLabContributions(result, gitlabToken, days, {
+        bypass,
+        userId: session.githubId ?? session.githubLogin,
       });
+
+      return Response.json(merged);
     } catch {
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
@@ -296,29 +307,12 @@ export async function GET(req: NextRequest) {
       return Response.json(merged);
     }
 
-    const gitlabResult = await fetchGitLabContributions(gitlabToken, days, {
+    const combined = await mergeGitLabContributions(merged, gitlabToken, days, {
       bypass,
       userId: session.githubId,
-    }).catch(() => null);
-
-    if (!gitlabResult) {
-      return Response.json(merged);
-    }
-
-    const combinedData = mergeContributionDays(
-      merged.data,
-      gitlabResult.data
-    );
-
-    return Response.json({
-      days: merged.days,
-      total: sumContributionDays(combinedData),
-      data: combinedData,
-      sources: {
-        github: merged.data,
-        gitlab: gitlabResult.data,
-      },
     });
+
+    return Response.json(combined);
   }
 
   if (accountId === session.githubId) {
@@ -334,30 +328,12 @@ export async function GET(req: NextRequest) {
         return Response.json(result);
       }
 
-      const gitlabResult = await fetchGitLabContributions(
-        gitlabToken,
-        days,
-        { bypass, userId: session.githubId }
-      ).catch(() => null);
-
-      if (!gitlabResult) {
-        return Response.json(result);
-      }
-
-      const combinedData = mergeContributionDays(
-        result.data,
-        gitlabResult.data
-      );
-
-      return Response.json({
-        days: result.days,
-        total: sumContributionDays(combinedData),
-        data: combinedData,
-        sources: {
-          github: result.data,
-          gitlab: gitlabResult.data,
-        },
+      const merged = await mergeGitLabContributions(result, gitlabToken, days, {
+        bypass,
+        userId: session.githubId,
       });
+
+      return Response.json(merged);
     } catch {
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -22,6 +22,17 @@ interface ContributionResponse {
   days: number;
   total: number;
   data: Record<string, number>;
+  sources?: {
+    github: Record<string, number>;
+    gitlab?: Record<string, number>;
+  };
+}
+
+interface GitLabEvent {
+  created_at: string;
+  push_data?: {
+    commit_count?: number;
+  };
 }
 
 function toLocalDateStr(d: Date): string {
@@ -37,6 +48,10 @@ function mergeContributionDays(
     result[date] = (result[date] ?? 0) + count;
   }
   return result;
+}
+
+function sumContributionDays(data: Record<string, number>): number {
+  return Object.values(data).reduce((total, count) => total + count, 0);
 }
 
 async function fetchContributionsForAccount(
@@ -87,7 +102,83 @@ async function fetchContributionsForAccount(
         commitsByDay[date] = (commitsByDay[date] ?? 0) + 1;
       }
 
-      return { days, total: data.total_count, data: commitsByDay };
+      return { days, total: sumContributionDays(commitsByDay), data: commitsByDay };
+    }
+  );
+}
+
+async function fetchGitLabContributions(
+  token: string,
+  days: number,
+  cacheContext: { bypass: boolean; userId: string }
+): Promise<ContributionResponse> {
+  const key = metricsCacheKey(cacheContext.userId, "contributions", {
+    days,
+    source: "gitlab",
+  });
+
+  return withMetricsCache(
+    {
+      bypass: cacheContext.bypass,
+      key,
+      ttlSeconds: METRICS_CACHE_TTL_SECONDS.contributions,
+    },
+    async () => {
+      const since = new Date();
+      since.setDate(since.getDate() - days);
+      since.setHours(0, 0, 0, 0);
+
+      let page = 1;
+      const commitsByDay: Record<string, number> = {};
+
+      while (page > 0) {
+        const url = new URL("https://gitlab.com/api/v4/events");
+        url.searchParams.set("action", "pushed");
+        url.searchParams.set("per_page", "100");
+        url.searchParams.set("page", String(page));
+
+        const response = await fetch(url.toString(), {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          cache: "no-store",
+        });
+
+        if (!response.ok) {
+          throw new Error("GitLab API error");
+        }
+
+        const events = (await response.json()) as GitLabEvent[];
+        if (events.length === 0) break;
+
+        let reachedCutoff = false;
+        for (const event of events) {
+          const eventDate = new Date(event.created_at);
+          if (eventDate < since) {
+            reachedCutoff = true;
+            continue;
+          }
+
+          const count = event.push_data?.commit_count ?? 0;
+          if (!count) continue;
+
+          const dateKey = event.created_at.slice(0, 10);
+          commitsByDay[dateKey] = (commitsByDay[dateKey] ?? 0) + count;
+        }
+
+        if (reachedCutoff) break;
+
+        const nextPage = response.headers.get("x-next-page");
+        if (!nextPage || nextPage === "0") break;
+        const parsedNext = Number(nextPage);
+        page = Number.isFinite(parsedNext) ? parsedNext : 0;
+      }
+
+      return {
+        days,
+        total: sumContributionDays(commitsByDay),
+        data: commitsByDay,
+      };
     }
   );
 }
@@ -102,6 +193,8 @@ export async function GET(req: NextRequest) {
   const accountId = req.nextUrl.searchParams.get("accountId");
   const username = req.nextUrl.searchParams.get("username")?.trim();
   const bypass = isMetricsCacheBypassed(req);
+  const gitlabToken =
+    typeof session.gitlabToken === "string" ? session.gitlabToken : undefined;
 
   // Compare mode path: explicitly fetch contributions for a target username.
   if (username) {
@@ -126,7 +219,35 @@ export async function GET(req: NextRequest) {
         days,
         { bypass, userId: session.githubId ?? session.githubLogin }
       );
-      return Response.json(result);
+
+      if (!gitlabToken) {
+        return Response.json(result);
+      }
+
+      const gitlabResult = await fetchGitLabContributions(
+        gitlabToken,
+        days,
+        { bypass, userId: session.githubId ?? session.githubLogin }
+      ).catch(() => null);
+
+      if (!gitlabResult) {
+        return Response.json(result);
+      }
+
+      const combinedData = mergeContributionDays(
+        result.data,
+        gitlabResult.data
+      );
+
+      return Response.json({
+        days: result.days,
+        total: sumContributionDays(combinedData),
+        data: combinedData,
+        sources: {
+          github: result.data,
+          gitlab: gitlabResult.data,
+        },
+      });
     } catch {
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
@@ -171,7 +292,33 @@ export async function GET(req: NextRequest) {
       return Response.json({ error: "All accounts failed" }, { status: 502 });
     }
 
-    return Response.json(merged);
+    if (!gitlabToken) {
+      return Response.json(merged);
+    }
+
+    const gitlabResult = await fetchGitLabContributions(gitlabToken, days, {
+      bypass,
+      userId: session.githubId,
+    }).catch(() => null);
+
+    if (!gitlabResult) {
+      return Response.json(merged);
+    }
+
+    const combinedData = mergeContributionDays(
+      merged.data,
+      gitlabResult.data
+    );
+
+    return Response.json({
+      days: merged.days,
+      total: sumContributionDays(combinedData),
+      data: combinedData,
+      sources: {
+        github: merged.data,
+        gitlab: gitlabResult.data,
+      },
+    });
   }
 
   if (accountId === session.githubId) {
@@ -182,7 +329,35 @@ export async function GET(req: NextRequest) {
         days,
         { bypass, userId: session.githubId }
       );
-      return Response.json(result);
+
+      if (!gitlabToken) {
+        return Response.json(result);
+      }
+
+      const gitlabResult = await fetchGitLabContributions(
+        gitlabToken,
+        days,
+        { bypass, userId: session.githubId }
+      ).catch(() => null);
+
+      if (!gitlabResult) {
+        return Response.json(result);
+      }
+
+      const combinedData = mergeContributionDays(
+        result.data,
+        gitlabResult.data
+      );
+
+      return Response.json({
+        days: result.days,
+        total: sumContributionDays(combinedData),
+        data: combinedData,
+        sources: {
+          github: result.data,
+          gitlab: gitlabResult.data,
+        },
+      });
     } catch {
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -28,6 +28,16 @@ interface GraphPoint {
   friend: number;
 }
 
+interface ContributionSources {
+  github?: Record<string, number>;
+  gitlab?: Record<string, number>;
+}
+
+interface ContributionResponse {
+  data: Record<string, number>;
+  sources?: ContributionSources;
+}
+
 type ViewMode = "bar" | "line" | "area";
 
 const RANGES = [
@@ -71,6 +81,23 @@ function mergeContributionData(
   return Array.from(map.values()).sort((a, b) =>
     a.date.localeCompare(b.date)
   );
+}
+
+function mergeContributionSources(
+  sources: ContributionSources | undefined,
+  fallback: Record<string, number>
+): Record<string, number> {
+  if (!sources) return fallback;
+
+  const github = sources.github ?? fallback;
+  const gitlab = sources.gitlab ?? {};
+  const merged = { ...github };
+
+  for (const [day, commits] of Object.entries(gitlab)) {
+    merged[day] = (merged[day] ?? 0) + commits;
+  }
+
+  return merged;
 }
 
 export default function ContributionGraph() {
@@ -142,8 +169,12 @@ export default function ContributionGraph() {
         if (!r.ok) throw new Error("API error");
         return r.json();
       })
-      .then((res: { data: Record<string, number> }) => {
-        const sorted = Object.entries(res.data ?? {})
+      .then((res: ContributionResponse) => {
+        const merged = mergeContributionSources(
+          res.sources,
+          res.data ?? {}
+        );
+        const sorted = Object.entries(merged)
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([day, commits]) => ({ day, commits }));
         setData(sorted);

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -5,6 +5,7 @@ declare module "next-auth" {
     accessToken?: string;
     githubId?: string;
     githubLogin?: string;
+    gitlabToken?: string;
     user?: DefaultSession["user"];
   }
 }
@@ -14,5 +15,6 @@ declare module "next-auth/jwt" {
     accessToken?: string;
     githubId?: string;
     githubLogin?: string;
+    gitlabToken?: string;
   }
 }


### PR DESCRIPTION
## Summary

Add GitLab pushed-event contributions to the contributions API and merge GitHub + GitLab day buckets in the contribution graph when `session.gitlabToken` is available. Includes GitLab pagination and consistent totals based on returned daily buckets.

Closes #10

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added GitLab events fetch with pagination and date cutoff; merged results into contributions response when `session.gitlabToken` exists.
- Unified contribution totals to be sum of returned day buckets (consistent across GitHub and GitLab).
- Contribution graph now merges GitHub + GitLab day buckets when sources are present.

## How to Test

Steps for the reviewer to verify this works:

1. Sign in with GitHub, open the dashboard, and confirm the contribution graph loads (GitHub-only).
2. Provide a valid `session.gitlabToken` (requires #317) and verify the graph includes GitLab push events.

## Screenshots (if UI change)

N/A


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
Notes:
- Depends on #317 to populate `session.gitlabToken`.
