### PR TITLE
Ignore additional build and coverage directories during file scanning

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -23,7 +23,7 @@ function collectFiles(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (["node_modules", ".next", "dist", ".git"].includes(entry.name)) continue;
+      if (["node_modules", ".next", "dist", ".git", "build", "coverage", "out"].includes(entry.name)) continue;
       out.push(...collectFiles(full));
     } else if (/\.(js|jsx|ts|tsx)$/.test(entry.name)) {
       out.push(full);


### PR DESCRIPTION
Summary

Improves file scanning by ignoring additional generated directories such as "build", "coverage", and "out".

Closes #864 

Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

Changes Made

- Extended ignored directory list
- Added support for skipping:
  - "build"
  - "coverage"
  - "out"
- Reduced unnecessary scanning of generated files

How to Test

Steps for the reviewer to verify this works:

1. Create a "build", "coverage", or "out" directory
2. Add source files inside those folders
3. Run the dependency validation script
4. Verify those directories are skipped during scanning

Screenshots (if UI change)

N/A

Checklist

Linked issue in summary
 "npm run lint" passes locally
No TypeScript errors ("npm run type-check")
Self-reviewed the diff
 Added/updated tests if applicable