### PR TITLE
feat(activity): add DiscussionEvent and DiscussionCommentEvent to activity feed

### DIFF
--- a/src/components/RecentActivity.tsx
+++ b/src/components/RecentActivity.tsx
@@ -8,6 +8,7 @@ type ActivityType =
   | "pull_request"
   | "issue"
   | "release"
+  | "discussion"
   | "other";
 
 interface ActivityItem {
@@ -25,6 +26,7 @@ function getTypeBadge(type: ActivityType): string {
   if (type === "pull_request") return "PR";
   if (type === "issue") return "Issue";
   if (type === "release") return "Release";
+  if (type === "discussion") return "Discussion";
   return "Event";
 }
 
@@ -78,6 +80,20 @@ function getTypeIcon(type: ActivityType): ReactNode {
       <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
         <path
           d="M8 2l1.6 3.2L13 6l-2.5 2.4L11 12l-3-1.6L5 12l.5-3.6L3 6l3.4-.8L8 2Z"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+
+  if (type === "discussion") {
+    return (
+      <svg viewBox="0 0 16 16" className="h-3.5 w-3.5" aria-hidden="true">
+        <path
+          d="M2 3.5A1.5 1.5 0 0 1 3.5 2h9A1.5 1.5 0 0 1 14 3.5v6A1.5 1.5 0 0 1 12.5 11H9l-3 2.5V11H3.5A1.5 1.5 0 0 1 2 9.5v-6Z"
           fill="none"
           stroke="currentColor"
           strokeWidth="1.2"

--- a/src/lib/activity-formatter.ts
+++ b/src/lib/activity-formatter.ts
@@ -6,7 +6,7 @@
  * only permits the HTTP-verb exports GET/POST/etc. from route files).
  */
 
-export type ActivityType = "push" | "pull_request" | "issue" | "release" | "other";
+export type ActivityType = "push" | "pull_request" | "issue" | "release" | "discussion" | "other";
 
 export interface ActivityItem {
   id: string;
@@ -44,6 +44,11 @@ export interface RawEvent {
       tag_name?: string;
       name?: string;
     };
+    discussion?: {
+      html_url?: string;
+      number?: number;
+      title?: string;
+    };
   };
 }
 
@@ -52,6 +57,8 @@ export const SUPPORTED_EVENT_TYPES = new Set([
   "PullRequestEvent",
   "IssuesEvent",
   "ReleaseEvent",
+  "DiscussionEvent",
+  "DiscussionCommentEvent",
 ]);
 
 function getRepoUrl(repoName: string): string {
@@ -139,6 +146,37 @@ export function formatActivity(event: RawEvent): ActivityItem | null {
       url: release?.html_url ?? getRepoUrl(repoName),
     };
   }
+  if (event.type === "DiscussionEvent") {
+    const action = event.payload?.action ?? "opened";
+    const discussion = event.payload?.discussion;
+    const number = discussion?.number ? `#${discussion.number}` : "Discussion";
+    const actionText = capitalize(action);
 
+    return {
+      id: event.id,
+      type: "discussion",
+      createdAt: event.created_at,
+      title: `${actionText} discussion ${number}`,
+      subtitle: discussion?.title ?? repoName,
+      repo: repoName,
+      url: discussion?.html_url ?? getRepoUrl(repoName),
+    };
+  }
+
+  if (event.type === "DiscussionCommentEvent") {
+    const discussion = event.payload?.discussion;
+    const number = discussion?.number ? `#${discussion.number}` : "Discussion";
+
+    return {
+      id: event.id,
+      type: "discussion",
+      createdAt: event.created_at,
+      title: `Commented on discussion ${number}`,
+      subtitle: discussion?.title ?? repoName,
+      repo: repoName,
+      url: discussion?.html_url ?? getRepoUrl(repoName),
+    };
+  }
+  
   return null;
 }


### PR DESCRIPTION
## What does this PR do?
Adds GitHub Discussion activity to the Recent Activity feed. Users who open or comment on discussions now see those events alongside their commits, PRs, and issues.

## Related issue
Closes #976

## Changes made
- Added `"discussion"` to `ActivityType` union in both `activity-formatter.ts` and `RecentActivity.tsx`
- Added `DiscussionEvent` and `DiscussionCommentEvent` to `SUPPORTED_EVENT_TYPES`
- Added `discussion` payload shape to `RawEvent` interface
- Added handlers in `formatActivity` for both event types
- Added discussion icon (speech bubble SVG) and "Discussion" badge in `RecentActivity.tsx`
- No new API calls — `/users/{login}/events` already includes discussion events

## How to test
1. Sign in and go to dashboard
2. Find the Recent Activity widget
3. If you have GitHub Discussion activity, it will show with a speech bubble icon and "Discussion" badge
4. Event titles show: "Opened discussion #N" or "Commented on discussion #N"

## Screenshots
[Not required — UI change only visible if user has discussion activity]