### PR TITLE
fix: prevent streak freeze race condition

### DIFF
--- a/src/app/api/streak/freeze/route.ts
+++ b/src/app/api/streak/freeze/route.ts
@@ -70,20 +70,6 @@ export async function POST() {
 
   const today = todayStr();
 
-  const { data: existing } = await supabaseAdmin
-    .from("streak_freezes")
-    .select("id")
-    .eq("user_id", user.id)
-    .eq("freeze_date", today)
-    .maybeSingle();
-
-  if (existing) {
-    return Response.json(
-      { error: "You already have an unused streak freeze." },
-      { status: 409 }
-    );
-  }
-
   const { data: freeze, error } = await supabaseAdmin
     .from("streak_freezes")
     .upsert({ user_id: user.id, freeze_date: today }, { onConflict: "user_id,freeze_date" })


### PR DESCRIPTION
## Summary

Removes the race condition in streak freeze creation by replacing the separate existence check and insert flow with an atomic Supabase upsert operation.

Closes #808 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Removed the pre-insert existence check for streak freezes
- Used Supabase upsert with onConflict: "user_id,freeze_date"
- Prevented duplicate streak freeze creation during concurrent requests

## How to Test

Steps for the reviewer to verify this works:

1. Run the application locally
2. Trigger the streak freeze API multiple times for the same user/date
3. Verify duplicate freeze entries are not created

## Screenshots (if UI change)

N/A

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
