### PR TITLE
fix : use deterministic comparison for cache key sorting

### DIFF
--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -58,7 +58,7 @@ export function metricsCacheKey(
 
   Object.entries(params)
     .filter(([, value]) => value !== undefined && value !== null)
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)
     .forEach(([key, value]) => cacheParams.set(key, String(value)));
 
   return `metrics:${userId}:${endpoint}:${cacheParams.toString() || "default"}`;


### PR DESCRIPTION
Closes #501.

Summary of What Has Been Done:
Replaced localeCompare with simple string comparison for cache key sorting. localeCompare is locale-aware and can produce different sort orders depending on the environment.

Changes Made:
- File: src/lib/metrics-cache.ts
- Changed sort to use a < b ? -1 : a > b ? 1 : 0

Impact it Made:
- Ensures consistent cache keys across all server instances
- Prevents cache misses due to locale differences