### PR TITLE
FIX: Git rate limit

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
 import { dateDiffDays, toDateStr } from "@/lib/dateUtils";
+import { cacheGet, cacheSet, getMetricsRedisClient } from "@/lib/metrics-cache";
 
 export const dynamic = "force-dynamic";
 
 const GITHUB_API = "https://api.github.com";
 const CACHE_TTL_MS = 60 * 60 * 1000;
+const CACHE_TTL_SECONDS = Math.floor(CACHE_TTL_MS / 1000);
 const RATE_LIMIT_REQUESTS = 20;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_WINDOW_SECONDS = Math.ceil(RATE_LIMIT_WINDOW_MS / 1000);
+const USER_BATCH_SIZE = 5;
 
 type LeaderboardMetric = "streak" | "commits" | "prs";
 
@@ -37,6 +41,7 @@ let leaderboardCache: { expiresAt: number; payload: LeaderboardPayload } | null 
   null;
 
 const ipRateLimits = new Map<string, { count: number; resetAt: number }>();
+const LEADERBOARD_CACHE_KEY = "leaderboard:v1";
 
 function getRateLimitKey(req: NextRequest): string {
   return (
@@ -47,7 +52,27 @@ function getRateLimitKey(req: NextRequest): string {
   );
 }
 
-function checkRateLimit(ip: string): { allowed: boolean; retryAfter?: number } {
+async function checkRateLimit(ip: string): Promise<{ allowed: boolean; retryAfter?: number }> {
+  const redis = getMetricsRedisClient();
+  if (redis) {
+    const key = `ratelimit:leaderboard:${ip}`;
+    try {
+      const count = await redis.incr(key);
+      if (count === 1) {
+        await redis.expire(key, RATE_LIMIT_WINDOW_SECONDS);
+      }
+      if (count > RATE_LIMIT_REQUESTS) {
+        const ttl = await redis.ttl(key);
+        const retryAfter =
+          typeof ttl === "number" && ttl > 0 ? ttl : RATE_LIMIT_WINDOW_SECONDS;
+        return { allowed: false, retryAfter };
+      }
+      return { allowed: true };
+    } catch {
+      // Fall back to in-memory limiter if Redis fails.
+    }
+  }
+
   const now = Date.now();
   for (const [key, record] of ipRateLimits) {
     if (now > record.resetAt) ipRateLimits.delete(key);
@@ -121,19 +146,34 @@ function calculateCurrentStreak(commitDates: string[]): number {
 }
 
 async function fetchCommitStats(username: string, since: string) {
+  const cacheKey = `leaderboard:user:${username}:commitsSince:${since}`;
+  const cached = await cacheGet<{
+    total_count: number;
+    items: Array<{ commit: { author: { date: string } } }>;
+  }>(cacheKey);
+  if (cached) return cached;
+
   const query = new URLSearchParams({
     q: `author:${username} author-date:>=${since}`,
     per_page: "100",
     sort: "author-date",
     order: "desc",
   });
-  return fetchGitHubJson<{
+  const fresh = await fetchGitHubJson<{
     total_count: number;
     items: Array<{ commit: { author: { date: string } } }>;
   }>(`/search/commits?${query.toString()}`);
+  if (fresh) {
+    await cacheSet(cacheKey, fresh, CACHE_TTL_SECONDS);
+  }
+  return fresh;
 }
 
 async function fetchPrCount(username: string, since: string): Promise<number> {
+  const cacheKey = `leaderboard:user:${username}:prsSince:${since}`;
+  const cached = await cacheGet<number>(cacheKey);
+  if (cached !== null) return cached;
+
   const query = new URLSearchParams({
     q: `author:${username} type:pr created:>=${since}`,
     per_page: "1",
@@ -141,7 +181,17 @@ async function fetchPrCount(username: string, since: string): Promise<number> {
   const data = await fetchGitHubJson<{ total_count: number }>(
     `/search/issues?${query.toString()}`
   );
-  return data?.total_count ?? 0;
+  const count = data?.total_count ?? 0;
+  await cacheSet(cacheKey, count, CACHE_TTL_SECONDS);
+  return count;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    result.push(items.slice(i, i + size));
+  }
+  return result;
 }
 
 async function buildLeaderboard(): Promise<LeaderboardPayload> {
@@ -161,32 +211,38 @@ async function buildLeaderboard(): Promise<LeaderboardPayload> {
   const monthStart = toDateStr(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)));
   const streakStart = toDateStr(new Date(Date.now() - 90 * 86400000));
 
-  const rows = await Promise.all(
-    ((users ?? []) as PublicUser[]).map(async (user) => {
-      const [monthlyCommits, streakCommits, prs] = await Promise.all([
-        fetchCommitStats(user.github_login, monthStart),
-        fetchCommitStats(user.github_login, streakStart),
-        fetchPrCount(user.github_login, monthStart),
-      ]);
+  const allUsers = (users ?? []) as PublicUser[];
+  const rows: LeaderboardEntry[] = [];
 
-      const streak = calculateCurrentStreak(
-        streakCommits?.items.map((item) => item.commit.author.date) ?? []
-      );
-      const commits = monthlyCommits?.total_count ?? 0;
-      const score = streak * 5 + commits + prs * 3;
+  for (const batch of chunk(allUsers, USER_BATCH_SIZE)) {
+    const batchRows = await Promise.all(
+      batch.map(async (user) => {
+        const [monthlyCommits, streakCommits, prs] = await Promise.all([
+          fetchCommitStats(user.github_login, monthStart),
+          fetchCommitStats(user.github_login, streakStart),
+          fetchPrCount(user.github_login, monthStart),
+        ]);
 
-      return {
-        rank: 0,
-        username: user.github_login,
-        avatarUrl: `https://github.com/${user.github_login}.png?size=96`,
-        profileUrl: `/u/${user.github_login}`,
-        streak,
-        commits,
-        prs,
-        score,
-      };
-    })
-  );
+        const streak = calculateCurrentStreak(
+          streakCommits?.items.map((item) => item.commit.author.date) ?? []
+        );
+        const commits = monthlyCommits?.total_count ?? 0;
+        const score = streak * 5 + commits + prs * 3;
+
+        return {
+          rank: 0,
+          username: user.github_login,
+          avatarUrl: `https://github.com/${user.github_login}.png?size=96`,
+          profileUrl: `/u/${user.github_login}`,
+          streak,
+          commits,
+          prs,
+          score,
+        };
+      })
+    );
+    rows.push(...batchRows);
+  }
 
   const rankBy = (metric: LeaderboardMetric) =>
     [...rows]
@@ -208,13 +264,18 @@ async function buildLeaderboard(): Promise<LeaderboardPayload> {
 export async function GET(req: NextRequest) {
   cleanupCache();
   const ip = getRateLimitKey(req);
-  const rateLimit = checkRateLimit(ip);
+  const rateLimit = await checkRateLimit(ip);
 
   if (!rateLimit.allowed) {
     return NextResponse.json(
       { error: "Rate limit exceeded" },
       { status: 429, headers: { "Retry-After": String(rateLimit.retryAfter) } }
     );
+  }
+
+  const cachedPayload = await cacheGet<LeaderboardPayload>(LEADERBOARD_CACHE_KEY);
+  if (cachedPayload) {
+    return NextResponse.json(cachedPayload);
   }
 
   if (leaderboardCache && Date.now() < leaderboardCache.expiresAt) {
@@ -224,6 +285,7 @@ export async function GET(req: NextRequest) {
   try {
     const payload = await buildLeaderboard();
     leaderboardCache = { payload, expiresAt: Date.now() + CACHE_TTL_MS };
+    await cacheSet(LEADERBOARD_CACHE_KEY, payload, CACHE_TTL_SECONDS);
     return NextResponse.json(payload);
   } catch {
     return NextResponse.json(

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -59,6 +59,11 @@ function getRedisClient(): Redis | null {
   return redisClient;
 }
 
+// Exposed for endpoints that need Redis primitives (incr/expire/ttl), not just get/set.
+export function getMetricsRedisClient(): Redis | null {
+  return getRedisClient();
+}
+
 export function isMetricsCacheBypassed(req: NextRequest): boolean {
   const bypassParam =
     req.nextUrl.searchParams.get("refresh") ??


### PR DESCRIPTION
## Summary

Prevents leaderboard cache misses from triggering a burst of GitHub Search API requests by batching requests, caching leaderboard payload/results in Upstash Redis, and moving the IP rate limiter to Redis for consistency across serverless instances.

Closes #696 

## Type of Change

- [x] Bug fix


## Changes Made

- Added Redis-backed leaderboard payload caching (shared across instances) and kept in-process cache as a local fallback.
- Added Redis-backed IP rate limiting for the leaderboard endpoint (with in-memory fallback if Redis is unavailable).
- Limited GitHub API burst by processing opted-in users in batches (default `5`) instead of all-at-once, and cached per-user GitHub query results for 1 hour.



## Checklist

- [ ] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
