### PR TITLE
test: cover leaderboard cache edge cases (#1278)

### DIFF
--- a/test/leaderboard-cache.test.mjs
+++ b/test/leaderboard-cache.test.mjs
@@ -27,6 +27,19 @@ test("pruneExpiredLeaderboardCache clears stale leaderboard payloads", () => {
   assert.equal(pruneExpiredLeaderboardCache(cache, 1_001), null);
 });
 
+test("pruneExpiredLeaderboardCache clears entries that expire exactly at now", () => {
+  const cache = {
+    expiresAt: 1_000,
+    payload: { ok: true },
+  };
+
+  assert.equal(pruneExpiredLeaderboardCache(cache, 1_000), null);
+});
+
+test("pruneExpiredLeaderboardCache returns null for a missing cache entry", () => {
+  assert.equal(pruneExpiredLeaderboardCache(null, 1_000), null);
+});
+
 test("pruneExpiredLeaderboardCache keeps fresh leaderboard payloads", () => {
   const cache = {
     expiresAt: 2_000,
@@ -34,4 +47,23 @@ test("pruneExpiredLeaderboardCache keeps fresh leaderboard payloads", () => {
   };
 
   assert.equal(pruneExpiredLeaderboardCache(cache, 1_999), cache);
+});
+
+test("pruneExpiredLeaderboardCache keeps far-future entries untouched", () => {
+  const cache = {
+    expiresAt: Number.MAX_SAFE_INTEGER,
+    payload: { rows: [1, 2, 3] },
+  };
+
+  assert.equal(pruneExpiredLeaderboardCache(cache, 1_000), cache);
+});
+
+test("pruneExpiredLeaderboardCache preserves payload shape for primitive values", () => {
+  const cache = {
+    expiresAt: 5_000,
+    payload: "leaderboard-json",
+  };
+
+  assert.equal(pruneExpiredLeaderboardCache(cache, 4_999), cache);
+  assert.equal(pruneExpiredLeaderboardCache(cache, 5_000), null);
 });


### PR DESCRIPTION
## Summary
- add exact-boundary expiry coverage for pruneExpiredLeaderboardCache
- cover null-entry, far-future expiry, and primitive-payload preservation cases
- keep the change scoped to test/leaderboard-cache.test.mjs only

## Testing
- node --test test/leaderboard-cache.test.mjs
- git diff --check

Closes #1278