### PR TITLE
feat: add external github indicator to top repositories

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -342,7 +342,15 @@ export default function TopRepos() {
                     title={repo.description || undefined}
                   >
                     <span className="mr-1 text-[var(--muted-foreground)]">#{idx + 1}</span>
-                    {shortName}
+                    <span className="inline-flex items-center gap-1">
+                      {shortName}
+                      <span
+                        aria-hidden="true"
+                        className="text-xs text-[var(--muted-foreground)]"
+                      >
+                        ↗
+                      </span>
+                    </span>
                     {isPinned && (
                       <span className="ml-2 inline-flex items-center rounded-md bg-[color-mix(in_srgb,var(--accent)_10%,transparent)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--accent)] ring-1 ring-inset ring-[color-mix(in_srgb,var(--accent)_20%,transparent)] align-middle">
                         Pinned


### PR DESCRIPTION
## Related Issue

Closes #1185 

## Description

Added a small external GitHub indicator (↗) beside repository names in the Top Repositories widget.

This improves:

* visibility of external links
* user navigation clarity
* overall dashboard UX

## Changes Made

* Added external link indicator beside repository names
* Kept existing styling and responsiveness intact
* Preserved accessibility support

## Type of PR

* [ ] Bug fix
* [x] Feature enhancement
* [ ] Documentation update
* [ ] Security enhancement
* [ ] Other (specify): _____________

## Checklist

* [x] Code follows project style guidelines
* [x] `npm run lint` passes
* [x] `npm run type-check` passes
* [x] No unrelated files modified
