### PR TITLE
test : added unit tests for metrics-cache isMetricsCacheBypassed

### DIFF
--- a/test/metrics-cache.test.ts
+++ b/test/metrics-cache.test.ts
@@ -63,6 +63,31 @@ describe('metrics-cache', () => {
       });
       expect(isMetricsCacheBypassed(req)).toBe(true);
     });
+
+    it('verify non-bypass values are rejected', () => {
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost?refresh=false'))).toBe(false);
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost?refresh=0'))).toBe(false);
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost?refresh=no'))).toBe(false);
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost?bypassCache=off'))).toBe(false);
+    });
+
+    it('verify missing parameters do not bypass', () => {
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost'))).toBe(false);
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost?other=value'))).toBe(false);
+    });
+
+    it('verify case insensitive bypass values', () => {
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost?refresh=TRUE'))).toBe(true);
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost?refresh=YES'))).toBe(true);
+      expect(isMetricsCacheBypassed(new NextRequest('http://localhost?refresh=ON'))).toBe(true);
+    });
+
+    it('verify combination of query param and header bypass', () => {
+      const req = new NextRequest('http://localhost?refresh=true', {
+        headers: new Headers({ 'x-devtrack-cache-bypass': '1' })
+      });
+      expect(isMetricsCacheBypassed(req)).toBe(true);
+    });
   });
 
   describe('cacheGet/cacheSet', () => {


### PR DESCRIPTION
Refs #1282.

Summary of What Has Been Done:
Added unit tests for the isMetricsCacheBypassed function in src/lib/metrics-cache.ts, covering various bypass parameters and header combinations.

Changes Made:
- Enhanced test/metrics-cache.test.ts with 4 new test cases:
  - Non-bypass values (false, 0, no, off)
  - Missing parameters
  - Case insensitive bypass values (TRUE, YES, ON)
  - Combination of query param and header bypass

Impact it Made:
Improved test coverage for cache bypass logic. All 13 tests pass.