### PR TITLE
fix: prune stale leaderboard cache entries

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
 import { dateDiffDays, toDateStr } from "@/lib/dateUtils";
+import {
+  pruneExpiredLeaderboardCache,
+  pruneExpiredRateLimits,
+  type LeaderboardCacheEntry,
+  type RateLimitEntry,
+} from "@/lib/leaderboard-cache";
 
 export const dynamic = "force-dynamic";
 
@@ -33,10 +39,9 @@ interface LeaderboardPayload {
   leaders: Record<LeaderboardMetric, LeaderboardEntry[]>;
 }
 
-let leaderboardCache: { expiresAt: number; payload: LeaderboardPayload } | null =
-  null;
+let leaderboardCache: LeaderboardCacheEntry<LeaderboardPayload> | null = null;
 
-const ipRateLimits = new Map<string, { count: number; resetAt: number }>();
+const ipRateLimits = new Map<string, RateLimitEntry>();
 
 function getRateLimitKey(req: NextRequest): string {
   return (
@@ -49,9 +54,6 @@ function getRateLimitKey(req: NextRequest): string {
 
 function checkRateLimit(ip: string): { allowed: boolean; retryAfter?: number } {
   const now = Date.now();
-  for (const [key, record] of ipRateLimits) {
-    if (now > record.resetAt) ipRateLimits.delete(key);
-  }
   const record = ipRateLimits.get(ip);
 
   if (!record || now > record.resetAt) {
@@ -69,9 +71,8 @@ function checkRateLimit(ip: string): { allowed: boolean; retryAfter?: number } {
 
 function cleanupCache(): void {
   const now = Date.now();
-  if (leaderboardCache && now > leaderboardCache.expiresAt) {
-    leaderboardCache = null;
-  }
+  pruneExpiredRateLimits(ipRateLimits, now);
+  leaderboardCache = pruneExpiredLeaderboardCache(leaderboardCache, now);
 }
 
 async function fetchGitHubJson<T>(path: string): Promise<T | null> {

--- a/src/lib/leaderboard-cache.ts
+++ b/src/lib/leaderboard-cache.ts
@@ -1,0 +1,31 @@
+export interface LeaderboardCacheEntry<T> {
+  expiresAt: number;
+  payload: T;
+}
+
+export interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+export function pruneExpiredRateLimits(
+  entries: Map<string, RateLimitEntry>,
+  now: number = Date.now()
+): void {
+  for (const [key, entry] of entries.entries()) {
+    if (entry.resetAt <= now) {
+      entries.delete(key);
+    }
+  }
+}
+
+export function pruneExpiredLeaderboardCache<T>(
+  cache: LeaderboardCacheEntry<T> | null,
+  now: number = Date.now()
+): LeaderboardCacheEntry<T> | null {
+  if (!cache) {
+    return null;
+  }
+
+  return cache.expiresAt <= now ? null : cache;
+}

--- a/test/leaderboard-cache.test.mjs
+++ b/test/leaderboard-cache.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  pruneExpiredLeaderboardCache,
+  pruneExpiredRateLimits,
+} from "../src/lib/leaderboard-cache.ts";
+
+test("pruneExpiredRateLimits removes only expired IP buckets", () => {
+  const buckets = new Map([
+    ["expired", { count: 20, resetAt: 1_000 }],
+    ["active", { count: 2, resetAt: 5_000 }],
+  ]);
+
+  pruneExpiredRateLimits(buckets, 2_000);
+
+  assert.equal(buckets.has("expired"), false);
+  assert.deepEqual(buckets.get("active"), { count: 2, resetAt: 5_000 });
+});
+
+test("pruneExpiredLeaderboardCache clears stale leaderboard payloads", () => {
+  const cache = {
+    expiresAt: 1_000,
+    payload: { ok: true },
+  };
+
+  assert.equal(pruneExpiredLeaderboardCache(cache, 1_001), null);
+});
+
+test("pruneExpiredLeaderboardCache keeps fresh leaderboard payloads", () => {
+  const cache = {
+    expiresAt: 2_000,
+    payload: { ok: true },
+  };
+
+  assert.equal(pruneExpiredLeaderboardCache(cache, 1_999), cache);
+});


### PR DESCRIPTION
## Summary
- proactively prune expired IP rate-limit buckets on every leaderboard request
- move leaderboard cache eviction into a small reusable helper so stale payloads are cleared consistently
- add a focused regression test for rate-limit and cache cleanup behavior

Closes #806

## Validation
- `node --experimental-strip-types --test test/leaderboard-cache.test.mjs`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`