### PR TITLE
test : add unit tests for crypto safeCompare and verifyGitHubSignature (closes #1274)

### DIFF
--- a/test/github-webhook.test.ts
+++ b/test/github-webhook.test.ts
@@ -1,6 +1,5 @@
-import { vi, describe, it, expect } from "vitest";
+import { vi, describe, it, expect, beforeEach } from "vitest";
 
-// Mock @/lib/supabase to prevent environment variable errors on import
 vi.mock("@/lib/supabase", () => ({
   supabaseAdmin: {
     from: vi.fn(),
@@ -37,6 +36,25 @@ describe("webhook signature verification", () => {
       expect(safeCompare(long1, long2)).toBe(true);
       expect(safeCompare(long1, "b" + "a".repeat(999))).toBe(false);
     });
+
+    it("handles unicode characters correctly", () => {
+      expect(safeCompare("héllo", "héllo")).toBe(true);
+      expect(safeCompare("héllo", "héllö")).toBe(false);
+    });
+
+    it("returns false for single character difference", () => {
+      expect(safeCompare("abc", "abd")).toBe(false);
+    });
+
+    it("handles special characters correctly", () => {
+      expect(safeCompare("!@#$%^&*()", "!@#$%^&*()")).toBe(true);
+      expect(safeCompare("!@#$%^&*()", "!@#$%^&*()+")).toBe(false);
+    });
+
+    it("handles whitespace correctly", () => {
+      expect(safeCompare("hello world", "hello world")).toBe(true);
+      expect(safeCompare("hello world", "hello  world")).toBe(false);
+    });
   });
 
   describe("verifyGitHubSignature", () => {
@@ -65,6 +83,32 @@ describe("webhook signature verification", () => {
       const sigWithoutPrefix = "0000000000000000000000000000000000000000000000000000000000000000";
       expect(verifyGitHubSignature(body, sigWithoutPrefix, secret)).toBe(false);
     });
+
+    it("returns false for signature with wrong sha256= prefix casing", () => {
+      const sigWithUpperCase = "SHA256=0000000000000000000000000000000000000000000000000000000000000000";
+      expect(verifyGitHubSignature(body, sigWithUpperCase, secret)).toBe(false);
+    });
+
+    it("returns false for tampered body", () => {
+      const validSignature = getExpectedSignature(secret, body);
+      expect(verifyGitHubSignature("tampered body", validSignature, secret)).toBe(false);
+    });
+
+    it("returns false for wrong secret", () => {
+      const signature = getExpectedSignature(secret, body);
+      expect(verifyGitHubSignature(body, signature, "wrong-secret")).toBe(false);
+    });
+
+    it("handles empty body correctly", () => {
+      const signature = getExpectedSignature(secret, "");
+      expect(verifyGitHubSignature("", signature, secret)).toBe(true);
+    });
+
+    it("handles unicode body correctly", () => {
+      const unicodeBody = '{"action":"push","repo":"test- héllo"}';
+      const signature = getExpectedSignature(secret, unicodeBody);
+      expect(verifyGitHubSignature(unicodeBody, signature, secret)).toBe(true);
+    });
   });
 
   describe("getExpectedSignature", () => {
@@ -77,6 +121,24 @@ describe("webhook signature verification", () => {
     it("starts with sha256= prefix", () => {
       const sig = getExpectedSignature("secret", "body");
       expect(sig.startsWith("sha256=")).toBe(true);
+    });
+
+    it("produces different signatures for different secrets", () => {
+      const sig1 = getExpectedSignature("secret1", "body");
+      const sig2 = getExpectedSignature("secret2", "body");
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it("produces different signatures for different bodies", () => {
+      const sig1 = getExpectedSignature("secret", "body1");
+      const sig2 = getExpectedSignature("secret", "body2");
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it("produces 64 character hex digest after prefix", () => {
+      const sig = getExpectedSignature("secret", "body");
+      const hexPart = sig.substring(7);
+      expect(hexPart).toMatch(/^[a-f0-9]{64}$/);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added comprehensive unit tests for `safeCompare` function covering edge cases like unicode characters, single character differences, special characters, and whitespace
- Added comprehensive unit tests for `verifyGitHubSignature` function covering edge cases like wrong prefix casing, tampered body, wrong secret, empty body, and unicode body
- Added tests for `getExpectedSignature` function covering different signatures for different secrets/bodies and hex format validation

Closes #1274