### PR TITLE
enhance : improve the UX/UI of exported PDF and CSV

### DIFF
--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 
@@ -23,9 +24,256 @@ interface Goal {
   current: number;
 }
 
+interface MonthlySummary {
+  month: string;
+  totalCommits: number;
+  activeDays: number;
+  bestDay: string;
+}
+
+interface GoalStatusSummary {
+  completed: number;
+  inProgress: number;
+  notStarted: number;
+}
+
+function formatDateLabel(dateInput: string): string {
+  const parsed = new Date(`${dateInput}T00:00:00`);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return dateInput;
+  }
+
+  return parsed.toLocaleDateString("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatGeneratedTimestamp(date = new Date()): string {
+  return date.toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function formatProgressValue(progress: number): string {
+  return `${progress.toFixed(1)}%`;
+}
+
+function getGoalProgress(goal: Goal): number {
+  if (goal.target <= 0) {
+    return 0;
+  }
+
+  return Math.min((goal.current / goal.target) * 100, 100);
+}
+
+function getGoalStatus(goal: Goal): string {
+  const progress = getGoalProgress(goal);
+
+  if (progress >= 100) {
+    return "Completed";
+  }
+
+  if (goal.current > 0) {
+    return "In Progress";
+  }
+
+  return "Not Started";
+}
+
+function getTotalCommits(commitActivity: DayData[]): number {
+  return commitActivity.reduce((total, day) => total + day.commits, 0);
+}
+
+function getActiveDays(commitActivity: DayData[]): number {
+  return commitActivity.filter((day) => day.commits > 0).length;
+}
+
+function getBestCommitDay(commitActivity: DayData[]): DayData | null {
+  if (commitActivity.length === 0) {
+    return null;
+  }
+
+  return commitActivity.reduce((best, current) => {
+    if (current.commits > best.commits) {
+      return current;
+    }
+
+    if (current.commits === best.commits && current.day < best.day) {
+      return current;
+    }
+
+    return best;
+  }, commitActivity[0]);
+}
+
+function getHighestCommitsInOneDay(commitActivity: DayData[]): number {
+  return getBestCommitDay(commitActivity)?.commits ?? 0;
+}
+
+function getAverageGoalProgress(goals: Goal[]): number {
+  if (goals.length === 0) {
+    return 0;
+  }
+
+  const totalProgress = goals.reduce((total, goal) => total + getGoalProgress(goal), 0);
+
+  return totalProgress / goals.length;
+}
+
+function getGoalStatusSummary(goals: Goal[]): GoalStatusSummary {
+  return goals.reduce(
+    (summary, goal) => {
+      const status = getGoalStatus(goal);
+
+      if (status === "Completed") {
+        summary.completed += 1;
+      } else if (status === "In Progress") {
+        summary.inProgress += 1;
+      } else {
+        summary.notStarted += 1;
+      }
+
+      return summary;
+    },
+    { completed: 0, inProgress: 0, notStarted: 0 }
+  );
+}
+
+function getMonthlySummary(commitActivity: DayData[]): MonthlySummary[] {
+  const months = new Map<
+    string,
+    {
+      totalCommits: number;
+      activeDays: number;
+      bestDay: DayData | null;
+    }
+  >();
+
+  commitActivity.forEach((day) => {
+    const monthKey = day.day.slice(0, 7);
+    const existing = months.get(monthKey) ?? {
+      totalCommits: 0,
+      activeDays: 0,
+      bestDay: null,
+    };
+
+    existing.totalCommits += day.commits;
+
+    if (day.commits > 0) {
+      existing.activeDays += 1;
+    }
+
+    if (!existing.bestDay || day.commits > existing.bestDay.commits) {
+      existing.bestDay = day;
+    }
+
+    months.set(monthKey, existing);
+  });
+
+  return Array.from(months.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([monthKey, value]) => {
+      const monthDate = new Date(`${monthKey}-01T00:00:00`);
+
+      return {
+        month: monthDate.toLocaleDateString("en-US", {
+          month: "short",
+          year: "numeric",
+        }),
+        totalCommits: value.totalCommits,
+        activeDays: value.activeDays,
+        bestDay: value.bestDay ? formatDateLabel(value.bestDay.day) : "-",
+      };
+    });
+}
+
+function getExportInsights(goals: Goal[], commitActivity: DayData[]): string[] {
+  const insights: string[] = [];
+  const totalCommits = getTotalCommits(commitActivity);
+  const activeDays = getActiveDays(commitActivity);
+  const bestDay = getBestCommitDay(commitActivity);
+  const goalSummary = getGoalStatusSummary(goals);
+
+  if (bestDay) {
+    insights.push(
+      `Most productive day: ${formatDateLabel(bestDay.day)} with ${bestDay.commits} commits.`
+    );
+  }
+
+  if (activeDays > 0) {
+    insights.push(`You were active on ${activeDays} different days in this report.`);
+  } else {
+    insights.push("No active commit days were captured in this report.");
+  }
+
+  if (goals.length > 0) {
+    if (
+      goalSummary.notStarted >= goalSummary.inProgress &&
+      goalSummary.notStarted >= goalSummary.completed
+    ) {
+      insights.push(`${goalSummary.notStarted} goals are currently not started.`);
+    } else if (goalSummary.inProgress >= goalSummary.completed) {
+      insights.push(`${goalSummary.inProgress} goals are currently in progress.`);
+    } else {
+      insights.push(`${goalSummary.completed} goals are already completed.`);
+    }
+  } else {
+    insights.push("No goals were included in this export.");
+  }
+
+  if (totalCommits > 0 && insights.length < 3) {
+    insights.push(`Total commit volume in this report: ${totalCommits} commits.`);
+  }
+
+  return insights.slice(0, 3);
+}
+
+function escapeCsvCell(value: string | number): string {
+  const text = String(value);
+
+  if (/[,"\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+
+  return text;
+}
+
+function appendCsvRow(cells: Array<string | number>): string {
+  return `${cells.map(escapeCsvCell).join(",")}\n`;
+}
+
+function addFooter(doc: jsPDF, generatedAt: string) {
+  const pageCount = doc.getNumberOfPages();
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+
+  for (let page = 1; page <= pageCount; page += 1) {
+    doc.setPage(page);
+    doc.setDrawColor(226, 232, 240);
+    doc.line(14, pageHeight - 16, pageWidth - 14, pageHeight - 16);
+    doc.setFontSize(9);
+    doc.setTextColor(100, 116, 139);
+    doc.text("Generated by DevTrack", 14, pageHeight - 10);
+    doc.text(`Exported ${generatedAt}`, pageWidth / 2, pageHeight - 10, {
+      align: "center",
+    });
+    doc.text(`Page ${page}`, pageWidth - 14, pageHeight - 10, { align: "right" });
+  }
+}
+
 export default function ExportButton() {
+  const { data: session } = useSession();
   const [isExportingCSV, setIsExportingCSV] = useState(false);
   const [isExportingPDF, setIsExportingPDF] = useState(false);
+
+  const reportName = useMemo(
+    () => session?.githubLogin ?? session?.user?.name ?? "",
+    [session]
+  );
 
   const fetchData = async () => {
     const fetchOptions: RequestInit = {
@@ -65,33 +313,87 @@ export default function ExportButton() {
     setIsExportingCSV(true);
     try {
       const { prData, goalsData, contribData } = await fetchData();
+      const generatedAt = formatGeneratedTimestamp();
+      const totalCommits = getTotalCommits(contribData);
+      const activeDays = getActiveDays(contribData);
+      const bestDay = getBestCommitDay(contribData);
+      const highestCommits = getHighestCommitsInOneDay(contribData);
+      const averageGoalProgress = getAverageGoalProgress(goalsData);
+      const monthlySummary = getMonthlySummary(contribData);
+      const insights = getExportInsights(goalsData, contribData);
+      const goalStatusSummary = getGoalStatusSummary(goalsData);
 
-      // FIX: Separate sheets using proper CSV sections without dashes
-      // PR Metrics sheet
-      let csv = "PR Metrics\n";
-      csv += "Open,Merged,Avg Review Hours,Merge Rate\n";
+      let csv = "Report Summary\n";
+      csv += appendCsvRow(["Generated on", generatedAt]);
+      if (reportName) {
+        csv += appendCsvRow(["GitHub user", `@${reportName}`]);
+      }
+      csv += appendCsvRow(["Total commits", totalCommits]);
+      csv += appendCsvRow(["Active coding days", activeDays]);
+      csv += appendCsvRow(["Best commit day", bestDay ? formatDateLabel(bestDay.day) : "-"]);
+      csv += appendCsvRow(["Highest commits in one day", highestCommits]);
+      csv += appendCsvRow(["Total goals", goalsData.length]);
+      csv += appendCsvRow(["Average goal progress", `${averageGoalProgress.toFixed(1)}%`]);
+
+      csv += "\nPR Metrics\n";
+      csv += appendCsvRow(["Open", "Merged", "Avg Review Hours", "Merge Rate"]);
       if (prData) {
-        csv += `${prData.open},${prData.merged},${prData.avgReviewHours},${prData.mergeRate}\n`;
+        csv += appendCsvRow([
+          prData.open,
+          prData.merged,
+          prData.avgReviewHours,
+          prData.mergeRate,
+        ]);
       }
 
-      // Contributions sheet
-      if (contribData && contribData.length > 0) {
+      csv += "\nInsights\n";
+      csv += appendCsvRow(["Insight"]);
+      insights.forEach((insight) => {
+        csv += appendCsvRow([insight]);
+      });
+
+      if (goalsData.length > 0) {
+        csv += "\nGoals Tracker\n";
+        csv += appendCsvRow(["Goal Label", "Current", "Target", "Progress (%)", "Status"]);
+        goalsData.forEach((goal) => {
+          csv += appendCsvRow([
+            goal.label,
+            goal.current,
+            goal.target,
+            formatProgressValue(getGoalProgress(goal)),
+            getGoalStatus(goal),
+          ]);
+        });
+      }
+
+      if (contribData.length > 0) {
         csv += "\nCommit Activity\n";
-        csv += "Date,Commits\n";
-        contribData.forEach((d) => {
-          csv += `${d.day},${d.commits}\n`;
+        csv += appendCsvRow(["Date", "Commits"]);
+        contribData.forEach((day) => {
+          csv += appendCsvRow([formatDateLabel(day.day), day.commits]);
         });
       }
 
-      // Goals sheet
-      if (goalsData && goalsData.length > 0) {
-        csv += "\nGoals\n";
-        csv += "Label,Current,Target,Progress (%)\n";
-        goalsData.forEach((g) => {
-          const pct = g.target > 0 ? ((g.current / g.target) * 100).toFixed(1) : "0";
-          csv += `"${g.label}",${g.current},${g.target},${pct}%\n`;
+      if (monthlySummary.length > 0) {
+        csv += "\nMonthly Summary\n";
+        csv += appendCsvRow(["Month", "Total Commits", "Active Days", "Best Day"]);
+        monthlySummary.forEach((entry) => {
+          csv += appendCsvRow([
+            entry.month,
+            entry.totalCommits,
+            entry.activeDays,
+            entry.bestDay,
+          ]);
         });
       }
+
+      csv += "\nGoal Status Overview\n";
+      csv += appendCsvRow(["Completed", "In Progress", "Not Started"]);
+      csv += appendCsvRow([
+        goalStatusSummary.completed,
+        goalStatusSummary.inProgress,
+        goalStatusSummary.notStarted,
+      ]);
 
       downloadFile(csv, "dashboard-metrics.csv", "text/csv");
     } finally {
@@ -104,70 +406,248 @@ export default function ExportButton() {
     try {
       const { prData, goalsData, contribData } = await fetchData();
       const doc = new jsPDF();
+      const generatedAt = formatGeneratedTimestamp();
+      const totalCommits = getTotalCommits(contribData);
+      const activeDays = getActiveDays(contribData);
+      const bestDay = getBestCommitDay(contribData);
+      const highestCommits = getHighestCommitsInOneDay(contribData);
+      const averageGoalProgress = getAverageGoalProgress(goalsData);
+      const monthlySummary = getMonthlySummary(contribData);
+      const insights = getExportInsights(goalsData, contribData);
+      const pageWidth = doc.internal.pageSize.getWidth();
+      const marginX = 14;
+      const contentWidth = pageWidth - marginX * 2;
+      const cardGap = 4;
+      const cardWidth = (contentWidth - cardGap * 2) / 3;
+      const cardHeight = 26;
 
-      // Title
-      doc.setFontSize(20);
-      doc.setTextColor(40, 40, 40);
-      doc.text("Dashboard Metrics Export", 14, 20);
-      doc.setFontSize(10);
-      doc.setTextColor(120, 120, 120);
-      doc.text(`Generated on ${new Date().toLocaleDateString()}`, 14, 27);
+      const drawSectionTitle = (title: string, y: number) => {
+        doc.setFontSize(14);
+        doc.setTextColor(15, 23, 42);
+        doc.setFont("helvetica", "bold");
+        doc.text(title, marginX, y);
+      };
 
-      // FIX: Track Y position properly after each table
-      let currentY = 35;
+      const drawSummaryCard = (
+        x: number,
+        y: number,
+        label: string,
+        value: string,
+        accent: [number, number, number]
+      ) => {
+        doc.setFillColor(248, 250, 252);
+        doc.setDrawColor(226, 232, 240);
+        doc.roundedRect(x, y, cardWidth, cardHeight, 3, 3, "FD");
+        doc.setFillColor(accent[0], accent[1], accent[2]);
+        doc.roundedRect(x, y, 2.5, cardHeight, 3, 3, "F");
+        doc.setFontSize(9);
+        doc.setTextColor(100, 116, 139);
+        doc.setFont("helvetica", "normal");
+        doc.text(label, x + 6, y + 9);
+        doc.setFontSize(13);
+        doc.setTextColor(15, 23, 42);
+        doc.setFont("helvetica", "bold");
+        doc.text(value, x + 6, y + 18);
+      };
 
-      // PR Analytics section
+      const drawInsightBox = (startY: number) => {
+        const boxHeight = 22 + insights.length * 8;
+        doc.setFillColor(248, 250, 252);
+        doc.setDrawColor(226, 232, 240);
+        doc.roundedRect(marginX, startY, contentWidth, boxHeight, 4, 4, "FD");
+        doc.setFontSize(10);
+        doc.setTextColor(100, 116, 139);
+        doc.setFont("helvetica", "bold");
+        doc.text("Quick Insights", marginX + 6, startY + 8);
+        doc.setFontSize(10);
+        doc.setTextColor(15, 23, 42);
+        doc.setFont("helvetica", "normal");
+        insights.forEach((insight, index) => {
+          doc.text(`• ${insight}`, marginX + 8, startY + 16 + index * 8, {
+            maxWidth: contentWidth - 14,
+          });
+        });
+      };
+
+      const drawMetricTable = (
+        title: string,
+        startY: number,
+        head: string[][],
+        body: Array<Array<string | number>>,
+        columnStyles: Record<string, { halign?: "left" | "center" | "right"; cellWidth?: number }> = {}
+      ) => {
+        drawSectionTitle(title, startY);
+        autoTable(doc, {
+          startY: startY + 4,
+          head,
+          body,
+          margin: { left: marginX, right: marginX, bottom: 20 },
+          theme: "grid",
+          styles: {
+            fontSize: 9,
+            cellPadding: 3,
+            lineColor: [226, 232, 240],
+            lineWidth: 0.2,
+            textColor: [15, 23, 42],
+            overflow: "linebreak",
+          },
+          headStyles: {
+            fillColor: [30, 41, 59],
+            textColor: [255, 255, 255],
+            fontStyle: "bold",
+            halign: "left",
+          },
+          alternateRowStyles: { fillColor: [248, 250, 252] },
+          pageBreak: "auto",
+          rowPageBreak: "avoid",
+          columnStyles,
+        });
+
+        return ((doc as any).lastAutoTable?.finalY ?? startY) + 8;
+      };
+
+      doc.setFont("helvetica", "bold");
+      doc.setTextColor(15, 23, 42);
+      doc.setFontSize(22);
+      doc.text("Developer Metrics Report", marginX, 18);
+      doc.setFontSize(11);
+      doc.setTextColor(71, 85, 105);
+      doc.text("Generated from DevTrack", marginX, 25);
+      doc.setFontSize(9);
+      doc.text(`Generated ${generatedAt}`, marginX, 31);
+      if (reportName) {
+        doc.text(`GitHub user: @${reportName}`, pageWidth - marginX, 18, {
+          align: "right",
+        });
+      }
+
+      const summaryTop = 38;
+      drawSummaryCard(marginX, summaryTop, "Total commits", String(totalCommits), [59, 130, 246]);
+      drawSummaryCard(
+        marginX + cardWidth + cardGap,
+        summaryTop,
+        "Active coding days",
+        String(activeDays),
+        [14, 165, 233]
+      );
+      drawSummaryCard(
+        marginX + (cardWidth + cardGap) * 2,
+        summaryTop,
+        "Best commit day",
+        bestDay ? formatDateLabel(bestDay.day) : "-",
+        [16, 185, 129]
+      );
+      drawSummaryCard(
+        marginX,
+        summaryTop + cardHeight + 6,
+        "Highest commits in one day",
+        String(highestCommits),
+        [245, 158, 11]
+      );
+      drawSummaryCard(
+        marginX + cardWidth + cardGap,
+        summaryTop + cardHeight + 6,
+        "Total goals",
+        String(goalsData.length),
+        [139, 92, 246]
+      );
+      drawSummaryCard(
+        marginX + (cardWidth + cardGap) * 2,
+        summaryTop + cardHeight + 6,
+        "Average goal progress",
+        formatProgressValue(averageGoalProgress),
+        [236, 72, 153]
+      );
+
+      let currentY = summaryTop + cardHeight * 2 + 18;
+
+      drawInsightBox(currentY);
+      currentY += 22 + insights.length * 8 + 10;
+
       if (prData) {
-        doc.setFontSize(13);
-        doc.setTextColor(40, 40, 40);
-        doc.text("PR Analytics", 14, currentY);
-        autoTable(doc, {
-          startY: currentY + 5,
-          head: [["Open PRs", "Merged", "Avg Review Time", "Merge Rate"]],
-          body: [[
-            prData.open,
-            prData.merged,
-            `${prData.avgReviewHours}h`,
-            prData.mergeRate,
-          ]],
-          styles: { fontSize: 10 },
-          headStyles: { fillColor: [59, 130, 246] },
-        });
-        // FIX: Update currentY after table using lastAutoTable
-        currentY = (doc as any).lastAutoTable.finalY + 12;
+        currentY = drawMetricTable(
+          "PR Metrics",
+          currentY,
+          [["Open", "Merged", "Avg Review Hours", "Merge Rate"]],
+          [[prData.open, prData.merged, `${prData.avgReviewHours}h`, prData.mergeRate]],
+          {
+            0: { halign: "right" },
+            1: { halign: "right" },
+            2: { halign: "right" },
+            3: { halign: "right" },
+          }
+        );
       }
 
-      // Goals section
-      if (goalsData && goalsData.length > 0) {
-        doc.setFontSize(13);
-        doc.setTextColor(40, 40, 40);
-        doc.text("Goals Tracker", 14, currentY);
-        autoTable(doc, {
-          startY: currentY + 5,
-          head: [["Goal Label", "Current", "Target", "Progress"]],
-          body: goalsData.map((g) => {
-            const pct = g.target > 0 ? ((g.current / g.target) * 100).toFixed(1) : "0";
-            return [g.label, g.current, g.target, `${pct}%`];
-          }),
-          styles: { fontSize: 10 },
-          headStyles: { fillColor: [59, 130, 246] },
-        });
-        currentY = (doc as any).lastAutoTable.finalY + 12;
+      if (goalsData.length > 0) {
+        currentY = drawMetricTable(
+          "Goals Tracker",
+          currentY,
+          [["Goal Label", "Current", "Target", "Progress", "Status"]],
+          goalsData.map((goal) => [
+            goal.label,
+            goal.current,
+            goal.target,
+            formatProgressValue(getGoalProgress(goal)),
+            getGoalStatus(goal),
+          ]),
+          {
+            1: { halign: "right", cellWidth: 18 },
+            2: { halign: "right", cellWidth: 18 },
+            3: { halign: "right", cellWidth: 22 },
+            4: { halign: "center", cellWidth: 24 },
+          }
+        );
       }
 
-      // Commit Activity section
-      if (contribData && contribData.length > 0) {
-        doc.setFontSize(13);
-        doc.setTextColor(40, 40, 40);
-        doc.text("Commit Activity", 14, currentY);
+      if (monthlySummary.length > 0) {
+        currentY = drawMetricTable(
+          "Monthly Summary",
+          currentY,
+          [["Month", "Total Commits", "Active Days", "Best Day"]],
+          monthlySummary.map((entry) => [
+            entry.month,
+            entry.totalCommits,
+            entry.activeDays,
+            entry.bestDay,
+          ]),
+          {
+            1: { halign: "right" },
+            2: { halign: "right" },
+          }
+        );
+      }
+
+      if (contribData.length > 0) {
+        drawSectionTitle("Commit Activity", currentY);
         autoTable(doc, {
-          startY: currentY + 5,
+          startY: currentY + 4,
           head: [["Date", "Commits"]],
-          body: contribData.map((d) => [d.day, d.commits]),
-          styles: { fontSize: 10 },
-          headStyles: { fillColor: [59, 130, 246] },
+          body: contribData.map((day) => [formatDateLabel(day.day), day.commits]),
+          margin: { left: marginX, right: marginX, bottom: 20 },
+          theme: "grid",
+          styles: {
+            fontSize: 9,
+            cellPadding: 3,
+            lineColor: [226, 232, 240],
+            lineWidth: 0.2,
+            textColor: [15, 23, 42],
+          },
+          headStyles: {
+            fillColor: [30, 41, 59],
+            textColor: [255, 255, 255],
+            fontStyle: "bold",
+          },
+          alternateRowStyles: { fillColor: [248, 250, 252] },
+          columnStyles: {
+            1: { halign: "right", cellWidth: 24 },
+          },
+          pageBreak: "auto",
+          rowPageBreak: "avoid",
         });
       }
+
+      addFooter(doc, generatedAt);
 
       doc.save("dashboard-metrics.pdf");
     } finally {


### PR DESCRIPTION
## Summary

Improve the Dashboard Metrics export experience by turning the PDF and CSV outputs into cleaner, more professional reports without changing the underlying metrics fetching or calculation flow.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup

## Changes Made

- Added a polished PDF report header with title, subtitle, generated timestamp, and GitHub username when available.
- Added summary cards at the top of the PDF using existing export data:
  - Total commits
  - Active coding days
  - Best commit day
  - Highest commits in one day
  - Total goals
  - Average goal progress
- Added simple insight lines computed only from the existing export payload.
- Improved PDF table styling for better spacing, headers, alternating rows, and numeric alignment.
- Added a monthly summary section derived from existing commit activity data.
- Added a footer with page number, export timestamp, and “Generated by DevTrack”.
- Reworked CSV output into clearer sections:
  - Report Summary
  - PR Metrics
  - Insights
  - Goals Tracker
  - Commit Activity
  - Monthly Summary
  - Goal Status Overview
- Added small helper functions near the export utility to keep the formatting logic readable and localized.

## How to Test

Steps for the reviewer to verify this works:

1. Open the dashboard.
2. Click `Export CSV` and confirm the file opens cleanly in Excel or Google Sheets with separated sections.
3. Click `Export PDF` and confirm the document includes the new header, summary cards, insights, improved tables, and footer.
4. Verify the exported data still matches the existing dashboard metrics.
5. Run `npm run type-check` and confirm there are no TypeScript errors.

## Screenshots (if UI change)

- PDF export layout updated
- 
[dashboard-metrics (2).pdf](https://github.com/user-attachments/files/28173843/dashboard-metrics.2.pdf)

- CSV output reorganized into sectioned report format [dashboard-metrics (2).csv](https://github.com/user-attachments/files/28173844/dashboard-metrics.2.csv)


<img width="1859" height="987" alt="image" src="https://github.com/user-attachments/assets/bffaddbe-fa1b-4401-be0f-d9e55588567d" />


## Checklist

- [ ] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
