### PR TITLE
fix : added node:test and node:assert/strict to BUILTINS in check-deps

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -10,10 +10,10 @@ const path = require("path");
 
 // Node built-ins (not in package.json but valid to import)
 const BUILTINS = new Set([
-  "assert", "buffer", "child_process", "cluster", "crypto", "dgram",
+  "assert", "assert/strict", "buffer", "child_process", "cluster", "crypto", "dgram",
   "dns", "domain", "events", "fs", "http", "http2", "https", "module",
   "net", "os", "path", "perf_hooks", "process", "punycode", "querystring",
-  "readline", "repl", "stream", "string_decoder", "timers", "tls", "tty",
+  "readline", "repl", "stream", "string_decoder", "test", "timers", "tls", "tty",
   "url", "util", "v8", "vm", "wasi", "worker_threads", "zlib",
 ]);
 


### PR DESCRIPTION
This PR fixes the check-deps script to recognize node:test and node:assert/strict as Node.js built-in modules. This allows test files using Node's native test module to pass CI.