### PR TITLE
docs: enhance FUNDING.yml with multiple sponsorship options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,17 @@
+# Support DevTrack Development
+# Your sponsorship helps us maintain and improve this open-source project
+
+# GitHub Sponsors - Direct monthly support
 github: Priyanshu-byte-coder
+
+# Open Collective - Community funding platform
+open_collective: devtrack
+
+# Buy Me a Coffee - One-time or recurring support
+buy_me_a_coffee: priyanshu_byte
+
+# Ko-fi - Simple and transparent sponsorship
+ko_fi: priyanshu_byte
+
+# Custom donation link (Stripe, PayPal, etc. can be configured)
+custom: ["https://paypal.me/priyanshu_byte"]


### PR DESCRIPTION
## Description
Add comprehensive sponsorship configuration to direct users and sponsors on how they can support the DevTrack project financially.

## Changes
- ✨ GitHub Sponsors (monthly recurring support)
- ✨ Open Collective (community funding platform)
- ✨ Buy Me a Coffee (one-time or recurring donations)
- ✨ Ko-fi (simple sponsorship platform)
- ✨ PayPal (custom donation link)

## Benefits
- 🎯 Displays "Sponsor" button on GitHub repository page
- 💳 Provides users with multiple payment methods
- 🙌 Makes it easy for community to support development
- ✅ Follows GitHub best practices for funding configuration

## Related Issues
Addresses the issue of missing financial support guidance for project sponsors.