### PR TITLE
fix : clamped score before grading in computeHealthScore

### DIFF
--- a/src/lib/repo-health.ts
+++ b/src/lib/repo-health.ts
@@ -61,11 +61,12 @@ export function computeHealthScore(
     scoreDaysSinceLastCommit(signals.daysSinceLastCommit);
 
   const rounded = Math.round(score);
+  const clampedScore = clamp(rounded, 0, 100);
 
   return {
     repo,
-    score: clamp(rounded, 0, 100),
+    score: clampedScore,
     signals,
-    grade: gradeForScore(rounded),
+    grade: gradeForScore(clampedScore),
   };
 }


### PR DESCRIPTION
Closes #481.

Summary of What Has Been Done:
Fixed the computeHealthScore function in src/lib/repo-health.ts to clamp the score BEFORE passing it to gradeForScore. Previously, if the score was above 100, the grade was calculated on the unclamped value while a different (clamped) score was returned.

Changes Made:
- File: src/lib/repo-health.ts
- Clamp score to [0, 100] before grading
- Now grade is consistent with returned score value

Impact it Made:
- Fixes incorrect grade assignment for scores above 100
- Ensures API returns consistent score/grade pairs