### PR TITLE
fix: cap GitLab contribution pagination (#1247)

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -187,10 +187,11 @@ async function fetchGitLabContributions(
       since.setDate(since.getDate() - days);
       since.setHours(0, 0, 0, 0);
 
+      const MAX_PAGES = 10;
       let page = 1;
       const commitsByDay: Record<string, number> = {};
 
-      while (page > 0) {
+      while (page > 0 && page <= MAX_PAGES) {
         const url = new URL("https://gitlab.com/api/v4/events");
         url.searchParams.set("action", "pushed");
         url.searchParams.set("per_page", "100");


### PR DESCRIPTION
## Description\n- add a GitLab pagination safety cap in etchGitLabContributions()\n- stop malformed or repeated x-next-page values from keeping the request alive indefinitely\n- align the GitLab fetch guard with the existing bounded GitHub pagination pattern in the same route\n\n## Related Issue\n- Closes #1247\n\n## Checklist\n- [x] one-file fix\n- [x] git diff --check passes\n- [x] change is scoped to the GitLab contributions pagination loop only\n\n## Pillar\n- Open Source\n