### PR TITLE
fix(a11y): add ARIA attributes to goal progress bar (#950)

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -408,6 +408,11 @@ export default function GoalTracker() {
 
                 <div className="h-2 overflow-hidden rounded-full bg-[var(--control)]">
                   <div
+                    role="progressbar"
+                    aria-valuenow={goal.current}
+                    aria-valuemin={0}
+                    aria-valuemax={goal.target}
+                    aria-label={`Goal progress: ${goal.current} of ${goal.target} ${goal.unit}`}
                     className={`h-full rounded-full transition-all ${completed ? "bg-emerald-500" : "bg-[var(--accent)]"}`}
                     style={{ width: `${pct}%` }}
                   />


### PR DESCRIPTION
## Summary
Adds role="progressbar" with aria-valuenow, aria-valuemin, 
aria-valuemax, and aria-label to the GoalTracker progress bar 
to meet WCAG 2.1 Level A requirement 1.3.1 (Info and Relationships).

## Changes
- `src/components/GoalTracker.tsx`: added 4 ARIA attributes to 
  the progress bar div

Closes #950