### PR TITLE
#1216 Fix hydration mismatch issue in AIMentorWidget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4564,6 +4564,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/AIMentorWidget.tsx
+++ b/src/components/AIMentorWidget.tsx
@@ -83,6 +83,11 @@ export function AIMentorWidget() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     fetch("/api/ai-insights?type=weekly_summary", { cache: "no-store" })
@@ -109,10 +114,13 @@ export function AIMentorWidget() {
 
   if (!data) return null;
 
-  const formattedDate = new Date(data.generatedAt).toLocaleDateString(
-    undefined,
-    { month: "short", day: "numeric", year: "numeric" }
-  );
+  const formattedDate = mounted
+    ? new Date(data.generatedAt).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "";
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">


### PR DESCRIPTION
## Summary

Fixed the React hydration mismatch issue in `AIMentorWidget.tsx` caused by using `toLocaleDateString()` during server-side rendering.

Closes #1216

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

## Changes Made

* Added a `mounted` state using `useState`
* Used `useEffect` to ensure date formatting runs only on the client side after hydration
* Prevented hydration mismatch warnings caused by locale/timezone differences between server and client rendering

## How to Test

Steps for the reviewer to verify this works:

1. Run `npm install`
2. Start the development server using `npm run dev`
3. Open the application in the browser
4. Navigate to the AI Mentor Widget component
5. Verify that no hydration mismatch warning appears in the console
6. Confirm the date renders correctly after page load


## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable
