### PR TITLE
fix: remove private repository scope from github oauth

### DIFF
--- a/src/app/api/auth/link-github/route.ts
+++ b/src/app/api/auth/link-github/route.ts
@@ -27,7 +27,7 @@ export async function GET() {
   const githubUrl = new URL("https://github.com/login/oauth/authorize");
   githubUrl.searchParams.set("client_id", process.env.GITHUB_ID ?? "");
   githubUrl.searchParams.set("redirect_uri", redirectUri);
-  githubUrl.searchParams.set("scope", "read:user repo");
+  githubUrl.searchParams.set("scope", "read:user");
   githubUrl.searchParams.set("state", state);
 
   const response = NextResponse.redirect(githubUrl, { status: 307 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,7 +18,7 @@ export const authOptions: NextAuthOptions = {
       clientId: process.env.GITHUB_ID ?? "",
       clientSecret: process.env.GITHUB_SECRET ?? "",
       authorization: {
-        params: { scope: "read:user user:email repo read:discussion" },
+        params: { scope: "read:user user:email read:discussion" },
       },
     }),
   ],


### PR DESCRIPTION
---

## Summary

This PR removes the unnecessary `repo` scope from the GitHub OAuth flow to prevent requesting access to users' private repositories. This addresses user privacy concerns, adheres to the principle of least privilege, and ensures the application only requests the minimum essential scopes (`read:user`, `user:email`, `read:discussion`) required for authentication and basic profile info.

*(Note: I worked on this PR as the associated issue was assigned to me under GSSoC 2026.)*

Closes #1088 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- **`src/lib/auth.ts`**: Removed the `repo` scope from the `GitHubProvider` authorization parameters.
- **`src/app/api/auth/link-github/route.ts`**: Removed the `repo` scope from the URL search parameters when a user links their GitHub account.

## How to Test

Steps for the reviewer to verify this works:

1. Pull this branch and run the application locally.
2. Sign out if you are currently signed in.
3. Click "Sign in with GitHub" (or the link account option).
4. On the GitHub authorization screen, observe that the application no longer requests access to private repositories.

## Screenshots (if UI change)

*N/A - This is an OAuth permission scope change.*

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable (N/A)

---

You can just copy and paste this into GitHub when you open your PR!