### PR TITLE
feat: add public profile comparison feature

### DIFF
--- a/src/app/api/public/[username]/route.ts
+++ b/src/app/api/public/[username]/route.ts
@@ -1,10 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getUserByUsername } from "@/lib/supabase";
-import {
-  fetchPublicTopRepos,
-  fetchPublicContributions,
-  fetchPublicStreak,
-} from "@/lib/public-profile-data";
+import { fetchPublicProfile } from "@/lib/public-profile-data";
 import { getUpstashConfig, upstashRateLimitFixedWindow } from "@/lib/upstash-rest";
 
 export const dynamic = "force-dynamic";
@@ -92,31 +87,14 @@ export async function GET(
     );
   }
 
-  // Look up user in Supabase
-  const user = await getUserByUsername(username);
+  const profile = await fetchPublicProfile(username);
 
-  if (!user) {
+  if (!profile) {
     return NextResponse.json(
       { error: "User not found or profile is not public" },
       { status: 404 }
     );
   }
 
-  // Use GITHUB_TOKEN env var if available for higher rate limits
-  const githubToken = process.env.GITHUB_TOKEN;
-
-  // Fetch all metrics in parallel
-  const [repos, contributions, streak] = await Promise.all([
-    fetchPublicTopRepos(user.github_login, githubToken, 30),
-    fetchPublicContributions(user.github_login, githubToken, 30),
-    fetchPublicStreak(user.github_login, githubToken),
-  ]);
-
-  return NextResponse.json({
-    username: user.github_login,
-    userId: user.id,
-    repos,
-    contributions,
-    streak,
-  });
+  return NextResponse.json(profile);
 }

--- a/src/app/compare/[users]/page.tsx
+++ b/src/app/compare/[users]/page.tsx
@@ -1,0 +1,419 @@
+import { Metadata } from "next";
+import { Scale, Trophy } from "lucide-react";
+import { normalizeGitHubUsername } from "@/lib/validate-github-username";
+import {
+  fetchPublicProfile,
+  type PublicLanguage,
+  type PublicProfileData,
+  type TopRepo,
+} from "@/lib/public-profile-data";
+
+export const dynamic = "force-dynamic";
+
+interface ComparePageProps {
+  params: { users: string };
+}
+
+type Winner = "left" | "right" | "tie";
+
+function parseUsers(users: string): [string, string] | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(users);
+  } catch {
+    return null;
+  }
+
+  const match = decoded.match(/^(.+)-vs-(.+)$/);
+  if (!match) return null;
+
+  const left = normalizeGitHubUsername(match[1]);
+  const right = normalizeGitHubUsername(match[2]);
+
+  if (!left || !right || left.toLowerCase() === right.toLowerCase()) {
+    return null;
+  }
+
+  return [left, right];
+}
+
+function compareNumbers(left: number, right: number): Winner {
+  if (left === right) return "tie";
+  return left > right ? "left" : "right";
+}
+
+function topLanguage(languages: PublicLanguage[]): string {
+  return languages[0]?.name ?? "No public data";
+}
+
+function repoCommitTotal(repos: TopRepo[]): number {
+  return repos.reduce((sum, repo) => sum + repo.commits, 0);
+}
+
+export async function generateMetadata({
+  params,
+}: ComparePageProps): Promise<Metadata> {
+  const parsed = parseUsers(params.users);
+  if (!parsed) {
+    return {
+      title: "Compare Public Profiles",
+      description: "Compare public DevTrack profile stats.",
+    };
+  }
+
+  const [left, right] = parsed;
+  return {
+    title: `${left} vs ${right} - DevTrack Compare`,
+    description: `Side-by-side public DevTrack stats comparison for ${left} and ${right}.`,
+  };
+}
+
+export default async function PublicProfileComparePage({
+  params,
+}: ComparePageProps) {
+  const parsed = parseUsers(params.users);
+
+  if (!parsed) {
+    return <CompareUnavailable title="Invalid compare URL" />;
+  }
+
+  const [leftUsername, rightUsername] = parsed;
+  const [leftProfile, rightProfile] = await Promise.all([
+    fetchPublicProfile(leftUsername),
+    fetchPublicProfile(rightUsername),
+  ]);
+
+  if (!leftProfile || !rightProfile) {
+    return (
+      <CompareUnavailable
+        title="Comparison unavailable"
+        message="One of these profiles does not exist, is private, or cannot be loaded right now."
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--background)] p-4 text-[var(--foreground)] transition-colors md:p-8">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+              Public Profile Compare
+            </p>
+            <h1 className="mt-2 text-3xl font-bold text-[var(--foreground)] md:text-4xl">
+              @{leftProfile.username} vs @{rightProfile.username}
+            </h1>
+            <p className="mt-2 text-[var(--muted-foreground)]">
+              Shareable comparison built only from publicly visible DevTrack stats.
+            </p>
+          </div>
+          <a
+            href={`/u/${encodeURIComponent(rightProfile.username)}`}
+            className="secondary-button inline-flex rounded-lg px-4 py-2 text-sm font-medium"
+          >
+            View profile
+          </a>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_auto_1fr] md:items-stretch">
+          <ProfileHeader profile={leftProfile} />
+          <div className="hidden items-center justify-center md:flex">
+            <div className="rounded-full border border-[var(--border)] bg-[var(--card)] p-3 text-[var(--muted-foreground)] shadow-[var(--shadow-soft)]">
+              <Scale size={22} />
+            </div>
+          </div>
+          <ProfileHeader profile={rightProfile} align="right" />
+        </div>
+
+        <div className="mt-6 rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-[var(--shadow-soft)] md:p-6">
+          <div className="mb-4 grid grid-cols-[1fr_auto_1fr] items-center gap-3 text-sm font-medium text-[var(--muted-foreground)]">
+            <div>@{leftProfile.username}</div>
+            <div className="text-center text-xs uppercase tracking-wide">
+              Metric
+            </div>
+            <div className="text-right">@{rightProfile.username}</div>
+          </div>
+
+          <div className="space-y-3">
+            <MetricRow
+              label="Current streak"
+              left={leftProfile.streak.current}
+              right={rightProfile.streak.current}
+              suffix=" days"
+            />
+            <MetricRow
+              label="Longest streak"
+              left={leftProfile.streak.longest}
+              right={rightProfile.streak.longest}
+              suffix=" days"
+            />
+            <MetricRow
+              label="Commits (30d)"
+              left={leftProfile.contributions.total}
+              right={rightProfile.contributions.total}
+            />
+            <MetricRow
+              label="Pull requests"
+              left={leftProfile.pullRequests}
+              right={rightProfile.pullRequests}
+            />
+            <MetricRow
+              label="Top repo commits"
+              left={repoCommitTotal(leftProfile.repos)}
+              right={repoCommitTotal(rightProfile.repos)}
+            />
+            <LanguageRow
+              left={topLanguage(leftProfile.topLanguages)}
+              right={topLanguage(rightProfile.topLanguages)}
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <LanguageCard
+            username={leftProfile.username}
+            languages={leftProfile.topLanguages}
+          />
+          <LanguageCard
+            username={rightProfile.username}
+            languages={rightProfile.topLanguages}
+          />
+          <ReposCard username={leftProfile.username} repos={leftProfile.repos} />
+          <ReposCard username={rightProfile.username} repos={rightProfile.repos} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CompareUnavailable({
+  title,
+  message = "Use /compare/user1-vs-user2 with two public DevTrack profiles.",
+}: {
+  title: string;
+  message?: string;
+}) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[var(--background)] p-4 text-[var(--foreground)]">
+      <div className="surface-card max-w-md rounded-2xl p-8 text-center">
+        <h1 className="mb-2 text-3xl font-bold">{title}</h1>
+        <p className="mb-6 text-sm text-[var(--muted-foreground)]">{message}</p>
+        <a href="/" className="primary-button inline-block rounded-lg px-6 py-2">
+          Back to Home
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function ProfileHeader({
+  profile,
+  align = "left",
+}: {
+  profile: PublicProfileData;
+  align?: "left" | "right";
+}) {
+  return (
+    <div
+      className={`rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-[var(--shadow-soft)] ${
+        align === "right" ? "md:text-right" : ""
+      }`}
+    >
+      <div
+        className={`flex items-center gap-4 ${
+          align === "right" ? "md:flex-row-reverse" : ""
+        }`}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`https://avatars.githubusercontent.com/${profile.username}`}
+          alt=""
+          className="h-14 w-14 rounded-full border border-[var(--border)]"
+        />
+        <div className="min-w-0">
+          <a
+            href={`/u/${encodeURIComponent(profile.username)}`}
+            className="truncate text-xl font-bold text-[var(--card-foreground)] hover:text-[var(--accent)]"
+          >
+            @{profile.username}
+          </a>
+          <p className="text-sm text-[var(--muted-foreground)]">
+            {profile.streak.current} day streak - {profile.contributions.total} commits
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetricRow({
+  label,
+  left,
+  right,
+  suffix = "",
+}: {
+  label: string;
+  left: number;
+  right: number;
+  suffix?: string;
+}) {
+  const winner = compareNumbers(left, right);
+
+  return (
+    <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-lg bg-[var(--control)] p-3">
+      <Value
+        value={`${left}${suffix}`}
+        state={winner === "tie" ? "tie" : winner === "left" ? "win" : "neutral"}
+      />
+      <div className="text-center text-xs font-medium text-[var(--muted-foreground)]">
+        {label}
+      </div>
+      <Value
+        value={`${right}${suffix}`}
+        state={winner === "tie" ? "tie" : winner === "right" ? "win" : "neutral"}
+        align="right"
+      />
+    </div>
+  );
+}
+
+function LanguageRow({ left, right }: { left: string; right: string }) {
+  const tied = left === right;
+
+  return (
+    <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-lg bg-[var(--control)] p-3">
+      <Value value={left} state={tied ? "tie" : "neutral"} />
+      <div className="text-center text-xs font-medium text-[var(--muted-foreground)]">
+        Top language
+      </div>
+      <Value value={right} state={tied ? "tie" : "neutral"} align="right" />
+    </div>
+  );
+}
+
+function Value({
+  value,
+  state,
+  align = "left",
+}: {
+  value: string;
+  state: "win" | "tie" | "neutral";
+  align?: "left" | "right";
+}) {
+  const className =
+    state === "win"
+      ? "border-[var(--success)]/30 bg-[var(--success)]/10 text-[var(--success)]"
+      : state === "tie"
+        ? "border-[var(--border)] bg-[var(--card)] text-[var(--card-foreground)]"
+        : "border-transparent text-[var(--foreground)]";
+
+  return (
+    <div className={`min-w-0 ${align === "right" ? "text-right" : ""}`}>
+      <span
+        className={`inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-1 text-sm font-bold ${className}`}
+      >
+        {state === "win" && <Trophy size={14} aria-hidden="true" />}
+        <span className="truncate">{value}</span>
+        {state === "tie" && <span className="text-xs font-medium">Tie</span>}
+      </span>
+    </div>
+  );
+}
+
+function LanguageCard({
+  username,
+  languages,
+}: {
+  username: string;
+  languages: PublicLanguage[];
+}) {
+  const total = languages.reduce((sum, language) => sum + language.count, 0);
+
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-[var(--shadow-soft)]">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
+        @{username} Top Languages
+      </h2>
+      {languages.length === 0 ? (
+        <p className="text-sm text-[var(--muted-foreground)]">
+          No public language data available.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {languages.map((language) => (
+            <li key={language.name}>
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <span className="font-medium text-[var(--card-foreground)]">
+                  {language.name}
+                </span>
+                <span className="text-[var(--muted-foreground)]">
+                  {language.count} repo{language.count !== 1 ? "s" : ""}
+                </span>
+              </div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-[var(--control)]">
+                <div
+                  className="h-full rounded-full bg-[var(--accent)]"
+                  style={{
+                    width: `${Math.max((language.count / total) * 100, 4)}%`,
+                  }}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ReposCard({ username, repos }: { username: string; repos: TopRepo[] }) {
+  const maxCommits = repos[0]?.commits ?? 1;
+
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-[var(--shadow-soft)]">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
+        @{username} Top Repositories
+      </h2>
+      {repos.length === 0 ? (
+        <p className="text-sm text-[var(--muted-foreground)]">
+          No public repository data available.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {repos.map((repo, index) => {
+            const shortName = repo.name.split("/")[1] ?? repo.name;
+            const width = Math.max(Math.round((repo.commits / maxCommits) * 100), 4);
+
+            return (
+              <li key={repo.name}>
+                <div className="mb-1 flex items-center justify-between gap-3 text-sm">
+                  <a
+                    href={repo.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="min-w-0 truncate font-medium text-[var(--card-foreground)] hover:text-[var(--accent)]"
+                    title={repo.name}
+                  >
+                    <span className="mr-1 text-[var(--muted-foreground)]">
+                      #{index + 1}
+                    </span>
+                    {shortName}
+                  </a>
+                  <span className="shrink-0 text-[var(--muted-foreground)]">
+                    {repo.commits} commit{repo.commits !== 1 ? "s" : ""}
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-[var(--control)]">
+                  <div
+                    className="h-full rounded-full bg-[var(--accent)]"
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -2,68 +2,32 @@ export const dynamic = "force-dynamic";
 
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
 import BadgeSection from "@/components/BadgeSection";
 import GitHubAchievements from "@/components/GitHubAchievements";
 import StatsCard from "@/components/StatsCard";
 import ShareProfileSection from "@/components/ShareProfileSection";
 import ThemeToggle from "@/components/ThemeToggle";
 import SponsorBadge from "@/components/SponsorBadge";
-import { getUserByUsername } from "@/lib/supabase";
-import { syncGitHubAchievementsForUser } from "@/lib/github-achievements";
 import PinnedReposWidget from "@/components/PinnedReposWidget";
-import { fetchPinnedRepoDetails } from "@/lib/pinned-repos";
+import CopyLinkButton from "@/components/CopyLinkButton";
+import { authOptions } from "@/lib/auth";
+import { fetchPublicProfile } from "@/lib/public-profile-data";
+import { getUserByGithubId, getUserByUsername } from "@/lib/supabase";
 
+async function getLoggedInGitHubUsername() {
+  const session = await getServerSession(authOptions);
 
-
-
-import {
-  fetchPublicTopRepos,
-  fetchPublicContributions,
-  fetchPublicStreak,
-  type PublicProfileData,
-} from "@/lib/public-profile-data";
-
-async function fetchPublicProfile(
-  username: string,
-  options: { includeAchievements?: boolean } = {}
-): Promise<PublicProfileData | null> {
-  const user = await getUserByUsername(username);
-
-  if (!user) return null;
-
-  const canonicalUsername = user.github_login.toLowerCase();
-
-  if (username !== canonicalUsername) {
-    redirect(`/u/${canonicalUsername}`);
+  if (typeof session?.githubLogin === "string" && session.githubLogin.trim()) {
+    return session.githubLogin;
   }
 
-  const githubToken = process.env.GITHUB_TOKEN || "";
+  if (typeof session?.githubId === "string" && session.githubId.trim()) {
+    const user = await getUserByGithubId(session.githubId);
+    return user?.github_login ?? null;
+  }
 
-  const [repos, contributions, streak, achievementsCache, spotlight] = await Promise.all([
-    fetchPublicTopRepos(user.github_login, githubToken, 30),
-    fetchPublicContributions(user.github_login, githubToken, 30),
-    fetchPublicStreak(user.github_login, githubToken),
-    options.includeAchievements
-      ? syncGitHubAchievementsForUser({
-          userId: user.id,
-          githubLogin: user.github_login,
-          token: githubToken,
-        })
-      : Promise.resolve({ achievements: [], syncedAt: null, error: null }),
-    fetchPinnedRepoDetails(user.github_login, user.pinned_repos || [], githubToken),
-  ]);
-
-  return {
-    username: user.github_login,
-    userId: user.id,
-    isSponsor: user.is_sponsor ?? false,
-    repos,
-    contributions,
-    streak,
-    achievements: achievementsCache.achievements,
-    achievementsError: achievementsCache.error,
-    spotlightRepos: spotlight,
-  };
+  return null;
 }
 
 function getProfileUrl(username: string) {
@@ -116,7 +80,10 @@ export default async function PublicProfilePage({
   params: { username: string };
 }) {
   const { username } = params;
-  const profile = await fetchPublicProfile(username, { includeAchievements: true });
+  const [profile, loggedInUsername] = await Promise.all([
+    fetchPublicProfile(username, { includeAchievements: true }),
+    getLoggedInGitHubUsername(),
+  ]);
   const profileUrl = getProfileUrl(username);
 
   if (!profile) {
@@ -150,8 +117,22 @@ export default async function PublicProfilePage({
     );
   }
 
+  const canonicalUsername = profile.username.toLowerCase();
+  if (username !== canonicalUsername) {
+    redirect(`/u/${canonicalUsername}`);
+  }
+
   const avatarUrl = `https://avatars.githubusercontent.com/${profile.username}`;
   const topRepo = profile.repos[0]?.name ?? "";
+  const showCompareButton =
+    loggedInUsername !== null &&
+    loggedInUsername.toLowerCase() !== profile.username.toLowerCase();
+  const compareHref = showCompareButton
+    ? `/compare/${encodeURIComponent(loggedInUsername)}-vs-${encodeURIComponent(profile.username)}`
+    : null;
+  const signInToCompareHref = `/auth/signin?callbackUrl=${encodeURIComponent(
+    `/u/${profile.username}`
+  )}`;
 
   return (
     <div className="min-h-screen bg-[var(--background)] p-4 text-[var(--foreground)] transition-colors md:p-8">
@@ -162,13 +143,30 @@ export default async function PublicProfilePage({
               @{profile.username}&apos;s Profile
               {profile.isSponsor && <SponsorBadge />}
             </h1>
+            <CopyLinkButton />
           </div>
           <p className="mt-2 text-[var(--muted-foreground)]">
             GitHub activity and coding stats
           </p>
+          {compareHref && (
+            <a
+              href={compareHref}
+              className="primary-button mt-4 inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
+            >
+              Compare with me
+            </a>
+          )}
+          {!loggedInUsername && (
+            <a
+              href={signInToCompareHref}
+              className="secondary-button mt-4 inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
+            >
+              Log in to compare
+            </a>
+          )}
         </div>
         {/* Download stats card button — client component */}
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <ThemeToggle />
           <StatsCard
             username={profile.username}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 import BadgeSection from "@/components/BadgeSection";
 import GitHubAchievements from "@/components/GitHubAchievements";
 import StatsCard from "@/components/StatsCard";

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -3,7 +3,6 @@ export const dynamic = "force-dynamic";
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
-import { redirect } from "next/navigation";
 import BadgeSection from "@/components/BadgeSection";
 import GitHubAchievements from "@/components/GitHubAchievements";
 import StatsCard from "@/components/StatsCard";

--- a/src/lib/public-profile-data.ts
+++ b/src/lib/public-profile-data.ts
@@ -1,6 +1,8 @@
 import { dateDiffDays, toDateStr } from "@/lib/dateUtils";
 import type { GitHubAchievement } from "@/lib/github-achievements";
+import { syncGitHubAchievementsForUser } from "@/lib/github-achievements";
 import { fetchPinnedRepoDetails, type PinnedRepoDetails } from "@/lib/pinned-repos";
+import { getUserByUsername } from "@/lib/supabase";
 
 const GITHUB_API = "https://api.github.com";
 
@@ -8,6 +10,12 @@ export interface TopRepo {
   name: string;
   commits: number;
   url: string;
+}
+
+export interface PublicLanguage {
+  name: string;
+  count: number;
+  percentage: number;
 }
 
 export interface ContributionData {
@@ -30,6 +38,8 @@ export interface PublicProfileData {
   repos: TopRepo[];
   contributions: ContributionData;
   streak: StreakData;
+  topLanguages: PublicLanguage[];
+  pullRequests: number;
   achievements: GitHubAchievement[];
   achievementsError?: string | null;
   spotlightRepos?: PinnedRepoDetails[];
@@ -199,4 +209,103 @@ export async function fetchTopLanguage(
   }
   
   return topLang;
+}
+
+export async function fetchPublicTopLanguages(
+  username: string,
+  token?: string
+): Promise<PublicLanguage[]> {
+  const res = await ghFetch(
+    `${GITHUB_API}/users/${username}/repos?sort=updated&per_page=30`,
+    token
+  );
+
+  if (!res.ok) return [];
+
+  const repos = (await res.json()) as Array<{ language: string | null }>;
+  const counts: Record<string, number> = {};
+
+  for (const repo of repos) {
+    if (repo.language) {
+      counts[repo.language] = (counts[repo.language] ?? 0) + 1;
+    }
+  }
+
+  const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
+  if (total === 0) return [];
+
+  return Object.entries(counts)
+    .map(([name, count]) => ({
+      name,
+      count,
+      percentage: Math.round((count / total) * 1000) / 10,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+}
+
+export async function fetchPublicPullRequests(
+  username: string,
+  token?: string
+): Promise<number> {
+  const res = await ghFetch(
+    `${GITHUB_API}/search/issues?q=type:pr+author:${username}&per_page=1`,
+    token
+  );
+
+  if (!res.ok) return 0;
+
+  const data = (await res.json()) as { total_count?: number };
+  return data.total_count ?? 0;
+}
+
+export async function fetchPublicProfile(
+  username: string,
+  options: { includeAchievements?: boolean } = {}
+): Promise<PublicProfileData | null> {
+  const user = await getUserByUsername(username);
+  if (!user) return null;
+
+  const githubToken = process.env.GITHUB_TOKEN;
+  const [
+    repos,
+    contributions,
+    streak,
+    topLanguages,
+    pullRequests,
+    achievementsCache,
+    spotlight,
+  ] = await Promise.all([
+    fetchPublicTopRepos(user.github_login, githubToken, 30),
+    fetchPublicContributions(user.github_login, githubToken, 30),
+    fetchPublicStreak(user.github_login, githubToken),
+    fetchPublicTopLanguages(user.github_login, githubToken),
+    fetchPublicPullRequests(user.github_login, githubToken),
+    options.includeAchievements
+      ? syncGitHubAchievementsForUser({
+          userId: user.id,
+          githubLogin: user.github_login,
+          token: githubToken,
+        })
+      : Promise.resolve({ achievements: [], syncedAt: null, error: null }),
+    fetchPinnedRepoDetails(
+      user.github_login,
+      user.pinned_repos || [],
+      githubToken || ""
+    ),
+  ]);
+
+  return {
+    username: user.github_login,
+    userId: user.id,
+    isSponsor: user.is_sponsor ?? false,
+    repos,
+    contributions,
+    streak,
+    topLanguages,
+    pullRequests,
+    achievements: achievementsCache.achievements,
+    achievementsError: achievementsCache.error,
+    spotlightRepos: spotlight,
+  };
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -83,6 +83,37 @@ export async function getUserByUsername(
 }
 
 /**
+ * Look up a user by GitHub id. Used for authenticated server-rendered pages
+ * where the session has an id but may not have the login claim populated.
+ */
+export async function getUserByGithubId(
+  githubId: string
+): Promise<User | null> {
+  if (!supabaseAdmin) return null;
+
+  try {
+    const { data, error } = await supabaseAdmin
+      .from("users")
+      .select("id,github_id,github_login,is_public,created_at,updated_at")
+      .eq("github_id", githubId)
+      .single();
+
+    if (error) {
+      if (error.code === "PGRST116") {
+        return null;
+      }
+      console.error("Error fetching user by GitHub id:", error);
+      return null;
+    }
+
+    return data as User;
+  } catch (err) {
+    console.error("Unexpected error fetching user by GitHub id:", err);
+    return null;
+  }
+}
+
+/**
  * Update the is_public flag for a user.
  */
 export async function updateUserPublicFlag(


### PR DESCRIPTION
## Summary

closes #1068 

Adds a public profile comparison system to DevTrack.

Users can now compare themselves with another public DevTrack profile directly from `/u/[username]`.

This introduces:
- shareable comparison URLs
- side-by-side public stat comparison
- winner/tie indicators
- privacy-safe public profile comparisons

---

## Features Added

### Public Profile Compare Button

On `/u/[username]`:

- Logged-out visitors see `Log in to compare`
- Logged-in visitors viewing another profile see `Compare with me`
- Logged-in visitors viewing their own profile do not see the compare button

Clicking the compare button navigates to:

```txt
/compare/currentUser-vs-profileUser
```

Example:

```txt
/compare/priyanshu-vs-ramlal
```

---

### Shareable Compare Route

Added:

```txt
src/app/compare/[users]/page.tsx
```

Supports routes like:

```txt
/compare/alice-vs-bob
```

The compare page:
- works without authentication
- fetches both users using public profile data
- shows side-by-side comparison
- highlights winners/ties per metric
- respects privacy/public profile visibility

---

## Architecture Changes

### Reused Existing Public Profile Infrastructure

Instead of creating a separate comparison backend, this PR reuses and extends the existing public-profile architecture.

### Shared Public Profile Logic

Moved reusable public profile fetch logic into shared helpers to reduce duplication and keep compare pages public-first and privacy-safe.

### Public Compare Data

Added support for:
- public PR counts
- public top languages
- reusable compare-ready public stats

---

## Privacy Handling

If either profile:
- is private
- unavailable
- missing

the compare page shows an unavailable state instead of exposing hidden data.

---

## Files Added / Updated

### Added

```txt
src/app/compare/[users]/page.tsx
```

### Updated

```txt
src/app/u/[username]/page.tsx
src/lib/public-profile-data.ts
src/app/api/public/[username]/route.ts
src/lib/supabase.ts
```

---

## Validation

Verified locally:

```bash
npm run lint
npm run type-check
npm run build
```

All passing successfully.