### PR TITLE
test: add unit tests for dateUtils week range calculations

### DIFF
--- a/test/dateUtils.test.ts
+++ b/test/dateUtils.test.ts
@@ -138,3 +138,123 @@ describe("getLastWeekRange", () => {
     expect(range.end).toBe(expectedEnd);
   });
 });
+
+describe("getThisWeekRange — additional edge cases", () => {
+  it("should return start as Monday at exactly 00:00:00.000Z (UTC midnight)", () => {
+    // Sunday 2024-04-21 23:59:59 UTC — still in previous week
+    const mockSunday = new Date("2024-04-21T23:59:59Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockSunday);
+
+    const range = getThisWeekRange();
+
+    // Week started on Monday 2024-04-15
+    expect(range.start).toBe(new Date(Date.UTC(2024, 3, 15, 0, 0, 0, 0)).toISOString());
+  });
+
+  it("should correctly set end to 23:59:59 on the current day (not midnight)", () => {
+    const mockFriday = new Date("2024-04-19T14:30:00Z"); // Friday mid-day
+    vi.useFakeTimers();
+    vi.setSystemTime(mockFriday);
+
+    const range = getThisWeekRange();
+
+    // End should be Friday 23:59:59
+    expect(range.end).toBe(new Date(Date.UTC(2024, 3, 19, 23, 59, 59, 0)).toISOString());
+  });
+
+  it("should return a valid ISO string for both start and end", () => {
+    const mockNow = new Date("2024-06-12T09:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+
+    const range = getThisWeekRange();
+
+    expect(() => new Date(range.start)).not.toThrow();
+    expect(() => new Date(range.end)).not.toThrow();
+    expect(new Date(range.start).toISOString()).toBe(range.start);
+    expect(new Date(range.end).toISOString()).toBe(range.end);
+  });
+
+  it("should have start before or equal to end", () => {
+    const mockNow = new Date("2024-09-25T18:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+
+    const range = getThisWeekRange();
+
+    expect(new Date(range.start).getTime()).toBeLessThanOrEqual(
+      new Date(range.end).getTime()
+    );
+  });
+
+  it("should span month boundary when week crosses two months", () => {
+    // 2024-01-29 is a Monday, week spans Jan 29 – current day Feb 1
+    const mockFebruaryDay = new Date("2024-02-01T10:00:00Z"); // Thursday
+    vi.useFakeTimers();
+    vi.setSystemTime(mockFebruaryDay);
+
+    const range = getThisWeekRange();
+
+    // Week started Monday Jan 29
+    expect(range.start).toBe(new Date(Date.UTC(2024, 0, 29, 0, 0, 0, 0)).toISOString());
+    // Current day is Feb 1 23:59:59
+    expect(range.end).toBe(new Date(Date.UTC(2024, 1, 1, 23, 59, 59, 0)).toISOString());
+  });
+});
+
+describe("getLastWeekRange — additional edge cases", () => {
+  it("should have last week end exactly one day before this week start", () => {
+    const mockNow = new Date("2024-05-15T10:00:00Z"); // Wednesday
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+
+    const thisWeek = getThisWeekRange();
+    const lastWeek = getLastWeekRange();
+
+    const thisWeekStartMs = new Date(thisWeek.start).getTime();
+    const lastWeekEndMs = new Date(lastWeek.end).getTime();
+
+    // Last week end (Sun 23:59:59) + 1 second = this week start (Mon 00:00:00)
+    expect(lastWeekEndMs + 1000).toBe(thisWeekStartMs);
+  });
+
+  it("should span exactly 7 days from Monday to Sunday", () => {
+    const mockNow = new Date("2024-04-17T10:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+
+    const range = getLastWeekRange();
+
+    const startDay = new Date(range.start).getUTCDay(); // 1 = Monday
+    const endDay = new Date(range.end).getUTCDay();   // 0 = Sunday
+
+    expect(startDay).toBe(1); // Monday
+    expect(endDay).toBe(0);   // Sunday
+  });
+
+  it("should handle month boundary — last week spanning two months", () => {
+    // 2024-09-02 is a Monday. Last week was Mon Aug 26 – Sun Sep 1
+    const mockMonday = new Date("2024-09-02T09:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockMonday);
+
+    const range = getLastWeekRange();
+
+    expect(range.start).toBe(new Date(Date.UTC(2024, 7, 26, 0, 0, 0, 0)).toISOString());
+    expect(range.end).toBe(new Date(Date.UTC(2024, 8, 1, 23, 59, 59, 0)).toISOString());
+  });
+
+  it("should return valid ISO strings", () => {
+    const mockNow = new Date("2024-11-20T12:00:00Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+
+    const range = getLastWeekRange();
+
+    expect(() => new Date(range.start)).not.toThrow();
+    expect(() => new Date(range.end)).not.toThrow();
+    expect(new Date(range.start).toISOString()).toBe(range.start);
+    expect(new Date(range.end).toISOString()).toBe(range.end);
+  });
+});


### PR DESCRIPTION
Closes #1279. Expands 	est/dateUtils.test.ts with comprehensive edge case tests for getThisWeekRange and getLastWeekRange:

**getThisWeekRange:**
- Verifies start is exactly Monday 00:00:00.000Z (UTC midnight)
- Verifies end is set to 23:59:59 on the current day (not midnight)
- Validates ISO string format for both start and end
- Asserts start is always <= end
- Tests week spanning a month boundary (e.g., Jan 29 – Feb 1)

**getLastWeekRange:**
- Asserts last week end + 1 second exactly equals this week start
- Verifies last week always spans Monday to Sunday (day-of-week check)
- Tests month boundary — week spanning two months (Aug 26 – Sep 1)
- Validates ISO string format for both start and end