### PR TITLE
test : added boundary tests for formatRelativeDate

### DIFF
--- a/test/repoAnalyticsUtils.test.ts
+++ b/test/repoAnalyticsUtils.test.ts
@@ -33,6 +33,17 @@ describe("repoAnalyticsUtils", () => {
       const formatted = formatRelativeDate(fortyDaysAgo.toISOString());
       expect(formatted).not.toContain("days ago");
     });
+
+    it("should return '29 days ago' for exactly 29 days ago", () => {
+      const twentyNineDaysAgo = new Date(Date.now() - 29 * 24 * 60 * 60 * 1000);
+      expect(formatRelativeDate(twentyNineDaysAgo.toISOString())).toBe("29 days ago");
+    });
+
+    it("should return absolute date for exactly 30 days ago", () => {
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const formatted = formatRelativeDate(thirtyDaysAgo.toISOString());
+      expect(formatted).not.toContain("days ago");
+    });
   });
 
   describe("formatDisplayDate", () => {


### PR DESCRIPTION
Refs #1410.

Summary of What Has Been Done:
Added boundary test coverage for formatRelativeDate function in src/lib/repoAnalyticsUtils.ts. Tests cover the transition from relative dates (X days ago) to absolute formatted dates at the 30-day boundary.

Changes Made:
- Added test for exactly 29 days ago (should return '29 days ago')
- Added test for exactly 30 days ago (should return absolute date, not '30 days ago')
- This ensures the relative/absolute boundary is correctly at 30 days

Impact it Made:
Ensures relative date formatting is correct at the boundary between relative and absolute dates. All 8 tests pass.