### PR TITLE
added weekly comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ Thumbs.db
 .claude/
 
 desktop.ini
+
+test-results/

--- a/e2e/dashboard-widgets.spec.js
+++ b/e2e/dashboard-widgets.spec.js
@@ -30,13 +30,6 @@ test.beforeEach(async ({ page }) => {
     },
   ]);
 
-  await page.route("**/api/auth/csrf", async (route) => {
-    await route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({ csrfToken: "test-csrf-token" }),
-    });
-  });
-
   await page.route("**/api/auth/session", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -124,36 +117,10 @@ test.beforeEach(async ({ page }) => {
       });
     });
   }
-
-  // Add a catch-all for any unmocked API requests
-  await page.route("**/api/**", async (route) => {
-    // Only log if not already handled by specific routes above
-    if (
-      !route.request().url().includes("/api/auth") &&
-      !route.request().url().includes("/api/user") &&
-      !route.request().url().includes("/api/metrics") &&
-      !route.request().url().includes("/api/goals") &&
-      !route.request().url().includes("/api/streak")
-    ) {
-      console.log("Unmocked API request:", route.request().url());
-    }
-    // Continue with default behavior for unmocked requests
-    await route.continue();
-  });
 });
 
 test("dashboard widgets render with mocked metrics", async ({ page }) => {
-  await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
-  
-  // Wait for the page to navigate and settle
-  await page.waitForTimeout(1000);
-  
-  // Check current URL to debug any unexpected redirects
-  const currentUrl = page.url();
-  if (!currentUrl.includes("/dashboard")) {
-    throw new Error(`Page redirected from /dashboard to ${currentUrl}. Session might not be recognized.`);
-  }
-
+  await page.goto("/dashboard", { waitUntil: "load" });
   await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 30000 });
   await expect(page.getByRole("heading", { name: "Your Commits" })).toBeVisible({ timeout: 10000 });
   await expect(page.getByRole("heading", { name: "PR Analytics" })).toBeVisible({ timeout: 10000 });
@@ -169,11 +136,8 @@ test("contribution graph range buttons request a new range", async ({ page }) =>
     }
   });
 
-  await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(1000);
-  
-  // Wait for button to be visible before clicking
-  await expect(page.getByRole("button", { name: "Show 90-day range" })).toBeVisible({ timeout: 10000 });
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 30000 });
   await page.getByRole("button", { name: "Show 90-day range" }).click();
 
   await expect.poll(() => contributionRequests.some((url) => url.includes("days=90")), { timeout: 15000 }).toBe(true);
@@ -187,11 +151,8 @@ test("goal form posts a new goal", async ({ page }) => {
     }
   });
 
-  await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(1000);
-  
-  // Wait for form elements to be visible before interacting
-  await expect(page.getByLabel("Goal title")).toBeVisible({ timeout: 10000 });
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 30000 });
   await page.getByLabel("Goal title").fill("Ship one PR");
   await page.getByLabel("Target").fill("1");
   await page.getByLabel("Unit").fill("PR");
@@ -241,8 +202,14 @@ function mockMetricResponse(url) {
   if (url.includes("/api/metrics/weekly-summary")) {
     return {
       commits: { current: 10, previous: 7, delta: 3, trend: "up" },
-      prs: { opened: 3, merged: 2 },
-      activeDays: 5,
+      prs: {
+        thisWeek: { opened: 3, merged: 2 },
+        lastWeek: { opened: 1, merged: 1 }
+      },
+      activeDays: {
+        thisWeek: 5,
+        lastWeek: 4
+      },
       streak: 3,
       topRepo: "demo/repo",
     };

--- a/e2e/dashboard-widgets.spec.js
+++ b/e2e/dashboard-widgets.spec.js
@@ -30,6 +30,13 @@ test.beforeEach(async ({ page }) => {
     },
   ]);
 
+  await page.route("**/api/auth/csrf", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ csrfToken: "test-csrf-token" }),
+    });
+  });
+
   await page.route("**/api/auth/session", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -117,11 +124,35 @@ test.beforeEach(async ({ page }) => {
       });
     });
   }
