### PR TITLE
Add unit tests for analyzePatterns and computeTrends

### DIFF
--- a/test/test/ai-mentor.test.ts
+++ b/test/test/ai-mentor.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { analyzePatterns, computeTrends } from '@/lib/ai-mentor';
+
+describe('analyzePatterns', () => {
+  it('returns insight for large commits', () => {
+    const metrics = {
+      commits: [{ count: 20 }, { count: 15 }],
+      streak: { activeDays: 2 },
+      repos: [],
+      prs: {
+        avgMergeTimeDays: 0
+      }
+    };
+
+    const result = analyzePatterns(metrics as any);
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0].id).toBe('large-commits');
+  });
+});
+
+describe('computeTrends', () => {
+  it('returns up when second half commits are higher', () => {
+    const metrics = {
+      commits: [
+        { count: 2 },
+        { count: 3 },
+        { count: 10 },
+        { count: 12 }
+      ],
+      repos: [],
+      streak: { activeDays: 1 }
+    };
+
+    const result = computeTrends(metrics as any);
+
+    expect(result.direction).toBe('up');
+  });
+
+  it('returns down when first half commits are higher', () => {
+    const metrics = {
+      commits: [
+        { count: 10 },
+        { count: 12 },
+        { count: 2 },
+        { count: 1 }
+      ],
+      repos: [],
+      streak: { activeDays: 1}
+    };
+
+    const result = computeTrends(metrics as any);
+
+    expect(result.direction).toBe('down');
+  });
+
+  it('returns zero for empty commits', () => {
+    const metrics = {
+      commits: [],
+      repos: [],
+      streak: { activeDays: 1 }
+    };
+
+    const result = computeTrends(metrics as any);
+
+    expect(result.percentage).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Added unit tests for analyzePatterns() and computeTrends() in ai-mentor.ts .

Closes #946 

## Type of Change

- [x] Documentation update
- [x] Refactor / code cleanup

## Changes Made

- Added test for large commit insight generation
- Added test for upward trend detection 
- Added test for downward trend detection 
- Added test for empty commits handling 

## How to Test

Steps for the reviewer to verify this works:

1. Run npm test
2. verify ai-mentor tests pass
3. confirm analyzePatterns and computeTrends behave correctly

## Screenshots (if UI change)

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable
