### PR TITLE
fix: dynamic contribution heatmap intensity scaling

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -122,7 +122,10 @@ export default function ContributionHeatmap({
   const { themeConfig, theme, setTheme } = useHeatmapTheme();
   const cells = useMemo(() => buildHeatmap(days, data), [days, data]);
   const weekCount = Math.ceil(cells.length / 7);
-
+  const maxCommits = Math.max(
+  ...cells.map((cell) => cell.count),
+  1
+);
   // 100% MATHEMATICALLY PRECISE MONTH TRACKING SYSTEM
   const monthMarkers = useMemo(() => {
     const markers: Array<{ label: string; weekIndex: number }> = [];
@@ -163,6 +166,25 @@ export default function ContributionHeatmap({
   } as const;
 
   const today = new Date();
+  const getHeatmapColor = (count: number) => {
+  if (count === 0) return themeConfig.missed;
+
+  const normalized = count / maxCommits;
+
+  if (normalized <= 0.25) {
+    return themeConfig.levelOne;
+  }
+
+  if (normalized <= 0.5) {
+    return themeConfig.levelTwo;
+  }
+
+  if (normalized <= 0.75) {
+    return themeConfig.levelThree;
+  }
+
+  return themeConfig.levelFour;
+};
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
@@ -194,18 +216,15 @@ export default function ContributionHeatmap({
         <div className="flex items-center gap-2 text-xs text-[var(--muted-foreground)]">
           <span>Less</span>
           <div className="flex items-center gap-1">
-            {[0, 1, 3, 6, 10].map((count) => {
-              const swatch =
-                count === 0
-                  ? themeConfig.missed
-                  : count < 3
-                  ? themeConfig.levelOne
-                  : count < 6
-                  ? themeConfig.levelTwo
-                  : count < 10
-                  ? themeConfig.levelThree
-                  : themeConfig.levelFour;
-
+            {[
+  0,
+  Math.ceil(maxCommits * 0.25),
+  Math.ceil(maxCommits * 0.5),
+  Math.ceil(maxCommits * 0.75),
+  maxCommits,
+].map((count) => {
+              const swatch = getHeatmapColor(count);
+                
               return (
                 <span
                   key={count}
@@ -298,15 +317,8 @@ export default function ContributionHeatmap({
                         gridColumn: weekIndex + 2,
                         backgroundColor: isFuture
                           ? "transparent"
-                          : cell.count === 0
-                          ? themeConfig.missed
-                          : cell.count < 3
-                          ? themeConfig.levelOne
-                          : cell.count < 6
-                          ? themeConfig.levelTwo
-                          : cell.count < 10
-                          ? themeConfig.levelThree
-                          : themeConfig.levelFour,
+                          : getHeatmapColor(cell.count),
+
                         borderColor: themeConfig.border,
                         ["--heatmap-focus-ring" as any]: themeConfig.accent,
                       }}


### PR DESCRIPTION
## Summary

Fixes incorrect contribution heatmap intensity scaling by replacing fixed thresholds with dynamic scaling based on the user's maximum commit count.

Closes #936

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Replaced fixed heatmap intensity thresholds with dynamic scaling
- Added relative contribution intensity calculation using max commit count
- Updated heatmap legend to reflect dynamic bucket scaling

## How to Test

1. Run the application using `npm run dev`
2. Open the dashboard contribution heatmap
3. Compare days with low and high commit counts
4. Verify that higher contribution days display stronger intensity levels dynamically

## Screenshots (if UI change)

N/A

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable