### PR TITLE
fix(session): redirect to sign-in when session expires silently

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -11,12 +11,10 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
   const router = useRouter();
 
   useEffect(() => {
-    // intercept all fetch calls — redirect on 401
     const originalFetch = window.fetch;
     window.fetch = async (...args) => {
       const response = await originalFetch(...args);
       if (response.status === 401) {
-        // clone so body can still be read by caller
         const cloned = response.clone();
         toast.error("Session expired. Please sign in again.");
         await signOut({ redirect: false });

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useSession, signOut } from "next-auth/react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { ReactNode } from "react";
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  const { status } = useSession({ required: true });
+  const router = useRouter();
+
+  useEffect(() => {
+    // intercept all fetch calls — redirect on 401
+    const originalFetch = window.fetch;
+    window.fetch = async (...args) => {
+      const response = await originalFetch(...args);
+      if (response.status === 401) {
+        // clone so body can still be read by caller
+        const cloned = response.clone();
+        toast.error("Session expired. Please sign in again.");
+        await signOut({ redirect: false });
+        router.push("/auth/signin");
+        return cloned;
+      }
+      return response;
+    };
+    return () => {
+      window.fetch = originalFetch;
+    };
+  }, [router]);
+
+  if (status === "loading") return null;
+
+  return <>{children}</>;
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -6,7 +6,6 @@ const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 export const SUPABASE_ADMIN_UNAVAILABLE_MESSAGE =
   "Supabase admin client is unavailable. Check NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SupabaseAdminClient = SupabaseClient<any, any, any>;
 
 function createUnavailableSupabaseAdmin(): SupabaseAdminClient {


### PR DESCRIPTION
## What does this PR do?
Fixes silent 401 failures on the dashboard. When any API call returns 401 (session expired), the user now sees a toast "Session expired. Please sign in again." and is redirected to the sign-in page.

## Related issue
Closes #930

## Changes made
- Added `src/app/dashboard/layout.tsx` scoped to /dashboard routes
- Uses `useSession({ required: true })` as primary session guard
- Global fetch interceptor detects 401 responses from any API call
- Shows sonner toast (already in project) before redirecting
- Restores original fetch on unmount — no memory leaks
- No changes to existing components

## How to test
1. Log in and open the dashboard
2. Delete the session cookie in DevTools
3. Click Refresh on any widget
4. Toast appears: "Session expired. Please sign in again."
5. Automatically redirected to /auth/signin