### PR TITLE
fix landing ticker Safari resume

### DIFF
--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -431,13 +431,30 @@ function HeroSection() {
    COMMIT TICKER
    ═══════════════════════════════════════════ */
 function CommitTicker() {
+  const tickerRef = useRef<HTMLDivElement>(null);
   const doubled = [...COMMITS, ...COMMITS];
+
+  useEffect(() => {
+    const restartTickerAnimation = () => {
+      const ticker = tickerRef.current;
+
+      if (document.hidden || !ticker) return;
+
+      ticker.style.animation = 'none';
+      void ticker.offsetHeight;
+      ticker.style.animation = '';
+    };
+
+    document.addEventListener('visibilitychange', restartTickerAnimation);
+    return () => document.removeEventListener('visibilitychange', restartTickerAnimation);
+  }, []);
+
   return (
     <div style={{
       borderTop: `1px solid ${BORDER}`, borderBottom: `1px solid ${BORDER}`,
       padding: '10px 0', overflow: 'hidden', background: BG,
     }}>
-      <div className="lnd-ticker" style={{ display: 'flex', gap: 48, whiteSpace: 'nowrap' }}>
+      <div ref={tickerRef} className="lnd-ticker" style={{ display: 'flex', gap: 48, whiteSpace: 'nowrap' }}>
         {doubled.map((c, i) => (
           <span
             key={i}


### PR DESCRIPTION
## Summary

Fixes the landing page commit ticker freezing on Safari iOS after the browser tab is backgrounded and reopened.

Closes #1071

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Added a ref to the landing page commit ticker element.
- Added a `visibilitychange` listener to restart the `lnd-ticker` CSS animation when the page becomes visible again.
- Forced a reflow before restoring the animation so Safari iOS resumes the ticker reliably.

## How to Test

Steps for the reviewer to verify this works:

1. Open the DevTrack landing page on iPhone/iPad Safari.
2. Confirm the commit ticker is scrolling.
3. Background Safari for 5+ seconds.
4. Return to Safari and confirm the commit ticker resumes scrolling.

## Screenshots (if UI change)

No visual UI changes.

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable