### PR TITLE
fix: include accountId in languages route cache key

### DIFF
--- a/e2e/landing.spec.js
+++ b/e2e/landing.spec.js
@@ -24,7 +24,7 @@ test("dashboard stays protected for unauthenticated users", async ({ page }) => 
   await expect(page.getByRole("link", { name: "Sign in with GitHub" }).first()).toBeVisible();
 });
 
-test("landing has dashboard link", async ({ page }) => {
+test("landing page shows dashboard link", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();

--- a/src/app/api/metrics/languages/route.ts
+++ b/src/app/api/metrics/languages/route.ts
@@ -11,14 +11,22 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) return Response.json({ error: "Unauthorized" }, { status: 401 });
 
   const bypass = isMetricsCacheBypassed(req);
-  const key = metricsCacheKey(session.githubId ?? session.githubLogin, "languages" as any);
 
+  const accountId = req.nextUrl.searchParams.get("accountId");
+
+  const key = metricsCacheKey(
+    session.githubId ?? session.githubLogin,
+    "languages" as any,
+    {
+      accountId: accountId || undefined,
+    }
+  );
   try {
     const data = await withMetricsCache({ bypass, key, ttlSeconds: 10 * 60 }, async () => {
       const headers = { Authorization: `Bearer ${session.accessToken}`, Accept: "application/vnd.github+json" };
       const since = new Date();
       since.setDate(since.getDate() - 90);
-      
+
       const searchRes = await fetch(
         `${GITHUB_API}/search/commits?q=author:${session.githubLogin}+author-date:>=${since.toISOString().slice(0, 10)}&per_page=100&sort=author-date&order=desc`,
         { headers, cache: "no-store" }
@@ -38,7 +46,7 @@ export async function GET(req: NextRequest) {
             for (const [lang, bytes] of Object.entries(langs)) {
               langTotals[lang] = (langTotals[lang] ?? 0) + (bytes as number);
             }
-          } catch {}
+          } catch { }
         })
       );
 


### PR DESCRIPTION
## Summary

Added `accountId` to the languages route cache key to ensure cache separation between different linked GitHub accounts and prevent cached language data from being shared across accounts.

Closes #812 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added `accountId` from request query parameters in `src/app/api/metrics/languages/route.ts`
- Updated `metricsCacheKey()` to include `accountId` in the cache key
- Ensured language cache entries are isolated per linked GitHub account

## How to Test

Steps for the reviewer to verify this works:

1. Link multiple GitHub accounts
2. Request the languages endpoint with different `accountId` values
3. Confirm responses are cached separately and data does not overlap between accounts
4. Run:

```bash
npm run type-check
npm run lint
```

## Screenshots (if UI change)

N/A (backend/cache fix)

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable