### PR TITLE
fix: zero fallback repo stats (#1245)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,11 +59,11 @@ async function fetchRepoStats(): Promise<RepoStats> {
     };
   } catch {
     return {
-      stars: 40,
-      forks: 160,
-      openIssues: 307,
-      contributorCount: 30,
-      goodFirstIssues: 36,
+      stars: 0,
+      forks: 0,
+      openIssues: 0,
+      contributorCount: 0,
+      goodFirstIssues: 0,
       contributors: [],
     };
   }


### PR DESCRIPTION
## Description\n- replace the landing page's hardcoded non-zero fallback repo stats with zero-safe values\n- prevent invented GitHub stars, forks, issues, and contributor counts from appearing during API failures\n- keep the change scoped to etchRepoStats() in src/app/page.tsx\n\n## Related Issue\n- Closes #1245\n\n## Checklist\n- [x] one-file fix\n- [x] git diff --check passes\n- [x] behavior now falls back to zero-safe stats instead of fabricated numbers\n\n## Pillar\n- Open Source\n