### PR TITLE
feat: add Wakatime integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4415,7 +4415,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/api/metrics/coding-time/route.ts
+++ b/src/app/api/metrics/coding-time/route.ts
@@ -1,0 +1,100 @@
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
+import { decryptToken } from "@/lib/crypto";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.githubId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const user = await resolveAppUser(session.githubId, session.githubLogin);
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const { data: userData, error: userError } = await supabaseAdmin
+      .from("users")
+      .select("wakatime_api_key_encrypted, wakatime_api_key_iv")
+      .eq("id", user.id)
+      .single();
+
+    if (userError || !userData?.wakatime_api_key_encrypted || !userData?.wakatime_api_key_iv) {
+      return NextResponse.json({ error: "Wakatime not configured", not_configured: true }, { status: 404 });
+    }
+
+    const apiKey = decryptToken(userData.wakatime_api_key_encrypted, userData.wakatime_api_key_iv);
+    if (!apiKey) {
+      return NextResponse.json({ error: "Failed to decrypt API key", not_configured: true }, { status: 500 });
+    }
+
+    const authHeader = `Basic ${Buffer.from(apiKey).toString("base64")}`;
+
+    const res = await fetch("https://wakatime.com/api/v1/users/current/summaries?range=Last%207%20Days", {
+      headers: { Authorization: authHeader },
+      next: { revalidate: 3600 },
+    });
+
+    if (!res.ok) {
+      console.error("Wakatime API error:", res.status, res.statusText);
+      return NextResponse.json({ error: "Failed to fetch from Wakatime" }, { status: 500 });
+    }
+
+    const json = await res.json();
+    const summaries = json.data || [];
+
+    if (summaries.length === 0) {
+      return NextResponse.json({ hasData: false });
+    }
+
+    // Process data
+    const today = summaries[summaries.length - 1];
+    const todaysSeconds = today?.grand_total?.total_seconds || 0;
+
+    let totalSeconds7Days = 0;
+    const languagesMap: Record<string, number> = {};
+    const projectsMap: Record<string, number> = {};
+
+    const chartData = summaries.map((day: any) => {
+      const dateStr = day.range.date; // e.g. 2023-10-01
+      const totalSeconds = day.grand_total.total_seconds || 0;
+      totalSeconds7Days += totalSeconds;
+
+      day.languages?.forEach((lang: any) => {
+        languagesMap[lang.name] = (languagesMap[lang.name] || 0) + lang.total_seconds;
+      });
+
+      day.projects?.forEach((proj: any) => {
+        projectsMap[proj.name] = (projectsMap[proj.name] || 0) + proj.total_seconds;
+      });
+
+      return {
+        date: dateStr,
+        hours: parseFloat((totalSeconds / 3600).toFixed(2)),
+      };
+    });
+
+    const getTop = (map: Record<string, number>) => {
+      return Object.entries(map).sort((a, b) => b[1] - a[1])[0]?.[0] || "None";
+    };
+
+    return NextResponse.json({
+      hasData: true,
+      todaysSeconds,
+      totalSeconds7Days,
+      chartData,
+      topLanguage: getTop(languagesMap),
+      topProject: getTop(projectsMap),
+    });
+  } catch (error) {
+    console.error("Error fetching Wakatime metrics:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/metrics/coding-time/route.ts
+++ b/src/app/api/metrics/coding-time/route.ts
@@ -35,11 +35,11 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "Failed to decrypt API key", not_configured: true }, { status: 500 });
     }
 
-    const authHeader = `Basic ${Buffer.from(apiKey).toString("base64")}`;
+    const authHeader = `Basic ${Buffer.from(apiKey + ":").toString("base64")}`;
 
     const res = await fetch("https://wakatime.com/api/v1/users/current/summaries?range=Last%207%20Days", {
       headers: { Authorization: authHeader },
-      next: { revalidate: 3600 },
+      cache: "no-store",
     });
 
     if (!res.ok) {

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -10,7 +10,7 @@ async function fetchUserSettings(userId: string) {
   // Tier 1: All columns
   const res1 = await supabaseAdmin
     .from("users")
-    .select("id, github_login, is_public, leaderboard_opt_in, pinned_repos")
+    .select("id, github_login, is_public, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv")
     .eq("id", userId)
     .single();
 
@@ -20,8 +20,11 @@ async function fetchUserSettings(userId: string) {
       error: null,
       hasLeaderboardOptIn: true,
       hasPinnedRepos: true,
+      hasWakatimeKey: true,
       leaderboard_opt_in: (res1.data as any).leaderboard_opt_in ?? false,
       pinned_repos: (res1.data as any).pinned_repos || [],
+      wakatime_api_key_encrypted: (res1.data as any).wakatime_api_key_encrypted || null,
+      wakatime_api_key_iv: (res1.data as any).wakatime_api_key_iv || null,
     };
   }
 
@@ -31,8 +34,11 @@ async function fetchUserSettings(userId: string) {
       error: res1.error,
       hasLeaderboardOptIn: false,
       hasPinnedRepos: false,
+      hasWakatimeKey: false,
       leaderboard_opt_in: false,
       pinned_repos: [] as string[],
+      wakatime_api_key_encrypted: null,
+      wakatime_api_key_iv: null,
     };
   }
 
