### PR TITLE
Add support for .mjs and .cjs files in dependency validation script

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -25,7 +25,7 @@ function collectFiles(dir) {
     if (entry.isDirectory()) {
       if (["node_modules", ".next", "dist", ".git"].includes(entry.name)) continue;
       out.push(...collectFiles(full));
-    } else if (/\.(js|jsx|ts|tsx)$/.test(entry.name)) {
+    } else if (/\.(js|jsx|mjs|cjs|ts|tsx)$/.test(entry.name)) {
       out.push(full);
     }
   }


### PR DESCRIPTION
Summary

Adds support for scanning ".mjs" and ".cjs" files in the dependency validation script.

Closes #865 

Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

Changes Made

- Extended file extension regex
- Added support for:
  - ".mjs"
  - ".cjs"
- Improved compatibility with modern Node.js module formats

How to Test

Steps for the reviewer to verify this works:

1. Add a ".mjs" or ".cjs" file inside "src/"
2. Import a package in that file
3. Run the dependency validation script
4. Verify the file is scanned correctly

Screenshots (if UI change)

N/A

Checklist

- Linked issue in summary
- "npm run lint" passes locally
-  No TypeScript errors ("npm run type-check")
-  Self-reviewed the diff
-  Added/updated tests if applicable