### PR TITLE
fix: useravatar image fails to load for users with non-ascii github u…

### DIFF
--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -5,7 +5,7 @@ import { useSession } from "next-auth/react";
 import { useState } from "react";
 
 function getInitial(name?: string | null) {
-  return name?.trim().charAt(0).toUpperCase() || "?";
+  return name ? Array.from(name)[0]?.toUpperCase() ?? '?' : '?';
 }
 
 export default function UserAvatar() {


### PR DESCRIPTION
## Summary

- Fixed UserAvatar fallback rendering for GitHub users with non-ASCII display names.
- Previously, when the avatar image failed to load, the initials fallback incorrectly displayed ? or garbled characters for Unicode names due to improper character extraction.
- Updated initials generation logic to correctly handle Unicode characters using Array.from().

Closes #1049 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Replaced direct string indexing (name[0] / name.charAt(0)) with Unicode-safe extraction.
` name ? Array.from(name)[0]?.toUpperCase() ?? '?' : '?'; `

## How to Test

Steps for the reviewer to verify this works:

1. Sign in with a GitHub account that has a display name containing non-ASCII characters.
2. Verify the fallback displays the correct initial instead of ? or broken characters.

If above steps won't work:
1. Block image request or use an invalid avatar URL
2. Verify the fallback displays the correct initial instead of ? or broken characters.

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
