### PR TITLE
feat(toprepos): add client-side search/filter to Repos widget

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -88,6 +88,7 @@ export default function TopRepos() {
   const [pinnedRepos, setPinnedRepos] = useState<string[]>([]);
   const [pinError, setPinError] = useState<string | null>(null);
   const [activeHealthRepo, setActiveHealthRepo] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
   useEffect(() => {
     fetch("/api/user/settings")
       .then((r) => r.json())
@@ -132,6 +133,7 @@ export default function TopRepos() {
   const fetchRepos = useCallback(() => {
     setLoading(true);
     setError(null);
+    setSearchQuery("");
     const accountParam = selectedAccount !== null
       ? `&accountId=${encodeURIComponent(selectedAccount)}`
       : "";
@@ -206,6 +208,12 @@ export default function TopRepos() {
     ...pinnedRepos.map(pin => repos.find(r => r.name === pin)).filter(Boolean) as Repo[],
     ...baseSortedRepos.filter(r => !pinnedRepos.includes(r.name))
   ];
+  // client-side search filter — only shown when list has more than 10 repos
+  const filteredRepos = searchQuery.trim()
+    ? sortedRepos.filter((r) =>
+        r.name.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    : sortedRepos;
 
   const maxCommits = repos.reduce((max, r) => Math.max(max, r.commits), 1);
 
@@ -263,6 +271,16 @@ export default function TopRepos() {
         <p className="text-sm text-[var(--muted-foreground)]">No commits in the last {days} days.</p>
       ) : (
       <>
+        {repos.length > 10 && (
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search repositories…"
+            aria-label="Search repositories"
+            className="mb-3 w-full rounded-lg border border-[var(--border)] bg-[var(--control)] px-3 py-1.5 text-sm text-[var(--card-foreground)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:border-[var(--accent)]"
+          />
+        )}
         <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)] mb-2 px-0">
           <button
             type="button"
@@ -288,7 +306,11 @@ export default function TopRepos() {
           </button>
         </div>
         <ul className="space-y-3">
-          {sortedRepos.map((repo, idx) => {
+          {filteredRepos.length === 0 ? (
+            <p className="text-sm text-[var(--muted-foreground)] py-4 text-center">
+              No repos match your search.
+            </p>
+          ) : filteredRepos.map((repo, idx) => {
             const isPinned = pinnedRepos.includes(repo.name);
             const barWidth = Math.max(
               Math.round((repo.commits / maxCommits) * 100),


### PR DESCRIPTION
## What does this PR do?
Adds a search input to the Top Repositories widget that filters repos by name in real-time. Only shown when the list has more than 10 repos.

## Related issue
Closes #965

## Changes made
- Added `searchQuery` state to TopRepos component
- Search input shown only when `repos.length > 10`
- Client-side filter: case-insensitive match on repo name
- "No repos match your search." empty state when filter returns nothing
- Search clears automatically on widget refresh
- `aria-label="Search repositories"` for accessibility
- No API changes — pure frontend filter

## How to test
1. Sign in and go to dashboard
2. If you have more than 10 repos, a search box appears above the list
3. Type a repo name — list filters instantly
4. Clear the input — full list returns
5. Type something with no match — "No repos match your search." shown