### PR TITLE
feat: add toast notifications for analytics data fetching errors

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -275,6 +275,7 @@ function SettingsPageContent() {
       }
     } catch (error) {
       console.error("Error updating settings:", error);
+      toast.error("Failed to update public profile setting");
     } finally {
       setSaving(false);
     }
@@ -299,6 +300,7 @@ function SettingsPageContent() {
       }
     } catch (error) {
       console.error("Error updating leaderboard setting:", error);
+      toast.error("Failed to update leaderboard setting");
     } finally {
       setSaving(false);
     }
@@ -338,7 +340,8 @@ function SettingsPageContent() {
       setCopied(true);
       toast.success("Link copied successfully!");
       setTimeout(() => setCopied(false), 2000);
-    }).catch(() => {
+    }).catch((err) => {
+      console.error("Clipboard copy failed:", err);
       toast.error("Failed to copy link");
     });
   };
@@ -361,8 +364,10 @@ function SettingsPageContent() {
       setLinkedAccounts((current) =>
         current.filter((account) => account.githubId !== githubId)
       );
-    } catch {
+    } catch (error) {
+      console.error("Failed to remove account:", error);
       setRemoveError("Failed to remove account");
+      toast.error("Failed to remove account");
     } finally {
       setRemovingAccountId(null);
     }

--- a/src/components/CommitTimeChart.tsx
+++ b/src/components/CommitTimeChart.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { Sun, Cloud, Sunset, Moon } from "lucide-react";
+import { toast } from "sonner";
   
 interface TimeBlocks {
   morning: number;
@@ -83,9 +84,11 @@ export default function CommitTimeChart() {
         setData(chartData);
         setPeakTime(peak.commits > 0 ? peak.name : null);
       })
-      .catch(() =>
-        setError("We couldn't load your time-of-day data right now."),
-      )
+      .catch((err) => {
+        console.error("Failed to fetch commit time data:", err);
+        setError("We couldn't load your time-of-day data right now.");
+        toast.error("Failed to load time-of-day data");
+      })
       .finally(() => setLoading(false));
   }, [days]);
 

--- a/src/components/CommunityMetrics.tsx
+++ b/src/components/CommunityMetrics.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { toast } from "sonner";
 
 interface CommunityData {
   discussionsStarted: number;
@@ -32,11 +33,13 @@ export default function CommunityMetrics() {
         return response.json();
       })
       .then((data: CommunityData) => setMetrics(data))
-      .catch(() =>
+      .catch((err) => {
+        console.error("Failed to fetch community metrics:", err);
         setError(
           "We couldn't load your discussion analytics right now. Please try again in a moment."
-        )
-      )
+        );
+        toast.error("Failed to load community metrics");
+      })
       .finally(() => setLoading(false));
   }, [selectedAccount]);
 

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -102,7 +102,8 @@ export default function StreakTracker() {
       setData(streakData);
       setContributionData(contribData);
       setFreezeDates(streakData.freezeDates || []);
-    } catch {
+    } catch (err) {
+      console.error("Failed to fetch streak data:", err);
       setError("We couldn't load your streak data right now. Please try again in a moment.");
     } finally {
       setLoading(false);
@@ -116,7 +117,10 @@ export default function StreakTracker() {
     fetch("/api/streak/freeze")
       .then((r) => r.json())
       .then((d: FreezeData) => setFreeze(d))
-      .catch(() => setFreeze(null))
+      .catch((err) => {
+        console.error("Failed to fetch freeze data:", err);
+        setFreeze(null);
+      })
       .finally(() => setFreezeLoading(false));
   };
 
@@ -186,7 +190,8 @@ export default function StreakTracker() {
       setData(streakData);
       setFreeze(freezeData);
       toast.success("Streak freeze activated for today!");
-    } catch {
+    } catch (err) {
+      console.error("Failed to apply streak freeze:", err);
       toast.error("Failed to activate streak freeze.");
       fetchFreeze();
     } finally {
@@ -221,7 +226,9 @@ export default function StreakTracker() {
       ]);
       setData(streakData);
       setFreeze(freezeData);
-    } catch {
+    } catch (err) {
+      console.error("Failed to cancel streak freeze:", err);
+      toast.error("Failed to cancel streak freeze.");
       fetchFreeze();
     } finally {
       setCancelling(false);
@@ -370,7 +377,8 @@ export default function StreakTracker() {
       toast.success("Streak stats copied to clipboard!");
 
       setTimeout(() => setCopied(false), 2000);
-    } catch {
+    } catch (err) {
+      console.error("Failed to copy streak stats:", err);
       toast.error("Failed to copy streak stats.");
     }
   };

--- a/src/components/repo-analytics/RepoAnalyticsExplorer.tsx
+++ b/src/components/repo-analytics/RepoAnalyticsExplorer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import RepoCarousel from "./RepoCarousel";
 import { ExplorerRepoCardData } from "@/lib/repoAnalytics";
+import { toast } from "sonner";
 
 export default function RepoAnalyticsExplorer() {
   const [repos, setRepos] = useState<ExplorerRepoCardData[]>([]);
@@ -19,7 +20,11 @@ export default function RepoAnalyticsExplorer() {
         return res.json();
       })
       .then((json: { repos: ExplorerRepoCardData[] }) => setRepos(json.repos ?? []))
-      .catch(() => setError("Could not load repo analytics right now."))
+      .catch((err) => {
+        console.error("Failed to fetch repo analytics:", err);
+        setError("Could not load repo analytics right now.");
+        toast.error("Failed to load repo analytics");
+      })
       .finally(() => setLoading(false));
   }, []);
 


### PR DESCRIPTION
## Summary

This PR addresses unhandled promise rejections and silent failures across several components by ensuring all `.catch()` blocks properly log errors to the console and surface user-facing toast notifications.

Closes #1350

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- **`CommitTimeChart.tsx`**: Added `toast.error` and `console.error` to `fetchContributions`.
- **`RepoAnalyticsExplorer.tsx`**: Added `toast.error` and `console.error` to `fetchRepos`.
- **`StreakTracker.tsx`**: Added `console.error` to `fetchStreak`, `fetchFreeze`, `handleApplyFreeze`, `handleCancelFreeze`, and `handleCopy`.
- **`CommunityMetrics.tsx`**: Added `toast.error` and `console.error` to `fetchMetrics`.
- **`settings/page.tsx`**: Added `toast.error` to `handleTogglePublic`, `handleToggleLeaderboard`, `handleRemoveAccount`, and `console.error` to `copyShareLink`.

## How to Test

Steps for the reviewer to verify this works:

1. Log into the Dashboard.
2. Open your browser's Developer Tools and go to the Network tab.
3. Block the request URL for any of the affected APIs (e.g., `contributions`, `streak`, `discussions`, `repo-explorer`).
4. Refresh the page and verify that a red toast notification appears and the error is logged in the Console.

## Screenshots (if UI change)

*N/A - Only adds toast notifications on error.*

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable
