### PR TITLE
fix: guard unavailable supabase admin client

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,12 +3,25 @@ import { createClient } from "@supabase/supabase-js";
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-// Do not throw here — build-time rendering can touch this module before
+export const SUPABASE_ADMIN_UNAVAILABLE_MESSAGE =
+  "Supabase admin client is unavailable. Check NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.";
+
+type SupabaseAdminClient = ReturnType<typeof createClient>;
+
+function createUnavailableSupabaseAdmin(): SupabaseAdminClient {
+  return {
+    from() {
+      throw new Error(SUPABASE_ADMIN_UNAVAILABLE_MESSAGE);
+    },
+  } as unknown as SupabaseAdminClient;
+}
+
+// Do not throw here - build-time rendering can touch this module before
 // runtime environment variables are present. Guard call sites instead.
-export const supabaseAdmin: any =
+export const supabaseAdmin: SupabaseAdminClient =
   supabaseUrl && serviceRoleKey && !supabaseUrl.includes("placeholder")
     ? createClient(supabaseUrl, serviceRoleKey)
-    : null;
+    : createUnavailableSupabaseAdmin();
 
 interface User {
   id: string;
@@ -26,8 +39,6 @@ interface User {
 export async function getUserByUsername(
   username: string
 ): Promise<User | null> {
-  if (!supabaseAdmin) return null;
-
   try {
     const { data, error } = await supabaseAdmin
       .from("users")
@@ -58,8 +69,6 @@ export async function updateUserPublicFlag(
   userId: string,
   isPublic: boolean
 ): Promise<User | null> {
-  if (!supabaseAdmin) return null;
-
   try {
     const { data, error } = await supabaseAdmin
       .from("users")

--- a/test/supabase-guard.test.ts
+++ b/test/supabase-guard.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("supabase admin guard", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("throws a clear configuration error instead of exposing a null client", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "");
+
+    const { supabaseAdmin, SUPABASE_ADMIN_UNAVAILABLE_MESSAGE } = await import("@/lib/supabase");
+
+    expect(() => supabaseAdmin.from("users")).toThrow(SUPABASE_ADMIN_UNAVAILABLE_MESSAGE);
+  });
+
+  it("lets helper functions fail safely when the admin client is unavailable", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "");
+
+    const { getUserByUsername } = await import("@/lib/supabase");
+    const result = await getUserByUsername("octocat");
+
+    expect(result).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the nullable ny admin client with a typed guarded client path
- throw a clear configuration error when the admin client is unavailable instead of allowing a 
ull.from(...) crash
- add a focused regression test covering the unavailable-client guard behavior

## Testing
- git diff --check
- static Node checks confirming the new guard constant/factory and the new regression test coverage shape

Closes #1249