@@ -49,8 +55,11 @@ async function fetchUserSettings(userId: string) {
       error: null,
       hasLeaderboardOptIn: true,
       hasPinnedRepos: false,
+      hasWakatimeKey: false,
       leaderboard_opt_in: (res2.data as any).leaderboard_opt_in ?? false,
       pinned_repos: [] as string[],
+      wakatime_api_key_encrypted: null,
+      wakatime_api_key_iv: null,
     };
   }
 
@@ -60,8 +69,11 @@ async function fetchUserSettings(userId: string) {
       error: res2.error,
       hasLeaderboardOptIn: false,
       hasPinnedRepos: false,
+      hasWakatimeKey: false,
       leaderboard_opt_in: false,
       pinned_repos: [] as string[],
+      wakatime_api_key_encrypted: null,
+      wakatime_api_key_iv: null,
     };
   }
 
@@ -78,8 +90,11 @@ async function fetchUserSettings(userId: string) {
       error: null,
       hasLeaderboardOptIn: false,
       hasPinnedRepos: false,
+      hasWakatimeKey: false,
       leaderboard_opt_in: false,
       pinned_repos: [] as string[],
+      wakatime_api_key_encrypted: null,
+      wakatime_api_key_iv: null,
     };
   }
 
@@ -88,8 +103,11 @@ async function fetchUserSettings(userId: string) {
     error: res3.error,
     hasLeaderboardOptIn: false,
     hasPinnedRepos: false,
+    hasWakatimeKey: false,
     leaderboard_opt_in: false,
     pinned_repos: [] as string[],
+    wakatime_api_key_encrypted: null,
+    wakatime_api_key_iv: null,
   };
 }
 
@@ -121,8 +139,11 @@ export async function GET(req: NextRequest) {
     is_public: (result.data as any).is_public,
     leaderboard_opt_in: result.leaderboard_opt_in,
     pinned_repos: result.pinned_repos,
+    has_wakatime_key: !!result.wakatime_api_key_encrypted && !!result.wakatime_api_key_iv,
   });
 }
+
+import { encryptToken } from "@/lib/crypto";
 
 export async function PATCH(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -140,14 +161,14 @@ export async function PATCH(req: NextRequest) {
     );
   }
 
-  let body: { is_public?: boolean; leaderboard_opt_in?: boolean; pinned_repos?: string[] };
+  let body: { is_public?: boolean; leaderboard_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key?: string };
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const { is_public, leaderboard_opt_in, pinned_repos } = body;
+  const { is_public, leaderboard_opt_in, pinned_repos, wakatime_api_key } = body;
 
   // Retrieve supported columns first
   const settingsResult = await fetchUserSettings(user.id);
@@ -156,8 +177,8 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Failed to update settings" }, { status: 500 });
   }
 
-  const { hasLeaderboardOptIn, hasPinnedRepos } = settingsResult;
-  const updates: { is_public?: boolean; leaderboard_opt_in?: boolean; pinned_repos?: string[] } = {};
+  const { hasLeaderboardOptIn, hasPinnedRepos, hasWakatimeKey } = settingsResult;
+  const updates: { is_public?: boolean; leaderboard_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key_encrypted?: string | null; wakatime_api_key_iv?: string | null } = {};
 
   if (is_public !== undefined && is_public !== null && typeof is_public === "boolean") {
     updates.is_public = is_public;
@@ -182,6 +203,27 @@ export async function PATCH(req: NextRequest) {
     updates.pinned_repos = pinned_repos;
   }
 
+  if (hasWakatimeKey && wakatime_api_key !== undefined) {
+    if (wakatime_api_key === "") {
+      updates.wakatime_api_key_encrypted = null;
+      updates.wakatime_api_key_iv = null;
+    } else if (typeof wakatime_api_key === "string") {
+      try {
+        const testRes = await fetch("https://wakatime.com/api/v1/users/current/summaries?range=Today", {
+          headers: { Authorization: `Basic ${Buffer.from(wakatime_api_key).toString("base64")}` },
+        });
+        if (!testRes.ok) {
+          return NextResponse.json({ error: "Invalid Wakatime API key" }, { status: 400 });
+        }
+        const { encrypted, iv } = encryptToken(wakatime_api_key);
+        updates.wakatime_api_key_encrypted = encrypted;
+        updates.wakatime_api_key_iv = iv;
+      } catch (err) {
+        return NextResponse.json({ error: "Failed to validate or encrypt Wakatime key" }, { status: 500 });
+      }
+    }
+  }
+
   // If there are no updates (or none that are supported by the schema)
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({
@@ -190,6 +232,7 @@ export async function PATCH(req: NextRequest) {
       is_public: (settingsResult.data as any).is_public,
       leaderboard_opt_in: settingsResult.leaderboard_opt_in,
       pinned_repos: settingsResult.pinned_repos,
+      has_wakatime_key: !!settingsResult.wakatime_api_key_encrypted && !!settingsResult.wakatime_api_key_iv,
     });
   }
 
@@ -197,6 +240,10 @@ export async function PATCH(req: NextRequest) {
   const selectCols = ["id", "github_login", "is_public"];
   if (hasLeaderboardOptIn) selectCols.push("leaderboard_opt_in");
   if (hasPinnedRepos) selectCols.push("pinned_repos");
+  if (hasWakatimeKey) {
+    selectCols.push("wakatime_api_key_encrypted");
+    selectCols.push("wakatime_api_key_iv");
+  }
 
   const { data: updated, error: updateError } = await supabaseAdmin
     .from("users")
@@ -216,5 +263,6 @@ export async function PATCH(req: NextRequest) {
     is_public: (updated as any).is_public,
     leaderboard_opt_in: (updated as any).leaderboard_opt_in ?? false,
     pinned_repos: (updated as any).pinned_repos || [],
+    has_wakatime_key: !!(updated as any).wakatime_api_key_encrypted && !!(updated as any).wakatime_api_key_iv,
   });
 }

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
+import { encryptToken } from "@/lib/crypto";
 
 export const dynamic = "force-dynamic";
 
@@ -143,8 +144,6 @@ export async function GET(req: NextRequest) {
   });
 }
 
