### PR TITLE
test: add unit tests for summarizeCodingActivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4564,7 +4564,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/lib/coding-activity-insights.test.ts
+++ b/src/lib/coding-activity-insights.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+
+import { summarizeCodingActivity } from "./coding-activity-insights";
+
+describe("summarizeCodingActivity", () => {
+  it("returns empty activity summary when timestamps array is empty", () => {
+    const result = summarizeCodingActivity([], "UTC");
+
+    expect(result.totalActivities).toBe(0);
+    expect(result.productivityLevel).toBe("Low");
+    expect(result.consistencyScore).toBe(0);
+    expect(result.averageDailyCommits).toBe(0);
+  });
+
+  it("counts valid timestamps correctly", () => {
+    const timestamps = [
+      "2026-05-24T10:00:00Z",
+      "2026-05-24T11:00:00Z",
+      "2026-05-25T12:00:00Z",
+    ];
+
+    const result = summarizeCodingActivity(timestamps, "UTC");
+
+    expect(result.totalActivities).toBe(3);
+  });
+
+  it("ignores invalid timestamps", () => {
+    const timestamps = [
+      "invalid-date",
+      "2026-05-24T10:00:00Z",
+    ];
+
+    const result = summarizeCodingActivity(timestamps, "UTC");
+
+    expect(result.totalActivities).toBe(1);
+  });
+
+  it("calculates productivity level correctly", () => {
+    const timestamps = [
+      "2026-05-18T10:00:00Z",
+      "2026-05-19T10:00:00Z",
+      "2026-05-20T10:00:00Z",
+      "2026-05-21T10:00:00Z",
+      "2026-05-22T10:00:00Z",
+      "2026-05-23T10:00:00Z",
+      "2026-05-24T10:00:00Z",
+    ];
+
+    const result = summarizeCodingActivity(timestamps, "UTC");
+
+    expect(result.consistencyScore).toBe(100);
+    expect(result.productivityLevel).toBe("Excellent");
+  });
+
+  it("detects most active hour correctly", () => {
+    const timestamps = [
+      "2026-05-24T10:00:00Z",
+      "2026-05-24T10:30:00Z",
+      "2026-05-24T15:00:00Z",
+    ];
+
+    const result = summarizeCodingActivity(timestamps, "UTC");
+
+    expect(result.mostActiveHour.hour).toBe(10);
+    expect(result.mostActiveHour.count).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Added unit tests for `summarizeCodingActivity` in `coding-activity-insights.ts`.

Closes #945

## Type of Change

- [x] Refactor / code cleanup

## Changes Made

- Added tests for empty timestamps array
- Added tests for valid timestamp counting
- Added tests for invalid timestamp handling
- Added tests for productivity level calculation
- Added tests for most active hour detection

## How to Test

1. Run:
   ```bash
   npm test
   ```
2. Verify all tests pass successfully

## Screenshots (if UI change)
      N/A
## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
