### PR TITLE
feat : added  inctive repo section

### DIFF
--- a/src/app/api/metrics/inactive-repos/route.ts
+++ b/src/app/api/metrics/inactive-repos/route.ts
@@ -1,0 +1,239 @@
+import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { getAccountToken, getAllAccounts, mergeMetrics } from "@/lib/github-accounts";
+import { fetchUserRepos, type GitHubRepo } from "@/lib/github";
+import {
+  isMetricsCacheBypassed,
+  METRICS_CACHE_TTL_SECONDS,
+  metricsCacheKey,
+  withMetricsCache,
+} from "@/lib/metrics-cache";
+import { resolveAppUser } from "@/lib/resolve-user";
+import { supabaseAdmin } from "@/lib/supabase";
+import type { InactiveRepo, InactiveReposResponse, RepoVisibility } from "@/types/inactive-repos";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_THRESHOLDS = new Set([30, 60, 90]);
+
+function parseThreshold(value: string | null): number {
+  const parsed = Number.parseInt(value ?? "30", 10);
+  return ALLOWED_THRESHOLDS.has(parsed) ? parsed : 30;
+}
+
+function getVisibility(repo: GitHubRepo): RepoVisibility {
+  if (repo.visibility === "public" || repo.visibility === "private" || repo.visibility === "internal") {
+    return repo.visibility;
+  }
+
+  return repo.private ? "private" : "public";
+}
+
+function getLastActiveAt(repo: GitHubRepo): string | null {
+  return repo.pushed_at ?? repo.updated_at ?? null;
+}
+
+function formatInactiveRepo(repo: GitHubRepo, thresholdDays: number): InactiveRepo | null {
+  const lastActiveAt = getLastActiveAt(repo);
+
+  if (!lastActiveAt) {
+    return null;
+  }
+
+  const activityDate = new Date(lastActiveAt);
+
+  if (Number.isNaN(activityDate.getTime())) {
+    return null;
+  }
+
+  const inactiveDays = Math.floor((Date.now() - activityDate.getTime()) / 86400000);
+
+  if (inactiveDays < thresholdDays) {
+    return null;
+  }
+
+  return {
+    name: repo.full_name,
+    lastActiveAt: activityDate.toISOString(),
+    inactiveDays,
+    visibility: getVisibility(repo),
+    url: repo.html_url,
+  };
+}
+
+function sortInactiveRepos(repos: InactiveRepo[]): InactiveRepo[] {
+  return [...repos].sort((a, b) => {
+    if (b.inactiveDays !== a.inactiveDays) {
+      return b.inactiveDays - a.inactiveDays;
+    }
+
+    return new Date(a.lastActiveAt).getTime() - new Date(b.lastActiveAt).getTime();
+  });
+}
+
+function mergeInactiveRepoLists(a: InactiveRepo[], b: InactiveRepo[]): InactiveRepo[] {
+  const map = new Map<string, InactiveRepo>();
+
+  for (const repo of [...a, ...b]) {
+    const existing = map.get(repo.name);
+
+    if (!existing) {
+      map.set(repo.name, repo);
+      continue;
+    }
+
+    const currentTime = new Date(repo.lastActiveAt).getTime();
+    const existingTime = new Date(existing.lastActiveAt).getTime();
+
+    if (repo.inactiveDays > existing.inactiveDays || (repo.inactiveDays === existing.inactiveDays && currentTime < existingTime)) {
+      map.set(repo.name, repo);
+    }
+  }
+
+  return sortInactiveRepos(Array.from(map.values()));
+}
+
+async function fetchInactiveReposForAccount(
+  token: string,
+  githubLogin: string,
+  thresholdDays: number,
+  cacheContext: { bypass: boolean; userId: string }
+): Promise<InactiveReposResponse> {
+  const key = metricsCacheKey(cacheContext.userId, "inactive-repos", {
+    thresholdDays,
+    githubLogin,
+  });
+
+  return withMetricsCache(
+    {
+      bypass: cacheContext.bypass,
+      key,
+      ttlSeconds: METRICS_CACHE_TTL_SECONDS["inactive-repos"],
+    },
+    async () => {
+      const repos = await fetchUserRepos(token);
+      const inactiveRepos = repos
+        .map((repo) => formatInactiveRepo(repo, thresholdDays))
+        .filter((repo): repo is InactiveRepo => repo !== null);
+
+      return {
+        repos: sortInactiveRepos(inactiveRepos),
+        thresholdDays,
+      };
+    }
+  );
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const thresholdDays = parseThreshold(req.nextUrl.searchParams.get("days"));
+  const accountId = req.nextUrl.searchParams.get("accountId");
+  const bypass = isMetricsCacheBypassed(req);
+
+  if (!accountId) {
+    try {
+      const result = await fetchInactiveReposForAccount(
+        session.accessToken,
+        session.githubLogin,
+        thresholdDays,
+        { bypass, userId: session.githubId ?? session.githubLogin }
+      );
+
+      return Response.json(result);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  if (!session.githubId) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userRow = await resolveAppUser(session.githubId, session.githubLogin);
+
+  if (!userRow) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (accountId === "combined") {
+    const accounts = await getAllAccounts(
+      {
+        token: session.accessToken,
+        githubId: session.githubId,
+        githubLogin: session.githubLogin,
+      },
+      userRow.id
+    );
+
+    const results = await Promise.allSettled(
+      accounts.map((account) =>
+        fetchInactiveReposForAccount(account.token, account.githubLogin, thresholdDays, {
+          bypass,
+          userId: account.githubId,
+        })
+      )
+    );
+
+    const merged = mergeMetrics(results, (a, b) => ({
+      thresholdDays: a.thresholdDays,
+      repos: mergeInactiveRepoLists(a.repos, b.repos),
+    }));
+
+    if (!merged) {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+
+    return Response.json(merged);
+  }
+
+  if (accountId === session.githubId) {
+    try {
+      const result = await fetchInactiveReposForAccount(
+        session.accessToken,
+        session.githubLogin,
+        thresholdDays,
+        { bypass, userId: session.githubId }
+      );
+
+      return Response.json(result);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
+  }
+
+  const accountToken = await getAccountToken(userRow.id, accountId);
+
+  if (!accountToken) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  const { data: accountRow } = await supabaseAdmin
+    .from("user_github_accounts")
+    .select("github_login")
+    .eq("user_id", userRow.id)
+    .eq("github_id", accountId)
+    .single();
+
+  if (!accountRow?.github_login) {
+    return Response.json({ error: "Account not found" }, { status: 404 });
+  }
+
+  try {
+    const result = await fetchInactiveReposForAccount(
+      accountToken,
+      accountRow.github_login,
+      thresholdDays,
+      { bypass, userId: accountId }
+    );
+
+    return Response.json(result);
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import DashboardHeader from "@/components/DashboardHeader";
 import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
 import PinnedRepos from "@/components/PinnedRepos";
+import InactiveRepositoriesCard from "@/components/InactiveRepositoriesCard";
 import LanguageBreakdown from "@/components/LanguageBreakdown";
 import CommitTimeChart from "@/components/CommitTimeChart";
 import PRReviewTrendChart from "@/components/PRReviewTrendChart";
@@ -92,14 +93,19 @@ export default async function DashboardPage() {
         <PinnedRepos />
       </div>
 
-      {/* Row 5: Top repos + Language breakdown + Goal tracker */}
+      {/* Row 5: Inactive repository reminder */}
+      <div className="mt-6">
+        <InactiveRepositoriesCard />
+      </div>
+
+      {/* Row 6: Top repos + Language breakdown + Goal tracker */}
       <div className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
         <TopRepos />
         <LanguageBreakdown />
         <GoalTracker />
       </div>
 
-      {/* Row 6: Recent GitHub activity */}
+      {/* Row 7: Recent GitHub activity */}
       <div className="mt-6">
         <RecentActivity />
       </div>

--- a/src/components/InactiveRepositoriesCard.tsx
+++ b/src/components/InactiveRepositoriesCard.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAccount } from "@/components/AccountContext";
+import type { InactiveRepo } from "@/types/inactive-repos";
+
+const THRESHOLDS = [30, 60, 90] as const;
+type ThresholdDays = (typeof THRESHOLDS)[number];
+
+function formatLastActive(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown date";
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatVisibility(value: InactiveRepo["visibility"]): string {
+  if (value === "internal") {
+    return "internal";
+  }
+
+  if (value === "unknown") {
+    return "unknown";
+  }
+
+  return value;
+}
+
+export default function InactiveRepositoriesCard() {
+  const { selectedAccount } = useAccount();
+  const [thresholdDays, setThresholdDays] = useState<ThresholdDays>(30);
+  const [repos, setRepos] = useState<InactiveRepo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchInactiveRepos = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    const accountParam =
+      selectedAccount !== null
+        ? `&accountId=${encodeURIComponent(selectedAccount)}`
+        : "";
+
+    fetch(`/api/metrics/inactive-repos?days=${thresholdDays}${accountParam}`)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("API error");
+        }
+
+        return response.json();
+      })
+      .then((payload: { repos?: InactiveRepo[] }) => {
+        setRepos(payload.repos ?? []);
+      })
+      .catch(() => {
+        setError("We couldn't load inactive repositories right now. Please try again in a moment.");
+      })
+      .finally(() => setLoading(false));
+  }, [selectedAccount, thresholdDays]);
+
+  useEffect(() => {
+    fetchInactiveRepos();
+  }, [fetchInactiveRepos]);
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            Inactive Repository Reminder
+          </h2>
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+            Repositories without recent pushes in your selected window
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={thresholdDays}
+            onChange={(event) => setThresholdDays(Number(event.target.value) as ThresholdDays)}
+            aria-label="Select inactivity threshold"
+            className="rounded-lg border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--card-foreground)] focus:border-[var(--accent)] focus:outline-none"
+          >
+            {THRESHOLDS.map((days) => (
+              <option key={days} value={days}>
+                {days} days
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={fetchInactiveRepos}
+            className="rounded-md border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--control)]"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="max-h-[320px] overflow-y-auto pr-1 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-[var(--border)]">
+        {loading ? (
+          <div role="status" aria-live="polite" aria-busy="true" className="space-y-3">
+            <span className="sr-only">Loading inactive repositories</span>
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                aria-hidden="true"
+                className="h-20 rounded-lg bg-[var(--card-muted)] animate-pulse"
+              />
+            ))}
+          </div>
+        ) : error ? (
+          <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
+            <p>{error}</p>
+            <button
+              type="button"
+              onClick={fetchInactiveRepos}
+              className="mt-3 rounded-md border border-[var(--destructive)]/30 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10"
+            >
+              Try again
+            </button>
+          </div>
+        ) : repos.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--card-muted)] p-4 text-sm text-[var(--muted-foreground)]">
+            Nice! No inactive repositories for this period.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {repos.map((repo) => (
+              <li key={repo.name}>
+                <a
+                  href={repo.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block rounded-lg border border-[var(--border)] bg-[var(--control)] p-4 transition-colors hover:border-[var(--accent)]"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="truncate text-sm font-semibold text-[var(--card-foreground)]">
+                          {repo.name}
+                        </span>
+                        <span className="rounded-full border border-[var(--border)] bg-[var(--card)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+                          {formatVisibility(repo.visibility)}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                        Open on GitHub
+                      </p>
+                    </div>
+
+                    <div className="flex shrink-0 flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--muted-foreground)] sm:text-right">
+                      <span>Last active: {formatLastActive(repo.lastActiveAt)}</span>
+                      <span>{repo.inactiveDays} inactive days</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,18 +30,41 @@ export async function fetchUserEvents(token: string): Promise<GitHubEvent[]> {
   return res.json();
 }
 
-export async function fetchUserRepos(token: string): Promise<GitHubRepo[]> {
-  const res = await githubFetch(
-    `${GITHUB_API}/user/repos?sort=pushed&per_page=10`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-      },
+interface FetchUserReposOptions {
+  perPage?: number;
+  maxPages?: number;
+}
+
+export async function fetchUserRepos(
+  token: string,
+  options: FetchUserReposOptions = {}
+): Promise<GitHubRepo[]> {
+  const perPage = options.perPage ?? 100;
+  const maxPages = options.maxPages ?? 10;
+  const repos: GitHubRepo[] = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const res = await githubFetch(
+      `${GITHUB_API}/user/repos?visibility=all&sort=pushed&direction=desc&per_page=${perPage}&page=${page}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+      }
+    );
+
+    if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+
+    const pageRepos = (await res.json()) as GitHubRepo[];
+    repos.push(...pageRepos);
+
+    if (pageRepos.length < perPage) {
+      break;
     }
-  );
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
-  return res.json();
+  }
+
+  return repos;
 }
 
 export interface GitHubEvent {
@@ -55,9 +78,14 @@ export interface GitHubRepo {
   id: number;
   name: string;
   full_name: string;
+  html_url: string;
+  private: boolean;
+  visibility?: "public" | "private" | "internal";
   open_issues_count: number;
   stargazers_count: number;
-  pushed_at: string;
+  pushed_at: string | null;
+  updated_at: string;
+  archived?: boolean;
 }
 
 export interface GitHubCommitSearchItem {

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -4,6 +4,7 @@ import type { NextRequest } from "next/server";
 export const METRICS_CACHE_TTL_SECONDS = {
   contributions: 5 * 60,
   repos: 10 * 60,
+  "inactive-repos": 10 * 60,
   prs: 10 * 60,
   "pr-review-time": 10 * 60,
   streak: 2 * 60,

--- a/src/types/inactive-repos.ts
+++ b/src/types/inactive-repos.ts
@@ -1,0 +1,14 @@
+export type RepoVisibility = "public" | "private" | "internal" | "unknown";
+
+export interface InactiveRepo {
+  name: string;
+  lastActiveAt: string;
+  inactiveDays: number;
+  visibility: RepoVisibility;
+  url: string;
+}
+
+export interface InactiveReposResponse {
+  repos: InactiveRepo[];
+  thresholdDays: number;
+}


### PR DESCRIPTION
## Summary

Adds an Inactive Repository Reminder dashboard card that shows GitHub repositories with no recent activity based on `pushed_at`, with threshold filters for 30, 60, and 90 days.

Closes #861

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added a new `/api/metrics/inactive-repos` route to fetch and compute inactive repositories from authenticated GitHub data.
- Reused the existing GitHub repo fetch flow and added pagination so all user repositories are considered.
- Created `InactiveRepositoriesCard` with loading, error, empty, and success states.
- Added a 30/60/90 day dropdown to filter inactive repositories.
- Displayed repository name, last active date, inactive days, visibility, and a GitHub link.
- Added the new card to the dashboard layout without changing existing cards.

## How to Test

1. Sign in and open the dashboard.
2. Open the Inactive Repository Reminder card and switch between 30, 60, and 90 days.
3. Verify inactive repositories are shown sorted by most inactive first.
4. Verify the empty state appears when no repositories qualify.
5. Confirm loading and error states render correctly.

## Screenshots (if UI change)
<img width="1772" height="574" alt="image" src="https://github.com/user-attachments/assets/7d3bccf3-85ac-4813-ad6c-2b55831fdc8b" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable