### PR TITLE
Fix text contrast landing page #1213

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4575,7 +4575,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -112,7 +112,7 @@ export default function SignInPage() {
         <p
           style={{
             fontSize: 14,
-            color: "#555",
+            color: "#9ca3af",
             lineHeight: 1.65,
             margin: "0 0 36px",
             fontFamily: MONO,
@@ -164,7 +164,7 @@ export default function SignInPage() {
           style={{
             fontFamily: MONO,
             fontSize: 11,
-            color: "#333",
+            color: "#9ca3af",
             letterSpacing: "0.06em",
             lineHeight: 1.8,
           }}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -12,8 +12,7 @@ function MouseSpotlight() {
   useEffect(() => {
     const fn = (e: MouseEvent) => {
       if (ref.current) {
-        ref.current.style.left = e.clientX + "px";
-        ref.current.style.top = e.clientY + "px";
+        ref.current.style.transform = `translate3d(calc(${e.clientX}px - 50%), calc(${e.clientY}px - 50%), 0)`;
       }
     };
     window.addEventListener("mousemove", fn, { passive: true });
@@ -25,11 +24,12 @@ function MouseSpotlight() {
       aria-hidden
       style={{
         position: "fixed", pointerEvents: "none", zIndex: 0,
+        left: 0, top: 0,
         width: 600, height: 600,
         background:
           "radial-gradient(circle, rgba(129,140,248,0.06) 0%, transparent 70%)",
-        transform: "translate(-50%,-50%)",
-        transition: "left 0.15s ease-out, top 0.15s ease-out",
+        transform: "translate3d(-50%, -50%, 0)",
+        willChange: "transform",
       }}
     />
   );
@@ -67,7 +67,7 @@ export default function SignInPage() {
       <div
         style={{
           width: "100%",
-          maxWidth: 420,
+          maxWidth: 520,
           border: "1px solid #1a1a1a",
           borderRadius: 12,
           padding: "clamp(28px,5vw,48px) clamp(24px,5vw,40px)",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -155,7 +155,7 @@ body {
 .dark::-webkit-scrollbar       { width: 6px; height: 6px; }
 .dark::-webkit-scrollbar-track { background: transparent; }
 .dark::-webkit-scrollbar-thumb { background: #222; border-radius: 6px; }
-.dark::-webkit-scrollbar-thumb:hover { background: #333; }
+.dark::-webkit-scrollbar-thumb:hover { background: #9ca3af; }
 
 /* ─────────────────────────────────────────
    LANDING PAGE
@@ -183,14 +183,14 @@ body {
   font-family: var(--font-jetbrains, ui-monospace, monospace);
   font-size: 12px;
   font-weight: 500;
-  color: #888;
+  color: #9ca3af;
   text-decoration: none;
   padding: 6px 14px;
   border: 1px solid #222;
   border-radius: 5px;
   transition: all 0.2s;
 }
-.lnd-nav-link:hover { color: #e0e0e0; border-color: #444; }
+.lnd-nav-link:hover { color: #e0e0e0; border-color: #6b7280; }
 
 .lnd-cta-primary {
   display: inline-flex;
@@ -239,7 +239,7 @@ body {
   font-family: var(--font-jetbrains, ui-monospace, monospace);
   font-size: 13px;
   font-weight: 500;
-  color: #555;
+  color: #9ca3af;
   background: transparent;
   padding: 11px 22px;
   border-radius: 6px;
@@ -269,7 +269,7 @@ body {
 .lnd-footer-link {
   font-family: var(--font-jetbrains, ui-monospace, monospace);
   font-size: 11px;
-  color: #333;
+  color: #9ca3af;
   text-decoration: none;
   transition: color 0.2s;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,6 +58,10 @@
   --shadow-medium: 0 24px 45px -28px rgba(2, 6, 23, 0.85);
 }
 
+html, body {
+  overscroll-behavior: none;
+}
+
 body {
   background:
     radial-gradient(circle at 0% 0%, rgba(96, 165, 250, 0.16), transparent 36%),
@@ -65,6 +69,7 @@ body {
     var(--background);
   color: var(--foreground);
   transition: background-color 200ms ease, color 200ms ease;
+  overscroll-behavior: none;
 }
 
 .surface-card {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,18 +4,23 @@ const year = new Date().getFullYear();
 
 export default function Footer() {
   return (
-    <footer className="dark mt-auto border-t border-[var(--border)] bg-[var(--background)] relative">
-      <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(59,130,246,0.08),transparent)] pointer-events-none" />
-      <div className="relative mx-auto w-full max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
-        <div className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr_0.8fr_0.8fr]">
+    <footer className="dark mt-auto border-t border-[var(--border)] bg-[var(--background)] relative overflow-hidden">
+      {/* Subtle top gradient using the accent color */}
+      <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(129,140,248,0.05),transparent_50%)] pointer-events-none" />
+      
+      <div className="relative mx-auto w-full max-w-7xl px-6 py-10 sm:px-8 lg:px-12">
+        <div className="grid gap-10 lg:grid-cols-[1.5fr_1fr_1fr_1fr]">
           <div>
-            <div className="inline-flex items-center rounded-full border border-[var(--accent)]/20 bg-[var(--accent-soft)] px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-[var(--accent)]">
+            <div className="inline-flex items-center rounded-full border border-[#818cf8]/20 bg-[#818cf8]/10 px-4 py-1.5 text-[10px] font-bold uppercase tracking-[0.2em] text-[#818cf8]">
               Open source developer dashboard
             </div>
-            <h2 className="mt-4 text-2xl font-semibold text-[var(--card-foreground)] sm:text-3xl">
-              DevTrack keeps your coding story in one place.
+            <h2 
+              className="mt-5 text-2xl font-extrabold text-[#e8e8e8] sm:text-3xl tracking-tight"
+              style={{ fontFamily: "var(--font-syne, system-ui, sans-serif)", letterSpacing: "-0.03em" }}
+            >
+              DevTrack keeps your<br />coding story in one place.
             </h2>
-            <p className="mt-3 max-w-xl text-sm leading-6 text-[var(--muted-foreground)] sm:text-base">
+            <p className="mt-4 max-w-md text-[15px] leading-relaxed text-[#9ca3af]" style={{ fontFamily: "var(--font-jetbrains, ui-monospace, monospace)" }}>
               Track GitHub contributions, PR velocity, streaks, goals, and
               community activity with a dashboard built for contributors who
               work in public.
@@ -23,29 +28,29 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-[var(--card-foreground)]">
+            <h3 className="text-[11px] font-bold uppercase tracking-[0.2em] text-[#e8e8e8]" style={{ fontFamily: "var(--font-jetbrains, ui-monospace, monospace)" }}>
               Product
             </h3>
-            <div className="mt-4 flex flex-col gap-3 text-sm text-[var(--muted-foreground)]">
-              <Link className="transition-colors hover:text-[var(--card-foreground)]" href="/">
+            <div className="mt-6 flex flex-col gap-4 text-[14px] text-[#9ca3af]">
+              <Link className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit" href="/">
                 Home
               </Link>
-              <Link className="transition-colors hover:text-[var(--card-foreground)]" href="/dashboard">
+              <Link className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit" href="/dashboard">
                 Dashboard
               </Link>
-              <Link className="transition-colors hover:text-[var(--card-foreground)]" href="/leaderboard">
+              <Link className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit" href="/leaderboard">
                 Leaderboard
               </Link>
             </div>
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-[var(--card-foreground)]">
+            <h3 className="text-[11px] font-bold uppercase tracking-[0.2em] text-[#e8e8e8]" style={{ fontFamily: "var(--font-jetbrains, ui-monospace, monospace)" }}>
               Community
             </h3>
-            <div className="mt-4 flex flex-col gap-3 text-sm text-[var(--muted-foreground)]">
+            <div className="mt-6 flex flex-col gap-4 text-[14px] text-[#9ca3af]">
               <a
-                className="transition-colors hover:text-[var(--card-foreground)]"
+                className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit"
                 href="https://github.com/Priyanshu-byte-coder/devtrack/discussions"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -53,7 +58,7 @@ export default function Footer() {
                 Discussions
               </a>
               <a
-                className="transition-colors hover:text-[var(--card-foreground)]"
+                className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit"
                 href="https://github.com/Priyanshu-byte-coder/devtrack/issues"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -61,7 +66,7 @@ export default function Footer() {
                 Issues
               </a>
               <a
-                className="transition-colors hover:text-[var(--card-foreground)]"
+                className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit"
                 href="https://github.com/Priyanshu-byte-coder/devtrack"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -71,13 +76,13 @@ export default function Footer() {
             </div>
           </div>
    
-            <div>
-            <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-[var(--card-foreground)]">
+          <div>
+            <h3 className="text-[11px] font-bold uppercase tracking-[0.2em] text-[#e8e8e8]" style={{ fontFamily: "var(--font-jetbrains, ui-monospace, monospace)" }}>
               Contact
             </h3>
-            <div className="mt-4 flex flex-col gap-3 text-sm text-[var(--muted-foreground)]">
+            <div className="mt-6 flex flex-col gap-4 text-[14px] text-[#9ca3af]">
               <a
-                className="transition-colors hover:text-[var(--card-foreground)]"
+                className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit"
                 href="https://www.linkedin.com/in/priyanshu-doshi-21a54230a/"
                 target="_blank"
                 rel="noreferrer"
@@ -85,7 +90,7 @@ export default function Footer() {
                 LinkedIn
               </a>
               <a
-                className="transition-colors hover:text-[var(--card-foreground)]"
+                className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit"
                 href="https://github.com/Priyanshu-byte-coder"
                 target="_blank"
                 rel="noreferrer"
@@ -93,7 +98,7 @@ export default function Footer() {
                 GitHub
               </a>
               <a
-                className="transition-colors hover:text-[var(--card-foreground)]"
+                className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit"
                 href="https://portfolio-eta-gilt-84.vercel.app/"
                 target="_blank"
                 rel="noreferrer"
@@ -101,7 +106,7 @@ export default function Footer() {
                 Portfolio
               </a>
               <a
-                className="transition-colors hover:text-[var(--card-foreground)]"
+                className="transition-all duration-200 hover:text-white hover:translate-x-1 w-fit"
                 href="mailto:doshipriyanshu3@gmail.com"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -112,9 +117,15 @@ export default function Footer() {
           </div>
         </div>
 
-        <div className="mt-10 flex flex-col gap-3 border-t border-[var(--border)] pt-6 text-sm text-[var(--muted-foreground)] sm:flex-row sm:items-center sm:justify-between">
+        <div 
+          className="mt-10 flex flex-col gap-4 border-t border-[var(--border)] pt-6 text-[12px] text-[#9ca3af] sm:flex-row sm:items-center sm:justify-between"
+          style={{ fontFamily: "var(--font-jetbrains, ui-monospace, monospace)" }}
+        >
           <p>© {year} DevTrack. Built for open-source contributors.</p>
-          <p>Self-hostable, privacy-conscious, and designed for daily use.</p>
+          <div className="flex gap-6">
+            <p>MIT License</p>
+            <p>Self-hostable & Privacy-conscious</p>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -108,8 +108,7 @@ function MouseSpotlight() {
   useEffect(() => {
     const fn = (e: MouseEvent) => {
       if (ref.current) {
-        ref.current.style.left = e.clientX + 'px';
-        ref.current.style.top = e.clientY + 'px';
+        ref.current.style.transform = `translate3d(calc(${e.clientX}px - 50%), calc(${e.clientY}px - 50%), 0)`;
       }
     };
     window.addEventListener('mousemove', fn, { passive: true });
@@ -121,10 +120,11 @@ function MouseSpotlight() {
       aria-hidden
       style={{
         position: 'fixed', pointerEvents: 'none', zIndex: 0,
+        left: 0, top: 0,
         width: 700, height: 700,
         background: 'radial-gradient(circle, rgba(129,140,248,0.05) 0%, transparent 70%)',
-        transform: 'translate(-50%,-50%)',
-        transition: 'left 0.15s ease-out, top 0.15s ease-out',
+        transform: 'translate3d(-50%, -50%, 0)',
+        willChange: 'transform',
       }}
     />
   );
@@ -391,7 +391,7 @@ margin: '0 0 24px',
         >
           YOUR<br />CODE<br />HAS A<br />
           <span style={{ color: A }}>PULSE</span>
-          <span style={{ color: '#222' }}>.</span>
+          <span style={{ color: '#9ca3af' }}>.</span>
         </h1>
 
         {/* Tagline */}
@@ -527,7 +527,7 @@ function StatItem({ value, label, delay }: { value: number; label: string; delay
         lineHeight: 1, letterSpacing: '-0.03em',
       }}>
         <Counter end={value} active={vis} />
-        <span style={{ color: '#222', fontSize: 'clamp(18px,3vw,28px)' }}>+</span>
+        <span style={{ color: '#9ca3af', fontSize: 'clamp(18px,3vw,28px)' }}>+</span>
       </div>
       <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.12em', marginTop: 8 }}>
         {label}
@@ -683,7 +683,7 @@ function SetupSection() {
         </a>
       </div>
 
-      <div style={{ fontFamily: MONO, fontSize: 11, color: '#222', marginTop: 20, letterSpacing: '0.06em' }}>
+      <div style={{ fontFamily: MONO, fontSize: 11, color: '#9ca3af', marginTop: 20, letterSpacing: '0.06em' }}>
         MIT License · Self-hostable · Free forever · Zero vendor lock-in
       </div>
     </section>
@@ -852,34 +852,7 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
   );
 }
 
-/* ═══════════════════════════════════════════
-   LANDING FOOTER  (above global Footer)
-   ═══════════════════════════════════════════ */
-function LandingFooter() {
-  return (
-    <footer style={{
-      borderTop: `1px solid #111`,
-      padding: '40px clamp(20px,4vw,48px)',
-      display: 'flex', flexWrap: 'wrap', gap: '8px 32px',
-      justifyContent: 'space-between', alignItems: 'center',
-    }}>
-      <span style={{ fontFamily: MONO, fontSize: 11, color: '#222' }}>
-        © {new Date().getFullYear()} DEVTRACK
-      </span>
-      <div style={{ display: 'flex', gap: 20 }}>
-        {[
-          { label: 'GitHub', href: 'https://github.com/Priyanshu-byte-coder/devtrack' },
-          { label: 'Docs', href: 'https://github.com/Priyanshu-byte-coder/devtrack/blob/main/DEVELOPMENT.md' },
-          { label: 'Issues', href: 'https://github.com/Priyanshu-byte-coder/devtrack/issues' },
-        ].map(l => (
-          <a key={l.label} href={l.href} target="_blank" rel="noopener noreferrer" className="lnd-footer-link">
-            {l.label}
-          </a>
-        ))}
-      </div>
-    </footer>
-  );
-}
+
 
 /* ═══════════════════════════════════════════
    MAIN EXPORT
@@ -899,7 +872,7 @@ export default function LandingPage({ repoStats }: { repoStats: RepoStats }) {
       <FeaturesSection />
       <ContributeSection stats={repoStats} />
       <SetupSection />
-      <LandingFooter />
+
     </div>
   );
 }

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -168,7 +168,7 @@ function LandingNav() {
    ═══════════════════════════════════════════ */
 const wLabel: React.CSSProperties = {
   fontFamily: MONO, fontSize: 10, fontWeight: 500,
-  color: '#444', textTransform: 'uppercase', letterSpacing: '0.1em',
+  color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.1em',
 };
 const wValue: React.CSSProperties = {
   fontFamily: MONO, fontWeight: 600, color: TEXT,
@@ -273,7 +273,7 @@ function MergeWidget() {
       <div ref={ref} style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%' }}>
         <span style={wLabel}>merge rate</span>
         <span style={{ ...wValue, fontSize: 26, marginTop: 4, color: A }}>
-          87<span style={{ color: '#333', fontSize: 14 }}>%</span>
+          87<span style={{ color: '#9ca3af', fontSize: 14 }}>%</span>
         </span>
         <div style={{ marginTop: 8, height: 3, borderRadius: 2, background: '#1a1a1a', overflow: 'hidden' }}>
           <div style={{
@@ -294,7 +294,7 @@ function GoalWidget() {
       <div ref={ref} style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100%' }}>
         <span style={wLabel}>weekly goal</span>
         <span style={{ ...wValue, fontSize: 26, marginTop: 4 }}>
-          84<span style={{ color: '#333', fontSize: 14 }}>%</span>
+          84<span style={{ color: '#9ca3af', fontSize: 14 }}>%</span>
         </span>
         <div style={{ marginTop: 8, height: 3, borderRadius: 2, background: '#1a1a1a', overflow: 'hidden' }}>
           <div style={{
@@ -445,7 +445,7 @@ function CommitTicker() {
           <span
             key={i}
             style={{
-              fontFamily: MONO, fontSize: 12, color: '#333',
+              fontFamily: MONO, fontSize: 12, color: '#9ca3af',
               display: 'inline-flex', alignItems: 'center', gap: 10,
             }}
           >
@@ -466,15 +466,15 @@ function HeatmapSection() {
   return (
     <section ref={ref} style={{ padding: '64px clamp(20px,4vw,48px)', overflow: 'hidden' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 20 }}>
-        <span style={{ fontFamily: MONO, fontSize: 11, color: '#333', textTransform: 'uppercase', letterSpacing: '0.1em' }}>
+        <span style={{ fontFamily: MONO, fontSize: 11, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.1em' }}>
           52 weeks of contributions
         </span>
         <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-          <span style={{ fontFamily: MONO, fontSize: 10, color: '#333' }}>less</span>
+          <span style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af' }}>less</span>
           {HC.map((c, i) => (
             <div key={i} style={{ width: 10, height: 10, borderRadius: 2, background: c, border: `1px solid ${BORDER}` }} />
           ))}
-          <span style={{ fontFamily: MONO, fontSize: 10, color: '#333' }}>more</span>
+          <span style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af' }}>more</span>
         </div>
       </div>
       <div style={{
@@ -529,7 +529,7 @@ function StatItem({ value, label, delay }: { value: number; label: string; delay
         <Counter end={value} active={vis} />
         <span style={{ color: '#222', fontSize: 'clamp(18px,3vw,28px)' }}>+</span>
       </div>
-      <div style={{ fontFamily: MONO, fontSize: 10, color: '#333', letterSpacing: '0.12em', marginTop: 8 }}>
+      <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.12em', marginTop: 8 }}>
         {label}
       </div>
     </div>
@@ -619,7 +619,7 @@ function FeaturesSection() {
       borderTop: '1px solid #111',
       maxWidth: 720, margin: '0 auto',
     }}>
-      <div style={{ fontFamily: MONO, fontSize: 10, color: '#333', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
+      <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
         FEATURES
       </div>
       {FEATURES.map((f, i) => (
@@ -645,7 +645,7 @@ function SetupSection() {
         transition: 'all 0.7s ease',
       }}
     >
-      <div style={{ fontFamily: MONO, fontSize: 10, color: '#333', letterSpacing: '0.12em', marginBottom: 24 }}>
+      <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.12em', marginBottom: 24 }}>
         SETUP
       </div>
 
@@ -655,12 +655,12 @@ function SetupSection() {
         textAlign: 'left', marginBottom: 32,
         fontFamily: MONO, fontSize: 13, lineHeight: 1.8,
       }}>
-        <div style={{ color: '#333' }}># start tracking in 30 seconds</div>
+        <div style={{ color: '#9ca3af' }}># start tracking in 30 seconds</div>
         <div style={{ color: TEXT }}>
           <span style={{ color: A }}>→</span> sign in at{' '}
           <span style={{ color: A }}>devtrack.vercel.app</span>
         </div>
-        <div style={{ color: '#333', marginTop: 4 }}># or self-host</div>
+        <div style={{ color: '#9ca3af', marginTop: 4 }}># or self-host</div>
         <div style={{ color: TEXT }}>
           <span style={{ color: A }}>$</span> git clone github.com/…/devtrack
         </div>
@@ -715,7 +715,7 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
       }}
     >
       {/* Label */}
-      <div style={{ fontFamily: MONO, fontSize: 10, color: '#333', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
+      <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
         OPEN SOURCE
       </div>
 
@@ -729,7 +729,7 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
               borderRadius: 8, padding: '20px 20px 16px',
             }}
           >
-            <div style={{ fontFamily: MONO, fontSize: 10, color: '#444', letterSpacing: '0.1em', marginBottom: 10 }}>
+            <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.1em', marginBottom: 10 }}>
               {s.icon} {s.label}
             </div>
             <div style={{
@@ -738,7 +738,7 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
               lineHeight: 1, letterSpacing: '-0.03em',
             }}>
               <Counter end={s.value} active={vis} />
-              {s.suffix && <span style={{ color: '#444', fontSize: '0.55em' }}>{s.suffix}</span>}
+              {s.suffix && <span style={{ color: '#9ca3af', fontSize: '0.55em' }}>{s.suffix}</span>}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary

This PR addresses several UI and performance issues on the landing page, primarily focusing on improving text contrast for accessibility, fixing severe layout lag, and unifying the footers.

Closes #1213

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup

## Changes Made

- **Accessibility:** Replaced low-contrast hardcoded hex values (`#222`, `#333`, `#444`, `#555`) across the landing page and `globals.css` with a highly readable grey (`#9ca3af`).
- **Performance:** Fixed a severe layout thrashing/lag issue caused by the `MouseSpotlight` component. It now correctly uses GPU-accelerated `translate3d` transforms instead of modifying `left`/`top` CSS properties on every mouse movement.
- **Scroll Fix:** Added `overscroll-behavior: none;` to the global `html` and `body` tags to prevent the Mac rubber-banding effect from exposing the background behind the footer.
- **Footer Clean-up:** Removed a redundant, overlapping `LandingFooter` component and integrated its essential links (like the MIT License) into a unified, beautified global `Footer`.
- **UI Overflow Fix:** Increased the `maxWidth` of the Sign-In page container to comfortably fit the large "WELCOME BACK" display text.

## How to Test

Steps for the reviewer to verify this works:

1. Spin up the dev server and visit the landing page and verify that small text, subheadings, and secondary buttons now have much better contrast.
2. Move your mouse rapidly around the landing page and sign-in page; the blue cursor spotlight should feel buttery smooth with no frame drops.
3. On a Mac trackpad, attempt to scroll past the top and bottom of the page (overscroll); the page should no longer bounce and expose the root background.
4. Check the bottom of the page to verify there is only one unified, responsive footer.


## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
