### PR TITLE
fix(goaltracker): add max validation for target input

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -296,6 +296,7 @@ export default function GoalTracker() {
               id="goal-target"
               type="number"
               min={1}
+              max={10000}
               value={target}
               onChange={(e) => setTarget(Number(e.target.value))}
               disabled={creating}
@@ -425,4 +426,4 @@ function ConfettiBurst() {
       ))}
     </div>
   );
-}
+}


### PR DESCRIPTION
## Summary

Adds frontend validation to the Goal Tracker target input by enforcing the same upper limit (`MAX_TARGET = 10000`) already defined in the backend API.

Closes #724 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added `max={10000}` to the target `<input type="number">` in `src/components/GoalTracker.tsx`
- Aligned frontend validation with backend `MAX_TARGET` constraint
- Prevents invalid values from being submitted unnecessarily

## How to Test

1. Open Dashboard → Goal Tracker
2. Enter a goal title
3. Try entering a target > `10000`
4. Verify browser validation prevents invalid submission
5. Enter a valid value ≤ `10000`
6. Verify goal creation still works normally

## Screenshots (if UI change)

N/A

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable