### PR TITLE
feat: add theme toggle to public profile page

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import BadgeSection from "@/components/BadgeSection";
 import StatsCard from "@/components/StatsCard";
 import CopyLinkButton from "@/components/CopyLinkButton";
+import ThemeToggle from "@/components/ThemeToggle"; 
 import { getUserByUsername } from "@/lib/supabase";
 import {
   fetchPublicTopRepos,
@@ -125,16 +126,18 @@ export default async function PublicProfilePage({
           </p>
         </div>
         {/* Download stats card button — client component */}
-        <StatsCard
-          username={profile.username}
-          avatarUrl={avatarUrl}
-          currentStreak={profile.streak.current}
-          longestStreak={profile.streak.longest}
-          totalCommits={profile.contributions.total}
-          topRepo={topRepo}
-        />
+        <div className="flex items-center gap-3">
+          <ThemeToggle />
+          <StatsCard
+            username={profile.username}
+            avatarUrl={avatarUrl}
+            currentStreak={profile.streak.current}
+            longestStreak={profile.streak.longest}
+            totalCommits={profile.contributions.total}
+            topRepo={topRepo}
+          />
+        </div>
       </div>
-
       {/* Row 1: Contribution graph + Streak */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">


### PR DESCRIPTION
## Summary

Adds the existing ThemeToggle component to the public profile page header 
so visitors can switch between dark and light mode.

Closes #1032 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added `ThemeToggle` import to `src/app/u/[username]/page.tsx`
- Wrapped existing `StatsCard` in a flex div alongside `ThemeToggle`

## How to Test

1. Visit public profile page `/u/[username]`
2. Toggle should be visible in the top-right corner next to the download card button
3. Click the toggle — page should switch between dark and light mode immediately
4. Refresh the page — preference should persist (saved in localStorage)
5. Test without being logged in — toggle should still work

## Screenshots (if UI change)

Toggle appears in top-right of profile header alongside StatsCard

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
