### PR TITLE
Fix/issue 1385 activity formatter tests

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -204,7 +204,6 @@ async function fetchGitLabContributions(
 
       const MAX_PAGES = 10;
       let page = 1;
-      const MAX_PAGES = 10;
       const commitsByDay: Record<string, number> = {};
 
       while (page > 0 && page <= MAX_PAGES) {

--- a/test/activity-formatter.test.ts
+++ b/test/activity-formatter.test.ts
@@ -103,4 +103,86 @@ describe("formatActivity", () => {
 
     expect(result?.title).toBe("Published release");
   });
+
+  it("returns null for unsupported event types", () => {
+    const event = {
+      type: "UnsupportedEvent",
+    };
+    expect(formatActivity(event as any)).toBeNull();
+  });
+
+  it("returns null for unsupported event types that still have repo names", () => {
+    const event = {
+      type: "RandomEvent",
+      repo: {
+        name: "test/repo",
+      },
+      payload: {},
+    };
+    expect(formatActivity(event as any)).toBeNull();
+  });
+
+  it("formats PushEvent with malformed refs correctly", () => {
+    const event = {
+      type: "PushEvent",
+      repo: {
+        name: "test/repo",
+      },
+      payload: {
+        commits: [{}],
+        ref: "refs/tags/v1.0",
+      },
+    };
+    const result = formatActivity(event as any);
+    expect(result?.title).toBe("Pushed 1 commit to refs/tags/v1.0");
+  });
+
+  it("formats ReleaseEvent edge cases (different action and missing tag)", () => {
+    const event = {
+      type: "ReleaseEvent",
+      repo: {
+        name: "test/repo",
+      },
+      payload: {
+        action: "created",
+        release: {
+          name: "Initial Release",
+        },
+      },
+    };
+    const result = formatActivity(event as any);
+    expect(result?.title).toBe("Created release");
+    expect(result?.subtitle).toBe("Initial Release");
+  });
+
+  it("formats DiscussionEvent with various action types", () => {
+    const event = {
+      type: "DiscussionEvent",
+      repo: {
+        name: "test/repo",
+      },
+      payload: {
+        action: "answered",
+        discussion: {
+          number: 10,
+          title: "How to use?",
+        },
+      },
+    };
+    const result = formatActivity(event as any);
+    expect(result?.title).toBe("Answered discussion #10");
+  });
+
+  it("is case sensitive in event type matching and returns null for lowercase types", () => {
+    const event = {
+      type: "pushevent",
+      repo: {
+        name: "test/repo",
+      },
+      payload: {
+        commits: [{}],
+      },
+    };
+    expect(formatActivity(event as any)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Adds comprehensive edge case tests for the `formatActivity` function to ensure it gracefully handles unexpected event formats without errors.

Closes #1385

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup (Testing)

## Changes Made

- Added tests for unsupported event types (should return `null`).
- Added tests for unsupported event types that still contain repo names.
- Added tests for `PushEvent` with malformed refs (e.g. `refs/tags/v1.0`).
- Added tests for `ReleaseEvent` edge cases with different action types and missing tags.
- Added tests for `DiscussionEvent` with various action types (e.g., `answered`).
- Added a test to ensure event type matching is case-sensitive (lowercase types return `null`).

## How to Test

Steps for the reviewer to verify this works:

1. Check out the branch locally.
2. Run `npm run test` or `npx vitest run test/activity-formatter.test.ts`.
3. Verify that all test cases for the `formatActivity` function pass successfully.

## Screenshots (if UI change)
N/A

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
