### PR TITLE
feat: add year in code wrapped page

### DIFF
--- a/src/app/api/wrapped/og/route.tsx
+++ b/src/app/api/wrapped/og/route.tsx
@@ -1,0 +1,140 @@
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+function getParam(req: NextRequest, key: string, fallback: string) {
+  const value = req.nextUrl.searchParams.get(key);
+  return value && value.trim().length > 0 ? value.slice(0, 80) : fallback;
+}
+
+export async function GET(req: NextRequest) {
+  const username = getParam(req, "username", "developer");
+  const year = getParam(req, "year", String(new Date().getFullYear()));
+  const commits = getParam(req, "commits", "0");
+  const streak = getParam(req, "streak", "0");
+  const language = getParam(req, "language", "Code");
+  const repo = getParam(req, "repo", "DevTrack");
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#0b1020",
+          color: "#f8fafc",
+          padding: "58px 64px",
+          fontFamily: "Inter, Arial, sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div
+              style={{
+                color: "#67e8f9",
+                fontSize: 24,
+                fontWeight: 800,
+                letterSpacing: 3,
+                textTransform: "uppercase",
+              }}
+            >
+              DevTrack Wrapped
+            </div>
+            <div style={{ fontSize: 72, fontWeight: 900, lineHeight: 0.95 }}>
+              {`@${username}`}
+            </div>
+          </div>
+          <div
+            style={{
+              border: "2px solid rgba(248,250,252,0.2)",
+              borderRadius: 18,
+              padding: "18px 24px",
+              fontSize: 32,
+              fontWeight: 800,
+              color: "#fde68a",
+              height: 72,
+            }}
+          >
+            {year}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            gap: 22,
+            width: "100%",
+          }}
+        >
+          <Stat label="Commits" value={commits} color="#67e8f9" />
+          <Stat label="Longest streak" value={`${streak}d`} color="#a7f3d0" />
+          <Stat label="Top language" value={language} color="#fde68a" />
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderTop: "1px solid rgba(248,250,252,0.16)",
+            paddingTop: 24,
+          }}
+        >
+          <div style={{ fontSize: 28, color: "#cbd5e1" }}>
+            {`Most contributed repo: ${repo}`}
+          </div>
+          <div style={{ fontSize: 24, color: "#94a3b8" }}>devtrack.app</div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+}
+
+function Stat({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color: string;
+}) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        border: "1px solid rgba(248,250,252,0.16)",
+        borderRadius: 20,
+        background: "rgba(255,255,255,0.06)",
+        padding: 28,
+        minHeight: 168,
+      }}
+    >
+      <div style={{ color, fontSize: 54, fontWeight: 900, lineHeight: 1 }}>
+        {value}
+      </div>
+      <div
+        style={{
+          color: "#cbd5e1",
+          fontSize: 22,
+          fontWeight: 700,
+          textTransform: "uppercase",
+          letterSpacing: 2,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/wrapped/route.ts
+++ b/src/app/api/wrapped/route.ts
@@ -1,0 +1,216 @@
+import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { GITHUB_API, GitHubCommitSearchItem } from "@/lib/github";
+import {
+  calculateLanguagePercentages,
+  calculateLongestStreak,
+  getMostContributedRepo,
+  getMostProductiveMonth,
+  getPeakCodingHour,
+  getYearRange,
+  type WrappedCommit,
+} from "@/lib/wrapped";
+
+export const dynamic = "force-dynamic";
+
+interface GitHubSearchResponse {
+  total_count: number;
+  items: GitHubCommitSearchItem[];
+}
+
+interface GitHubLanguageResponse {
+  [language: string]: number;
+}
+
+function getRequestedYear(req: NextRequest) {
+  const now = new Date();
+  const parsed = Number(req.nextUrl.searchParams.get("year"));
+  const currentYear = now.getFullYear();
+
+  if (!Number.isInteger(parsed)) {
+    return currentYear;
+  }
+
+  return Math.min(currentYear, Math.max(2008, parsed));
+}
+
+async function fetchYearCommits(
+  token: string,
+  githubLogin: string,
+  startDate: string,
+  endDate: string
+) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+  };
+  const commits: WrappedCommit[] = [];
+  const hours: number[] = [];
+  const contributionsByDate: Record<string, number> = {};
+  let totalCommits = 0;
+
+  for (let page = 1; page <= 10; page += 1) {
+    const searchUrl = new URL(`${GITHUB_API}/search/commits`);
+    searchUrl.searchParams.set(
+      "q",
+      `author:${githubLogin} author-date:${startDate}..${endDate}`
+    );
+    searchUrl.searchParams.set("per_page", "100");
+    searchUrl.searchParams.set("page", String(page));
+    searchUrl.searchParams.set("sort", "author-date");
+    searchUrl.searchParams.set("order", "desc");
+
+    const res = await fetch(searchUrl.toString(), {
+      headers,
+      cache: "no-store",
+    });
+
+    if (!res.ok) {
+      if ((res.status === 403 || res.status === 429) && commits.length > 0) {
+        break;
+      }
+
+      throw new Error(`GitHub commit search failed: ${res.status}`);
+    }
+
+    const data = (await res.json()) as GitHubSearchResponse;
+    if (page === 1) {
+      totalCommits = data.total_count;
+    }
+
+    for (const item of data.items) {
+      const date = item.commit.author.date.slice(0, 10);
+      const hour = new Date(item.commit.author.date).getHours();
+      contributionsByDate[date] = (contributionsByDate[date] ?? 0) + 1;
+      commits.push({
+        date,
+        repo: item.repository?.full_name ?? "unknown",
+      });
+      hours.push(hour);
+    }
+
+    if (
+      data.items.length < 100 ||
+      commits.length >= 1000 ||
+      commits.length >= data.total_count
+    ) {
+      break;
+    }
+  }
+
+  return { commits, contributionsByDate, hours, totalCommits };
+}
+
+async function fetchMergedPRCount(
+  token: string,
+  githubLogin: string,
+  startDate: string,
+  endDate: string
+) {
+  const searchUrl = new URL(`${GITHUB_API}/search/issues`);
+  searchUrl.searchParams.set(
+    "q",
+    `type:pr author:${githubLogin} merged:${startDate}..${endDate}`
+  );
+  searchUrl.searchParams.set("per_page", "1");
+
+  const res = await fetch(searchUrl.toString(), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    return 0;
+  }
+
+  const data = (await res.json()) as { total_count: number };
+  return data.total_count;
+}
+
+async function fetchTopLanguages(token: string, repos: string[]) {
+  const langTotals: Record<string, number> = {};
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+  };
+
+  await Promise.all(
+    repos.slice(0, 30).map(async (repo) => {
+      try {
+        const res = await fetch(`${GITHUB_API}/repos/${repo}/languages`, {
+          headers,
+          cache: "no-store",
+        });
+
+        if (!res.ok) {
+          return;
+        }
+
+        const languages = (await res.json()) as GitHubLanguageResponse;
+        for (const [language, bytes] of Object.entries(languages)) {
+          langTotals[language] = (langTotals[language] ?? 0) + bytes;
+        }
+      } catch {
+        // Language data is nice-to-have for the recap. The rest of the wrapped
+        // experience should still render if one repository cannot be read.
+      }
+    })
+  );
+
+  return calculateLanguagePercentages(langTotals, 3);
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const year = getRequestedYear(req);
+  const { startDate, endDate, partial } = getYearRange(year);
+
+  try {
+    const { commits, contributionsByDate, hours, totalCommits } =
+      await fetchYearCommits(
+        session.accessToken,
+        session.githubLogin,
+        startDate,
+        endDate
+      );
+    const repos = Array.from(new Set(commits.map((commit) => commit.repo))).filter(
+      (repo) => repo !== "unknown"
+    );
+    const [topLanguages, prsMerged] = await Promise.all([
+      fetchTopLanguages(session.accessToken, repos),
+      fetchMergedPRCount(
+        session.accessToken,
+        session.githubLogin,
+        startDate,
+        endDate
+      ),
+    ]);
+
+    return Response.json({
+      year,
+      username: session.githubLogin,
+      totalCommits,
+      activeDays: Object.values(contributionsByDate).filter(
+        (count) => count > 0
+      ).length,
+      longestStreak: calculateLongestStreak(contributionsByDate),
+      mostProductiveMonth: getMostProductiveMonth(contributionsByDate),
+      topLanguages,
+      prsMerged,
+      mostContributedRepo: getMostContributedRepo(commits),
+      peakCodingHour: getPeakCodingHour(hours),
+      generatedAt: new Date().toISOString(),
+      partial,
+    });
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -43,6 +43,12 @@ export default async function DashboardPage() {
       <DashboardHeader />
       <div className="mb-6 flex justify-end items-center gap-2">
         <Link
+          href="/wrapped"
+          className="rounded-lg border border-[var(--accent)] bg-[var(--accent-soft)] px-4 py-2 text-sm font-semibold text-[var(--accent)] hover:opacity-90 transition-opacity min-w-[140px] flex items-center justify-center"
+        >
+          Year in Code
+        </Link>
+        <Link
           href="/dashboard/settings"
           className="rounded-lg border border-[var(--border)] bg-[var(--control)] px-4 py-2 text-sm text-[var(--foreground)] hover:opacity-90 transition-opacity min-w-[140px] flex items-center justify-center"
         >

--- a/src/app/wrapped/page.tsx
+++ b/src/app/wrapped/page.tsx
@@ -1,0 +1,19 @@
+import WrappedExperience from "@/components/WrappedExperience";
+import { authOptions } from "@/lib/auth";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+export const metadata = {
+  title: "Year in Code | DevTrack",
+  description: "A shareable annual recap of your coding activity.",
+};
+
+export default async function WrappedPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session || session.error === "TokenRevoked") {
+    redirect("/");
+  }
+
+  return <WrappedExperience />;
+}

--- a/src/components/WrappedExperience.tsx
+++ b/src/components/WrappedExperience.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import type { WrappedStats } from "@/lib/wrapped";
+
+const SLIDE_THEMES = [
+  "from-cyan-500/20 via-slate-900 to-emerald-500/20",
+  "from-amber-400/20 via-slate-900 to-cyan-500/20",
+  "from-emerald-400/20 via-slate-900 to-rose-500/20",
+  "from-sky-400/20 via-slate-900 to-lime-400/20",
+  "from-fuchsia-400/20 via-slate-900 to-amber-300/20",
+  "from-teal-400/20 via-slate-900 to-indigo-400/20",
+  "from-orange-300/20 via-slate-900 to-cyan-300/20",
+];
+
+const formatter = new Intl.NumberFormat("en-US");
+
+function formatNumber(value: number) {
+  return formatter.format(value);
+}
+
+function buildYearOptions() {
+  const currentYear = new Date().getFullYear();
+  const years = [];
+  for (let year = currentYear; year >= Math.max(2008, currentYear - 8); year -= 1) {
+    years.push(year);
+  }
+  return years;
+}
+
+function getShareText(stats: WrappedStats) {
+  return `My ${stats.year} Year in Code: ${formatNumber(
+    stats.totalCommits
+  )} commits, ${stats.longestStreak}-day streak, and ${
+    stats.topLanguages[0]?.name ?? "code"
+  } on top.`;
+}
+
+function getOgImageUrl(stats: WrappedStats) {
+  const params = new URLSearchParams({
+    username: stats.username,
+    year: String(stats.year),
+    commits: String(stats.totalCommits),
+    streak: String(stats.longestStreak),
+    language: stats.topLanguages[0]?.name ?? "Code",
+    repo: stats.mostContributedRepo.name,
+  });
+
+  return `/api/wrapped/og?${params.toString()}`;
+}
+
+export default function WrappedExperience() {
+  const years = useMemo(buildYearOptions, []);
+  const [selectedYear, setSelectedYear] = useState(years[0]);
+  const [stats, setStats] = useState<WrappedStats | null>(null);
+  const [slide, setSlide] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [origin, setOrigin] = useState("");
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const requestedYear = Number(params.get("year"));
+    if (years.includes(requestedYear)) {
+      setSelectedYear(requestedYear);
+    }
+    setOrigin(window.location.origin);
+  }, [years]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    setSlide(0);
+
+    fetch(`/api/wrapped?year=${selectedYear}`, {
+      signal: controller.signal,
+      cache: "no-store",
+    })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error("Failed to load wrapped data");
+        }
+        return res.json();
+      })
+      .then((data: WrappedStats) => setStats(data))
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          setError("We could not build your Year in Code right now.");
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [selectedYear, reloadKey]);
+
+  const slides = useMemo(() => {
+    if (!stats) return [];
+
+    const languages =
+      stats.topLanguages.length > 0
+        ? stats.topLanguages
+            .map((language) => `${language.name} ${language.percentage}%`)
+            .join(" / ")
+        : "No language data yet";
+
+    return [
+      {
+        eyebrow: `${stats.year} recap`,
+        title: `${formatNumber(stats.totalCommits)} commits`,
+        body: `${stats.activeDays} active coding days captured by DevTrack.`,
+        metric: "Total commits",
+      },
+      {
+        eyebrow: "Consistency",
+        title: `${stats.longestStreak} day streak`,
+        body: "Your longest run of back-to-back coding days this year.",
+        metric: "Longest streak",
+      },
+      {
+        eyebrow: "Best month",
+        title: stats.mostProductiveMonth.name,
+        body: `${formatNumber(
+          stats.mostProductiveMonth.commits
+        )} commits landed in your busiest month.`,
+        metric: "Most productive month",
+      },
+      {
+        eyebrow: "Languages",
+        title: stats.topLanguages[0]?.name ?? "No clear leader",
+        body: languages,
+        metric: "Top 3 languages",
+      },
+      {
+        eyebrow: "Pull requests",
+        title: `${formatNumber(stats.prsMerged)} merged`,
+        body: "Merged pull requests authored by you during the selected year.",
+        metric: "Total PRs merged",
+      },
+      {
+        eyebrow: "Repository",
+        title: stats.mostContributedRepo.name,
+        body: `${formatNumber(
+          stats.mostContributedRepo.commits
+        )} sampled commits came from this repository.`,
+        metric: "Most contributed repo",
+      },
+      {
+        eyebrow: "Coding clock",
+        title: stats.peakCodingHour.label,
+        body:
+          stats.peakCodingHour.hour === null
+            ? "Commit timestamps were too sparse for a peak-hour insight."
+            : `You coded at ${stats.peakCodingHour.label} most often.`,
+        metric: "Peak coding time",
+      },
+    ];
+  }, [stats]);
+
+  const shareUrl = origin
+    ? `${origin}/wrapped?year=${selectedYear}`
+    : `/wrapped?year=${selectedYear}`;
+  const shareText = stats ? getShareText(stats) : "My Year in Code on DevTrack";
+  const twitterUrl = `https://twitter.com/intent/tweet?${new URLSearchParams({
+    text: shareText,
+    url: shareUrl,
+  }).toString()}`;
+  const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?${new URLSearchParams(
+    { url: shareUrl }
+  ).toString()}`;
+  const currentSlide = slides[slide];
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-50">
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-6 sm:px-6 lg:px-8">
+        <header className="flex flex-col gap-4 border-b border-white/10 pb-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200">
+              DevTrack
+            </p>
+            <h1 className="mt-2 text-3xl font-extrabold leading-tight sm:text-5xl">
+              Year in Code
+            </h1>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="text-sm font-medium text-slate-300" htmlFor="wrapped-year">
+              Year
+            </label>
+            <select
+              id="wrapped-year"
+              value={selectedYear}
+              onChange={(event) => setSelectedYear(Number(event.target.value))}
+              className="h-10 rounded-md border border-white/20 bg-slate-900 px-3 text-sm font-semibold text-white outline-none transition focus:border-cyan-300 focus:ring-2 focus:ring-cyan-300/30"
+            >
+              {years.map((year) => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+            </select>
+            <Link
+              href="/dashboard"
+              className="inline-flex h-10 items-center rounded-md border border-white/20 px-4 text-sm font-semibold text-slate-100 transition hover:border-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-300/40"
+            >
+              Dashboard
+            </Link>
+          </div>
+        </header>
+
+        {loading ? (
+          <section
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+            className="grid flex-1 place-items-center py-16"
+          >
+            <div className="h-[520px] w-full max-w-4xl animate-pulse rounded-lg border border-white/10 bg-white/5" />
+            <span className="sr-only">Loading your Year in Code</span>
+          </section>
+        ) : error ? (
+          <section className="grid flex-1 place-items-center py-16">
+            <div className="max-w-xl rounded-lg border border-rose-300/30 bg-rose-500/10 p-6 text-center">
+              <h2 className="text-xl font-bold">Wrapped is taking a breather</h2>
+              <p className="mt-2 text-sm text-rose-100">{error}</p>
+              <button
+                type="button"
+                onClick={() => setReloadKey((value) => value + 1)}
+                className="mt-5 rounded-md bg-rose-100 px-4 py-2 text-sm font-bold text-rose-950"
+              >
+                Try again
+              </button>
+            </div>
+          </section>
+        ) : stats && currentSlide ? (
+          <>
+            <section className="grid flex-1 items-center gap-6 py-8 lg:grid-cols-[minmax(0,1.35fr)_minmax(300px,0.65fr)]">
+              <div
+                className={`relative min-h-[520px] overflow-hidden rounded-lg border border-white/10 bg-gradient-to-br ${
+                  SLIDE_THEMES[slide % SLIDE_THEMES.length]
+                } p-6 shadow-2xl shadow-cyan-950/30 sm:p-10`}
+                aria-live="polite"
+              >
+                <div className="absolute inset-x-0 top-0 h-1 bg-white/10">
+                  <div
+                    className="h-full bg-cyan-300 transition-all duration-500"
+                    style={{ width: `${((slide + 1) / slides.length) * 100}%` }}
+                  />
+                </div>
+                <div
+                  key={currentSlide.metric}
+                  className="flex min-h-[450px] flex-col justify-between transition duration-500 ease-out animate-[fadeUp_0.45s_ease-out]"
+                >
+                  <div>
+                    <p className="text-sm font-bold uppercase tracking-[0.28em] text-cyan-200">
+                      {currentSlide.eyebrow}
+                    </p>
+                    <h2 className="mt-6 max-w-3xl break-words text-5xl font-black leading-[0.95] text-white sm:text-7xl">
+                      {currentSlide.title}
+                    </h2>
+                    <p className="mt-6 max-w-2xl text-lg leading-8 text-slate-200">
+                      {currentSlide.body}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-end justify-between gap-4 border-t border-white/10 pt-6">
+                    <div>
+                      <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                        Slide {slide + 1} of {slides.length}
+                      </p>
+                      <p className="mt-2 text-xl font-bold text-slate-100">
+                        {currentSlide.metric}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setSlide((value) => Math.max(0, value - 1))}
+                        disabled={slide === 0}
+                        className="h-11 rounded-md border border-white/20 px-4 text-sm font-bold text-white transition hover:border-cyan-300 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        Previous
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setSlide((value) => Math.min(slides.length - 1, value + 1))
+                        }
+                        disabled={slide === slides.length - 1}
+                        className="h-11 rounded-md bg-cyan-300 px-4 text-sm font-black text-slate-950 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        Next
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <aside className="space-y-4">
+                <div className="rounded-lg border border-white/10 bg-white/[0.04] p-5">
+                  <h2 className="text-lg font-bold">Share card</h2>
+                  <p className="mt-1 text-sm text-slate-300">
+                    Generated from your selected year.
+                  </p>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={getOgImageUrl(stats)}
+                    alt={`${stats.year} Year in Code share card for ${stats.username}`}
+                    className="mt-4 aspect-[1200/630] w-full rounded-md border border-white/10 object-cover"
+                  />
+                  <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <a
+                      href={twitterUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex h-10 items-center justify-center rounded-md bg-white px-3 text-sm font-black text-slate-950 transition hover:bg-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+                    >
+                      Share on X
+                    </a>
+                    <a
+                      href={linkedInUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex h-10 items-center justify-center rounded-md border border-white/20 px-3 text-sm font-bold text-white transition hover:border-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-300"
+                    >
+                      LinkedIn
+                    </a>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <MiniStat label="Commits" value={formatNumber(stats.totalCommits)} />
+                  <MiniStat label="Active days" value={formatNumber(stats.activeDays)} />
+                  <MiniStat label="Merged PRs" value={formatNumber(stats.prsMerged)} />
+                  <MiniStat label="Peak hour" value={stats.peakCodingHour.label} />
+                </div>
+
+                {stats.partial && (
+                  <p className="rounded-md border border-amber-300/30 bg-amber-300/10 p-3 text-sm text-amber-100">
+                    {stats.year} is still in progress, so this recap uses year-to-date data.
+                  </p>
+                )}
+              </aside>
+            </section>
+
+            <nav
+              aria-label="Wrapped slides"
+              className="flex flex-wrap justify-center gap-2 pb-6"
+            >
+              {slides.map((item, index) => (
+                <button
+                  key={item.metric}
+                  type="button"
+                  onClick={() => setSlide(index)}
+                  aria-current={slide === index ? "step" : undefined}
+                  className={`h-3 w-10 rounded-full transition ${
+                    slide === index ? "bg-cyan-300" : "bg-white/20 hover:bg-white/40"
+                  }`}
+                >
+                  <span className="sr-only">{item.metric}</span>
+                </button>
+              ))}
+            </nav>
+          </>
+        ) : null}
+      </div>
+    </main>
+  );
+}
+
+function MiniStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/[0.04] p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+        {label}
+      </p>
+      <p className="mt-2 break-words text-2xl font-black text-white">{value}</p>
+    </div>
+  );
+}

--- a/src/lib/wrapped.ts
+++ b/src/lib/wrapped.ts
@@ -1,0 +1,179 @@
+export interface WrappedCommit {
+  date: string;
+  repo: string;
+}
+
+export interface WrappedLanguage {
+  name: string;
+  bytes: number;
+  percentage: number;
+}
+
+export interface WrappedStats {
+  year: number;
+  username: string;
+  totalCommits: number;
+  activeDays: number;
+  longestStreak: number;
+  mostProductiveMonth: {
+    name: string;
+    commits: number;
+  };
+  topLanguages: WrappedLanguage[];
+  prsMerged: number;
+  mostContributedRepo: {
+    name: string;
+    commits: number;
+  };
+  peakCodingHour: {
+    hour: number | null;
+    label: string;
+    commits: number;
+  };
+  generatedAt: string;
+  partial: boolean;
+}
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+export function getYearRange(year: number, now = new Date()) {
+  const start = new Date(Date.UTC(year, 0, 1, 0, 0, 0));
+  const requestedEnd = new Date(Date.UTC(year, 11, 31, 23, 59, 59));
+  const end = requestedEnd.getTime() > now.getTime() ? now : requestedEnd;
+
+  return {
+    start,
+    end,
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+    partial: requestedEnd.getTime() > now.getTime(),
+  };
+}
+
+export function calculateLongestStreak(contributionsByDate: Record<string, number>) {
+  const activeDates = new Set(
+    Object.entries(contributionsByDate)
+      .filter(([, count]) => count > 0)
+      .map(([date]) => date)
+  );
+  const dates = Array.from(activeDates).sort();
+  let longest = 0;
+  let current = 0;
+  let previous: Date | null = null;
+
+  for (const date of dates) {
+    const currentDate = new Date(`${date}T00:00:00Z`);
+    const dayDiff =
+      previous === null
+        ? 1
+        : Math.round(
+            (currentDate.getTime() - previous.getTime()) / 86400000
+          );
+
+    current = dayDiff === 1 ? current + 1 : 1;
+    longest = Math.max(longest, current);
+    previous = currentDate;
+  }
+
+  return longest;
+}
+
+export function getMostProductiveMonth(contributionsByDate: Record<string, number>) {
+  const monthlyTotals = Array.from({ length: 12 }, () => 0);
+
+  for (const [date, count] of Object.entries(contributionsByDate)) {
+    const month = Number(date.slice(5, 7)) - 1;
+    if (month >= 0 && month < 12) {
+      monthlyTotals[month] += count;
+    }
+  }
+
+  const bestMonth = monthlyTotals.reduce(
+    (best, count, index) => (count > monthlyTotals[best] ? index : best),
+    0
+  );
+
+  return {
+    name: MONTH_NAMES[bestMonth],
+    commits: monthlyTotals[bestMonth],
+  };
+}
+
+export function getMostContributedRepo(commits: WrappedCommit[]) {
+  const repoCounts: Record<string, number> = {};
+
+  for (const commit of commits) {
+    repoCounts[commit.repo] = (repoCounts[commit.repo] ?? 0) + 1;
+  }
+
+  const [name = "No repository data", commitsCount = 0] =
+    Object.entries(repoCounts).sort((a, b) => b[1] - a[1])[0] ?? [];
+
+  return { name, commits: commitsCount };
+}
+
+export function getPeakCodingHour(hours: number[]) {
+  const hourCounts = Array.from({ length: 24 }, () => 0);
+
+  for (const hour of hours) {
+    if (Number.isInteger(hour) && hour >= 0 && hour <= 23) {
+      hourCounts[hour] += 1;
+    }
+  }
+
+  const bestHour = hourCounts.reduce(
+    (best, count, index) => (count > hourCounts[best] ? index : best),
+    0
+  );
+  const commits = hourCounts[bestHour];
+
+  if (commits === 0) {
+    return { hour: null, label: "Not enough data yet", commits: 0 };
+  }
+
+  return {
+    hour: bestHour,
+    label: formatHour(bestHour),
+    commits,
+  };
+}
+
+export function calculateLanguagePercentages(
+  langTotals: Record<string, number>,
+  limit = 3
+): WrappedLanguage[] {
+  const totalBytes = Object.values(langTotals).reduce(
+    (sum, bytes) => sum + bytes,
+    0
+  );
+
+  return Object.entries(langTotals)
+    .map(([name, bytes]) => ({
+      name,
+      bytes,
+      percentage:
+        totalBytes > 0 ? Math.round((bytes / totalBytes) * 1000) / 10 : 0,
+    }))
+    .sort((a, b) => b.bytes - a.bytes)
+    .slice(0, limit);
+}
+
+function formatHour(hour: number) {
+  const normalized = hour % 24;
+  const suffix = normalized >= 12 ? "pm" : "am";
+  const display = normalized % 12 === 0 ? 12 : normalized % 12;
+  return `${display}${suffix}`;
+}

--- a/test/wrapped.test.ts
+++ b/test/wrapped.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateLanguagePercentages,
+  calculateLongestStreak,
+  getMostContributedRepo,
+  getMostProductiveMonth,
+  getPeakCodingHour,
+  getYearRange,
+} from "@/lib/wrapped";
+
+describe("wrapped helpers", () => {
+  it("calculates the longest contribution streak", () => {
+    expect(
+      calculateLongestStreak({
+        "2025-01-01": 2,
+        "2025-01-02": 1,
+        "2025-01-04": 4,
+        "2025-01-05": 1,
+        "2025-01-06": 1,
+      })
+    ).toBe(3);
+  });
+
+  it("finds the most productive month", () => {
+    expect(
+      getMostProductiveMonth({
+        "2025-02-01": 3,
+        "2025-02-03": 2,
+        "2025-07-10": 8,
+      })
+    ).toEqual({ name: "July", commits: 8 });
+  });
+
+  it("finds the most contributed repository", () => {
+    expect(
+      getMostContributedRepo([
+        { date: "2025-01-01", repo: "open/devtrack" },
+        { date: "2025-01-02", repo: "open/devtrack" },
+        { date: "2025-01-03", repo: "open/docs" },
+      ])
+    ).toEqual({ name: "open/devtrack", commits: 2 });
+  });
+
+  it("formats the peak coding hour", () => {
+    expect(getPeakCodingHour([0, 13, 13, 23])).toEqual({
+      hour: 13,
+      label: "1pm",
+      commits: 2,
+    });
+  });
+
+  it("calculates top language percentages", () => {
+    expect(
+      calculateLanguagePercentages({
+        TypeScript: 300,
+        Python: 100,
+        CSS: 100,
+        HTML: 50,
+      })
+    ).toEqual([
+      { name: "TypeScript", bytes: 300, percentage: 54.5 },
+      { name: "Python", bytes: 100, percentage: 18.2 },
+      { name: "CSS", bytes: 100, percentage: 18.2 },
+    ]);
+  });
+
+  it("marks future year ranges as partial", () => {
+    expect(getYearRange(2026, new Date("2026-05-25T00:00:00Z"))).toMatchObject({
+      startDate: "2026-01-01",
+      endDate: "2026-05-25",
+      partial: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `/wrapped` Year in Code annual recap experience with animated stat slides, annual GitHub activity aggregation, social sharing, and a generated shareable OG image card.

Closes #1073

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added authenticated `/wrapped` page for the Year in Code recap.
- Added animated slide-based recap UI with year picker and social share buttons.
- Added `/api/wrapped` endpoint to aggregate annual stats including commits, longest streak, top languages, merged PRs, most contributed repo, most productive month, and peak coding hour.
- Added `/api/wrapped/og` ImageResponse endpoint for shareable recap cards.
- Added dashboard link to access the Wrapped page.
- Added tests for wrapped stat helper calculations.

## How to Test

Steps for the reviewer to verify this works:

1. Run `npm run type-check`.
2. Run `npm run lint`.
3. Run `npm test -- --run test/wrapped.test.ts`.
4. Start the app with `npm run dev`.
5. Sign in and open `/wrapped`.
6. Verify the year picker loads annual stats.
7. Navigate through the recap slides.
8. Verify the Twitter/X and LinkedIn share buttons are present.
9. Open `/api/wrapped/og?username=test&year=2025&commits=42&streak=7&language=TypeScript&repo=test%2Frepo` and confirm a PNG share card is generated.

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable