### PR TITLE
fix(activity): deduplicate combined account activity feed

### DIFF
--- a/src/app/api/metrics/activity/route.ts
+++ b/src/app/api/metrics/activity/route.ts
@@ -1,10 +1,7 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
-import {
-  getAccountToken,
-  getAllAccounts,
-} from "@/lib/github-accounts";
+import { getAccountToken, getAllAccounts } from "@/lib/github-accounts";
 import { GITHUB_API, fetchUserEvents } from "@/lib/github";
 import {
   isMetricsCacheBypassed,
@@ -21,7 +18,6 @@ import {
 } from "@/lib/activity-formatter";
 
 export const dynamic = "force-dynamic";
-
 
 async function fetchFormattedActivity(token: string): Promise<ActivityItem[]> {
   const events = (await fetchUserEvents(token)) as RawEvent[];
@@ -135,19 +131,34 @@ export async function GET(req: NextRequest) {
 
           const results = await Promise.allSettled(
             accounts.map((account) =>
-              fetchFormattedActivityWithFallback(account.token, account.githubLogin)
+              fetchFormattedActivityWithFallback(
+                account.token,
+                account.githubLogin
+              )
             )
           );
 
-          const merged = results
+          const mergedActivities = results
             .filter(
               (result): result is PromiseFulfilledResult<ActivityItem[]> =>
                 result.status === "fulfilled"
             )
-            .flatMap((result) => result.value)
+            .flatMap((result) => result.value);
+
+          const uniqueActivities = Array.from(
+            new Map(
+              mergedActivities.map((item) => [
+                `${item.type}-${item.repo}-${item.createdAt}-${item.title}`,
+                item,
+              ])
+            ).values()
+          );
+
+          const merged = uniqueActivities
             .sort(
               (a, b) =>
-                new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+                new Date(b.createdAt).getTime() -
+                new Date(a.createdAt).getTime()
             )
             .slice(0, 15);
 

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -204,7 +204,6 @@ async function fetchGitLabContributions(
 
       const MAX_PAGES = 10;
       let page = 1;
-      const MAX_PAGES = 10;
       const commitsByDay: Record<string, number> = {};
 
       while (page > 0 && page <= MAX_PAGES) {


### PR DESCRIPTION
## Summary

Fixes duplicate activity items showing up in the combined account view when multiple linked GitHub accounts have access to the same repo.

Earlier the feed was only checking event IDs while deduplicating, but the same activity can have different event IDs across accounts. Added a better deduplication check before returning the final activity list.

Closes #931

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- updated the activity merge logic in `src/app/api/metrics/activity/route.ts`
- added composite-key based deduplication for merged activity items
- prevented duplicate activity entries from shared repositories in combined view

## How to Test

Steps for the reviewer to verify this works:

1. Link multiple GitHub accounts with access to the same repository
2. Switch to the combined account view
3. Check the activity feed and verify duplicate entries are no longer shown

## Screenshots (if UI change)

N/A

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable
