### PR TITLE
fix: make public profile lookup case-insensitive

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { redirect } from "next/navigation";
 import BadgeSection from "@/components/BadgeSection";
 import GitHubAchievements from "@/components/GitHubAchievements";
 import StatsCard from "@/components/StatsCard";
@@ -6,6 +7,10 @@ import CopyLinkButton from "@/components/CopyLinkButton";
 import ThemeToggle from "@/components/ThemeToggle"; 
 import { getUserByUsername } from "@/lib/supabase";
 import { syncGitHubAchievementsForUser } from "@/lib/github-achievements";
+
+
+
+
 import {
   fetchPublicTopRepos,
   fetchPublicContributions,
@@ -18,9 +23,17 @@ async function fetchPublicProfile(
   options: { includeAchievements?: boolean } = {}
 ): Promise<PublicProfileData | null> {
   const user = await getUserByUsername(username);
+
   if (!user) return null;
 
+  const canonicalUsername = user.github_login.toLowerCase();
+
+  if (username !== canonicalUsername) {
+    redirect(`/u/${canonicalUsername}`);
+  }
+
   const githubToken = process.env.GITHUB_TOKEN;
+
   const [repos, contributions, streak, achievementsCache] = await Promise.all([
     fetchPublicTopRepos(user.github_login, githubToken, 30),
     fetchPublicContributions(user.github_login, githubToken, 30),

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -32,7 +32,7 @@ export async function getUserByUsername(
     const { data, error } = await supabaseAdmin
       .from("users")
       .select("id,github_id,github_login,is_public,created_at,updated_at")
-      .eq("github_login", username)
+      .ilike("github_login", username)
       .eq("is_public", true)
       .single();
 


### PR DESCRIPTION
## Summary

Fixes the issue where public profile URLs returned a 404 when usernames contained uppercase characters.

Closes #933

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Replaced case-sensitive `.eq("github_login", username)` queries with `.ilike(...)`
* Added canonical lowercase redirect for public profile URLs
* Prevented 404 errors for usernames with uppercase characters
* Improved URL consistency and canonical routing behavior

## How to Test

Steps for the reviewer to verify this works:

1. Run the application locally
2. Navigate to a public profile URL using uppercase characters
3. Example: `/u/PriyanshU`
4. Verify the profile loads successfully instead of returning 404
5. Verify the URL redirects to the lowercase canonical version

## Screenshots (if UI change)

N/A

## Checklist

* [x] Linked issue in summary
* [ ] `npm run lint` passes locally
* [ ] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable
