### PR TITLE
fix: defer Vercel analytics loading

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,11 @@
 import type { Metadata, Viewport } from "next";
 import { Inter, Syne, JetBrains_Mono } from "next/font/google";
 import Footer from "@/components/Footer";
+import DeferredVercelMetrics from "@/components/DeferredVercelMetrics";
 import Providers from "./providers";
 import PWARegister from "@/components/pwa-register";
 import "./globals.css";
 import { Toaster } from "sonner";
-// Load Vercel integrations dynamically so build doesn't fail when packages
-// aren't installed in CI/environments where they're optional.
 
 const inter = Inter({ subsets: ["latin"] });
 const syne = Syne({
@@ -54,18 +53,6 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  let Analytics: any = null;
-  let SpeedInsights: any = null;
-
-  try {
-    const a = await import("@vercel/analytics/next");
-    Analytics = a?.Analytics ?? a?.default ?? null;
-  } catch (e) {}
-
-  try {
-    const s = await import("@vercel/speed-insights/next");
-    SpeedInsights = s?.SpeedInsights ?? s?.default ?? null;
-  } catch (e) {}
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -109,8 +96,7 @@ export default async function RootLayout({
 
           <Toaster richColors position="top-right" />
         </div>
-        {Analytics ? <Analytics /> : null}
-        {SpeedInsights ? <SpeedInsights /> : null}
+        <DeferredVercelMetrics />
       </body>
     </html>
   );

--- a/src/components/DeferredVercelMetrics.tsx
+++ b/src/components/DeferredVercelMetrics.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ComponentType } from "react";
+
+type IdleWindow = Window &
+  typeof globalThis & {
+    requestIdleCallback?: (
+      callback: IdleRequestCallback,
+      options?: IdleRequestOptions,
+    ) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+export default function DeferredVercelMetrics() {
+  const [shouldLoadMetrics, setShouldLoadMetrics] = useState(false);
+  const [Analytics, setAnalytics] = useState<ComponentType | null>(null);
+  const [SpeedInsights, setSpeedInsights] = useState<ComponentType | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (shouldLoadMetrics) return;
+
+    const browserWindow: IdleWindow = window;
+    const loadMetrics = () => setShouldLoadMetrics(true);
+
+    if (browserWindow.requestIdleCallback && browserWindow.cancelIdleCallback) {
+      const idleCallbackId = browserWindow.requestIdleCallback(loadMetrics, {
+        timeout: 3000,
+      });
+
+      return () => browserWindow.cancelIdleCallback?.(idleCallbackId);
+    }
+
+    const timeoutId = browserWindow.setTimeout(loadMetrics, 2000);
+
+    return () => browserWindow.clearTimeout(timeoutId);
+  }, [shouldLoadMetrics]);
+
+  useEffect(() => {
+    if (!shouldLoadMetrics) return;
+
+    let isMounted = true;
+
+    import("@vercel/analytics/next")
+      .then((module) => {
+        if (isMounted) setAnalytics(() => module.Analytics ?? null);
+      })
+      .catch(() => {});
+
+    import("@vercel/speed-insights/next")
+      .then((module) => {
+        if (isMounted) setSpeedInsights(() => module.SpeedInsights ?? null);
+      })
+      .catch(() => {});
+
+    return () => {
+      isMounted = false;
+    };
+  }, [shouldLoadMetrics]);
+
+  if (!shouldLoadMetrics || (!Analytics && !SpeedInsights)) return null;
+
+  return (
+    <>
+      {Analytics ? <Analytics /> : null}
+      {SpeedInsights ? <SpeedInsights /> : null}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Defers Vercel Analytics and Speed Insights initialization until browser idle time so they do not block the dashboard’s critical rendering path.

Closes #1076

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added a `DeferredVercelMetrics` client component.
- Delayed loading analytics scripts with `requestIdleCallback`, with a timeout fallback.
- Preserved dynamic imports for Vercel packages.
- Rendered deferred metrics at the bottom of the root layout after main app content.

## How to Test

Steps for the reviewer to verify this works:

1. Run `npm run lint`.
2. Run `npm run type-check`.
3. Load the dashboard with Chrome DevTools CPU throttling enabled.
4. Confirm Analytics and Speed Insights are initialized after the main content is interactive.

## Screenshots (if UI change)

No UI changes.

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable