### PR TITLE
fix: add TTL-based eviction to ipRateLimits Map to prevent memory leak

### DIFF
--- a/src/app/api/public/[username]/route.ts
+++ b/src/app/api/public/[username]/route.ts
@@ -22,6 +22,13 @@ const ipRateLimits = new Map<
 const RATE_LIMIT_REQUESTS = 30;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
 
+function cleanOldEntries(map: Map<string, { count: number; resetAt: number }>) {
+  const now = Date.now();
+  for (const [key, val] of map.entries()) {
+    if (val.resetAt <= now) map.delete(key);
+  }
+}
+
 function getRateLimitKey(req: NextRequest): string {
   // req.ip is populated by the Next.js / Vercel runtime from the verified
   // network-layer source address and cannot be spoofed by the caller.
@@ -61,8 +68,8 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { username: string } }
 ): Promise<NextResponse> {
+  cleanOldEntries(ipRateLimits);
   const { username } = params;
-
   // Rate limiting
   const ip = getRateLimitKey(req);
   const rateLimit = getUpstashConfig()


### PR DESCRIPTION
## Summary
Added TTL-based eviction to the ipRateLimits Map to prevent unbounded memory growth in long-running server instances.
Closes #805 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made
- Added `cleanOldEntries()` function that iterates over the ipRateLimits Map and deletes expired entries
- Called `cleanOldEntries(ipRateLimits)` at the start of each GET request to ensure cleanup on every request

## How to Test
1. Run the dev server with `npm run dev`
2. Send multiple requests from different IPs to `/api/public/[username]`
3. Wait for the rate limit window (1 minute) to expire
4. Verify that expired entries are removed from the ipRateLimits Map

## Screenshots (if UI change)
N/A - backend change only

## Checklist
- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable