### PR TITLE
fix(heatmap): prevent tooltip overflow on rightmost cells

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -276,6 +276,7 @@ export default function ContributionHeatmap({
                   const dayIndex = index % 7;
                   const isFuture = cell.date > today;
                   const showTooltipBelow = dayIndex < 2;
+                  const isNearRightEdge = weekIndex >= weekCount - 3;
                   const tooltip = `${cell.date.toLocaleDateString("en-US", {
                     weekday: "short",
                     month: "short",
@@ -313,8 +314,12 @@ export default function ContributionHeatmap({
                     >
                       {!isFuture && (
                         <span
-                          className={`pointer-events-none absolute left-1/2 z-50 hidden -translate-x-1/2 whitespace-nowrap rounded-md bg-[var(--foreground)] px-2 py-1 text-[11px] text-[var(--background)] shadow-lg group-hover:block group-focus:block ${
+                          className={`pointer-events-none absolute z-50 hidden whitespace-nowrap rounded-md bg-[var(--foreground)] px-2 py-1 text-[11px] text-[var(--background)] shadow-lg group-hover:block group-focus:block ${
                             showTooltipBelow ? "top-full mt-2" : "bottom-full mb-2"
+                          } ${
+                            isNearRightEdge
+                              ? "right-0 translate-x-0"
+                              : "left-1/2 -translate-x-1/2"
                           }`}
                         >
                           {tooltip}


### PR DESCRIPTION
## What does this PR do?
Fixes tooltip overflow on the rightmost cells of the contribution heatmap. Tooltip now flips to align right when near the viewport edge instead of overflowing.

## Related issue
Closes #1046

## Changes made
- Added `isNearRightEdge` check: true when `weekIndex >= weekCount - 3`
- Near right edge: tooltip uses `right-0 translate-x-0` alignment
- Center cells: unchanged `left-1/2 -translate-x-1/2` alignment
- Existing top/bottom flip logic unchanged
- No new dependencies

## How to test
1. Go to dashboard → Contribution Heatmap
2. Hover over cells in the last 2-3 columns (far right)
3. Tooltip appears to the left, fully visible within viewport
4. Hover middle cells — tooltip still centers normally



<img width="1858" height="620" alt="image" src="https://github.com/user-attachments/assets/ab44d848-da75-4b57-8260-8cdeb4ff12f6" />
