### PR TITLE
fix: add toast feedback and error handling for profile copy actions

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { redirect, useSearchParams } from "next/navigation";
 import { useHeatmapTheme } from "@/hooks/useHeatmapTheme";
 import PrivacySettings from "@/components/PrivacySettings";
+import { toast } from "sonner";
 
 interface UserSettings {
   id: string;
@@ -235,8 +236,11 @@ function SettingsPageContent() {
     const link = `${window.location.origin}/u/${settings.github_login}`;
     navigator.clipboard.writeText(link).then(() => {
       setCopied(true);
+      toast.success("Link copied successfully!");
       setTimeout(() => setCopied(false), 2000);
-    }).catch(() => { });
+    }).catch(() => { 
+      toast.error("Failed to copy link");
+     });
   };
 
   const handleRemoveAccount = async (githubId: string) => {

--- a/src/components/CopyLinkButton.tsx
+++ b/src/components/CopyLinkButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 
 export default function CopyLinkButton() {
   const [copied, setCopied] = useState(false);
@@ -9,11 +10,13 @@ export default function CopyLinkButton() {
     try {
       await navigator.clipboard.writeText(window.location.href);
       setCopied(true);
+      toast.success("Link copied successfully!");
       setTimeout(() => {
         setCopied(false);
       }, 2000);
     } catch (error) {
       console.error("Failed to copy link:", error);
+      toast.error("Failed to copy link");
     }
   };
 


### PR DESCRIPTION
## Related Issue

Closes #608

## Changes Made

* Added toast feedback for the "Share your profile" copy button in `dashboard/settings/page.tsx`
* Added success toast notifications for successful copy actions
* Added error toast handling for clipboard copy failures
* Updated `CopyLinkButton.tsx` to improve copy interaction feedback
* Preserved existing UI styling and functionality

## Testing

* Tested profile copy functionality locally
* Verified success and error toast behavior
* Ran lint and type-check successfully

## Screenshots

(attach screenshots here)
<img width="1030" height="318" alt="image" src="https://github.com/user-attachments/assets/a53a557a-76ed-427a-a8ba-48b3019f186b" />
