### PR TITLE
fix: resolve GitHub OAuth sign-in flow on custom auth page

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,4 +1,6 @@
-import Link from "next/link";
+"use client";
+
+import { signIn } from "next-auth/react";
 
 export default function SignInPage() {
   return (
@@ -13,12 +15,16 @@ export default function SignInPage() {
           Track your developer journey, GitHub activity, and coding consistency.
         </p>
 
-        <Link
-          href="/api/auth/signin/github?callbackUrl=/dashboard"
+        <button
+          onClick={() =>
+            signIn("github", {
+              callbackUrl: "/dashboard",
+            })
+          }
           className="w-full inline-flex items-center justify-center gap-3 bg-[var(--background)] text-[var(--foreground)] font-semibold py-3 rounded-xl hover:opacity-90 transition-all duration-200 hover:scale-[1.02]"
         >
           Sign in with GitHub
-        </Link>
+        </button>
       </div>
     </main>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,62 +4,118 @@ import { supabaseAdmin } from "./supabase";
 
 const SESSION_MAX_AGE = 30 * 24 * 60 * 60;
 const SESSION_UPDATE_AGE = 24 * 60 * 60;
-const useSecureCookies = process.env.NODE_ENV === "production";
 
 export const authOptions: NextAuthOptions = {
   providers: [
     GitHubProvider({
       clientId: process.env.GITHUB_ID ?? "",
       clientSecret: process.env.GITHUB_SECRET ?? "",
+
       authorization: {
-        params: { scope: "read:user user:email repo read:discussion" },
+        params: {
+          scope: "read:user user:email",
+        },
       },
     }),
   ],
+
   pages: {
-  signIn: "/auth/signin",
-},
+    signIn: "/auth/signin",
+  },
+
   session: {
     strategy: "jwt",
     maxAge: SESSION_MAX_AGE,
     updateAge: SESSION_UPDATE_AGE,
   },
+
   jwt: {
     maxAge: SESSION_MAX_AGE,
   },
+
   callbacks: {
     async signIn({ account, profile }) {
-      if (account?.provider === "github" && profile) {
-        const p = profile as { id: number; login: string };
-        await supabaseAdmin.from("users").upsert(
-          {
-            github_id: String(p.id),
-            github_login: p.login,
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: "github_id" }
-        );
+      try {
+        if (account?.provider === "github" && profile) {
+          const p = profile as {
+            id: number;
+            login: string;
+          };
+
+          const { data, error } = await supabaseAdmin
+            .from("users")
+            .upsert(
+              {
+                github_id: String(p.id),
+                github_login: p.login,
+                updated_at: new Date().toISOString(),
+              },
+              {
+                onConflict: "github_id",
+              }
+            );
+
+          console.log("Supabase response:", data);
+
+          if (error) {
+            console.error("Supabase error:", error);
+            return false;
+          }
+
+          console.log("GitHub sign in success");
+        }
+
+        return true;
+      } catch (err) {
+        console.error("SignIn callback failed:", err);
+        return false;
       }
-      return true;
     },
+
     async jwt({ token, account, profile }) {
-      if (account?.access_token) token.accessToken = account.access_token;
-      if (profile) {
-        const p = profile as { id: number; login: string };
-        token.githubId = String(p.id);
-        token.githubLogin = p.login;
+      try {
+        if (account?.access_token) {
+          token.accessToken = account.access_token;
+        }
+
+        if (profile) {
+          const p = profile as {
+            id: number;
+            login: string;
+          };
+
+          token.githubId = String(p.id);
+          token.githubLogin = p.login;
+        }
+
+        return token;
+      } catch (err) {
+        console.error("JWT callback failed:", err);
+        return token;
       }
-      return token;
     },
+
     async session({ session, token }) {
-      if (typeof token.accessToken === "string")
-        session.accessToken = token.accessToken;
-      if (typeof token.githubId === "string")
-        session.githubId = token.githubId;
-      if (typeof token.githubLogin === "string")
-        session.githubLogin = token.githubLogin;
-      return session;
+      try {
+        if (typeof token.accessToken === "string") {
+          session.accessToken = token.accessToken;
+        }
+
+        if (typeof token.githubId === "string") {
+          session.githubId = token.githubId;
+        }
+
+        if (typeof token.githubLogin === "string") {
+          session.githubLogin = token.githubLogin;
+        }
+
+        return session;
+      } catch (err) {
+        console.error("Session callback failed:", err);
+        return session;
+      }
     },
   },
+
   secret: process.env.NEXTAUTH_SECRET,
 };


### PR DESCRIPTION
## Summary

Fixes the **GitHub OAuth sign-in flow** on the custom authentication page.

Previously, clicking "Sign in with GitHub" redirected users back to the sign-in page with authentication errors instead of completing the OAuth flow and navigating to the dashboard.

Closes #886 

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

---

## Changes Made

* Updated the custom sign-in page to use NextAuth's `signIn()` helper instead of direct API route navigation
* Fixed the OAuth redirect flow for GitHub authentication
* Cleaned up the GitHub provider configuration in `auth.ts`
* Removed problematic OAuth scopes causing authentication issues
* Added safer callback error handling for authentication flow
* Improved authentication debugging and session handling

---

## Why This Change Was Needed

**The custom sign-in page was using direct navigation to the NextAuth API route through a `<Link>` component. This caused issues with the OAuth authentication flow and resulted in users being redirected back to the sign-in page with `error=github`**.

Using NextAuth's `signIn("github")` helper properly handles:

* CSRF protection
* OAuth redirects
* session creation
* callback handling

This ensures users can successfully authenticate with GitHub and reach the dashboard after login.

---

## How to Test

1. Run the project locally using `npm run dev`
2. Open the homepage
3. Click "Sign in with GitHub"
4. Complete GitHub OAuth authentication
5. Verify the user is redirected to `/dashboard`
6. Verify session is created successfully

---

## Screenshots (if UI change)
<img width="1850" height="961" alt="Screenshot from 2026-05-24 11-41-10" src="https://github.com/user-attachments/assets/12289c3f-20ed-40e9-aede-ef42524243ed" />
<img width="1850" height="961" alt="Screenshot from 2026-05-24 11-41-22" src="https://github.com/user-attachments/assets/78870e1b-221b-4616-aa6b-19e1e8c3c034" />
<img width="1850" height="309" alt="Screenshot from 2026-05-24 11-52-50" src="https://github.com/user-attachments/assets/daa8268f-564e-45da-a5a8-14faa4f4aa0b" />
[``](url)

---

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable

