### PR TITLE
fix : validate goal target is positive number

### DIFF
--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -113,8 +113,8 @@ export async function POST(req: Request) {
     recurrence?: Recurrence;
   };
 
-  if (!body.title || !body.target) {
-    return Response.json({ error: "title and target required" }, { status: 400 });
+  if (!body.title || typeof body.target !== "number" || body.target <= 0) {
+    return Response.json({ error: "title and positive target required" }, { status: 400 });
   }
 
   const recurrence: Recurrence = body.recurrence ?? "none";


### PR DESCRIPTION
Closes #499.

Summary of What Has Been Done:
Fixed the goals route to validate that target is explicitly a positive number. Previously, target: 0 would be accepted because !body.target is false when body.target === 0.

Changes Made:
- File: src/app/api/goals/route.ts
- Changed validation to check typeof body.target !== number || body.target <= 0
- Updated error message to indicate positive target is required

Impact it Made:
- Prevents creation of invalid goals with target of 0
- Ensures goals have meaningful target values