+
+  // Add a catch-all for any unmocked API requests
+  await page.route("**/api/**", async (route) => {
+    // Only log if not already handled by specific routes above
+    if (
+      !route.request().url().includes("/api/auth") &&
+      !route.request().url().includes("/api/user") &&
+      !route.request().url().includes("/api/metrics") &&
+      !route.request().url().includes("/api/goals") &&
+      !route.request().url().includes("/api/streak")
+    ) {
+      console.log("Unmocked API request:", route.request().url());
+    }
+    // Continue with default behavior for unmocked requests
+    await route.continue();
+  });
 });
 
 test("dashboard widgets render with mocked metrics", async ({ page }) => {
-  await page.goto("/dashboard", { waitUntil: "load" });
-  await page.waitForTimeout(2000);
+  await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+  
+  // Wait for the page to navigate and settle
+  await page.waitForTimeout(1000);
+  
+  // Check current URL to debug any unexpected redirects
+  const currentUrl = page.url();
+  if (!currentUrl.includes("/dashboard")) {
+    throw new Error(`Page redirected from /dashboard to ${currentUrl}. Session might not be recognized.`);
+  }
 
   await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 30000 });
   await expect(page.getByRole("heading", { name: "Your Commits" })).toBeVisible({ timeout: 10000 });
@@ -138,8 +169,11 @@ test("contribution graph range buttons request a new range", async ({ page }) =>
     }
   });
 
-  await page.goto("/dashboard", { waitUntil: "load" });
-  await page.waitForTimeout(2000);
+  await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(1000);
+  
+  // Wait for button to be visible before clicking
+  await expect(page.getByRole("button", { name: "Show 90-day range" })).toBeVisible({ timeout: 10000 });
   await page.getByRole("button", { name: "Show 90-day range" }).click();
 
   await expect.poll(() => contributionRequests.some((url) => url.includes("days=90")), { timeout: 15000 }).toBe(true);
@@ -153,8 +187,11 @@ test("goal form posts a new goal", async ({ page }) => {
     }
   });
 
-  await page.goto("/dashboard", { waitUntil: "load" });
-  await page.waitForTimeout(2000);
+  await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(1000);
+  
+  // Wait for form elements to be visible before interacting
+  await expect(page.getByLabel("Goal title")).toBeVisible({ timeout: 10000 });
   await page.getByLabel("Goal title").fill("Ship one PR");
   await page.getByLabel("Target").fill("1");
   await page.getByLabel("Unit").fill("PR");

