### PR TITLE
fix: improve mobile notification dismiss behavior

### DIFF
--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -46,9 +46,9 @@ export default function NotificationBell() {
       }
     }
 
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("pointerdown", handleClickOutside);
     return () =>
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("pointerdown", handleClickOutside);
   }, []);
 
   const handleOpen = useCallback(async () => {
@@ -120,12 +120,33 @@ export default function NotificationBell() {
             <h3 className="text-sm font-semibold text-[var(--card-foreground)]">
               Notifications
             </h3>
-
-            {unreadCount === 0 && (
-              <span className="text-xs text-[var(--muted-foreground)]">
-                All caught up
-              </span>
-            )}
+            <div className="flex items-center gap-2">
+              {unreadCount === 0 && (
+                <span className="text-xs text-[var(--muted-foreground)]">
+                  All caught up
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="rounded-md p-1 text-[var(--muted-foreground)] hover:bg-[var(--control)] hover:text-[var(--card-foreground)] transition-colors"
+                aria-label="Close notifications"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M18 6 6 18" />
+                  <path d="m6 6 12 12" />
+                </svg>
+              </button>
+            </div>
           </div>
 
           <ul className="max-h-72 overflow-y-auto divide-y divide-[var(--border)]  scrollbar-thin">
@@ -150,9 +171,7 @@ export default function NotificationBell() {
                 </li>
               ))
             )}
-          </ul>
-
-          
+          </ul>          
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Fixed the mobile notification drawer behavior by adding a close button and improving outside click handling for touch devices.

Closes #1054

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- changed outside click handling from `mousedown` to `pointerdown` for better mobile support
- added a close button inside the notification drawer
- improved mobile dismissal behavior for the notifications dropdown

## How to Test

1. Run the app locally and sign in
2. Open the dashboard in mobile view / DevTools mobile emulation
3. Open the notification drawer from the bell icon
4. Tap outside the drawer and verify it closes
5. Open it again and use the new close button
6. Verify the drawer closes properly

## Screenshots

Added a close button to the notification drawer UI.

<img width="623" height="400" alt="Screenshot showing change in notification drawer UI with close button" src="https://github.com/user-attachments/assets/6961b8e7-9d9d-49c1-8882-7f0da1dc2b5c" />

<img width="620" height="408" alt="image" src="https://github.com/user-attachments/assets/e03439bf-cd11-487c-b4b0-a03ad8a4cacc" />


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable