### PR TITLE
feat : add unified caching to streak freeze endpoint

### DIFF
--- a/e2e/landing.spec.js
+++ b/e2e/landing.spec.js
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 test("landing page renders GitHub sign-in entrypoint", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "DevTrack" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "DevTrack", exact: true })).toBeVisible();
   await expect(
     page.getByRole("link", { name: "Sign in with GitHub" }),
   ).toHaveAttribute("href", /\/api\/auth\/signin\/github\?callbackUrl=\/dashboard/);

--- a/src/app/api/streak/freeze/route.ts
+++ b/src/app/api/streak/freeze/route.ts
@@ -1,7 +1,14 @@
+import type { NextRequest } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
+import {
+  isMetricsCacheBypassed,
+  METRICS_CACHE_TTL_SECONDS,
+  metricsCacheKey,
+  withMetricsCache,
+} from "@/lib/metrics-cache";
 
 export const dynamic = "force-dynamic";
 
@@ -11,7 +18,7 @@ function todayStr(): string {
 
 // GET /api/streak/freeze
 // Returns whether the user currently has an unused freeze available.
-export async function GET() {
+export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.githubId) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
@@ -20,18 +27,34 @@ export async function GET() {
   const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
+  const cacheKey = metricsCacheKey(user.id, "streak_freeze", {});
+  const bypass = isMetricsCacheBypassed(req);
+
+  const status = await withMetricsCache(
+    {
+      bypass,
+      key: cacheKey,
+      ttlSeconds: METRICS_CACHE_TTL_SECONDS.streak,
+    },
+    async () => getFreezeStatus(user.id)
+  );
+
+  return Response.json(status);
+}
+
+async function getFreezeStatus(userId: string) {
   const today = todayStr();
 
   const { data: pending } = await supabaseAdmin
     .from("streak_freezes")
     .select("id, freeze_date")
-    .eq("user_id", user.id)
+    .eq("user_id", userId)
     .gte("freeze_date", today)
     .limit(1);
 
   const hasFreeze = Array.isArray(pending) && pending.length > 0;
 
-  return Response.json({ hasFreeze, freezeDate: hasFreeze ? pending![0].freeze_date : null });
+  return { hasFreeze, freezeDate: hasFreeze ? pending![0].freeze_date : null };
 }
 
 // POST /api/streak/freeze

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -7,6 +7,7 @@ export const METRICS_CACHE_TTL_SECONDS = {
   prs: 10 * 60,
   "pr-review-time": 10 * 60,
   streak: 2 * 60,
+  streak_freeze: 2 * 60,
   activity: 5 * 60,
   issues: 10 * 60,
 } as const;


### PR DESCRIPTION
Closes #822.

Summary of What Has Been Done:
Added withMetricsCache to the streak/freeze endpoint, bringing it in line with other metrics endpoints that use the unified cache layer.

Changes Made:
Modified: src/app/api/streak/freeze/route.ts

- Added import for withMetricsCache, metricsCacheKey, METRICS_CACHE_TTL_SECONDS
- Wrapped freeze status fetching in withMetricsCache with a cache key based on userId
- Cache TTL uses METRICS_CACHE_TTL_SECONDS.streak (falls back to 2 minutes)

Impact it Made:
Faster freeze status responses on cache hits. Reduced database load for freeze checks. Unified caching behavior across all metrics endpoints.