### PR TITLE
test : add unit tests for computeHealthScore, gradeForScore, and clamp functions

### DIFF
--- a/test/repo-health.test.ts
+++ b/test/repo-health.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { computeHealthScore } from '../src/lib/repo-health';
+
+describe('computeHealthScore', () => {
+  it('returns object with repo, score, signals, and grade', () => {
+    const signals = {
+      commitFrequency: 10,
+      prMergeRate: 1.0,
+      avgPrOpenTimeHours: 12,
+      openIssuesCount: 0,
+      daysSinceLastCommit: 3,
+    };
+    const result = computeHealthScore('test/repo', signals);
+    expect(result).toHaveProperty('repo', 'test/repo');
+    expect(result).toHaveProperty('score');
+    expect(result).toHaveProperty('signals');
+    expect(result).toHaveProperty('grade');
+  });
+
+  it('score is clamped between 0 and 100', () => {
+    const signals = {
+      commitFrequency: 100,
+      prMergeRate: 1.0,
+      avgPrOpenTimeHours: 0,
+      openIssuesCount: 0,
+      daysSinceLastCommit: 0,
+    };
+    const result = computeHealthScore('test/repo', signals);
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+
+  it('returns green grade for high scores', () => {
+    const signals = {
+      commitFrequency: 20,
+      prMergeRate: 1.0,
+      avgPrOpenTimeHours: 12,
+      openIssuesCount: 0,
+      daysSinceLastCommit: 3,
+    };
+    const result = computeHealthScore('test/repo', signals);
+    expect(result.grade).toBe('green');
+  });
+
+  it('returns yellow grade for medium scores', () => {
+    const signals = {
+      commitFrequency: 5,
+      prMergeRate: 0.5,
+      avgPrOpenTimeHours: 96,
+      openIssuesCount: 10,
+      daysSinceLastCommit: 15,
+    };
+    const result = computeHealthScore('test/repo', signals);
+    expect(result.grade).toBe('yellow');
+  });
+
+  it('returns red grade for low scores', () => {
+    const signals = {
+      commitFrequency: 1,
+      prMergeRate: 0.2,
+      avgPrOpenTimeHours: 200,
+      openIssuesCount: 25,
+      daysSinceLastCommit: 35,
+    };
+    const result = computeHealthScore('test/repo', signals);
+    expect(result.grade).toBe('red');
+  });
+
+  it('signals object is preserved in result', () => {
+    const signals = {
+      commitFrequency: 7,
+      prMergeRate: 0.8,
+      avgPrOpenTimeHours: 24,
+      openIssuesCount: 5,
+      daysSinceLastCommit: 10,
+    };
+    const result = computeHealthScore('test/repo', signals);
+    expect(result.signals).toEqual(signals);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+    globals: true,
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
Closes #674.

Summary of What Has Been Done:
Added unit tests for the computeHealthScore function in src/lib/repo-health.ts. Since gradeForScore and clamp are private functions, they are tested indirectly through computeHealthScore behavior.

Changes Made:
- Created test/repo-health.test.ts with vitest tests
- Created vitest.config.ts with proper configuration including @ alias
- Tests verify computeHealthScore returns correct structure
- Tests verify score clamping between 0-100
- Tests verify grade assignment (green/yellow/red)
- Tests verify signals object is preserved

Impact it Made:
- All 6 tests pass with npx vitest run
- Uses vitest framework with proper imports from source
- Test file ends with newline