### PR TITLE
fix: support node: built-in module imports

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -82,7 +82,17 @@ function collectMissingDeps(files, allDeps, cwd = process.cwd()) {
         continue;
       }
       const pkgName = extractPackageName(mod);
-      if (BUILTINS.has(pkgName) || FRAMEWORK_ALIASES.has(pkgName)) continue;
+
+      const normalizedPkg = pkgName.startsWith("node:")
+        ? pkgName.slice(5)
+        : pkgName;
+
+      if (
+        BUILTINS.has(normalizedPkg) ||
+        FRAMEWORK_ALIASES.has(normalizedPkg)
+      ) {
+        continue;
+      }
       if (allDeps.has(pkgName)) continue;
 
       if (!missing.has(pkgName)) missing.set(pkgName, new Set());


### PR DESCRIPTION
Summary

Adds support for Node.js built-in imports using the "node:" prefix in the dependency validation script.

Previously, imports such as:

import fs from "node:fs";

could be incorrectly treated as missing dependencies.

This PR normalizes "node:" imports before checking against Node.js built-in modules.

Closes #882 

Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

Changes Made

- Added normalization for "node:" imports
- Prevented false positives for built-in modules
- Improved compatibility with modern Node.js syntax

How to Test

1. Add an import such as:

import fs from "node:fs";

2. Run:

node scripts/check-deps.js

3. Verify the script does not report "node:fs" as a missing dependency.

Screenshots (if UI change)

N/A

Checklist

- [x] Linked issue in summary
- [x] "npm run lint" passes locally
- [x] No TypeScript errors ("npm run type-check")
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable