### PR TITLE
fix: disable streak freeze button after activation

### DIFF
--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -637,11 +637,16 @@ export default function StreakTracker() {
           <button
             type="button"
             onClick={handleApplyFreeze}
-            className="rounded-md bg-[var(--accent)] px-3 py-1 text-xs font-medium text-[var(--accent-foreground)] hover:opacity-90 transition"
+            disabled={freezeLoading || freeze?.hasFreeze}
+            className={`rounded-md px-3 py-1 text-xs font-medium transition ${
+              freezeLoading || freeze?.hasFreeze
+                ? "cursor-not-allowed opacity-50 bg-[var(--accent)]"
+                : "bg-[var(--accent)] hover:opacity-90"
+            } text-[var(--accent-foreground)]`}
           >
-            Freeze Streak
+            {freeze?.hasFreeze ? "Freeze Active" : "Freeze Streak"}
           </button>
-        </div>
+        </div>    
       )}
 
       {/* Streak Calendar Section */}


### PR DESCRIPTION
## Summary

Fixes the issue where the "Freeze Streak" button remained enabled and clickable after a streak freeze was successfully applied.

Closes #932

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Disabled the streak freeze button after successful activation
* Added visual disabled state styles (`opacity-50`, `cursor-not-allowed`)
* Updated button text dynamically from `Freeze Streak` to `Freeze Active`
* Prevented duplicate freeze requests from repeated clicks

## How to Test

Steps for the reviewer to verify this works:

1. Run the application locally
2. Navigate to the dashboard streak tracker section
3. Click the `Freeze Streak` button
4. Verify the freeze is successfully applied
5. Verify the button changes to `Freeze Active`
6. Verify the button becomes disabled and cannot be clicked again

## Screenshots (if UI change)

N/A

## Checklist

* [x] Linked issue in summary
* [ ] `npm run lint` passes locally
* [ ] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable


 