### PR TITLE
fix: correct merged PR count in weekly summary and remove Playwright auth bypass

### DIFF
--- a/e2e/dashboard-widgets.spec.js
+++ b/e2e/dashboard-widgets.spec.js
@@ -27,16 +27,6 @@ test.beforeEach(async ({ page }) => {
       secure: false,
       expires: Math.floor(Date.now() / 1000) + 60 * 60,
     },
-    {
-      name: "playwright-dashboard-auth",
-      value: "1",
-      domain: "127.0.0.1",
-      path: "/",
-      httpOnly: true,
-      sameSite: "Lax",
-      secure: false,
-      expires: Math.floor(Date.now() / 1000) + 60 * 60,
-    },
   ]);
 
   await page.route("**/api/auth/session", async (route) => {

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -33,7 +33,6 @@ export default defineConfig({
       NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co",
       NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder-anon-key",
       SUPABASE_SERVICE_ROLE_KEY: "placeholder-service-role-key",
-      PLAYWRIGHT_AUTH_BYPASS: "1",
     },
   },
   projects: [

--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -177,6 +177,7 @@ export async function GET() {
       items: Array<{
         created_at: string;
         state: string;
+        pull_request?: { merged_at: string | null };
       }>;
     };
 
@@ -187,7 +188,7 @@ export async function GET() {
       const createdAt = new Date(item.created_at);
       if (createdAt >= currentWeekStart) {
         prsOpenedThisWeek++;
-        if (item.state === "closed") {
+        if (item.pull_request?.merged_at != null) {
           prsMergedThisWeek++;
         }
       }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -19,21 +19,12 @@ import ExportButton from "@/components/ExportButton";
 import Link from "next/link";
 import PersonalRecords from "@/components/PersonalRecords";
 import { authOptions } from "@/lib/auth";
-import { cookies } from "next/headers";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
 export default async function DashboardPage() {
-  const allowPlaywrightBypass =
-    process.env.PLAYWRIGHT_AUTH_BYPASS === "1" &&
-    cookies().get("playwright-dashboard-auth")?.value === "1";
-  const session = allowPlaywrightBypass
-    ? null
-    : await getServerSession(authOptions);
-
-  if (!session && !allowPlaywrightBypass) {
-    redirect("/");
-  }
+  const session = await getServerSession(authOptions);
+  if (!session) redirect("/");
 
   return (
     <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors">


### PR DESCRIPTION
## Summary

  Closes #451, Closes #450

  Two independent bugs fixed together — both are data-correctness or security issues with no new features.

  ---

  ### Fix 1 — Weekly summary counts all closed PRs as merged (#451)

  **File:** `src/app/api/metrics/weekly-summary/route.ts`

  The PR counting loop used `item.state === "closed"` to decide whether a PR was merged. A PR can be `state: "closed"` for two reasons: merged, or
  rejected/abandoned without merging. The GitHub search/issues response includes `pull_request.merged_at` which is `null` for closed-but-not-merged
  PRs. Updated the type and condition to use `item.pull_request?.merged_at != null` so `prsMergedThisWeek` no longer inflates for
  closed-but-unmerged PRs.

  ---

  ### Fix 2 — Playwright auth bypass reachable in production (#450)

  **Files:** `src/app/dashboard/page.tsx`, `e2e/dashboard-widgets.spec.js`, `playwright.config.mjs`

  alternative to real NextAuth authentication. If that env var was accidentally deployed to production (a realistic Vercel misconfiguration), any
  visitor could access the full dashboard by running `document.cookie = "playwright-dashboard-auth=1"` in their browser.
  
  The e2e tests already inject a properly signed `next-auth.session-token` JWT (via `next-auth/jwt encode()` with the same `NEXTAUTH_SECRET` as the
  dev server), so the cookie bypass was always redundant. Removed the bypass entirely: `dashboard/page.tsx` now calls `getServerSession`
  unconditionally, the redundant `playwright-dashboard-auth` cookie is dropped from the test `beforeEach`, and `PLAYWRIGHT_AUTH_BYPASS` is removed
  from `playwright.config.mjs`. Tests continue to pass through the JWT-based auth path. 

  ## Test plan
  
  **#451 — Merged PR count**
  - [x] PR with `merged_at` non-null, `state: "closed"` → counted in `prsMergedThisWeek`
  - [x] PR with `merged_at: null`, `state: "closed"` (rejected) → **not** counted in `prsMergedThisWeek`
  - [x] Open PR → not counted in `prsMergedThisWeek`
  - [x] PR created before current week → excluded regardless of state
  - [x] `prsOpenedThisWeek` count is unaffected
  
  **#450 — Auth bypass**
  - [x] `grep` confirms zero remaining references to `playwright-dashboard-auth`, `PLAYWRIGHT_AUTH_BYPASS`, `allowPlaywrightBypass`, or `cookies()`
  across all three files
  - [x] `dashboard/page.tsx` calls `getServerSession` unconditionally with no conditional bypass
  - [x] Playwright tests still set `next-auth.session-token` signed JWT — auth works without the bypass
  - [x] `npm run lint` and `npm run type-check` pass with zero errors