### PR TITLE
fix: correct landing page e2e test heading selector

### DIFF
--- a/e2e/landing.spec.js
+++ b/e2e/landing.spec.js
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 test("landing page renders GitHub sign-in entrypoint", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "DevTrack" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "DevTrack", exact: true })).toBeVisible();
   await expect(
     page.getByRole("link", { name: "Sign in with GitHub" }),
   ).toHaveAttribute("href", /\/api\/auth\/signin\/github\?callbackUrl=\/dashboard/);

--- a/src/lib/badge-rate-limit.ts
+++ b/src/lib/badge-rate-limit.ts
@@ -19,6 +19,11 @@ function pruneBuckets(now: number) {
   }
 }
 
+/**
+ * Checks if the given IP is within rate limits for badge generation.
+ * @param ip - Client IP address
+ * @returns BadgeRateLimitResult indicating if request is allowed
+ */
 export function checkBadgeRateLimit(ip: string): BadgeRateLimitResult {
   const now = Date.now();
   pruneBuckets(now);
@@ -38,6 +43,11 @@ export function checkBadgeRateLimit(ip: string): BadgeRateLimitResult {
   return { allowed: true, remaining: BADGE_LIMIT - active.length, reset };
 }
 
+/**
+ * Extracts the client IP from a NextRequest for rate limiting.
+ * @param req - NextRequest object
+ * @returns Client IP address string
+ */
 export function getBadgeClientIp(req: NextRequest): string {
   return (
     req.ip ??

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,5 +1,10 @@
 export const GITHUB_API = "https://api.github.com";
 
+/**
+ * Fetches the recent GitHub events for the authenticated user.
+ * @param token - GitHub personal access token
+ * @returns Promise resolving to array of GitHubEvent objects
+ */
 export async function fetchUserEvents(token: string): Promise<GitHubEvent[]> {
   const res = await fetch(`${GITHUB_API}/user/events?per_page=100`, {
     headers: {
@@ -11,6 +16,11 @@ export async function fetchUserEvents(token: string): Promise<GitHubEvent[]> {
   return res.json();
 }
 
+/**
+ * Fetches the user's most recently pushed GitHub repositories.
+ * @param token - GitHub personal access token
+ * @returns Promise resolving to array of GitHubRepo objects
+ */
 export async function fetchUserRepos(token: string): Promise<GitHubRepo[]> {
   const res = await fetch(
     `${GITHUB_API}/user/repos?sort=pushed&per_page=10`,
@@ -75,6 +85,11 @@ export interface IssuesMetrics {
   mostActiveRepo: string | null;
 }
 
+/**
+ * Fetches issue metrics for the authenticated user over the last 30 days.
+ * @param token - GitHub personal access token
+ * @returns Promise resolving to IssuesMetrics object
+ */
 export async function fetchIssuesMetrics(
   token: string
 ): Promise<IssuesMetrics> {

--- a/src/lib/repo-health.ts
+++ b/src/lib/repo-health.ts
@@ -43,12 +43,23 @@ function scoreDaysSinceLastCommit(days: number): number {
   return clamp(normalized, 0, 1) * 15;
 }
 
+/**
+ * Determines the health grade based on the composite score.
+ * @param score - Numeric score from 0-100
+ * @returns Grade string: 'green' (70+), 'yellow' (40-69), or 'red' (<40)
+ */
 function gradeForScore(score: number): RepoHealthScore["grade"] {
   if (score >= 70) return "green";
   if (score >= 40) return "yellow";
   return "red";
 }
 
+/**
+ * Computes the overall health score for a repository based on various signals.
+ * @param repo - Repository full name (owner/repo)
+ * @param signals - RepoHealthSignals containing repository metrics
+ * @returns RepoHealthScore with score, grade, and signals
+ */
 export function computeHealthScore(
   repo: string,
   signals: RepoHealthSignals

--- a/src/lib/resolve-user.ts
+++ b/src/lib/resolve-user.ts
@@ -4,6 +4,12 @@ export interface AppUser {
   id: string;
 }
 
+/**
+ * Resolves a GitHub user to an app user, creating one if they don't exist.
+ * @param githubId - The GitHub user ID
+ * @param githubLogin - Optional GitHub username
+ * @returns Promise resolving to AppUser or null if operation failed
+ */
 export async function resolveAppUser(
   githubId: string,
   githubLogin?: string

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -20,6 +20,8 @@ interface User {
 /**
  * Look up a user by GitHub username only if their profile is public.
  * Returns the user row if found and is_public is true, otherwise null.
+ * @param username - The GitHub username to search for
+ * @returns Promise resolving to User object or null if not found
  */
 export async function getUserByUsername(username: string): Promise<User | null> {
   const { data, error } = await supabaseAdmin
@@ -43,6 +45,9 @@ export async function getUserByUsername(username: string): Promise<User | null> 
 
 /**
  * Update the is_public flag for a user.
+ * @param userId - The user's ID
+ * @param isPublic - The new public visibility flag
+ * @returns Promise resolving to updated User object or null on failure
  */
 export async function updateUserPublicFlag(
   userId: string,


### PR DESCRIPTION
Fixes the strict mode violation where getByRole('heading', { name: 'DevTrack' }) matched multiple elements. Uses exact match instead.