### PR TITLE
fix(ui): remove dark overlay on chart hover

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -411,7 +411,7 @@ export default function ContributionGraph() {
                   color: "var(--foreground)",
                   fontSize: "12px",
                 }}
-                cursor={{ fill: "var(--background)" }}
+                cursor={false}
               />
               {hasFriendData && (
                 <Legend wrapperStyle={{ color: "var(--muted-foreground)", fontSize: "12px" }} />
@@ -459,7 +459,7 @@ export default function ContributionGraph() {
                   color: "var(--foreground)",
                   fontSize: "12px",
                 }}
-                cursor={{ fill: "var(--background)" }}
+                cursor={false}
               />
               {hasFriendData && (
                 <Legend wrapperStyle={{ color: "var(--muted-foreground)", fontSize: "12px" }} />
@@ -513,7 +513,7 @@ export default function ContributionGraph() {
                   color: "var(--foreground)",
                   fontSize: "12px",
                 }}
-                cursor={{ fill: "var(--background)" }}
+                cursor={false}
               />
               {hasFriendData && (
                 <Legend wrapperStyle={{ color: "var(--muted-foreground)", fontSize: "12px" }} />


### PR DESCRIPTION
## Summary

This PR fixes a visual UI bug in the "Your Commits" section where a dark rectangular shadow/overlay appeared behind hovered bars. The default Recharts `<Tooltip />` cursor background was enabled but was visually inconsistent with the dashboard styling. 

Setting the `cursor` prop to `false` across all chart variants (`Bar`, `Line`, and `Area`) successfully resolves this, ensuring clean and native-feeling hover states.

Closes #584 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Edited `src/components/ContributionGraph.tsx`
- Modified `<Tooltip />` configurations inside `<BarChart>`, `<LineChart>`, and `<AreaChart>`
- Explicitly set `cursor={false}` to disable the default Recharts background rectangle overlay.

## How to Test

Steps for the reviewer to verify this works:

1. Run the development server locally using `npm run dev`.
2. Navigate to the dashboard.
3. Scroll down to the "Your Commits" section.
4. Hover your mouse over individual data points across Bar, Line, and Area views.
5. Verify that no dark background overlay appears behind the active datapoint and the tooltip itself displays flawlessly.

## Screenshots (if UI change)

**Before:**
<img width="1178" height="507" alt="ui_bar_issue" src="https://github.com/user-attachments/assets/5e626b18-f3b2-4892-aab3-49d04992ad51" />


**After:**
<img width="1223" height="523" alt="graph_fixed" src="https://github.com/user-attachments/assets/97fb3dfb-ebcb-47cf-ba7c-8be596641c8e" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