-import { encryptToken } from "@/lib/crypto";
-
 export async function PATCH(req: NextRequest) {
   const session = await getServerSession(authOptions);
 
@@ -210,7 +209,7 @@ export async function PATCH(req: NextRequest) {
     } else if (typeof wakatime_api_key === "string") {
       try {
         const testRes = await fetch("https://wakatime.com/api/v1/users/current/summaries?range=Today", {
-          headers: { Authorization: `Basic ${Buffer.from(wakatime_api_key).toString("base64")}` },
+          headers: { Authorization: `Basic ${Buffer.from(wakatime_api_key + ":").toString("base64")}` },
         });
         if (!testRes.ok) {
           return NextResponse.json({ error: "Invalid Wakatime API key" }, { status: 400 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -25,6 +25,7 @@ import ExportButton from "@/components/ExportButton";
 import Link from "next/link";
 import PersonalRecords from "@/components/PersonalRecords";
 import LocalCodingTime from "@/components/LocalCodingTime";
+import CodingTimeCard from "@/components/CodingTimeCard";
 import RecentActivity from "@/components/RecentActivity";
 import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
@@ -78,6 +79,9 @@ export default async function DashboardPage() {
         <div>
           <StreakTracker />
           <LocalCodingTime />
+          <div className="mt-6">
+            <CodingTimeCard />
+          </div>
         </div>
       </div>
 

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -602,6 +602,7 @@ function SettingsPageContent() {
                   value={wakatimeKey}
                   onChange={(e) => setWakatimeKey(e.target.value)}
                   placeholder={settings.has_wakatime_key ? "•••••••••••••••• (Configured)" : "Enter your Wakatime API key"}
+                  autoComplete="new-password"
                   className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--control)] px-4 py-2 text-sm text-[var(--card-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
                 />
                 <button

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -12,6 +12,7 @@ interface UserSettings {
   github_login: string;
   is_public: boolean;
   leaderboard_opt_in: boolean;
+  has_wakatime_key?: boolean;
 }
 
 interface LinkedAccount {
@@ -115,6 +116,8 @@ function SettingsPageContent() {
   const [removingAccountId, setRemovingAccountId] = useState<string | null>(
     null
   );
+  const [wakatimeKey, setWakatimeKey] = useState("");
+  const [savingWakatime, setSavingWakatime] = useState(false);
 
   const statusMessage = useMemo(
     () =>
@@ -228,6 +231,32 @@ function SettingsPageContent() {
       console.error("Error updating leaderboard setting:", error);
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleSaveWakatime = async () => {
+    if (!settings) return;
+    setSavingWakatime(true);
+    try {
+      const res = await fetch("/api/user/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ wakatime_api_key: wakatimeKey }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        setSettings(updated);
+        setWakatimeKey("");
+        toast.success(wakatimeKey === "" ? "Wakatime key removed" : "Wakatime key saved successfully!");
+      } else {
+        const errorData = await res.json();
+        toast.error(errorData.error || "Failed to update Wakatime key");
+      }
+    } catch (error) {
+      console.error("Error updating Wakatime key:", error);
+      toast.error("Failed to update Wakatime key");
+    } finally {
+      setSavingWakatime(false);
     }
   };
 
@@ -546,6 +575,48 @@ function SettingsPageContent() {
                 ))}
               </div>
             )}
+          </div>
+        </div>
+
+        <div className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-4">
+            <div>
+              <h2 className="text-xl font-semibold text-[var(--card-foreground)]">
+                Wakatime Integration
+              </h2>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                Connect your Wakatime account to display accurate coding time and language usage.
+              </p>
+            </div>
+          </div>
+          
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="wakatime-key" className="block text-sm font-medium text-[var(--card-foreground)] mb-1">
+                API Key
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="wakatime-key"
+                  type="password"
+                  value={wakatimeKey}
+                  onChange={(e) => setWakatimeKey(e.target.value)}
+                  placeholder={settings.has_wakatime_key ? "•••••••••••••••• (Configured)" : "Enter your Wakatime API key"}
+                  className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--control)] px-4 py-2 text-sm text-[var(--card-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+                />
+                <button
+                  type="button"
+                  onClick={handleSaveWakatime}
+                  disabled={savingWakatime}
+                  className="px-4 py-2 rounded-lg bg-[var(--accent)] text-[var(--accent-foreground)] text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-60 min-w-[80px]"
+                >
+                  {savingWakatime ? "Saving..." : "Save"}
+                </button>
+              </div>
+              <p className="mt-2 text-xs text-[var(--muted-foreground)]">
+                {settings.has_wakatime_key ? "Leave blank and click Save to remove your key." : "You can find your API key in your Wakatime Settings."}
+              </p>
+            </div>
           </div>
         </div>
 

--- a/src/components/CodingTimeCard.tsx
+++ b/src/components/CodingTimeCard.tsx
@@ -36,13 +36,8 @@ export default function CodingTimeCard() {
     async function loadStats() {
       try {
         const res = await fetch("/api/metrics/coding-time");
-        if (res.ok) {
-          const json = await res.json();
-          setData(json);
-        } else {
-          const json = await res.json();
-          setData(json);
-        }
+        const json = await res.json();
+        setData(json);
       } catch {
         setData(null);
       } finally {

--- a/src/components/CodingTimeCard.tsx
+++ b/src/components/CodingTimeCard.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+
+interface CodingTimeData {
+  hasData: boolean;
+  not_configured?: boolean;
+  todaysSeconds: number;
+  totalSeconds7Days: number;
+  chartData: { date: string; hours: number }[];
+  topLanguage: string;
+  topProject: string;
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  return date.toLocaleDateString("en-US", { weekday: "short" });
+}
+
+export default function CodingTimeCard() {
+  const [data, setData] = useState<CodingTimeData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadStats() {
+      try {
+        const res = await fetch("/api/metrics/coding-time");
+        if (res.ok) {
+          const json = await res.json();
+          setData(json);
+        } else {
+          const json = await res.json();
+          setData(json);
+        }
+      } catch {
+        setData(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadStats();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <div className="h-5 w-40 bg-[var(--card-muted)] rounded animate-pulse mb-4" />
+        <div className="h-48 bg-[var(--card-muted)] rounded animate-pulse w-full" />
+      </div>
+    );
+  }
+
+  if (!data || data.not_configured || !data.hasData) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="text-lg font-semibold text-[var(--card-foreground)] mb-4">
+        Wakatime Coding Activity (7 Days)
+      </h2>
+      
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+        <div>
+          <div className="text-2xl font-bold text-[var(--card-foreground)]">
+            {formatDuration(data.todaysSeconds)}
+          </div>
+          <div className="text-xs text-[var(--muted-foreground)]">Today</div>
+        </div>
+        <div>
+          <div className="text-2xl font-bold text-[var(--card-foreground)]">
+            {formatDuration(data.totalSeconds7Days)}
+          </div>
+          <div className="text-xs text-[var(--muted-foreground)]">Last 7 Days</div>
+        </div>
+        <div>
+          <div className="text-2xl font-bold text-[var(--card-foreground)] truncate" title={data.topLanguage}>
+            {data.topLanguage}
+          </div>
+          <div className="text-xs text-[var(--muted-foreground)]">Top Language</div>
+        </div>
+        <div>
+          <div className="text-2xl font-bold text-[var(--card-foreground)] truncate" title={data.topProject}>
+            {data.topProject}
+          </div>
+          <div className="text-xs text-[var(--muted-foreground)]">Top Project</div>
+        </div>
+      </div>
+
+      <div className="h-48 w-full mt-4">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data.chartData} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
+            <XAxis 
+              dataKey="date" 
+              tickFormatter={formatDate}
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis 
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <Tooltip 
+              cursor={{ fill: "var(--control)" }}
+              contentStyle={{ 
+                backgroundColor: "var(--card)", 
+                borderColor: "var(--border)",
+                borderRadius: "8px",
+                color: "var(--card-foreground)",
+              }}
+              formatter={(value: number) => [`${value} hours`, 'Time']}
+              labelFormatter={(label) => formatDate(label as string)}
+            />
+            <Bar dataKey="hours" fill="var(--accent)" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260525000000_add_wakatime_api_key.sql
+++ b/supabase/migrations/20260525000000_add_wakatime_api_key.sql
@@ -1,0 +1,3 @@
+-- Migration to add wakatime_api_key columns
+ALTER TABLE users ADD COLUMN IF NOT EXISTS wakatime_api_key_encrypted text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS wakatime_api_key_iv text;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -6,7 +6,9 @@ create table if not exists users (
   github_login text not null,
   is_public    boolean default false,
   created_at   timestamptz default now(),
-  updated_at   timestamptz default now()
+  updated_at   timestamptz default now(),
+  wakatime_api_key_encrypted text,
+  wakatime_api_key_iv text
 );
 
 create table if not exists goals (


### PR DESCRIPTION
## Summary

This PR adds Wakatime integration for local coding time tracking. It allows users to securely save their Wakatime API key and view a comprehensive breakdown of their coding activity over the last 7 days directly on the DevTrack dashboard.

Closes #963

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added a database migration and updated `schema.sql` to include `wakatime_api_key_encrypted` and `wakatime_api_key_iv` in the `users` table.
- Updated the settings API (`src/app/api/user/settings/route.ts`) to securely encrypt and save the Wakatime API key.
- Created a new proxy API route (`src/app/api/metrics/coding-time/route.ts`) to fetch coding summaries from Wakatime using the user's decrypted key.
- Added a Wakatime Integration section to the Settings page (`src/app/dashboard/settings/page.tsx`).
- Created a new `CodingTimeCard` component (`src/components/CodingTimeCard.tsx`) to visualize daily coding hours, top languages, and top projects using Recharts.
- Integrated the `CodingTimeCard` into the main Dashboard layout (`src/app/dashboard/page.tsx`).

## How to Test

Steps for the reviewer to verify this works:

1. Ensure your `.env` contains a valid 32-byte hex `ENCRYPTION_KEY`.
2. Apply the latest Supabase migrations locally.
3. Navigate to the Settings page, enter a valid Wakatime API Key, and save.
4. Navigate to the Dashboard and confirm that the "Wakatime Coding Activity (7 Days)" widget is visible and displaying accurate data.
5. Remove the Wakatime API Key from the Settings page and ensure the widget is hidden on the Dashboard.


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable