### PR TITLE
fix: improve visible focus styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,7 @@
   --card-muted: #e2e8f0;
   --border: #cbd5e1;
   --accent: #6366f1;
+  --focus-ring: #4338ca;
   --success: #10b981;
   --warning: #f59e0b;
   --destructive: #ef4444;
@@ -37,6 +38,7 @@
   --card-muted: #161616;
   --border: #222222;
   --accent: #818cf8;
+  --focus-ring: #a5b4fc;
   --success: #10b981;
   --warning: #fbbf24;
   --destructive: #f87171;
@@ -56,6 +58,19 @@ body {
   color: var(--foreground);
   transition: background-color 200ms ease, color 200ms ease;
 }
+
+:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 3px;
+  border-radius: 0.375rem;
+}
+
+@media (forced-colors: active) {
+  :focus-visible {
+    outline: 3px solid Highlight;
+  }
+}
+
 /* Custom slim scrollbar for dashboard widgets */
 .scrollbar-thin {
   scrollbar-width: thin;


### PR DESCRIPTION
## Summary
- Add a dedicated focus ring color token for light and dark themes
- Add global `:focus-visible` styling with a 3px outline and offset for keyboard users
- Preserve high-contrast/forced-colors support with `Highlight`

Closes #1034

## Checks
- `npm run lint`
- `npm run type-check`

## Accessibility impact
Keyboard users get a visible focus indicator on buttons, links, and other focusable controls, including dashboard header controls in light mode.