### PR TITLE
fix : add scroll to the activity feed and show last 20 insted of 15

### DIFF
--- a/src/app/api/metrics/activity/route.ts
+++ b/src/app/api/metrics/activity/route.ts
@@ -256,7 +256,7 @@ export async function GET(req: NextRequest) {
         session.githubLogin,
         { bypass, userId: session.githubId ?? session.githubLogin }
       );
-      return Response.json({ items: items.slice(0, 15) });
+      return Response.json({ items: items.slice(0, 20) });
     } catch {
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }

--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -174,7 +174,7 @@ export default function RecentActivity() {
       </div>
 
       {loading ? (
-        <div className="space-y-3">
+        <div className="max-h-[320px] space-y-3 overflow-y-auto pr-1">
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
@@ -198,7 +198,7 @@ export default function RecentActivity() {
           No recent GitHub activity yet.
         </p>
       ) : (
-        <ul className="space-y-3 border-l border-[var(--border)] pl-4">
+        <ul className="max-h-[320px] space-y-3 overflow-y-auto border-l border-[var(--border)] pl-4 pr-1">
           {items.map((item) => (
             <li key={item.id} className="relative">
               <span


### PR DESCRIPTION
## Summary

The current activity feed was too long without a scroll box, so I set a max height of 320px and enabled scrolling. As mentioned in #33, I also updated the code to display the last 20 activities.



## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup

## Changes Made

- added max height 320 px
- The response will include the last 20 activities instead of 15.



## Screenshots (if UI change)
<img width="1783" height="583" alt="image" src="https://github.com/user-attachments/assets/8eda3c48-8f41-4a75-9404-b65e408fac17" />

## Checklist

- [ ] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
