### PR TITLE
fix: add MAX_PAGES cap to GitLab contributions fetch to prevent infin…

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -188,9 +188,10 @@ async function fetchGitLabContributions(
       since.setHours(0, 0, 0, 0);
 
       let page = 1;
+      const MAX_PAGES = 10;
       const commitsByDay: Record<string, number> = {};
 
-      while (page > 0) {
+      while (page > 0 && page <= MAX_PAGES) {
         const url = new URL("https://gitlab.com/api/v4/events");
         url.searchParams.set("action", "pushed");
         url.searchParams.set("per_page", "100");


### PR DESCRIPTION
## What does this PR fix?
Closes #1247 

The `fetchGitLabContributions()` function had no page limit, risking 
an infinite loop if GitLab returned a malformed `x-next-page` header 
or the same page number repeatedly.

## Root Cause
The while loop condition was only `while (page > 0)` with no upper 
bound. The GitHub fetch in the same file already uses `while (page <= 10)` 
as a safety cap — the GitLab fetch was missing this protection.

## Changes Made
- Added `const MAX_PAGES = 10` constant
- Updated loop condition to `while (page > 0 && page <= MAX_PAGES)`

## Files Changed
- `src/app/api/metrics/contributions/route.ts`

## Testing Done
1. Hit `/api/metrics/contributions` with GitLab token connected
2. ✅ Fetches up to 10 pages maximum
3. ✅ Returns collected data after cap is reached
4. ✅ No hanging requests