### PR TITLE
fix: add failure notifications to GoalTracker deletion rollback #745

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -33,6 +33,7 @@ export default function GoalTracker() {
   const [createError, setCreateError] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const [activeConfettiGoalId, setActiveConfettiGoalId] = useState<string | null>(null);
   const prevGoalsRef = useRef<Map<string, boolean>>(new Map());
@@ -88,14 +89,23 @@ export default function GoalTracker() {
     setGoals((prev) => prev.filter((g) => g.id !== id));
     setConfirmingId(null);
     setDeletingId(id);
+    setDeleteError(null);
 
     try {
       const res = await fetch(`/api/goals/${id}`, { method: "DELETE" });
       if (!res.ok) {
         setGoals(previousGoals);
+        setDeleteError("Failed to delete goal. Please try again.");
+        setTimeout(() => {
+          setDeleteError(null);
+        }, 5000);
       }
     } catch {
       setGoals(previousGoals);
+      setDeleteError("Failed to delete goal. Please try again.");
+      setTimeout(() => {
+        setDeleteError(null);
+      }, 5000);
     } finally {
       setDeletingId(null);
     }
@@ -172,6 +182,26 @@ export default function GoalTracker() {
   return (
     <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">Weekly Goals</h2>
+
+      {deleteError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 p-3 text-xs text-[var(--destructive)] flex items-center justify-between animate-in fade-in duration-200"
+        >
+          <div className="flex items-center gap-2">
+            <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <span>{deleteError}</span>
+          </div>
+          <button
+            onClick={() => setDeleteError(null)}
+            className="text-[var(--destructive)] hover:opacity-80 font-semibold text-xs ml-2"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {goals.length === 0 ? (
         <p className="text-sm text-[var(--muted-foreground)]">


### PR DESCRIPTION
# [BUG / UX] Add failure notifications to GoalTracker deletion rollback #745

## 📖 Summary
This Pull Request addresses the issue of silent failures when deleting goals. DevTrack uses optimistic UI updates to instantly delete goals from the interface. However, if the deletion fetch request failed on the backend (due to server errors, authentication expiry, or network drops), the goal was silently rolled back and re-appended to the goals list without informing the user.

This PR adds a dedicated `deleteError` warning banner below the widget header, providing elegant visual feedback and error messaging when an optimistic deletion has to be rolled back.

Closes #745

---

## 🚀 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX/UI improvement

---

## 🛠️ Changes Made
- **`src/components/GoalTracker.tsx`**:
  - Added a `deleteError` state variable.
  - Reset `deleteError` state when launching a deletion.
  - Refactored `handleDelete` to populate `deleteError` with a user-facing error message inside `!res.ok` and `catch` blocks.
  - Added an auto-dismiss timer that clears the delete error banner after 5 seconds.
  - Rendered a beautifully themed warning banner with an error icon, error details, and an interactive **Dismiss** button directly under the **Weekly Goals** heading.

---

## 🧪 How to Test
1. Check out the branch: `git checkout fix/issue-745-goal-deletion-feedback`.
2. Run the development server: `npm run dev`.
3. Open the dashboard and locate the **Weekly Goals** widget.
4. **Test Error & Rollback State**:
   - Open browser Developer Tools, switch to the *Network* tab, and manually block or throttle the `DELETE` API requests for `/api/goals/*` (or mock a `500` server response).
   - Try to delete any goal in the tracker.
   - The goal will immediately vanish (optimistic update), and then suddenly reappear on the list accompanied by a beautiful warning banner: *"Failed to delete goal. Please try again."*.
   - Verify the error banner auto-dismisses after 5 seconds, or manually dismiss it by clicking **Dismiss**.

---

## ✅ Checklist
- [x] My code follows the code style of this project
- [x] I have self-reviewed my changes
- [x] All existing/new tests pass locally
- [x] No TypeScript or build compilation errors
