### PR TITLE
test : added unit tests for check-deps utilities

### DIFF
--- a/test/check-deps.test.js
+++ b/test/check-deps.test.js
@@ -15,6 +15,17 @@ test("extractPackageName keeps scoped package names intact", () => {
   assert.equal(extractPackageName("react/jsx-runtime"), "react");
 });
 
+test("extractPackageName handles @scope packages correctly", () => {
+  assert.equal(extractPackageName("@org/name"), "@org/name");
+  assert.equal(extractPackageName("@org/name/sub/path"), "@org/name");
+});
+
+test("extractPackageName handles unscoped packages correctly", () => {
+  assert.equal(extractPackageName("react"), "react");
+  assert.equal(extractPackageName("lodash/debounce"), "lodash");
+  assert.equal(extractPackageName("axios"), "axios");
+});
+
 test("extractImports includes side-effect imports", () => {
   const imports = extractImports(`
     import "server-only";
@@ -28,6 +39,22 @@ test("extractImports includes side-effect imports", () => {
     "@scope/pkg/path",
     "server-only",
     "package-two",
+  ]);
+});
+
+test("extractImports handles various import syntax", () => {
+  const imports = extractImports(`
+    import default1 from "pkg1";
+    import * as namespaced from "pkg2";
+    import { named1, named2 } from "pkg3";
+    import "side-effect-only";
+  `);
+
+  assert.deepEqual(imports, [
+    "pkg1",
+    "pkg2",
+    "pkg3",
+    "side-effect-only",
   ]);
 });
 
@@ -50,4 +77,52 @@ test("collectMissingDeps reports undeclared side-effect imports", () => {
 
   assert.deepEqual([...missing.keys()], ["missing-side-effect"]);
   assert.deepEqual([...missing.get("missing-side-effect")], ["src/entry.ts"]);
+});
+
+test("collectMissingDeps skips relative imports", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "check-deps-"));
+  const srcFile = path.join(dir, "src", "entry.ts");
+  fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+  fs.writeFileSync(
+    srcFile,
+    `
+      import local from "./local";
+      import sibling from "../utils/helper";
+      import absolute from "/absolute/path";
+      import alias from "@/lib/alias";
+      import react from "react";
+    `
+  );
+
+  const missing = collectMissingDeps([srcFile], new Set(["react"]), dir);
+
+  assert.ok(!missing.has("local"), "should skip relative imports starting with ./");
+  assert.ok(!missing.has("sibling"), "should skip relative imports starting with ../");
+  assert.ok(!missing.has("absolute"), "should skip absolute imports starting with /");
+});
+
+test("collectMissingDeps skips framework aliases", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "check-deps-"));
+  const srcFile = path.join(dir, "src", "entry.ts");
+  fs.mkdirSync(path.dirname(srcFile), { recursive: true });
+  fs.writeFileSync(
+    srcFile,
+    `
+      import next from "next";
+      import react from "react";
+      import reactDOM from "react-dom";
+      import serverOnly from "server-only";
+      import clientOnly from "client-only";
+      import missing from "nonexistent-package";
+    `
+  );
+
+  const missing = collectMissingDeps([srcFile], new Set(["react", "next"]), dir);
+
+  assert.ok(!missing.has("next"), "should skip next framework alias");
+  assert.ok(!missing.has("react"), "should skip react framework alias");
+  assert.ok(!missing.has("react-dom"), "should skip react-dom framework alias");
+  assert.ok(!missing.has("server-only"), "should skip server-only alias");
+  assert.ok(!missing.has("client-only"), "should skip client-only alias");
+  assert.deepEqual([...missing.keys()], ["nonexistent-package"], "should only report truly missing packages");
 });


### PR DESCRIPTION
Closes #568.

Summary of What Has Been Done:
Added comprehensive unit tests for the check-deps script including extractPackageName, extractImports, and collectMissingDeps functions.

Changes Made:
- Added test: extractPackageName handles @scope packages correctly
- Added test: extractPackageName handles unscoped packages correctly
- Added test: extractImports handles various import syntax
- Added test: collectMissingDeps skips relative imports
- Added test: collectMissingDeps skips framework aliases

Impact it Made:
- Improves test coverage for dependency checking utilities