### PR TITLE
fix : added target validation in useCountUp hook

### DIFF
--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -18,6 +18,11 @@ export function useCountUp(target: number, duration?: number): number {
       return;
     }
 
+    if (target < 0) {
+      setCount(0);
+      return;
+    }
+
     if (hasAnimated.current) {
       setCount(target);
       return;


### PR DESCRIPTION
Closes #488.

Summary of What Has Been Done:
Added target validation to the useCountUp hook to handle negative values gracefully. If target is negative, the hook now sets count to 0 and returns early.

Changes Made:
- File: src/hooks/useCountUp.ts
- Added check for target < 0
- Returns early with count set to 0 for negative values

Impact it Made:
- Prevents unexpected behavior with negative values
- Makes the hook more robust against invalid inputs
- Ensures consistent animation behavior