### PR TITLE
fix : added TTL validation in cacheSet function

### DIFF
--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -87,6 +87,11 @@ export async function cacheSet<T>(
     return;
   }
 
+  if (typeof ttlSeconds !== "number" || ttlSeconds <= 0 || !Number.isFinite(ttlSeconds)) {
+    console.warn("Invalid TTL value:", ttlSeconds);
+    return;
+  }
+
   try {
     await redis.set(key, value, { ex: ttlSeconds });
   } catch {


### PR DESCRIPTION
Closes #489.

Summary of What Has Been Done:
Added TTL validation to the cacheSet function in src/lib/metrics-cache.ts. Previously, invalid TTL values (negative, non-finite) would be passed to Redis. Now invalid values are caught and logged with a warning, and the function returns early.

Changes Made:
- File: src/lib/metrics-cache.ts
- Added validation: ttlSeconds must be a positive finite number
- Logs warning and returns early for invalid TTL values

Impact it Made:
- Prevents Redis errors from invalid TTL values
- Maintains cache reliability
- Follows defensive programming patterns