### PR TITLE
feat : added today main goal quote

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import LazyWidget from "@/components/LazyWidget";
 import DiscussionsWidget from "@/components/DiscussionsWidget";
 import CommunityMetrics from "@/components/CommunityMetrics";
 import GoalTracker from "@/components/GoalTracker";
+import TodayFocusHero from "@/components/TodayFocusHero";
 import DashboardHeader from "@/components/DashboardHeader";
 import StreakTracker from "@/components/StreakTracker";
 import TopRepos from "@/components/TopRepos";
@@ -105,6 +106,10 @@ export default async function DashboardPage() {
     <DashboardSSEProvider>
       <div className="min-h-screen bg-[var(--background)] p-4 text-[var(--foreground)] transition-colors md:p-8">
         <DashboardHeader />
+
+        <div className="mt-6 mb-6">
+          <TodayFocusHero userName={session.user?.name ?? null} />
+        </div>
 
         {/* Action bar */}
         <div className="mb-6 flex flex-wrap items-stretch justify-center gap-2 sm:justify-end">

--- a/src/components/TodayFocusHero.tsx
+++ b/src/components/TodayFocusHero.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type TodayFocusHeroProps = {
+  userName?: string | null;
+};
+
+const PROMPTS = [
+  "What are you building today?",
+  "What is one small win you want today?",
+  "Ship one meaningful thing today.",
+  "What problem are you solving today?",
+  "Make one part of your project better today.",
+];
+
+const STORAGE_PREFIX = "devtrack_today_goal_";
+
+function getTodayKey(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${STORAGE_PREFIX}${year}-${month}-${day}`;
+}
+
+function getGreeting(hour: number): "morning" | "afternoon" | "evening" {
+  if (hour < 12) return "morning";
+  if (hour < 18) return "afternoon";
+  return "evening";
+}
+
+function getDailyPrompt(date = new Date()): string {
+  const dayIndex = Math.floor(date.getTime() / 86400000);
+  return PROMPTS[Math.abs(dayIndex) % PROMPTS.length];
+}
+
+export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
+  const [goal, setGoal] = useState("");
+  const [inputValue, setInputValue] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [prompt, setPrompt] = useState(PROMPTS[0]);
+  const [greeting, setGreeting] = useState<"morning" | "afternoon" | "evening">("morning");
+  const [todayKey, setTodayKey] = useState("");
+  const [isMounted, setIsMounted] = useState(false);
+
+  const greetingLabel = useMemo(() => {
+    const base =
+      greeting === "morning"
+        ? "Good morning"
+        : greeting === "afternoon"
+          ? "Good afternoon"
+          : "Good evening";
+    return userName?.trim() ? `${base}, ${userName.trim()}` : base;
+  }, [greeting, userName]);
+
+  useEffect(() => {
+    const now = new Date();
+    const nextKey = getTodayKey(now);
+    setTodayKey(nextKey);
+    setGreeting(getGreeting(now.getHours()));
+    setPrompt(getDailyPrompt(now));
+
+    try {
+      const storedGoal = window.localStorage.getItem(nextKey)?.trim() ?? "";
+      setGoal(storedGoal);
+      setInputValue(storedGoal);
+      setIsEditing(storedGoal.length === 0);
+    } catch {
+      setGoal("");
+      setInputValue("");
+      setIsEditing(true);
+    }
+
+    setIsMounted(true);
+  }, []);
+
+  function handleSave() {
+    const trimmedGoal = inputValue.trim();
+    if (!trimmedGoal || !todayKey) return;
+
+    try {
+      window.localStorage.setItem(todayKey, trimmedGoal);
+    } catch {}
+
+    setGoal(trimmedGoal);
+    setInputValue(trimmedGoal);
+    setIsEditing(false);
+  }
+
+  function handleClear() {
+    if (!todayKey) return;
+
+    try {
+      window.localStorage.removeItem(todayKey);
+    } catch {}
+
+    setGoal("");
+    setInputValue("");
+    setIsEditing(true);
+  }
+
+  function handleEdit() {
+    setInputValue(goal);
+    setIsEditing(true);
+  }
+
+  if (!isMounted) {
+    return (
+      <section className="surface-card fade-up relative overflow-hidden rounded-3xl border border-[var(--border)] px-5 py-6 shadow-sm md:px-8 md:py-8">
+        <div className="space-y-4">
+          <div className="h-6 w-52 rounded bg-[var(--card-muted)] animate-pulse" />
+          <div className="h-4 w-full max-w-xl rounded bg-[var(--card-muted)] animate-pulse" />
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+            <div className="h-12 rounded-xl bg-[var(--card-muted)] animate-pulse" />
+            <div className="flex gap-3">
+              <div className="h-12 w-24 rounded-xl bg-[var(--card-muted)] animate-pulse" />
+              <div className="h-12 w-24 rounded-xl bg-[var(--card-muted)] animate-pulse" />
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="surface-card fade-up relative overflow-hidden rounded-3xl border border-[var(--border)] px-5 py-6 shadow-sm md:px-8 md:py-8">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(96,165,250,0.16),transparent_34%),radial-gradient(circle_at_bottom_left,rgba(59,130,246,0.1),transparent_28%)]" />
+      <div className="pointer-events-none absolute right-0 top-0 h-28 w-28 rounded-full bg-[var(--accent-soft)] blur-3xl" />
+
+      <div className="relative grid gap-6 lg:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.95fr)] lg:items-stretch">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--muted-foreground)]">
+              Today&apos;s Focus
+            </p>
+            <h1
+              className="text-3xl font-semibold tracking-tight text-[var(--foreground)] sm:text-4xl"
+              style={{ fontFamily: "var(--font-syne, system-ui, sans-serif)" }}
+            >
+              {greetingLabel}
+            </h1>
+            <p className="max-w-2xl text-sm leading-6 text-[var(--muted-foreground)] sm:text-base">
+              {prompt}
+            </p>
+          </div>
+
+          <p className="text-sm text-[var(--muted-foreground)] sm:text-base">
+            Progress is built one focused session at a time.
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-[var(--border)] bg-[color-mix(in_srgb,var(--card)_92%,white_8%)] p-4 shadow-[0_14px_34px_-26px_rgba(15,23,42,0.35)] sm:p-5">
+          {goal && !isEditing ? (
+            <div className="flex h-full flex-col justify-between gap-4">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                  Today&apos;s Focus
+                </p>
+                <p className="text-lg font-semibold leading-7 text-[var(--card-foreground)] sm:text-xl">
+                  {goal}
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <button
+                  type="button"
+                  onClick={handleEdit}
+                  className="secondary-button inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-medium sm:w-auto"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  className="inline-flex w-full items-center justify-center rounded-xl border border-[var(--destructive-muted-border)] bg-[var(--destructive-muted)] px-4 py-3 text-sm font-medium text-[var(--destructive)] transition hover:opacity-90 sm:w-auto"
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+                  Set your goal for today
+                </p>
+                <p className="text-sm text-[var(--muted-foreground)]">
+                  Save a single goal for this day. You can update it anytime.
+                </p>
+              </div>
+
+              <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+                <label className="block">
+                  <span className="sr-only">Write your main dev goal for today</span>
+                  <input
+                    value={inputValue}
+                    onChange={(event) => setInputValue(event.target.value)}
+                    placeholder="Write your main dev goal for today..."
+                    className="w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] shadow-sm transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)] focus:outline-none"
+                  />
+                </label>
+
+                <div className="flex flex-col gap-3 sm:flex-row lg:flex-col xl:flex-row">
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={!inputValue.trim()}
+                    className="primary-button inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto lg:w-full xl:w-auto"
+                  >
+                    Save
+                  </button>
+                  {goal ? (
+                    <button
+                      type="button"
+                      onClick={handleClear}
+                      className="secondary-button inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-medium sm:w-auto lg:w-full xl:w-auto"
+                    >
+                      Clear
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Add a responsive, client only Today’s Focus hero to the DevTrack dashboard so users can set, edit, and clear a personal daily dev goal saved in localStorage by date.



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added a new `TodayFocusHero` component for the top of the dashboard.
- Stores today’s goal in `localStorage` using a date-scoped key like `devtrack_today_goal_YYYY-MM-DD`.
- Shows a time-based greeting and rotates a daily prompt.
- Supports save, edit, and clear actions for the current day’s goal.
- Kept the hero fully client-side to avoid hydration issues.
- Placed the hero below the existing dashboard navbar/header and improved mobile wrapping for the top dashboard controls.

## How to Test

Steps for the reviewer to verify this works:

1. Open the dashboard on desktop and mobile widths.
2. Confirm the dashboard navbar/header stays at the top and the new hero appears below it.
3. Enter a goal and click Save.
4. Refresh the page and confirm today’s goal is restored from localStorage.
5. Click Edit, update the goal, and save again.
6. Click Clear and confirm the goal is removed for that day.

## Screenshots (if UI change)
<img width="1857" height="993" alt="Screenshot 2026-05-26 170904" src="https://github.com/user-attachments/assets/06b6bef7-b20e-4866-8890-ee9d6d31c02f" />

<img width="474" height="809" alt="Screenshot 2026-05-26 170930" src="https://github.com/user-attachments/assets/dace70ca-a017-41b8-a58d-8f9ee3ff5039" />


## Checklist

- [ ] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
