### PR TITLE
fix : added NaN check for createdAt in weekly summary route

### DIFF
--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -185,6 +185,7 @@ export async function GET() {
 
     for (const item of prsData.items) {
       const createdAt = new Date(item.created_at);
+      if (Number.isNaN(createdAt.getTime())) continue;
       if (createdAt >= currentWeekStart) {
         prsOpenedThisWeek++;
         if (item.state === "closed") {


### PR DESCRIPTION
Closes #490.

Summary of What Has Been Done:
Added Number.isNaN check for createdAt.getTime() in the weekly-summary route to skip malformed dates in PR processing. Previously, if createdAt was an invalid date, the comparison would behave unexpectedly.

Changes Made:
- File: src/app/api/metrics/weekly-summary/route.ts
- Added Number.isNaN check to skip invalid dates
- Returns early for malformed date data

Impact it Made:
- Prevents unexpected behavior from invalid dates
- Improves data processing robustness
- Ensures valid data is processed correctly