### PR TITLE
fix: restore goal form after failed refresh in create flow

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState, useRef } from "react";
+import { submitGoalWithRefresh } from "@/lib/goal-tracker";
 
 type Recurrence = "none" | "weekly" | "monthly";
 
@@ -125,34 +126,29 @@ export default function GoalTracker() {
     setCreateError(null);
 
     try {
-      const response = await fetch("/api/goals", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title, target, unit, recurrence, deadline: deadline || null }),
+      const result = await submitGoalWithRefresh({
+        payload: { title, target, unit, recurrence, deadline: deadline || null },
+        handleSync,
+        loadGoals,
       });
 
-      if (!response.ok) {
-        throw new Error("Failed to create goal");
+      if (!result.created) {
+        setCreateError(result.error);
+        return;
       }
-    } catch {
-      setCreateError("Failed to create goal. Please try again.");
+
+      setTitle("");
+      setTarget(7);
+      setUnit("commits");
+      setRecurrence("none");
+      setDeadline("");
+
+      if (result.error) {
+        setCreateError(result.error);
+      }
+    } finally {
       setCreating(false);
-      return;
     }
-
-    setTitle("");
-    setTarget(7);
-    setUnit("commits");
-    setRecurrence("none");
-    setDeadline("");
-
-    // Immediately sync if it was a commit-based goal or prs
-    if (unit === "commits" || unit === "prs") {
-      await handleSync();
-    } else {
-      await loadGoals().catch(() => {});
-    }
-    setCreating(false);
   }
 
   async function handleDelete(id: string) {

--- a/src/lib/goal-tracker.ts
+++ b/src/lib/goal-tracker.ts
@@ -1,0 +1,68 @@
+type Recurrence = "none" | "weekly" | "monthly";
+
+export interface CreateGoalPayload {
+  title: string;
+  target: number;
+  unit: string;
+  recurrence: Recurrence;
+  deadline: string | null;
+}
+
+interface SubmitGoalOptions {
+  fetchImpl?: typeof fetch;
+  payload: CreateGoalPayload;
+  handleSync: () => Promise<unknown>;
+  loadGoals: () => Promise<unknown>;
+}
+
+export interface SubmitGoalResult {
+  created: boolean;
+  error: string | null;
+}
+
+export async function submitGoalWithRefresh({
+  fetchImpl = fetch,
+  payload,
+  handleSync,
+  loadGoals,
+}: SubmitGoalOptions): Promise<SubmitGoalResult> {
+  let response: Response;
+
+  try {
+    response = await fetchImpl("/api/goals", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    return {
+      created: false,
+      error: "Failed to create goal. Please try again.",
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      created: false,
+      error: "Failed to create goal. Please try again.",
+    };
+  }
+
+  try {
+    if (payload.unit === "commits" || payload.unit === "prs") {
+      await handleSync();
+    } else {
+      await loadGoals();
+    }
+  } catch {
+    return {
+      created: true,
+      error: "Goal created, but refreshing goals failed. Please try refreshing.",
+    };
+  }
+
+  return {
+    created: true,
+    error: null,
+  };
+}

--- a/test/goal-tracker-submit-flow.test.ts
+++ b/test/goal-tracker-submit-flow.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { submitGoalWithRefresh, type CreateGoalPayload } from "@/lib/goal-tracker";
+
+const payload: CreateGoalPayload = {
+  title: "Ship more fixes",
+  target: 5,
+  unit: "commits",
+  recurrence: "none",
+  deadline: null,
+};
+
+describe("submitGoalWithRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a create error when the POST request fails", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false });
+    const handleSync = vi.fn();
+    const loadGoals = vi.fn();
+
+    const result = await submitGoalWithRefresh({
+      fetchImpl,
+      payload,
+      handleSync,
+      loadGoals,
+    });
+
+    expect(result).toEqual({
+      created: false,
+      error: "Failed to create goal. Please try again.",
+    });
+    expect(handleSync).not.toHaveBeenCalled();
+    expect(loadGoals).not.toHaveBeenCalled();
+  });
+
+  it("keeps the goal created and returns a refresh error when sync fails", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
+    const handleSync = vi.fn().mockRejectedValue(new Error("sync failed"));
+    const loadGoals = vi.fn();
+
+    const result = await submitGoalWithRefresh({
+      fetchImpl,
+      payload,
+      handleSync,
+      loadGoals,
+    });
+
+    expect(result).toEqual({
+      created: true,
+      error: "Goal created, but refreshing goals failed. Please try refreshing.",
+    });
+    expect(handleSync).toHaveBeenCalledTimes(1);
+    expect(loadGoals).not.toHaveBeenCalled();
+  });
+
+  it("reloads goals for non auto-synced units", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true });
+    const handleSync = vi.fn();
+    const loadGoals = vi.fn().mockResolvedValue(undefined);
+
+    const result = await submitGoalWithRefresh({
+      fetchImpl,
+      payload: { ...payload, unit: "hours" },
+      handleSync,
+      loadGoals,
+    });
+
+    expect(result).toEqual({
+      created: true,
+      error: null,
+    });
+    expect(handleSync).not.toHaveBeenCalled();
+    expect(loadGoals).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- move goal creation and follow-up refresh into a small reusable helper
- always release the create button state even when the post-create sync/reload step fails
- add focused tests covering create failure, refresh failure, and non-auto-synced goal reloads

## Testing
- git diff --check
- bundled Node smoke test for submitGoalWithRefresh covering failed create, failed refresh, and successful reload paths

Closes #1243