### PR TITLE
fix : remove non-null assertion from pending array access

### DIFF
--- a/src/app/api/streak/freeze/route.ts
+++ b/src/app/api/streak/freeze/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
 
   const hasFreeze = Array.isArray(pending) && pending.length > 0;
 
-  return Response.json({ hasFreeze, freezeDate: hasFreeze ? pending![0].freeze_date : null });
+  return Response.json({ hasFreeze, freezeDate: hasFreeze ? pending[0].freeze_date : null });
 }
 
 // POST /api/streak/freeze


### PR DESCRIPTION
Closes #502.

Summary of What Has Been Done:
Removed the non-null assertion (!) from pending array access after checking that pending is an array with length > 0. This was unnecessary and could mask potential type errors.

Changes Made:
- File: src/app/api/streak/freeze/route.ts
- Removed ! from pending![0] since we already check Array.isArray(pending) && pending.length > 0

Impact it Made:
- Cleaner code with no change in functionality
- Avoids potential runtime errors if the type assumptions are incorrect