### PR TITLE
fix : added username validation in compare route

### DIFF
--- a/src/app/api/metrics/compare/route.ts
+++ b/src/app/api/metrics/compare/route.ts
@@ -25,6 +25,15 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "Username required" }, { status: 400 });
   }
 
+  username = username.trim();
+  if (username.length === 0) {
+    return Response.json({ error: "Username required" }, { status: 400 });
+  }
+
+  if (username.length > 39 || !/^[a-zA-Z0-9-_]+$/.test(username)) {
+    return Response.json({ error: "Invalid username format" }, { status: 400 });
+  }
+
   if (username === "me") {
     username = session.githubLogin as string;
   }


### PR DESCRIPTION
Closes #482.

Summary of What Has Been Done:
Added username validation to the compare route in src/app/api/metrics/compare/route.ts to properly reject empty strings after trimming, validate length (max 39 chars for GitHub username), and validate format (only alphanumeric, hyphen, underscore allowed).

Changes Made:
- File: src/app/api/metrics/compare/route.ts
- Added trim() to remove whitespace from username
- Added empty string check after trim
- Added length validation (max 39 chars)
- Added format validation using regex ^[a-zA-Z0-9-_]+$

Impact it Made:
- Prevents unnecessary API calls to GitHub with invalid usernames
- Returns clear error messages for malformed input
- Improves API robustness against malformed requests