--- a/e2e/public-profile.spec.js
+++ b/e2e/public-profile.spec.js
@@ -1,44 +1,13 @@
-import { defineConfig, devices } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-const PORT = Number(process.env.PORT ?? 3000);
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+test("public profile route renders without requiring authentication", async ({ page }) => {
+  await page.goto("/u/playwright-user");
 
-export default defineConfig({
-  testDir: "./e2e",
-  timeout: 60_000,
-  expect: {
-    timeout: 15_000,
-  },
-  fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
-  use: {
-    baseURL,
-    trace: "retain-on-failure",
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-  },
-  webServer: {
-    command: `node node_modules/next/dist/bin/next dev -H 127.0.0.1 -p ${PORT}`,
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-    env: {
-      NEXTAUTH_SECRET: "playwright-placeholder-secret-that-is-long-enough",
-      NEXTAUTH_URL: baseURL,
-      NEXT_PUBLIC_APP_URL: baseURL,
-      GITHUB_ID: "playwright-github-id",
-      GITHUB_SECRET: "playwright-github-secret",
-      NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co",
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder-anon-key",
-      SUPABASE_SERVICE_ROLE_KEY: "placeholder-service-role-key",
-    },
-  },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  await expect(page).toHaveURL(/\/u\/playwright-user$/);
+  await expect(
+    page.getByRole("heading", {
+      name: /(@playwright-user's Profile|Profile Not Found)/,
+    }),
+  ).toBeVisible();
+  await expect(page.getByRole("link", { name: "Sign in with GitHub" })).toHaveCount(0);
 });

--- a/e2e/public-profile.spec.js
+++ b/e2e/public-profile.spec.js
@@ -1,13 +1,44 @@
-import { expect, test } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
 
-test("public profile route renders without requiring authentication", async ({ page }) => {
-  await page.goto("/u/playwright-user");
+const PORT = Number(process.env.PORT ?? 3000);
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${PORT}`;
 
-  await expect(page).toHaveURL(/\/u\/playwright-user$/);
-  await expect(
-    page.getByRole("heading", {
-      name: /(@playwright-user's Profile|Profile Not Found)/,
-    }),
-  ).toBeVisible();
-  await expect(page.getByRole("link", { name: "Sign in with GitHub" })).toHaveCount(0);
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: `node node_modules/next/dist/bin/next dev -H 127.0.0.1 -p ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NEXTAUTH_SECRET: "playwright-placeholder-secret-that-is-long-enough",
+      NEXTAUTH_URL: baseURL,
+      NEXT_PUBLIC_APP_URL: baseURL,
+      GITHUB_ID: "playwright-github-id",
+      GITHUB_SECRET: "playwright-github-secret",
+      NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder-anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: "placeholder-service-role-key",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
 });

--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -78,6 +78,7 @@ const commitsData = (await commitsRes.json()) as {
       let commitsThisWeek = 0;
       let commitsPrevWeek = 0;
       const activeDaysThisWeek = new Set<string>();
+      const activeDaysLastWeek = new Set<string>();
       const repoCounts = new Map<string, number>();
 
       for (const item of commitsData.items) {
@@ -91,6 +92,7 @@ const commitsData = (await commitsRes.json()) as {
           repoCounts.set(repoName, (repoCounts.get(repoName) ?? 0) + 1);
         } else if (commitDate >= prevWeekStart && commitDate <= prevWeekEnd) {
           commitsPrevWeek++;
+          activeDaysLastWeek.add(item.commit.author.date.slice(0, 10));
         }
       }
 
@@ -128,6 +130,8 @@ const commitsData = (await commitsRes.json()) as {
 
       let prsOpenedThisWeek = 0;
       let prsMergedThisWeek = 0;
+      let prsOpenedLastWeek = 0;
+      let prsMergedLastWeek = 0;
 
       for (const item of prsData.items) {
         const createdAt = new Date(item.created_at);
@@ -136,6 +140,11 @@ const commitsData = (await commitsRes.json()) as {
           prsOpenedThisWeek++;
           if (item.pull_request?.merged_at != null) {
             prsMergedThisWeek++;
+          }
+        } else if (createdAt >= prevWeekStart && createdAt <= prevWeekEnd) {
+          prsOpenedLastWeek++;
+          if (item.pull_request?.merged_at != null) {
+            prsMergedLastWeek++;
           }
         }
       }
@@ -150,8 +159,14 @@ const commitsData = (await commitsRes.json()) as {
           delta: commitDelta,
           trend: commitDelta > 0 ? "up" : commitDelta < 0 ? "down" : "same",
         },
-        prs: { opened: prsOpenedThisWeek, merged: prsMergedThisWeek },
-        activeDays: activeDaysThisWeek.size,
+        prs: {
+          thisWeek: { opened: prsOpenedThisWeek, merged: prsMergedThisWeek },
+          lastWeek: { opened: prsOpenedLastWeek, merged: prsMergedLastWeek },
+        },
+        activeDays: {
+          thisWeek: activeDaysThisWeek.size,
+          lastWeek: activeDaysLastWeek.size,
+        },
         streak: calculateCurrentStreak(streakDates),
         topRepo,
       };

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -181,3 +181,4 @@ export default async function LeaderboardPage({
     </main>
   );
 }
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -102,7 +102,7 @@ export default function Footer() {
               <a
                 className="transition-colors hover:text-[var(--card-foreground)]"
                 href="mailto:doshipriyanshu3@gmail.com"
-                target="_blank"
+                target="_blank" rel="noreferrer"
               >
                   Email
               </a>

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -10,10 +10,10 @@ interface WeeklySummaryData {
     trend: "up" | "down" | "same";
   };
   prs: {
-    opened: number;
-    merged: number;
+    thisWeek: { opened: number; merged: number };
+    lastWeek: { opened: number; merged: number };
   };
-  activeDays: number;
+  activeDays: { thisWeek: number; lastWeek: number };
   streak: number;
   topRepo: string | null;
 }
@@ -83,68 +83,170 @@ export default function WeeklySummaryCard() {
             {error}
           </div>
         ) : summary ? (
-          <div className="mt-4 space-y-3">
-            <div className="flex items-center justify-between rounded-lg bg-[var(--control)] p-4">
-              <span className="text-sm text-[var(--muted-foreground)]">
-                Commits
-              </span>
-              <div className="flex items-center gap-2">
+          <div className="mt-4 space-y-4">
+            {/* Commits Comparison */}
+            <div className="rounded-lg bg-[var(--control)] p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-sm text-[var(--muted-foreground)]">
+                  Commits
+                </span>
                 <span className="text-base font-semibold text-[var(--card-foreground)]">
                   {summary.commits.current}
+                  {summary.commits.trend !== "same" && (
+                    <span
+                      className="ml-2 text-sm font-medium"
+                      style={{
+                        color: summary.commits.trend === "up" ? "var(--success)" : "var(--destructive)",
+                      }}
+                    >
+                      {summary.commits.trend === "up" ? "+" : "-"}
+                      {Math.abs(summary.commits.delta)}
+                    </span>
+                  )}
                 </span>
-                {summary.commits.trend === "up" && (
-                  <span className="text-sm font-medium text-[var(--success)]">
-                    + {summary.commits.delta}
+              </div>
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <span className="w-16 text-xs text-[var(--muted-foreground)]">Last week</span>
+                  <div className="flex-1">
+                    <div className="h-2 rounded bg-[var(--border)] overflow-hidden">
+                      <div
+                        className="h-full bg-[var(--muted-foreground)]"
+                        style={{
+                          width: `${((summary.commits.previous / (summary.commits.current || summary.commits.previous || 1)) * 100).toFixed(0)}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <span className="w-10 text-right text-xs font-medium text-[var(--card-foreground)]">
+                    {((summary.commits.previous / (summary.commits.current + summary.commits.previous || 1)) * 100).toFixed(0)}%
                   </span>
-                )}
-                {summary.commits.trend === "down" && (
-                  <span className="text-sm font-medium text-[var(--destructive)]">
-                    - {Math.abs(summary.commits.delta)}
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="w-16 text-xs text-[var(--muted-foreground)]">This week</span>
+                  <div className="flex-1">
+                    <div className="h-2 rounded bg-[var(--border)] overflow-hidden">
+                      <div
+                        className="h-full bg-[var(--success)]"
+                        style={{
+                          width: `${((summary.commits.current / (summary.commits.current || summary.commits.previous || 1)) * 100).toFixed(0)}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <span className="w-10 text-right text-xs font-medium text-[var(--card-foreground)]">
+                    {((summary.commits.current / (summary.commits.current + summary.commits.previous || 1)) * 100).toFixed(0)}%
                   </span>
-                )}
-                {summary.commits.trend === "same" && (
-                  <span className="text-sm font-medium text-[var(--muted-foreground)]">
-                    0
-                  </span>
-                )}
+                </div>
               </div>
             </div>
 
-            <div className="flex items-center justify-between rounded-lg bg-[var(--control)] p-4">
-              <span className="text-sm text-[var(--muted-foreground)]">PRs</span>
-              <span className="text-base font-semibold text-[var(--card-foreground)]">
-                {summary.prs.opened} opened / {summary.prs.merged} merged
-              </span>
+            {/* PRs Comparison */}
+            <div className="rounded-lg bg-[var(--control)] p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-sm text-[var(--muted-foreground)]">PRs Merged</span>
+                <span className="text-base font-semibold text-[var(--card-foreground)]">
+                  {summary.prs.thisWeek.merged}
+                </span>
+              </div>
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <span className="w-16 text-xs text-[var(--muted-foreground)]">Last week</span>
+                  <div className="flex-1">
+                    <div className="h-2 rounded bg-[var(--border)] overflow-hidden">
+                      <div
+                        className="h-full bg-[var(--muted-foreground)]"
+                        style={{
+                          width: `${((summary.prs.lastWeek.merged / (summary.prs.thisWeek.merged || summary.prs.lastWeek.merged || 1)) * 100).toFixed(0)}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <span className="w-10 text-right text-xs font-medium text-[var(--card-foreground)]">
+                    {((summary.prs.lastWeek.merged / (summary.prs.thisWeek.merged + summary.prs.lastWeek.merged || 1)) * 100).toFixed(0)}%
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="w-16 text-xs text-[var(--muted-foreground)]">This week</span>
+                  <div className="flex-1">
+                    <div className="h-2 rounded bg-[var(--border)] overflow-hidden">
+                      <div
+                        className="h-full bg-[var(--success)]"
+                        style={{
+                          width: `${((summary.prs.thisWeek.merged / (summary.prs.thisWeek.merged || summary.prs.lastWeek.merged || 1)) * 100).toFixed(0)}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <span className="w-10 text-right text-xs font-medium text-[var(--card-foreground)]">
+                    {((summary.prs.thisWeek.merged / (summary.prs.thisWeek.merged + summary.prs.lastWeek.merged || 1)) * 100).toFixed(0)}%
+                  </span>
+                </div>
+              </div>
             </div>
 
-            <div className="flex items-center justify-between rounded-lg bg-[var(--control)] p-4">
-              <span className="text-sm text-[var(--muted-foreground)]">
-                Active days
-              </span>
-              <span className="text-base font-semibold text-[var(--card-foreground)]">
-                {summary.activeDays} / 7 days
-              </span>
+            {/* Active Days Comparison */}
+            <div className="rounded-lg bg-[var(--control)] p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-sm text-[var(--muted-foreground)]">Active Days</span>
+                <span className="text-base font-semibold text-[var(--card-foreground)]">
+                  {summary.activeDays.thisWeek} / 7
+                </span>
+              </div>
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-2">
+                  <span className="w-16 text-xs text-[var(--muted-foreground)]">Last week</span>
+                  <div className="flex-1">
+                    <div className="h-2 rounded bg-[var(--border)] overflow-hidden">
+                      <div
+                        className="h-full bg-[var(--muted-foreground)]"
+                        style={{
+                          width: `${((summary.activeDays.lastWeek / (summary.activeDays.thisWeek || summary.activeDays.lastWeek || 1)) * 100).toFixed(0)}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <span className="w-10 text-right text-xs font-medium text-[var(--card-foreground)]">
+                    {((summary.activeDays.lastWeek / (summary.activeDays.thisWeek + summary.activeDays.lastWeek || 1)) * 100).toFixed(0)}%
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="w-16 text-xs text-[var(--muted-foreground)]">This week</span>
+                  <div className="flex-1">
+                    <div className="h-2 rounded bg-[var(--border)] overflow-hidden">
+                      <div
+                        className="h-full bg-[var(--success)]"
+                        style={{
+                          width: `${((summary.activeDays.thisWeek / (summary.activeDays.thisWeek || summary.activeDays.lastWeek || 1)) * 100).toFixed(0)}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <span className="w-10 text-right text-xs font-medium text-[var(--card-foreground)]">
+                    {((summary.activeDays.thisWeek / (summary.activeDays.thisWeek + summary.activeDays.lastWeek || 1)) * 100).toFixed(0)}%
+                  </span>
+                </div>
+              </div>
             </div>
 
-            <div className="flex items-center justify-between rounded-lg bg-[var(--control)] p-4">
-              <span className="text-sm text-[var(--muted-foreground)]">
-                Streak
-              </span>
-              <span className="text-base font-semibold text-[var(--card-foreground)]">
-                {summary.streak} day streak
-              </span>
-            </div>
-
-            <div className="flex items-center justify-between rounded-lg bg-[var(--control)] p-4">
-              <span className="text-sm text-[var(--muted-foreground)]">
-                Top repo
-              </span>
-              <span className="text-base font-semibold text-[var(--card-foreground)]">
-                {summary.topRepo ?? "-"}
-              </span>
+            {/* Streak & Top Repo */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between rounded-lg bg-[var(--control)] p-4">
+                <span className="text-sm text-[var(--muted-foreground)]">Streak</span>
+                <span className="text-base font-semibold text-[var(--card-foreground)]">
+                  {summary.streak} day streak
+                </span>
+              </div>
+              <div className="flex items-center justify-between rounded-lg bg-[var(--control)] p-4">
+                <span className="text-sm text-[var(--muted-foreground)]">Top repo</span>
+                <span className="text-base font-semibold text-[var(--card-foreground)]">
+                  {summary.topRepo ?? "-"}
+                </span>
+              </div>
             </div>
           </div>
         ) : null)}
     </div>
   );
 }
+

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -24,6 +24,10 @@ export default function WeeklySummaryCard() {
   const [error, setError] = useState<string | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(false);
 
+  const maxCommits = summary ? Math.max(summary.commits.current, summary.commits.previous, 1) : 1;
+  const maxPRs = summary ? Math.max(summary.prs.thisWeek.merged, summary.prs.lastWeek.merged, 1) : 1;
+  const maxActiveDays = summary ? Math.max(summary.activeDays.thisWeek, summary.activeDays.lastWeek, 1) : 1;
+
   useEffect(() => {
     setLoading(true);
     setError(null);
@@ -113,7 +117,7 @@ export default function WeeklySummaryCard() {
                       <div
                         className="h-full bg-[var(--muted-foreground)]"
                         style={{
-                          width: `${((summary.commits.previous / (summary.commits.current || summary.commits.previous || 1)) * 100).toFixed(0)}%`,
+                          width: `${((summary.commits.previous / maxCommits) * 100).toFixed(0)}%`,
                         }}
                       />
                     </div>
@@ -129,7 +133,7 @@ export default function WeeklySummaryCard() {
                       <div
                         className="h-full bg-[var(--success)]"
                         style={{
-                          width: `${((summary.commits.current / (summary.commits.current || summary.commits.previous || 1)) * 100).toFixed(0)}%`,
+                          width: `${((summary.commits.current / maxCommits) * 100).toFixed(0)}%`,
                         }}
                       />
                     </div>
@@ -157,7 +161,7 @@ export default function WeeklySummaryCard() {
                       <div
                         className="h-full bg-[var(--muted-foreground)]"
                         style={{
-                          width: `${((summary.prs.lastWeek.merged / (summary.prs.thisWeek.merged || summary.prs.lastWeek.merged || 1)) * 100).toFixed(0)}%`,
+                          width: `${((summary.prs.lastWeek.merged / maxPRs) * 100).toFixed(0)}%`,
                         }}
                       />
                     </div>
@@ -173,7 +177,7 @@ export default function WeeklySummaryCard() {
                       <div
                         className="h-full bg-[var(--success)]"
                         style={{
-                          width: `${((summary.prs.thisWeek.merged / (summary.prs.thisWeek.merged || summary.prs.lastWeek.merged || 1)) * 100).toFixed(0)}%`,
+                          width: `${((summary.prs.thisWeek.merged / maxPRs) * 100).toFixed(0)}%`,
                         }}
                       />
                     </div>
@@ -201,7 +205,7 @@ export default function WeeklySummaryCard() {
                       <div
                         className="h-full bg-[var(--muted-foreground)]"
                         style={{
-                          width: `${((summary.activeDays.lastWeek / (summary.activeDays.thisWeek || summary.activeDays.lastWeek || 1)) * 100).toFixed(0)}%`,
+                          width: `${((summary.activeDays.lastWeek / maxActiveDays) * 100).toFixed(0)}%`,
                         }}
                       />
                     </div>
@@ -217,7 +221,7 @@ export default function WeeklySummaryCard() {
                       <div
                         className="h-full bg-[var(--success)]"
                         style={{
-                          width: `${((summary.activeDays.thisWeek / (summary.activeDays.thisWeek || summary.activeDays.lastWeek || 1)) * 100).toFixed(0)}%`,
+                          width: `${((summary.activeDays.thisWeek / maxActiveDays) * 100).toFixed(0)}%`,
                         }}
                       />
                     </div>
@@ -249,4 +253,3 @@ export default function WeeklySummaryCard() {
     </div>
   );
 }
-


### PR DESCRIPTION
### Summary
Adds "This Week" dashboard widget showing commit trends, PR activity, active days, and streak status with side-by-side bar chart comparison.

Closes #231 

### Changes Made
- **Frontend**: New `WeeklySummaryCard` component with bar chart (recharts), collapsible UI, loading/error states
- **API**: New `/api/metrics/weekly-summary` endpoint aggregating GitHub commits & PRs for 14-day window
- **Metrics**: Commits (with delta/trend), PRs opened/merged, active days, current streak, top repo

### How to Test
1. Log in with GitHub account
2. Go to dashboard
3. Verify widget loads and shows correct data
4. Test collapse/expand toggle

### Checklist
- [x] Closes #99
- [x] No lint/TS errors
- [x] Self-reviewed

<img width="1895" height="748" alt="image" src="https://github.com/user-attachments/assets/8c732636-5471-402f-a51e-fbb8bcbac217" />

