### PR TITLE
feat: support additional internal path aliases

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -78,7 +78,14 @@ function collectMissingDeps(files, allDeps, cwd = process.cwd()) {
 
     for (const mod of extractImports(src)) {
       // Skip relative imports, path aliases (@/ is the src alias — not a pkg)
-      if (mod.startsWith(".") || mod.startsWith("/") || mod.startsWith("@/")) continue;
+      const INTERNAL_ALIASES = ["@/", "~/", "src/"];
+      if (
+        mod.startsWith(".") || 
+        mod.startsWith("/") || 
+        INTERNAL_ALIASES.some(alias => mod.startsWith(alias))
+      ) {
+        continue;
+      }
       const pkgName = extractPackageName(mod);
       if (BUILTINS.has(pkgName) || FRAMEWORK_ALIASES.has(pkgName)) continue;
       if (allDeps.has(pkgName)) continue;


### PR DESCRIPTION

Improves dependency validation by supporting additional internal path aliases such as "~/" and "src/".

Closes #727 

Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

Changes Made

- Added configurable internal alias list
- Updated alias detection logic using "Array.some()"
- Reduced false positives for internal imports

How to Test

Steps for the reviewer to verify this works:

1. Add imports using aliases like "~/" or "src/"
2. Run the dependency validation script
3. Verify aliases are not reported as missing dependencies

Screenshots (if UI change)

N/A

Checklist

 Linked issue in summary
 "npm run lint" passes locally
 No TypeScript errors ("npm run type-check")
Self-reviewed the diff
Added/updated tests if applicable