### PR TITLE
fix: Improve pin repository tooltip clarity in Top Repositories

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -377,7 +377,11 @@ export default function TopRepos() {
                       type="button"
                       onClick={() => togglePin(repo.name)}
                       className="ml-1 p-1 hover:bg-[var(--card-muted)] rounded-md transition-colors"
-                      title={isPinned ? "Unpin repository" : "Pin repository"}
+                      title={
+                        isPinned
+                          ? `Unpin ${shortName} repository`
+                          : `Pin ${shortName} repository`
+                      }
                       aria-label={isPinned ? `Unpin ${repo.name}` : `Pin ${repo.name}`}
                     >
                       <svg


### PR DESCRIPTION
## Related Issue
Closes #1193 

## Description
Improved accessibility text for the pin/unpin repository button in the Top Repositories widget by making tooltip text more descriptive and context-aware.

This ensures better clarity when users interact with multiple repositories.

## Changes Made
- Updated `title` attribute in `TopRepos.tsx`
- Made tooltip dynamic using `shortName`
- Improved consistency with existing `aria-label`
- No changes to core logic or styling

## Type of PR
- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): UI/UX improvement

## Checklist
- [x] Code follows project style guidelines
- [x] npm run lint passes
- [ ] npm run type-check passes (local dependency issue unrelated to this PR)
- [x] No unrelated files modified