### PR TITLE
refactor: use module builtinModules for node builtins

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -7,15 +7,10 @@
 
 const fs = require("fs");
 const path = require("path");
+const { builtinModules } = require("module");
 
 // Node built-ins (not in package.json but valid to import)
-const BUILTINS = new Set([
-  "assert", "buffer", "child_process", "cluster", "crypto", "dgram",
-  "dns", "domain", "events", "fs", "http", "http2", "https", "module",
-  "net", "os", "path", "perf_hooks", "process", "punycode", "querystring",
-  "readline", "repl", "stream", "string_decoder", "timers", "tls", "tty",
-  "url", "util", "v8", "vm", "wasi", "worker_threads", "zlib",
-]);
+const BUILTINS = new Set(builtinModules);
 
 // Next.js / framework aliases that resolve internally
 const FRAMEWORK_ALIASES = new Set([


### PR DESCRIPTION
Refactors the dependency validation script to use Node.js module.builtinModules instead of a manually maintained built-in modules list.
Closes #728 
Type of Change
[ ] Bug fix
[ ] New feature
[ ] Documentation update
[x] Refactor / code cleanup
Changes Made
Removed hardcoded Node.js built-in modules array
Added module.builtinModules
Simplified built-in module handling
Improved future compatibility with newer Node.js versions
How to Test
Steps for the reviewer to verify this works:
Run the dependency validation script
Verify Node.js built-in modules are still ignored correctly
Ensure no new missing dependency errors appear for built-in modules
Screenshots (if UI change)
N/A

Checklist

 Linked issue in summary
`npm run lint` passes locally
No TypeScript errors (`npm run type-check`)
 Self-reviewed the diff
Added/updated tests if applicable
