### PR TITLE
fix : add TTL-based eviction to ipRateLimits Map

### DIFF
--- a/e2e/landing.spec.js
+++ b/e2e/landing.spec.js
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 test("landing page renders GitHub sign-in entrypoint", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "DevTrack" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "DevTrack", exact: true })).toBeVisible();
   await expect(
     page.getByRole("link", { name: "Sign in with GitHub" }),
   ).toHaveAttribute("href", /\/api\/auth\/signin\/github\?callbackUrl=\/dashboard/);

--- a/src/app/api/public/[username]/route.ts
+++ b/src/app/api/public/[username]/route.ts
@@ -32,6 +32,9 @@ function getRateLimitKey(req: NextRequest): string {
 
 function checkRateLimit(ip: string): { allowed: boolean; retryAfter?: number } {
   const now = Date.now();
+  for (const [key, record] of ipRateLimits) {
+    if (now > record.resetAt) ipRateLimits.delete(key);
+  }
   const record = ipRateLimits.get(ip);
 
   if (!record || now > record.resetAt) {


### PR DESCRIPTION
fix : add TTL-based eviction to ipRateLimits Map