### PR TITLE
test : added unit tests for public-profile-data.ts

### DIFF
--- a/test/public-profile-data.test.ts
+++ b/test/public-profile-data.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  fetchPublicTopRepos,
+  fetchPublicContributions,
+  fetchPublicStreak,
+  fetchTopLanguage,
+} from "../src/lib/public-profile-data";
+
+describe("public-profile-data", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("fetchPublicTopRepos", () => {
+    it("should return sorted top repositories on successful API response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          items: [
+            { repository: { full_name: "owner/repo-a", html_url: "https://github.com/owner/repo-a" } },
+            { repository: { full_name: "owner/repo-a", html_url: "https://github.com/owner/repo-a" } },
+            { repository: { full_name: "owner/repo-b", html_url: "https://github.com/owner/repo-b" } },
+          ],
+        }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const repos = await fetchPublicTopRepos("user123");
+      expect(repos.length).toBe(2);
+      expect(repos[0].name).toBe("owner/repo-a");
+      expect(repos[0].commits).toBe(2);
+      expect(repos[1].name).toBe("owner/repo-b");
+      expect(repos[1].commits).toBe(1);
+    });
+
+    it("should return empty array on failed API response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const repos = await fetchPublicTopRepos("user123");
+      expect(repos).toEqual([]);
+    });
+  });
+
+  describe("fetchPublicContributions", () => {
+    it("should aggregate commits by day on successful response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          total_count: 3,
+          items: [
+            { commit: { author: { date: "2026-05-10T12:00:00Z" } } },
+            { commit: { author: { date: "2026-05-10T15:00:00Z" } } },
+            { commit: { author: { date: "2026-05-11T12:00:00Z" } } },
+          ],
+        }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const contributions = await fetchPublicContributions("user123");
+      expect(contributions.total).toBe(3);
+      expect(contributions.data["2026-05-10"]).toBe(2);
+      expect(contributions.data["2026-05-11"]).toBe(1);
+    });
+  });
+
+  describe("fetchPublicStreak", () => {
+    it("should compute current and longest streak correctly", async () => {
+      // Mock dates: today and yesterday
+      const today = new Date().toISOString().slice(0, 10);
+      const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+      const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10);
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          items: [
+            { commit: { author: { date: today } } },
+            { commit: { author: { date: yesterday } } },
+            { commit: { author: { date: twoDaysAgo } } },
+          ],
+        }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const streak = await fetchPublicStreak("user123");
+      expect(streak.current).toBe(3);
+      expect(streak.longest).toBe(3);
+      expect(streak.totalActiveDays).toBe(3);
+    });
+
+    it("should return zero values on failed API response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const streak = await fetchPublicStreak("user123");
+      expect(streak.current).toBe(0);
+      expect(streak.longest).toBe(0);
+      expect(streak.lastCommitDate).toBeNull();
+    });
+  });
+
+  describe("fetchTopLanguage", () => {
+    it("should extract most frequent repository language", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { language: "TypeScript" },
+          { language: "TypeScript" },
+          { language: "Python" },
+          { language: null },
+        ],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const topLang = await fetchTopLanguage("user123");
+      expect(topLang).toBe("TypeScript");
+    });
+
+    it("should return null on failed API response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const topLang = await fetchTopLanguage("user123");
+      expect(topLang).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Refs #1369.

Summary of What Has Been Done:
Added a comprehensive, mocked API unit test suite to test all helper methods in `src/lib/public-profile-data.ts`.

Changes Made:
- Created `test/public-profile-data.test.ts` unit test suite.
- Wrote mocked API tests for `fetchPublicTopRepos` verifying sorting of top repos.
- Wrote mocked API tests for `fetchPublicContributions` verifying daily commit grouping.
- Wrote mocked API tests for `fetchPublicStreak` verifying current/longest streak computation using dynamic dates.
- Wrote mocked API tests for `fetchTopLanguage` verifying primary language selection.

Impact it Made:
Improves unit test coverage for user public profile retrieval utilities without relying on external network connectivity, preventing API schema mismatch regression bugs.