### PR TITLE
fix(ui): prevent welcome text overflow on sign-in page

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -67,7 +67,9 @@ export default function SignInPage() {
       <div
         style={{
           width: "100%",
-          maxWidth: 420,
+          maxWidth: 520,
+          boxSizing: "border-box",
+          minWidth: 0,
           border: "1px solid #1a1a1a",
           borderRadius: 12,
           padding: "clamp(28px,5vw,48px) clamp(24px,5vw,40px)",
@@ -94,18 +96,22 @@ export default function SignInPage() {
           </span>
         </div>
 
-        <h1
-          style={{
-            fontFamily: DISP,
-            fontWeight: 800,
-            fontSize: "clamp(34px,6vw,52px)",
-            letterSpacing: "-0.04em",
-            lineHeight: 0.95,
-            color: "#e8e8e8",
-            margin: "0 0 16px",
-          }}
+        <h1 style={{
+          fontFamily: DISP,
+          fontWeight: 800,
+          fontSize: "clamp(18px, 4vw, 42px)",
+
+          lineHeight: 1,
+          letterSpacing: "-0.01em",
+
+          color: "#e8e8e8",
+          margin: "0 0 16px",
+          textAlign: "center",
+          width: "100%",
+        }}
         >
-          WELCOME<br />
+          WELCOME
+          <br />
           <span style={{ color: A }}>BACK.</span>
         </h1>
 


### PR DESCRIPTION
## Summary

Improved the responsiveness of the sign-in page heading to prevent text overflow outside the container on smaller screen sizes and browser zoom levels.

Closes #1225 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Updated heading font scaling using responsive `clamp()`
- Adjusted typography spacing for improved responsiveness
- Improved sign-in card layout behavior on smaller screens
- Prevented heading overflow during browser zoom and viewport resizing

## How to Test

Steps for the reviewer to verify this works:

1. Run the application locally
2. Open the sign-in page
3. Resize the browser window to smaller widths
4. Test browser zoom levels such as 125% and 150%
5. Verify that the "WELCOME BACK." heading stays within the container boundaries

## Screenshots (if UI change)

Added screenshots demonstrating the responsiveness improvements.

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable