### PR TITLE
fix : explicitly list columns in user data export SELECT to prevent schema bleed (closes #810)

### DIFF
--- a/src/app/api/user/data-export/route.ts
+++ b/src/app/api/user/data-export/route.ts
@@ -56,7 +56,7 @@ export async function GET() {
   const webhookIds = webhooks?.map((w) => w.id) || [];
   const { data: webhookDeliveries } = await supabaseAdmin
     .from("webhook_deliveries")
-    .select("*")
+    .select("id, webhook_id, event_type, payload, response_status, response_body, delivered_at, created_at")
     .in("webhook_id", webhookIds);
   sections.webhookDeliveries = webhookDeliveries || [];
 


### PR DESCRIPTION
## Summary
- Changed `SELECT *` to explicit column list in webhook_deliveries query within the user data export endpoint
- Explicit columns: id, webhook_id, event_type, payload, response_status, response_body, delivered_at, created_at
- Prevents schema bleed issues if the database schema changes

Closes #810