### PR TITLE
test : added unit tests for getRedisClient lazy initialization

### DIFF
--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -42,7 +42,7 @@ function isTruthyCacheBypass(value: string | null): boolean {
   return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
 }
 
-function getRedisClient(): Redis | null {
+export function getRedisClient(): Redis | null {
   if (redisClient !== undefined) {
     return redisClient;
   }

--- a/test/getRedisClient.test.ts
+++ b/test/getRedisClient.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@upstash/redis', () => {
+  const MockRedis = vi.fn(function() { return {}; });
+  return { Redis: MockRedis };
+});
+
+describe('getRedisClient lazy initialization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns null when UPSTASH_REDIS_REST_URL is not set', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const { getRedisClient } = await import('../src/lib/metrics-cache');
+    const client = getRedisClient();
+    expect(client).toBeNull();
+  });
+
+  it('returns null when UPSTASH_REDIS_REST_TOKEN is not set', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const { getRedisClient } = await import('../src/lib/metrics-cache');
+    const client = getRedisClient();
+    expect(client).toBeNull();
+  });
+
+  it('returns Redis instance when both env vars are set', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token-123';
+
+    const { getRedisClient } = await import('../src/lib/metrics-cache');
+    const client = getRedisClient();
+    expect(client).not.toBeNull();
+    expect(client).toBeDefined();
+  });
+
+  it('returns same singleton instance on repeated calls', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token-123';
+
+    const { getRedisClient } = await import('../src/lib/metrics-cache');
+    const client1 = getRedisClient();
+    const client2 = getRedisClient();
+    expect(client1).toBe(client2);
+  });
+});


### PR DESCRIPTION
Closes #776.

Summary of What Has Been Done:
Added test/getRedisClient.test.ts with 4 vitest tests covering the getRedisClient lazy initialization from src/lib/metrics-cache.ts.

Changes Made:
New file: test/getRedisClient.test.ts

Test coverage:
- Returns null when UPSTASH_REDIS_REST_URL is not set
- Returns null when UPSTASH_REDIS_REST_TOKEN is not set
- Returns Redis instance when both env vars are set
- Returns same singleton instance on repeated calls (cache behavior)

Impact it Made:
All 4 tests pass. Redis client initialization validated.