### PR TITLE
test : added edge case tests for calculateLanguagePercentages

### DIFF
--- a/test/wrapped.test.ts
+++ b/test/wrapped.test.ts
@@ -64,6 +64,35 @@ describe("wrapped helpers", () => {
     ]);
   });
 
+  it("returns empty array when total bytes is zero", () => {
+    expect(calculateLanguagePercentages({})).toEqual([]);
+  });
+
+  it("respects the limit parameter", () => {
+    expect(
+      calculateLanguagePercentages(
+        {
+          TypeScript: 300,
+          Python: 100,
+          CSS: 100,
+          HTML: 50,
+        },
+        2
+      )
+    ).toEqual([
+      { name: "TypeScript", bytes: 300, percentage: 54.5 },
+      { name: "Python", bytes: 100, percentage: 18.2 },
+    ]);
+  });
+
+  it("handles single language as 100 percent", () => {
+    expect(
+      calculateLanguagePercentages({
+        JavaScript: 500,
+      })
+    ).toEqual([{ name: "JavaScript", bytes: 500, percentage: 100 }]);
+  });
+
   it("marks future year ranges as partial", () => {
     expect(getYearRange(2026, new Date("2026-05-25T00:00:00Z"))).toMatchObject({
       startDate: "2026-01-01",


### PR DESCRIPTION
Refs #1412.

Summary of What Has Been Done:
Added edge case test coverage for calculateLanguagePercentages function in src/lib/wrapped.ts. Tests cover zero total bytes, single language (100%), and the limit parameter behavior.

Changes Made:
- Added test for zero total bytes (returns empty array)
- Added test for limit parameter (only top N languages returned)
- Added test for single language (100% percentage)
- All 9 tests pass

Impact it Made:
Ensures year-in-review language statistics are accurate for all edge cases.