### PR TITLE
fix(supabase): add server-only guard to prevent client bundle exposure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react": "^18",
         "react-dom": "^18",
         "recharts": "^2.12.7",
+        "server-only": "^0.0.1",
         "sonner": "^2.0.7"
       },
       "devDependencies": {
@@ -7388,6 +7389,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "^18",
     "react-dom": "^18",
     "recharts": "^2.12.7",
+    "server-only": "^0.0.1",
     "sonner": "^2.0.7"
   },
   "devDependencies": {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -89,3 +90,4 @@ export async function updateUserPublicFlag(
     return null;
   }
 }
+

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -7,7 +7,6 @@ const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 export const SUPABASE_ADMIN_UNAVAILABLE_MESSAGE =
   "Supabase admin client is unavailable. Check NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SupabaseAdminClient = SupabaseClient<any, any, any>;
 
 function createUnavailableSupabaseAdmin(): SupabaseAdminClient {
@@ -90,4 +89,5 @@ export async function updateUserPublicFlag(
     return null;
   }
 }
+
 


### PR DESCRIPTION
## Summary
Closes #958

`src/lib/supabase.ts` exports `supabaseAdmin` which uses `SUPABASE_SERVICE_ROLE_KEY`. Without a server-only guard, accidentally importing this in a client component would expose the service role key in the browser bundle, bypassing all RLS policies.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made
- Installed `server-only` package
- Added `import 'server-only'` as the first line of `src/lib/supabase.ts`
- This causes a build-time error if `supabaseAdmin` is ever accidentally imported from a client component

## How to Test
1. Try importing `supabaseAdmin` from a client component (`'use client'`)
2. Run `npm run build` — it will fail with a clear error message
3. Remove the import — build succeeds

## Checklist
- [x] Linked issue in summary
- [x] No TypeScript errors
- [x] Self-reviewed the diff
- [x] No behavior change — server-side imports unaffected