### PR TITLE
fix: improve assignment workflow automation robustness & path-independent check-deps

### DIFF
--- a/.github/workflows/auto-unassign.yml
+++ b/.github/workflows/auto-unassign.yml
@@ -30,7 +30,16 @@ jobs:
 
             for (const issue of issues) {
               if (issue.pull_request) continue; // skip PRs in results
-              if (!issue.assignees || issue.assignees.length === 0) continue;
+              if (!issue.assignees || issue.assignees.length === 0) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: issue.number, name: 'gssoc:assigned',
+                  });
+                } catch {
+                  // Label already removed — ignore
+                }
+                continue;
+              }
 
               // Find when this issue was last assigned via events
               const events = await github.paginate(
@@ -47,21 +56,30 @@ jobs:
               const assignedAt = new Date(assignedEvents[0].created_at).getTime();
               if (now - assignedAt < MS_LIMIT) continue; // still within deadline
 
+              const assignees = issue.assignees.map(a => a.login);
+
               // Check if any PR references this issue (via timeline cross-references)
               const timeline = await github.paginate(
                 "GET /repos/{owner}/{repo}/issues/{issue_number}/timeline",
                 { owner, repo, issue_number: issue.number, per_page: 100 },
               );
 
-              const hasLinkedPR = timeline.some(event =>
-                event.event === 'cross-referenced' &&
-                event.source?.issue?.pull_request != null
-              );
+              const hasLinkedPR = timeline.some(event => {
+                if (event.event !== 'cross-referenced') return false;
+                const pr = event.source?.issue;
+                if (!pr || !pr.pull_request) return false;
+
+                // Only count open or successfully merged PRs (closed without merging shouldn't block)
+                const isPRActive = pr.state === 'open' || pr.pull_request.merged_at != null;
+                if (!isPRActive) return false;
+
+                const prCreator = pr.user?.login;
+                return assignees.includes(prCreator);
+              });
 
               if (hasLinkedPR) continue; // contributor opened a PR — leave them alone
 
               // Unassign
-              const assignees = issue.assignees.map(a => a.login);
               await github.rest.issues.removeAssignees({
                 owner, repo, issue_number: issue.number, assignees,
               });

--- a/.github/workflows/gssoc-labels.yml
+++ b/.github/workflows/gssoc-labels.yml
@@ -92,6 +92,19 @@ jobs:
               console.log(`Added labels: ${newLabels.join(', ')}`);
             }
 
+            // Auto-assign PR author to PR
+            const creator = pr.user.login;
+            const currentAssignees = pr.assignees.map(a => a.login);
+            if (!currentAssignees.includes(creator)) {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: prNumber,
+                assignees: [creator]
+              });
+              console.log(`Assigned PR #${prNumber} to author @${creator}`);
+            }
+
       - name: Post admin checklist comment
         uses: actions/github-script@v7
         if: github.event.action == 'opened'

--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -39,6 +39,9 @@ jobs:
             // Skip bots
             if (context.payload.comment.user.type === 'Bot') return;
 
+            // Skip if the issue is closed
+            if (context.payload.issue.state !== 'open') return;
+
             const { owner, repo } = context.repo;
             const issueNumber = context.payload.issue.number;
             const commenter = context.payload.comment.user.login;

--- a/package-lock.json
+++ b/package-lock.json
@@ -523,7 +523,6 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
       "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "playwright": "1.49.1"
       },
@@ -765,7 +764,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1213,7 +1211,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1666,7 +1663,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2536,7 +2532,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2705,7 +2700,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4151,7 +4145,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4223,7 +4216,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5110,7 +5102,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5281,7 +5272,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -5372,7 +5362,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5385,7 +5374,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6439,7 +6427,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6609,7 +6596,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -53,10 +53,15 @@ const DYNAMIC_RE = /(?:require|import)\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
 function extractImports(src) {
   const imports = [];
 
+  // Strip single-line and multi-line comments to prevent quotes inside comments from throwing off the regex
+  const cleanSrc = src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*/g, "");
+
   for (const re of [IMPORT_RE, SIDE_EFFECT_IMPORT_RE, DYNAMIC_RE]) {
     re.lastIndex = 0;
     let m;
-    while ((m = re.exec(src)) !== null) {
+    while ((m = re.exec(cleanSrc)) !== null) {
       imports.push(m[1]);
     }
   }
@@ -87,14 +92,17 @@ function collectMissingDeps(files, allDeps, cwd = process.cwd()) {
 }
 
 function main() {
-  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const pkgPath = path.resolve(__dirname, "../package.json");
+  const srcDir = path.resolve(__dirname, "../src");
+
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
   const allDeps = new Set([
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.devDependencies || {}),
   ]);
 
-  const files = collectFiles("src");
-  const missing = collectMissingDeps(files, allDeps);
+  const files = collectFiles(srcDir);
+  const missing = collectMissingDeps(files, allDeps, path.resolve(__dirname, ".."));
 
   if (missing.size > 0) {
     console.error("\n❌  Imports found with no matching entry in package.json:\n");

--- a/test/check-deps.test.js
+++ b/test/check-deps.test.js
@@ -31,6 +31,23 @@ test("extractImports includes side-effect imports", () => {
   ]);
 });
 
+test("extractImports handles comments with quotes inside multiline imports", () => {
+  const imports = extractImports(`
+    import {
+      // we'll use this
+      foo
+    } from "package-three";
+    
+    /* some other comment with "double" quotes */
+    import "package-four";
+  `);
+
+  assert.deepEqual(imports, [
+    "package-three",
+    "package-four",
+  ]);
+});
+
 test("collectMissingDeps reports undeclared side-effect imports", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "check-deps-"));
   const srcFile = path.join(dir, "src", "entry.ts");


### PR DESCRIPTION
### Summary of Changes

This Pull Request addresses multiple robustness issues and bugs across workflow automation and dependency checking:

1. **Auto-Assignment & Unassignment Improvements**:
   - Prevent assignment of contributors to already-closed issues in \.github/workflows/issue-assignment.yml\.
   - Automatically assign the pull request author to their opened/reopened Pull Request in \.github/workflows/gssoc-labels.yml\.
   - Make the stale unassignment logic in \.github/workflows/auto-unassign.yml\ robust: it now specifically verifies only the open/merged PRs created by the assigned user, rather than incorrectly considering closed/unmerged PRs or PRs from other contributors as activity.

2. **\check-deps\ CLI Script Robustness**:
   - Modified \scripts/check-deps.js\ to resolve paths relative to \__dirname\, making the script CWD-independent.
   - Updated comment stripping logic to handle comments cleanly first, resolving issues where quotes within code comments could break multiline import matching.
   - Added automated tests to \	est/check-deps.test.js\ to verify robust comment handling.

All changes have been successfully implemented and validated locally.