### PR TITLE
fix : validate days parameter in repos route

### DIFF
--- a/src/app/api/metrics/repos/route.ts
+++ b/src/app/api/metrics/repos/route.ts
@@ -115,7 +115,9 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const days = Number(req.nextUrl.searchParams.get("days")) || 30;
+  const daysParam = req.nextUrl.searchParams.get("days");
+  const parsedDays = daysParam ? parseInt(daysParam, 10) : NaN;
+  const days = isNaN(parsedDays) ? 30 : Math.max(1, Math.min(365, parsedDays));
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
 


### PR DESCRIPTION
Closes #500.

Summary of What Has Been Done:
Fixed the repos route to validate the days parameter properly. Previously, days=-5 would convert to -5 instead of defaulting to 30.

Changes Made:
- File: src/app/api/metrics/repos/route.ts
- Added proper parsing with parseInt
- Constrained value to range [1, 365]

Impact it Made:
- Prevents invalid date range calculations
- Ensures consistent API behavior