### PR TITLE
fix: allow updating current goal progress

### DIFF
--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -69,7 +69,8 @@ export async function PATCH(
 
   const updates: Record<string, unknown> = {};
 
-  const { title, target, unit, recurrence } = body as Record<string, unknown>;
+  const { title, target, unit, recurrence, current } =
+  body as Record<string, unknown>;
 
   if (title !== undefined) {
     if (typeof title !== "string" || title.trim().length === 0) {
@@ -95,6 +96,31 @@ export async function PATCH(
     }
     updates.target = target;
   }
+
+if (current !== undefined) {
+  if (
+    typeof current !== "number" ||
+    !Number.isInteger(current) ||
+    current < 0
+  ) {
+    return Response.json(
+      { error: "current must be a non-negative integer" },
+      { status: 400 }
+    );
+  }
+
+  const effectiveTarget =
+    typeof target === "number" ? target : existing.target;
+
+  if (current > effectiveTarget) {
+    return Response.json(
+      { error: "current cannot exceed target" },
+      { status: 400 }
+    );
+  }
+
+  updates.current = current;
+}
 
   if (unit !== undefined) {
     const safeUnit = typeof unit === "string" ? unit.slice(0, 30) : "commits";

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -245,6 +245,38 @@ export default function GoalTracker() {
                       {goal.current}/{goal.target} {goal.unit}
                     </span>
 
+                    <button
+  onClick={async () => {
+    const newCurrent = goal.current + 1;
+
+    if (newCurrent > goal.target) return;
+
+    const res = await fetch(`/api/goals/${goal.id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        current: newCurrent,
+      }),
+    });
+
+    if (res.ok) {
+      setGoals((prevGoals) =>
+        prevGoals.map((g) =>
+          g.id === goal.id
+            ? { ...g, current: newCurrent }
+            : g
+        )
+      );
+    }
+  }}
+  disabled={goal.current >= goal.target}
+  className="rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50"
+>
+  +1
+</button>
+
                     {isConfirming ? (
                       <span className="flex items-center gap-1 text-xs">
                         <span className="text-[var(--muted-foreground)]">Delete?</span>


### PR DESCRIPTION
## Summary

Fixes goal progress remaining permanently at 0 by allowing the `current` field to be updated in the PATCH `/api/goals/[id]` API route.

Closes #883

## Type of Change

- [x] Bug fix

## Changes Made

- Added support for `current` field in PATCH handler
- Added validation for non-negative integers
- Prevented `current` from exceeding target
- Preserved existing validation structure

## How to Test

1. Create a goal
2. Send PATCH request with updated `current` value
3. Verify progress updates correctly
4. Verify invalid values are rejected

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors
- [x] Self-reviewed the diff