### PR TITLE
fix : validate repository_url before extracting repo name

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -110,8 +110,11 @@ export async function fetchIssuesMetrics(
 
   const repoCounts: Record<string, number> = {};
   for (const item of items) {
-    const repo = item.repository_url.split("/").pop() ?? "";
-    repoCounts[repo] = (repoCounts[repo] ?? 0) + 1;
+    const parts = item.repository_url.split("/");
+    const repo = parts.length >= 2 ? parts.pop()! : item.repository_url;
+    if (repo) {
+      repoCounts[repo] = (repoCounts[repo] ?? 0) + 1;
+    }
   }
   const mostActiveRepo =
     Object.keys(repoCounts).length > 0


### PR DESCRIPTION
Closes #498.

Summary of What Has Been Done:
Added validation to ensure repository_url has the expected structure before extracting the repo name. Previously, malformed URLs would result in empty string keys in the repoCounts map.

Changes Made:
- File: src/lib/github.ts
- Check that URL has at least 2 path segments before extracting repo name
- Only increment count if repo name is non-empty

Impact it Made:
- Prevents crashes from malformed URLs
- Makes the code more robust against unexpected API responses