### PR TITLE
fix: improve sign out button theme contrast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -80,7 +79,6 @@
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -938,7 +936,6 @@
       "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.49.1"
       },
@@ -1418,7 +1415,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.106.1.tgz",
       "integrity": "sha512-gP4HurGkGu7Z3xoOCjtAI17BKKp7jpsmwY0Ssbsks9XQRzJ7ZhK7LxfLdBSYgUdgZCQgjRK+Mr7+cl4Gxrk0Rw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.106.1",
         "@supabase/functions-js": "2.106.1",
@@ -1540,7 +1536,6 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1571,7 +1566,6 @@
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2316,7 +2310,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2792,7 +2785,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3773,7 +3765,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3942,7 +3933,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5469,7 +5459,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5541,7 +5530,6 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
       "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -5905,7 +5893,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
       "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -6578,7 +6565,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -6749,7 +6735,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
       "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6840,7 +6825,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6853,7 +6837,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7886,7 +7869,6 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8045,7 +8027,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8245,7 +8226,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -5,10 +5,11 @@ import { signOut } from "next-auth/react"
 
 export default function SignOutButton() {
     const [signingOut, setSigningOut] = useState(false)
-    const [confirming, setConfirming] = useState(false);
+    const [confirming, setConfirming] = useState(false)
 
     const handleSignOut = async () => {
         setSigningOut(true)
+
         try {
             await signOut({ callbackUrl: "/" })
         } catch (error) {
@@ -46,11 +47,11 @@ export default function SignOutButton() {
             type="button"
             disabled={signingOut}
             onClick={() => setConfirming(true)}
-            className="inline-flex h-10 items-center gap-2 rounded-full border border-[var(--destructive)]/50 bg-[var(--destructive)]/80 px-4 text-sm font-semibold text-[var(--accent-foreground)] transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-70"
+            className="inline-flex h-10 items-center gap-2 rounded-full border border-[var(--destructive)]/50 bg-[var(--destructive)]/80 px-4 text-sm font-semibold text-[var(--destructive-foreground)] transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-70"
         >
             {signingOut && (
                 <svg
-                    className="h-4 w-4 animate-spin text-[var(--accent-foreground)]"
+                    className="h-4 w-4 animate-spin text-[var(--destructive-foreground)]"
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"
                     viewBox="0 0 24 24"
@@ -62,13 +63,15 @@ export default function SignOutButton() {
                         r="10"
                         stroke="currentColor"
                         strokeWidth="4"
-                    ></circle>
+                    />
 
                     <path
                         className="opacity-75"
                         fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 
+                        5.291A7.962 7.962 0 014 12H0c0 
+                        3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
                 </svg>
             )}
 
@@ -76,4 +79,3 @@ export default function SignOutButton() {
         </button>
     )
 }
-


### PR DESCRIPTION
## Summary

Fixed the sign out button text contrast issue across light and dark themes.

The Sign Out button was using `--accent-foreground` for its text and loading spinner colors. Since `--accent-foreground` changes between themes, the button text could become difficult to read depending on the active theme. This update replaces it with `--destructive-foreground`, which is intended for destructive actions and provides consistent contrast across both themes.

Closes #1117

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Replaced `text-[var(--accent-foreground)]` with `text-[var(--destructive-foreground)]` for the Sign Out button text.
* Updated the loading spinner color to use `--destructive-foreground`.
* Improved readability and accessibility of the Sign Out button in both light and dark themes.

## How to Test

1. Run the application locally.
2. Navigate to the user/account menu containing the Sign Out button.
3. Switch between light and dark themes.
4. Verify that the Sign Out button text remains clearly visible in both themes.
5. Verify that the loading spinner remains visible while signing out.

## Screenshots (if UI change)

Issue screenshots already demonstrate the contrast problem. The implemented fix updates the theme-aware foreground color used by the Sign Out button and loading spinner.

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable
