### PR TITLE
fix: add timeBlocks aggregation to contributions endpoint for CommitTimeChart

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -19,11 +19,19 @@ import { normalizeGitHubUsername } from "@/lib/validate-github-username";
 
 export const dynamic = "force-dynamic";
 
+interface TimeBlocks {
+  morning: number;
+  afternoon: number;
+  evening: number;
+  night: number;
+}
+
 interface ContributionResponse {
   days: number;
   total: number;
   data: Record<string, number>;
   commits: CommitItem[];
+  timeBlocks: TimeBlocks;
   sources?: {
     github: Record<string, number>;
     gitlab?: Record<string, number>;
@@ -149,6 +157,7 @@ async function fetchContributionsForAccount(
       }
 
       const commitsByDay: Record<string, number> = {};
+      const timeBlocks: TimeBlocks = { morning: 0, afternoon: 0, evening: 0, night: 0 };
       for (const item of allItems) {
         const date = item.commit.author.date.slice(0, 10);
         commitsByDay[date] = (commitsByDay[date] ?? 0) + 1;
@@ -159,9 +168,15 @@ async function fetchContributionsForAccount(
           repo: item.repository?.full_name ?? "unknown",
           url: item.html_url,
         });
+
+        const hour = new Date(item.commit.author.date).getHours();
+        if (hour >= 6 && hour < 12) timeBlocks.morning++;
+        else if (hour >= 12 && hour < 18) timeBlocks.afternoon++;
+        else if (hour >= 18 && hour < 22) timeBlocks.evening++;
+        else timeBlocks.night++;
       }
 
-      return { days, total: totalCount, data: commitsByDay, commits: commitItems };
+      return { days, total: totalCount, data: commitsByDay, commits: commitItems, timeBlocks };
     }
   );
 }
@@ -238,6 +253,7 @@ async function fetchGitLabContributions(
         total: sumContributionDays(commitsByDay),
         data: commitsByDay,
         commits: [],
+        timeBlocks: { morning: 0, afternoon: 0, evening: 0, night: 0 },
       };
     }
   );
@@ -267,6 +283,7 @@ async function mergeGitLabContributions(
     total: combinedTotal,
     data: combinedData,
     commits: result.commits,
+    timeBlocks: result.timeBlocks,
     sources: {
       github: result.data,
       gitlab: gitlabResult.data,
@@ -387,6 +404,12 @@ export async function GET(req: NextRequest) {
       commits: [...a.commits, ...b.commits].sort(
         (c, d) => d.date.localeCompare(c.date) || d.sha.localeCompare(c.sha)
       ),
+      timeBlocks: {
+        morning: a.timeBlocks.morning + b.timeBlocks.morning,
+        afternoon: a.timeBlocks.afternoon + b.timeBlocks.afternoon,
+        evening: a.timeBlocks.evening + b.timeBlocks.evening,
+        night: a.timeBlocks.night + b.timeBlocks.night,
+      },
     }));
 
     if (!merged) {


### PR DESCRIPTION
## Description

Fixes #1309

The `CommitTimeChart` component reads the `timeBlocks` field from the `/api/metrics/contributions` response to display commit distribution across morning, afternoon, evening, and night. However, the backend endpoint never computed or returned this field, causing the chart to always render "No commits" for every user.

### Changes

**`src/app/api/metrics/contributions/route.ts`**
- Added `TimeBlocks` interface with `morning`, `afternoon`, `evening`, `night` counters
- Added `timeBlocks` field to `ContributionResponse`
- Computes time-of-day bins inside `fetchContributionsForAccount` by extracting the hour from each commit's `author.date`:
  - **Morning** (6–12): `timeBlocks.morning++`
  - **Afternoon** (12–18): `timeBlocks.afternoon++`
  - **Evening** (18–22): `timeBlocks.evening++`
  - **Night** (22–6): `timeBlocks.night++`
- Returns `timeBlocks` alongside existing `days`, `total`, `data`, and `commits`
- Merges `timeBlocks` correctly in the combined-accounts path (per-block sums)
- Passes through `timeBlocks` from the GitHub result in GitLab merge
- GitLab contributions return zeroed `timeBlocks` (events don't carry hour precision)

### Verification

1. Navigate to `/dashboard` and observe the "Commits by Time of Day" chart
2. **Before**: always shows "No commits in the last N days"
3. **After**: shows horizontal bar chart with commit counts for each time block, plus peak-time label
4. Test with 7d / 30d / 90d range selector
5. Verify combined-accounts mode correctly aggregates time blocks across all linked accounts