### PR TITLE
fix: support custom TypeScript path aliases

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -63,7 +63,37 @@ function extractImports(src) {
 
   return imports;
 }
+function loadInternalAliases(rootDir) {
+  const aliases = ["@/", "~/", "src/"];
 
+  const configFiles = ["tsconfig.json", "jsconfig.json"];
+
+  for (const file of configFiles) {
+    const configPath = path.join(rootDir, file);
+
+    if (!fs.existsSync(configPath)) continue;
+
+    try {
+      const config = JSON.parse(
+        fs.readFileSync(configPath, "utf8")
+      );
+
+      const paths = config.compilerOptions?.paths || {};
+
+      for (const key of Object.keys(paths)) {
+        aliases.push(
+          key.replace(/\*.*$/, "")
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `Warning: Failed to parse ${file}`
+      );
+    }
+  }
+
+  return aliases;
+}
 function collectMissingDeps(files, allDeps, cwd = process.cwd()) {
   const missing = new Map(); // pkgName → Set of files
 
@@ -73,7 +103,7 @@ function collectMissingDeps(files, allDeps, cwd = process.cwd()) {
 
     for (const mod of extractImports(src)) {
       // Skip relative imports, path aliases (@/ is the src alias — not a pkg)
-      const INTERNAL_ALIASES = ["@/", "~/", "src/"];
+      const INTERNAL_ALIASES = loadInternalAliases(cwd);
       if (
         mod.startsWith(".") || 
         mod.startsWith("/") || 


### PR DESCRIPTION
Summary

Adds support for reading custom internal aliases from "tsconfig.json" and "jsconfig.json" in the dependency validation script.

Previously, only hardcoded aliases such as "@/", "~/", and "src/" were ignored. This caused false positives in projects using custom TypeScript path aliases.

Closes #881 

Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

Changes Made

- Added "loadInternalAliases()" helper function
- Read aliases dynamically from:
  - "tsconfig.json"
  - "jsconfig.json"
- Replaced hardcoded alias array with dynamic alias loading
- Preserved existing alias behavior

How to Test

1. Add custom aliases in "tsconfig.json"

{
  "compilerOptions": {
    "paths": {
      "@components/*": ["src/components/*"]
    }
  }
}

2. Add an import using the alias

import Button from "@components/Button";

3. Run:

node scripts/check-deps.js

4. Verify the script does not report "@components" as a missing dependency.

Screenshots (if UI change)

N/A

Checklist

- [x] Linked issue in summary
- [x] "npm run lint" passes locally
- [x] No TypeScript errors ("npm run type-check")
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable