### PR TITLE
fix : added input validation for decryptToken in crypto.ts

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -53,8 +53,25 @@ export function decryptToken(
 ): string | null {
   try {
     const key = getEncryptionKey();
+
+    if (!/^[0-9a-fA-F]*$/.test(encrypted) || encrypted.length % 2 !== 0) {
+      throw new Error("Invalid encrypted token format");
+    }
+
+    if (!/^[0-9a-fA-F]*$/.test(iv) || iv.length % 2 !== 0) {
+      throw new Error("Invalid IV format");
+    }
+
     const encryptedBuffer = Buffer.from(encrypted, "hex");
     const ivBuffer = Buffer.from(iv, "hex");
+
+    if (ivBuffer.length !== IV_LENGTH) {
+      throw new Error("Invalid IV length");
+    }
+
+    if (encryptedBuffer.length < AUTH_TAG_LENGTH + 1) {
+      throw new Error("Encrypted token too short");
+    }
 
     const ciphertext = encryptedBuffer.subarray(
       0,


### PR DESCRIPTION
Closes #480.

Summary of What Has Been Done:
Added input validation to the decryptToken function in src/lib/crypto.ts to properly validate hex string format before attempting decryption. This prevents silent failures when invalid encrypted tokens or IVs are passed.

Changes Made:
- File: src/lib/crypto.ts
- Added hex format validation for encrypted token (must be valid hex, even length)
- Added hex format validation for IV
- Added IV length validation (must be exactly 12 bytes / 24 hex chars)
- Added minimum length check for encrypted token
- Errors are caught and logged, returning null as before, but now with better error messages logged

Impact it Made:
- Prevents silent data corruption when invalid encrypted tokens are passed
- Provides clear error messages logged for debugging when validation fails
- Makes the codebase more robust against malformed input