### PR TITLE
fix(ui): improve mobile responsiveness across dashboard components (#514)

### DIFF
--- a/src/components/CIAnalytics.tsx
+++ b/src/components/CIAnalytics.tsx
@@ -78,7 +78,7 @@ export default function CIAnalytics() {
           role="status"
           aria-live="polite"
           aria-busy="true"
-          className="grid grid-cols-2 gap-4"
+          className="grid grid-cols-1 sm:grid-cols-2 gap-4"
         >
           <span className="sr-only">Loading CI analytics</span>
           {[1, 2, 3, 4].map((item) => (
@@ -102,7 +102,7 @@ export default function CIAnalytics() {
         </div>
       ) : data ? (
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {stats.map((stat) => (
               <div
                 key={stat.label}

--- a/src/components/FriendComparison.tsx
+++ b/src/components/FriendComparison.tsx
@@ -124,35 +124,39 @@ export default function FriendComparison() {
 
       {friendData && myData && (
         <div className="space-y-4">
-          <div className="flex justify-between items-center text-sm font-medium text-[var(--muted-foreground)] px-2">
-            <div className="w-1/3 text-left">You ({myData.username})</div>
-            <div className="w-1/3 text-center uppercase tracking-wider text-xs">Metric</div>
-            <div className="w-1/3 text-right">Them ({friendData.username})</div>
-          </div>
+          <div className="overflow-x-auto pb-2">
+            <div className="min-w-[400px]">
+              <div className="flex justify-between items-center text-sm font-medium text-[var(--muted-foreground)] px-2 mb-4">
+                <div className="w-1/3 text-left">You ({myData.username})</div>
+                <div className="w-1/3 text-center uppercase tracking-wider text-xs">Metric</div>
+                <div className="w-1/3 text-right">Them ({friendData.username})</div>
+              </div>
 
-          <div className="space-y-2">
-            <ComparisonRow 
-              label="Current Streak" 
-              myValue={myData.streak} 
-              theirValue={friendData.streak} 
-              suffix=" days" 
-            />
-            <ComparisonRow 
-              label="Commits (30d)" 
-              myValue={myData.commits30d} 
-              theirValue={friendData.commits30d} 
-            />
-            <ComparisonRow 
-              label="Pull Requests" 
-              myValue={myData.prs} 
-              theirValue={friendData.prs} 
-            />
-            <ComparisonRow 
-              label="Top Language" 
-              myValue={myData.topLanguage} 
-              theirValue={friendData.topLanguage} 
-              isString 
-            />
+              <div className="space-y-2">
+                <ComparisonRow 
+                  label="Current Streak" 
+                  myValue={myData.streak} 
+                  theirValue={friendData.streak} 
+                  suffix=" days" 
+                />
+                <ComparisonRow 
+                  label="Commits (30d)" 
+                  myValue={myData.commits30d} 
+                  theirValue={friendData.commits30d} 
+                />
+                <ComparisonRow 
+                  label="Pull Requests" 
+                  myValue={myData.prs} 
+                  theirValue={friendData.prs} 
+                />
+                <ComparisonRow 
+                  label="Top Language" 
+                  myValue={myData.topLanguage} 
+                  theirValue={friendData.topLanguage} 
+                  isString 
+                />
+              </div>
+            </div>
           </div>
 
           <div className="flex justify-center items-center gap-3 pt-4">

--- a/src/components/IssueMetrics.tsx
+++ b/src/components/IssueMetrics.tsx
@@ -65,7 +65,7 @@ export default function IssueMetrics() {
           role="status"
           aria-live="polite"
           aria-busy="true"
-          className="grid grid-cols-2 md:grid-cols-5 gap-4"
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4"
         >
           <span className="sr-only">Loading issue analytics</span>
           {[1, 2, 3, 4, 5].map((i) => (
@@ -88,7 +88,7 @@ export default function IssueMetrics() {
           </button>
         </div>
       ) : (
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
           {stats.map((stat, idx) => (
             <div
               key={stat.label}

--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -70,7 +70,7 @@ export default function LanguageBreakdown() {
             aria-hidden="true"
             className="h-6 rounded-full bg-[var(--card-muted)] animate-pulse"
           />
-          <div aria-hidden="true" className="grid grid-cols-2 gap-2 mt-3">
+          <div aria-hidden="true" className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-3">
             {[1, 2, 3, 4].map((i) => (
               <div key={i} className="h-5 rounded bg-[var(--card-muted)] animate-pulse" />
             ))}
@@ -99,7 +99,7 @@ export default function LanguageBreakdown() {
           </div>
 
           {/* Legend */}
-          <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-2">
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
             {displayLanguages.map((lang) => (
               <div key={lang.name} className="flex items-center gap-2 text-sm">
                 <span

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -79,7 +79,7 @@ export default function PRMetrics() {
           className="space-y-4"
         >
           <span className="sr-only">Loading PR analytics</span>
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
             {[1, 2, 3, 4, 5].map((i) => (
               <div
                 key={i}
@@ -104,7 +104,7 @@ export default function PRMetrics() {
       ) : (
         <div className="space-y-6">
           {/* Stat grid */}
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
             {stats.map((stat) => (
               <div
                 key={stat.label}

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -143,7 +143,7 @@ export default function StreakTracker() {
             aria-hidden="true"
             className="h-6 w-36 bg-[var(--card-muted)] rounded animate-pulse mb-4"
           />
-          <div aria-hidden="true" className="grid grid-cols-2 gap-4">
+          <div aria-hidden="true" className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {[1, 2, 3, 4].map((i) => (
               <div key={i} className="bg-[var(--card-muted)] rounded-lg h-28 animate-pulse" />
             ))}
@@ -264,7 +264,7 @@ export default function StreakTracker() {
           </button>
         )}
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {stats.map((stat) => (
           <div
             key={stat.label}


### PR DESCRIPTION
## Summary

This PR addresses layout and overflow issues on smaller screen sizes for the DevTrack dashboard, ensuring components scale and stack properly on mobile devices.

Closes #514

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup

## Changes Made

- **`IssueMetrics.tsx` & `PRMetrics.tsx`:** Updated grid layouts from `grid-cols-2 md:grid-cols-5` to a mobile-friendly `grid-cols-1 sm:grid-cols-2 lg:grid-cols-5` to allow individual metric cards to stack cleanly.
- **`FriendComparison.tsx`:** Added a responsive `overflow-x-auto` wrapper with a `min-w-[400px]` boundary around the data table to prevent metrics from overlapping when the viewport drops below typical mobile widths.
- **`CIAnalytics.tsx` & `LanguageBreakdown.tsx`:** Adjusted internal grid classes (e.g., `grid-cols-2` to `grid-cols-1 sm:grid-cols-2`) so stats collapse gracefully into single columns on small devices.
- **`StreakTracker.tsx`:** Refactored the overview stats to use `grid-cols-1 sm:grid-cols-2` to prevent lengthy labels from truncating poorly.

## How to Test

Steps for the reviewer to verify this works:

1. Run the development server locally using `npm run dev`.
2. Navigate to the dashboard page.
3. Open browser Developer Tools and switch to Responsive Design Mode.
4. Test at mobile breakpoints (320px, 375px) and verify that stat cards stack cleanly into single columns without horizontal scroll leaks.
5. Verify the `FriendComparison` widget allows horizontal scrolling instead of collapsing its contents.
6. Check tablet (768px) and desktop sizes to ensure the original, larger grid layouts render correctly as before.


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
