### PR TITLE
feat : Add Coding Activity Insights dashboard card

### DIFF
--- a/src/app/api/metrics/coding-activity-insights/route.ts
+++ b/src/app/api/metrics/coding-activity-insights/route.ts
@@ -1,0 +1,247 @@
+import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
+import { authOptions } from "@/lib/auth";
+import {
+  getAccountToken,
+  getAllAccounts,
+} from "@/lib/github-accounts";
+import { GITHUB_API } from "@/lib/github";
+import {
+  isMetricsCacheBypassed,
+  METRICS_CACHE_TTL_SECONDS,
+  metricsCacheKey,
+  withMetricsCache,
+} from "@/lib/metrics-cache";
+import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
+import {
+  summarizeCodingActivity,
+  type CodingActivityInsight,
+} from "@/lib/coding-activity-insights";
+
+export const dynamic = "force-dynamic";
+
+interface CommitSearchItem {
+  commit: {
+    author: {
+      date: string;
+    };
+  };
+}
+
+const SEARCH_WINDOW_DAYS = 90;
+
+function getRequestedTimeZone(req: NextRequest): string {
+  const raw = req.nextUrl.searchParams.get("timeZone")?.trim();
+  if (!raw) {
+    return "UTC";
+  }
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: raw }).format(new Date());
+    return raw;
+  } catch {
+    return "UTC";
+  }
+}
+
+async function fetchCommitTimestampsForAccount(
+  token: string,
+  githubLogin: string,
+  cacheContext: { bypass: boolean; userId: string }
+): Promise<string[]> {
+  const key = metricsCacheKey(cacheContext.userId, "coding-activity-insights", {
+    githubLogin,
+    days: SEARCH_WINDOW_DAYS,
+  });
+
+  return withMetricsCache(
+    {
+      bypass: cacheContext.bypass,
+      key,
+      ttlSeconds: METRICS_CACHE_TTL_SECONDS["coding-activity-insights"],
+    },
+    async () => {
+      const since = new Date();
+      since.setDate(since.getDate() - SEARCH_WINDOW_DAYS);
+      const sinceStr = since.toISOString().slice(0, 10);
+
+      const timestamps: string[] = [];
+      let totalCount = 0;
+      let page = 1;
+
+      while (page <= 10) {
+        const response = await fetch(
+          `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${sinceStr}&per_page=100&page=${page}&sort=author-date&order=desc`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "application/vnd.github+json",
+            },
+            cache: "no-store",
+          }
+        );
+
+        if (!response.ok) {
+          if ((response.status === 403 || response.status === 429) && timestamps.length > 0) {
+            break;
+          }
+
+          throw new Error("GitHub API error");
+        }
+
+        const payload = (await response.json()) as {
+          total_count: number;
+          items: CommitSearchItem[];
+        };
+
+        if (page === 1) {
+          totalCount = payload.total_count;
+        }
+
+        timestamps.push(
+          ...payload.items
+            .map((item) => item.commit?.author?.date)
+            .filter((date): date is string => Boolean(date))
+        );
+
+        if (payload.items.length < 100) {
+          break;
+        }
+
+        if (timestamps.length >= 1000 || timestamps.length >= totalCount) {
+          break;
+        }
+
+        page += 1;
+      }
+
+      return timestamps;
+    }
+  );
+}
+
+async function buildInsightsForAccount(
+  token: string,
+  githubLogin: string,
+  timeZone: string,
+  cacheContext: { bypass: boolean; userId: string }
+): Promise<CodingActivityInsight> {
+  const timestamps = await fetchCommitTimestampsForAccount(
+    token,
+    githubLogin,
+    cacheContext
+  );
+
+  return summarizeCodingActivity(timestamps, timeZone);
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const accountId = req.nextUrl.searchParams.get("accountId");
+  const timeZone = getRequestedTimeZone(req);
+  const bypass = isMetricsCacheBypassed(req);
+  const cacheUserId = session.githubId ?? session.githubLogin;
+
+  if (!accountId) {
+    try {
+      const data = await buildInsightsForAccount(
+        session.accessToken,
+        session.githubLogin,
+        timeZone,
+        { bypass, userId: cacheUserId }
+      );
+
+      return Response.json(data);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  if (!session.githubId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!userRow) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    if (accountId === "combined") {
+      const accounts = await getAllAccounts(
+        {
+          token: session.accessToken,
+          githubId: session.githubId,
+          githubLogin: session.githubLogin,
+        },
+        userRow.id
+      );
+
+      const results = await Promise.allSettled(
+        accounts.map((account) =>
+          fetchCommitTimestampsForAccount(account.token, account.githubLogin, {
+            bypass,
+            userId: account.githubId,
+          })
+        )
+      );
+
+      const fulfilled = results
+        .filter(
+          (result): result is PromiseFulfilledResult<string[]> =>
+            result.status === "fulfilled"
+        )
+        .map((result) => result.value);
+
+      if (fulfilled.length === 0) {
+        return Response.json({ error: "GitHub API error" }, { status: 502 });
+      }
+
+      const timestamps = fulfilled.flat();
+      const data = summarizeCodingActivity(timestamps, timeZone);
+      return Response.json(data);
+    }
+
+    if (accountId === session.githubId) {
+      const data = await buildInsightsForAccount(
+        session.accessToken,
+        session.githubLogin,
+        timeZone,
+        { bypass, userId: session.githubId }
+      );
+
+      return Response.json(data);
+    }
+
+    const token = await getAccountToken(userRow.id, accountId);
+    if (!token) {
+      return Response.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    const { data: accountRow } = await supabaseAdmin
+      .from("user_github_accounts")
+      .select("github_login")
+      .eq("user_id", userRow.id)
+      .eq("github_id", accountId)
+      .single();
+
+    if (!accountRow?.github_login) {
+      return Response.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    const data = await buildInsightsForAccount(token, accountRow.github_login, timeZone, {
+      bypass,
+      userId: accountId,
+    });
+
+    return Response.json(data);
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import TopRepos from "@/components/TopRepos";
 import PinnedRepos from "@/components/PinnedRepos";
 import LanguageBreakdown from "@/components/LanguageBreakdown";
 import CommitTimeChart from "@/components/CommitTimeChart";
+import CodingActivityInsightsCard from "@/components/CodingActivityInsightsCard";
 import PRReviewTrendChart from "@/components/PRReviewTrendChart";
 import CIAnalytics from "@/components/CIAnalytics";
 import IssueMetrics from "@/components/IssueMetrics";
@@ -73,6 +74,10 @@ export default async function DashboardPage() {
         <PRMetrics />
         <PRBreakdownChart />
         <CommitTimeChart />
+      </div>
+
+      <div className="mt-6">
+        <CodingActivityInsightsCard />
       </div>
 
       <div className="mt-6">

--- a/src/components/CodingActivityInsightsCard.tsx
+++ b/src/components/CodingActivityInsightsCard.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+  type TooltipProps,
+} from "recharts";
+import { useAccount } from "@/components/AccountContext";
+import {
+  formatHourRange,
+  type CodingActivityInsight,
+} from "@/lib/coding-activity-insights";
+
+const DATA_WINDOW_DAYS = 90;
+
+function formatCommitCount(count: number): string {
+  return `${count} commit${count === 1 ? "" : "s"}`;
+}
+
+function InsightRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-lg bg-[var(--control)] px-3 py-2">
+      <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+        {label}
+      </p>
+      <p className="mt-1 text-sm font-medium text-[var(--card-foreground)]">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function HourTooltip({
+  active,
+  payload,
+}: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const entry = payload[0]?.payload as { hour?: number; count?: number } | undefined;
+  if (!entry || typeof entry.hour !== "number") {
+    return null;
+  }
+
+  const count = entry.count ?? 0;
+
+  return (
+    <div className="rounded-md border border-[var(--border)] bg-[var(--tooltip)] px-3 py-2 text-sm text-[var(--tooltip-foreground)] shadow-lg">
+      <div className="font-medium">{formatHourRange(entry.hour)}</div>
+      <div className="mt-1 text-xs text-[var(--muted-foreground)]">
+        {formatCommitCount(count)}
+      </div>
+    </div>
+  );
+}
+
+export default function CodingActivityInsightsCard() {
+  const { selectedAccount } = useAccount();
+  const [timezone, setTimezone] = useState<string | null>(null);
+  const [data, setData] = useState<CodingActivityInsight | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    setTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone ?? null);
+  }, []);
+
+  const fetchInsights = useCallback(() => {
+    if (!timezone) {
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams();
+    params.set("timeZone", timezone);
+    if (selectedAccount !== null) {
+      params.set("accountId", selectedAccount);
+    }
+
+    fetch(`/api/metrics/coding-activity-insights?${params.toString()}`)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("API error");
+        }
+        return response.json();
+      })
+      .then((payload: CodingActivityInsight) => {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+
+        setData(payload);
+      })
+      .catch(() => {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+
+        setError("We couldn't load your coding activity insights right now. Please try again in a moment.");
+      })
+      .finally(() => {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+
+        setLoading(false);
+      });
+  }, [selectedAccount, timezone]);
+
+  useEffect(() => {
+    if (!timezone) {
+      return;
+    }
+
+    fetchInsights();
+  }, [fetchInsights, timezone]);
+
+  const chartData = useMemo(
+    () => data?.hourlyCounts.map(({ hour, count }) => ({ hour, count })) ?? [],
+    [data]
+  );
+
+  const hasData = Boolean(
+    data && data.totalActivities > 0 && chartData.some((entry) => entry.count > 0)
+  );
+
+  const insightRows = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+
+    const rows = [
+      {
+        label: "Most active",
+        value: `${data.mostActiveHour.label} with ${formatCommitCount(data.mostActiveHour.count)}`,
+      },
+      {
+        label: "Least active",
+        value: `${data.leastActiveHour.label} with ${formatCommitCount(data.leastActiveHour.count)}`,
+      },
+    ];
+
+    if (data.mostActiveDay) {
+      rows.push({
+        label: "Best day",
+        value: `${data.mostActiveDay.day} with ${formatCommitCount(data.mostActiveDay.count)}`,
+      });
+    }
+
+    return rows;
+  }, [data]);
+
+  const dataWindowLabel = `Last ${DATA_WINDOW_DAYS} days`;
+
+  const subtitle = data
+    ? `${dataWindowLabel} · Commits by hour · ${data.timezone}`
+    : timezone
+      ? `${dataWindowLabel} · Commits by hour · ${timezone}`
+      : `${dataWindowLabel} · Commits by hour · Local timezone`;
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            Coding Activity Insights
+          </h2>
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+            {subtitle}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={fetchInsights}
+          className="rounded-md border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--control)]"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading ? (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="space-y-4"
+        >
+          <span className="sr-only">Loading coding activity insights</span>
+          <div className="h-[260px] rounded-lg bg-[var(--card-muted)] animate-pulse" />
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {[1, 2, 3].map((item) => (
+              <div
+                key={item}
+                aria-hidden="true"
+                className="h-16 rounded-lg bg-[var(--card-muted)] animate-pulse"
+              />
+            ))}
+          </div>
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={fetchInsights}
+            className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
+          >
+            Try again
+          </button>
+        </div>
+      ) : !hasData ? (
+        <div className="flex min-h-[320px] items-center justify-center rounded-lg border border-dashed border-[var(--border)] bg-[var(--card-muted)] px-4 text-center">
+          <p className="text-sm text-[var(--muted-foreground)]">
+            Not enough commit activity to generate coding insights yet.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="h-[260px] min-h-[260px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={{ top: 8, right: 12, left: 0, bottom: 0 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  vertical={false}
+                  stroke="var(--border)"
+                  opacity={0.35}
+                />
+                <XAxis
+                  dataKey="hour"
+                  axisLine={false}
+                  tickLine={false}
+                  interval={2}
+                  tickFormatter={(value) => String(value)}
+                  style={{ fill: "var(--muted-foreground)", fontSize: "0.75rem" }}
+                />
+                <YAxis
+                  allowDecimals={false}
+                  axisLine={false}
+                  tickLine={false}
+                  width={28}
+                  style={{ fill: "var(--muted-foreground)", fontSize: "0.75rem" }}
+                />
+                <Tooltip content={HourTooltip} />
+                <Bar
+                  dataKey="count"
+                  fill="var(--accent)"
+                  radius={[4, 4, 0, 0]}
+                  barSize={10}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div
+            className={`grid gap-3 ${data?.mostActiveDay ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3" : "grid-cols-1 sm:grid-cols-2"}`}
+          >
+            {insightRows.map((row) => (
+              <InsightRow key={row.label} label={row.label} value={row.value} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/coding-activity-insights.ts
+++ b/src/lib/coding-activity-insights.ts
@@ -1,0 +1,183 @@
+export interface CodingActivityHourlyCount {
+  hour: number;
+  count: number;
+}
+
+export interface CodingActivityInsightDayCount {
+  day: string;
+  count: number;
+}
+
+export interface CodingActivityInsight {
+  timezone: string;
+  hourlyCounts: CodingActivityHourlyCount[];
+  mostActiveHour: {
+    hour: number;
+    count: number;
+    label: string;
+  };
+  leastActiveHour: {
+    hour: number;
+    count: number;
+    label: string;
+  };
+  mostActiveDay?: {
+    day: string;
+    count: number;
+  };
+  totalActivities: number;
+  dayCounts?: CodingActivityInsightDayCount[];
+}
+
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+function formatClockHour(hour: number): string {
+  const normalizedHour = ((hour % 24) + 24) % 24;
+  const period = normalizedHour < 12 ? "AM" : "PM";
+  const displayHour = normalizedHour % 12 === 0 ? 12 : normalizedHour % 12;
+  return `${displayHour} ${period}`;
+}
+
+export function formatHourRange(hour: number): string {
+  return `${formatClockHour(hour)} – ${formatClockHour(hour + 1)}`;
+}
+
+function getHourInTimeZone(date: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+
+  const hourPart = parts.find((part) => part.type === "hour")?.value ?? "0";
+  const parsedHour = Number(hourPart);
+  return Number.isFinite(parsedHour) ? parsedHour : 0;
+}
+
+function getDayNameInTimeZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "long",
+  }).formatToParts(date);
+
+  const dayPart = parts.find((part) => part.type === "weekday")?.value ?? "Sunday";
+  return DAY_NAMES.includes(dayPart) ? dayPart : "Sunday";
+}
+
+function normalizeOffsetLabel(value: string): string {
+  const normalized = value.replace(/^GMT/, "UTC");
+  return /^UTC[+-]/.test(normalized) ? normalized.replace(/^UTC/, "UTC ") : normalized;
+}
+
+export function formatTimeZoneLabel(timeZone: string): string {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "shortOffset",
+    });
+    const offset = formatter
+      .formatToParts(new Date())
+      .find((part) => part.type === "timeZoneName")?.value;
+
+    if (offset) {
+      return normalizeOffsetLabel(offset);
+    }
+  } catch {
+    // Fallback to the raw zone name below.
+  }
+
+  return timeZone;
+}
+
+function pickHighestCount<T extends { count: number }>(items: T[]): T | null {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return items.reduce((best, current) => {
+    if (current.count > best.count) {
+      return current;
+    }
+
+    return best;
+  }, items[0]);
+}
+
+function pickLowestNonZeroCount<T extends { count: number }>(items: T[]): T | null {
+  const nonZeroItems = items.filter((item) => item.count > 0);
+
+  if (nonZeroItems.length === 0) {
+    return null;
+  }
+
+  return nonZeroItems.reduce((best, current) => {
+    if (current.count < best.count) {
+      return current;
+    }
+
+    return best;
+  }, nonZeroItems[0]);
+}
+
+export function summarizeCodingActivity(
+  timestamps: string[],
+  timeZone: string
+): CodingActivityInsight {
+  const hourlyCounts = Array.from({ length: 24 }, (_, hour) => ({
+    hour,
+    count: 0,
+  }));
+  const dayCounts = DAY_NAMES.map((day) => ({ day, count: 0 }));
+
+  let totalActivities = 0;
+
+  for (const timestamp of timestamps) {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+      continue;
+    }
+
+    totalActivities += 1;
+    const hour = getHourInTimeZone(date, timeZone);
+    hourlyCounts[hour].count += 1;
+
+    const dayName = getDayNameInTimeZone(date, timeZone);
+    const dayIndex = DAY_NAMES.indexOf(dayName);
+    if (dayIndex >= 0) {
+      dayCounts[dayIndex].count += 1;
+    }
+  }
+
+  const mostActiveHour = pickHighestCount(hourlyCounts) ?? hourlyCounts[0];
+  const leastActiveHour = pickLowestNonZeroCount(hourlyCounts) ?? hourlyCounts[0];
+  const mostActiveDay = pickHighestCount(dayCounts);
+
+  return {
+    timezone: formatTimeZoneLabel(timeZone),
+    hourlyCounts,
+    mostActiveHour: {
+      hour: mostActiveHour.hour,
+      count: mostActiveHour.count,
+      label: formatHourRange(mostActiveHour.hour),
+    },
+    leastActiveHour: {
+      hour: leastActiveHour.hour,
+      count: leastActiveHour.count,
+      label: formatHourRange(leastActiveHour.hour),
+    },
+    mostActiveDay:
+      mostActiveDay && mostActiveDay.count > 0
+        ? { day: mostActiveDay.day, count: mostActiveDay.count }
+        : undefined,
+    totalActivities,
+    dayCounts: dayCounts.some((item) => item.count > 0) ? dayCounts : undefined,
+  };
+}

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -10,6 +10,7 @@ export const METRICS_CACHE_TTL_SECONDS = {
   streak_freeze: 2 * 60,
   activity: 5 * 60,
   issues: 10 * 60,
+  "coding-activity-insights": 5 * 60,
 } as const;
 
 type MetricsCacheEndpoint = keyof typeof METRICS_CACHE_TTL_SECONDS;


### PR DESCRIPTION
## Summary

Adds a new Coding Activity Insights dashboard card that visualizes commit activity by hour and surfaces the most active hour, least active hour, and most active day when available. The card uses the user’s local timezone, clearly indicates the data window as the last 90 days, and includes loading, error, and empty states.

Closes #859

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made


Added a reusable coding activity summarizer utility for hourly and day-wise aggregation.
Added a new /api/metrics/coding-activity-insights endpoint to fetch and aggregate commit timestamps.
Wired the new card into the dashboard layout.
Updated metrics cache configuration for the new endpoint.
Added unit tests for the aggregation logic.


## Screenshots (if UI change)
**
<img width="1778" height="562" alt="image" src="https://github.com/user-attachments/assets/65e2bb77-6ad7-4969-9e60-bfcbb365b7bb" />
**
## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
