### PR TITLE
fix: use Array.at(-1) to extract repo name from URL

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -110,8 +110,11 @@ export async function fetchIssuesMetrics(
 
   const repoCounts: Record<string, number> = {};
   for (const item of items) {
-    const repo = item.repository_url.split("/").pop() ?? "";
-    repoCounts[repo] = (repoCounts[repo] ?? 0) + 1;
+    const parts = item.repository_url.split("/");
+    const repo = parts.length >= 2 ? parts.pop()! : item.repository_url;
+    if (repo) {
+      repoCounts[repo] = (repoCounts[repo] ?? 0) + 1;
+    }
   }
   const mostActiveRepo =
     Object.keys(repoCounts).length > 0

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -110,8 +110,7 @@ export async function fetchIssuesMetrics(
 
   const repoCounts: Record<string, number> = {};
   for (const item of items) {
-    const parts = item.repository_url.split("/");
-    const repo = parts.length >= 2 ? parts.pop()! : item.repository_url;
+    const repo = item.repository_url.split("/").at(-1) ?? "";
     if (repo) {
       repoCounts[repo] = (repoCounts[repo] ?? 0) + 1;
     }


### PR DESCRIPTION
Closes #498.

Summary of What Has Been Done:
Replaced the length check and pop() pattern with Array.at(-1) for extracting repo name from URL, as suggested by the maintainer. This is simpler and has no edge cases.

Changes Made:
- File: src/lib/github.ts
- Changed from  to 

Impact it Made:
- Simpler code with no fallback to full URL edge case
- Uses the recommended Array.at(-1) approach