### PR TITLE
"Add explicit type attribute to retry button"

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -52,7 +52,12 @@
   <main class="card">
     <h1>You are offline</h1>
     <p>DevTrack is installed, but this page needs internet. Please reconnect and try again.</p>
-    <button onclick="window.location.reload()">Retry</button>
+    <button
+    type="button"
+    onclick="window.location.reload()"
+    >
+      Retry
+    </button>
   </main>
 </body>
 </html>


### PR DESCRIPTION
Summary

Adds an explicit "type="button"" attribute to the retry button to prevent unintended form submission behavior and follow HTML best practices.

Closes #1272 

Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

Changes Made

- Added "type="button"" to the retry button
- Improved HTML semantic correctness
- Prevented potential future form submission issues

How to Test

Steps for the reviewer to verify this works:

1. Open the offline page
2. Click the Retry button
3. Verify the page reloads correctly

Screenshots (if UI change)

N/A

Checklist

- [x] Linked issue in summary
- [ ] "npm run lint" passes locally
- [ ] No TypeScript errors ("npm run type-check")
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable