### PR TITLE
fix: improve landing page visual polish, contrast, and local dev data fetching robustness

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -275,7 +275,11 @@ body {
   box-shadow: 
     inset 0 1px 0 rgba(255, 255, 255, 0.05),
     0 4px 20px rgba(0, 0, 0, 0.35);
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: 
+    background 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
 .lnd-cell:hover {
   background: rgba(12, 12, 16, 0.75);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,6 +67,12 @@ html, body {
   overscroll-behavior: none;
 }
 
+/* Strip body background on landing page so the dark bg is visible */
+body:has(.lnd-root) {
+  background: #050505 !important;
+  background-color: #050505 !important;
+}
+
 body {
   background:
     radial-gradient(circle at 0% 0%, rgba(96, 165, 250, 0.16), transparent 36%),
@@ -260,13 +266,25 @@ body {
 
 
 .lnd-cell {
-  background: #0e0e0e;
-  border: 1px solid #1a1a1a;
-  border-radius: 8px;
-  padding: 14px 16px;
-  transition: background 0.2s, border-color 0.2s;
+  background: rgba(8, 8, 10, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.035);
+  border-radius: 12px;
+  padding: 18px 20px;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 4px 20px rgba(0, 0, 0, 0.35);
+  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
-.lnd-cell:hover { background: #141414; border-color: #2a2a2a; }
+.lnd-cell:hover {
+  background: rgba(12, 12, 16, 0.75);
+  border-color: rgba(129, 140, 248, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 8px 30px rgba(129, 140, 248, 0.12);
+}
 
 .lnd-heatmap-cell { cursor: crosshair; }
 .lnd-heatmap-cell:hover {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,11 @@ const jetbrains = JetBrains_Mono({
 });
 
 async function fetchRepoStats(): Promise<RepoStats> {
-  const GH_HEADERS = { Accept: "application/vnd.github.v3+json" };
+  const token = process.env.GITHUB_TOKEN;
+  const GH_HEADERS: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
   const OPTS = (ttl: number) => ({ next: { revalidate: ttl }, headers: GH_HEADERS });
 
   try {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,7 +56,7 @@ async function fetchRepoStats(): Promise<RepoStats> {
         }))
       : [];
 
-    if (mappedContributors.length > 0) {
+    if (mappedContributors.length > 0 && supabaseAdmin) {
       try {
         const logins = mappedContributors.map((c) => c.login);
         const { data: sponsors } = await supabaseAdmin

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,20 +56,24 @@ async function fetchRepoStats(): Promise<RepoStats> {
         }))
       : [];
 
-    if (mappedContributors.length > 0 && supabaseAdmin) {
-      const logins = mappedContributors.map((c) => c.login);
-      const { data: sponsors } = await supabaseAdmin
-        .from("users")
-        .select("github_login")
-        .in("github_login", logins)
-        .eq("is_sponsor", true);
+    if (mappedContributors.length > 0) {
+      try {
+        const logins = mappedContributors.map((c) => c.login);
+        const { data: sponsors } = await supabaseAdmin
+          .from("users")
+          .select("github_login")
+          .in("github_login", logins)
+          .eq("is_sponsor", true);
 
-      if (sponsors && sponsors.length > 0) {
-        const sponsorSet = new Set(sponsors.map((s: { github_login: string }) => s.github_login));
-        mappedContributors = mappedContributors.map((c) => ({
-          ...c,
-          isSponsor: sponsorSet.has(c.login),
-        }));
+        if (sponsors && sponsors.length > 0) {
+          const sponsorSet = new Set(sponsors.map((s: { github_login: string }) => s.github_login));
+          mappedContributors = mappedContributors.map((c) => ({
+            ...c,
+            isSponsor: sponsorSet.has(c.login),
+          }));
+        }
+      } catch {
+        // Supabase not configured locally — skip sponsor enrichment, show contributors as-is
       }
     }
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,16 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 const year = new Date().getFullYear();
 
 export default function Footer() {
+  const pathname = usePathname();
+  const isLanding = pathname === "/";
+
   return (
-    <footer className="dark mt-auto border-t border-[var(--border)] bg-[var(--background)] relative overflow-hidden">
+    <footer className={`dark mt-auto border-t relative overflow-hidden ${isLanding ? 'bg-transparent border-slate-900/40' : 'border-[var(--border)] bg-[var(--background)]'}`}>
       {/* Subtle top gradient using the accent color */}
       <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(129,140,248,0.05),transparent_50%)] pointer-events-none" />
       

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -22,7 +22,7 @@ const BG = 'transparent'
 const SURF = '#0e0e0e';
 const BORDER = '#1a1a1a';
 const TEXT = '#e0e0e0';
-const MUTED = '#555';
+const MUTED = '#94a3b8';
 const HC = ['#111', '#1e1b4b', '#3730a3', '#4f46e5', A]; // heatmap levels
 const MC = ['#111', '#1e1b4b', '#3730a3', A];             // mini heatmap
 
@@ -538,7 +538,7 @@ function StatsSection() {
     <section style={{
       padding: '64px clamp(20px,4vw,48px)',
       display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px,1fr))',
-      gap: 24, borderTop: '1px solid #111',
+        gap: 24, borderTop: '1px solid #1f293b',
     }}>
       {STATS.map((s, i) => (
         <StatItem key={s.label} value={s.value} label={s.label} delay={i * 80} />
@@ -584,7 +584,7 @@ function FeatureItem({ f, index }: { f: typeof FEATURES[0]; index: number }) {
       ref={ref}
       style={{
         display: 'flex', gap: 'clamp(16px,3vw,32px)',
-        padding: '24px 0', borderBottom: '1px solid #111',
+        padding: '24px 0', borderBottom: '1px solid #1f293b',
         opacity: vis ? 1 : 0,
         transform: vis ? 'translateX(0)' : 'translateX(-12px)',
         transition: `all 0.5s ease ${index * 50}ms`,
@@ -613,10 +613,10 @@ function FeaturesSection() {
   return (
     <section style={{
       padding: '64px clamp(20px,4vw,48px) 80px',
-      borderTop: '1px solid #111',
+      borderTop: '1px solid #1f293b',
       maxWidth: 720, margin: '0 auto',
     }}>
-      <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
+      <div style={{ fontFamily: MONO, fontSize: 10, color: A, letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
         FEATURES
       </div>
       {FEATURES.map((f, i) => (
@@ -642,22 +642,29 @@ function SetupSection() {
         transition: 'all 0.7s ease',
       }}
     >
-      <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.12em', marginBottom: 24 }}>
+      <div style={{ fontFamily: MONO, fontSize: 10, color: A, letterSpacing: '0.12em', marginBottom: 24 }}>
         SETUP
       </div>
 
       <div style={{
-        background: SURF, border: `1px solid ${BORDER}`,
-        borderRadius: 8, padding: '20px 28px', maxWidth: 480, width: '100%',
+        background: '#0a0a0c', border: `1px solid #1f293b`,
+        borderRadius: 8, padding: '24px 28px', maxWidth: 480, width: '100%',
         textAlign: 'left', marginBottom: 32,
         fontFamily: MONO, fontSize: 13, lineHeight: 1.8,
+        boxShadow: '0 8px 30px rgba(0,0,0,0.4)',
       }}>
-        <div style={{ color: '#9ca3af' }}># start tracking in 30 seconds</div>
+        {/* Terminal Header Mock */}
+        <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
+          <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#ef4444' }} />
+          <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#f59e0b' }} />
+          <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#10b981' }} />
+        </div>
+        <div style={{ color: '#10b981', fontWeight: 500 }}># start tracking in 30 seconds</div>
         <div style={{ color: TEXT }}>
           <span style={{ color: A }}>→</span> sign in at{' '}
           <span style={{ color: A }}>devtrack.vercel.app</span>
         </div>
-        <div style={{ color: '#9ca3af', marginTop: 4 }}># or self-host</div>
+        <div style={{ color: '#10b981', marginTop: 8, fontWeight: 500 }}># or self-host</div>
         <div style={{ color: TEXT }}>
           <span style={{ color: A }}>$</span> git clone github.com/…/devtrack
         </div>
@@ -705,14 +712,14 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
       ref={ref}
       style={{
         padding: '80px clamp(20px,4vw,48px)',
-        borderTop: '1px solid #111',
+        borderTop: '1px solid #1f293b',
         opacity: vis ? 1 : 0,
         transform: vis ? 'translateY(0)' : 'translateY(24px)',
         transition: 'all 0.7s ease',
       }}
     >
       {/* Label */}
-      <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
+      <div style={{ fontFamily: MONO, fontSize: 10, color: A, letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
         OPEN SOURCE
       </div>
 
@@ -722,11 +729,11 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
           <div
             key={s.label}
             style={{
-              background: SURF, border: `1px solid ${BORDER}`,
+              background: '#0a0a0c', border: `1px solid #1f293b`,
               borderRadius: 8, padding: '20px 20px 16px',
             }}
           >
-            <div style={{ fontFamily: MONO, fontSize: 10, color: '#9ca3af', letterSpacing: '0.1em', marginBottom: 10 }}>
+            <div style={{ fontFamily: MONO, fontSize: 10, color: '#94a3b8', letterSpacing: '0.1em', marginBottom: 10 }}>
               {s.icon} {s.label}
             </div>
             <div style={{
@@ -735,7 +742,7 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
               lineHeight: 1, letterSpacing: '-0.03em',
             }}>
               <Counter end={s.value} active={vis} />
-              {s.suffix && <span style={{ color: '#9ca3af', fontSize: '0.55em' }}>{s.suffix}</span>}
+              {s.suffix && <span style={{ color: A, fontSize: '0.75em' }}>{s.suffix}</span>}
             </div>
           </div>
         ))}
@@ -807,10 +814,10 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
           {stats.contributorCount > stats.contributors.length && (
             <div style={{
               width: 38, height: 38, borderRadius: '50%',
-              border: `2px solid ${BG}`,
-              background: '#181818', marginLeft: -11,
+              border: `2px solid #000000`,
+              background: '#1e293b', marginLeft: -11,
               display: 'flex', alignItems: 'center', justifyContent: 'center',
-              fontFamily: MONO, fontSize: 9, color: '#555', flexShrink: 0,
+              fontFamily: MONO, fontSize: 10, color: '#cbd5e1', flexShrink: 0,
             }}>
               +{stats.contributorCount - stats.contributors.length}
             </div>

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -538,7 +538,7 @@ function StatsSection() {
     <section style={{
       padding: '64px clamp(20px,4vw,48px)',
       display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px,1fr))',
-        gap: 24, borderTop: '1px solid #1f293b',
+        gap: 24, borderTop: '1px solid #1e293b',
     }}>
       {STATS.map((s, i) => (
         <StatItem key={s.label} value={s.value} label={s.label} delay={i * 80} />
@@ -584,7 +584,7 @@ function FeatureItem({ f, index }: { f: typeof FEATURES[0]; index: number }) {
       ref={ref}
       style={{
         display: 'flex', gap: 'clamp(16px,3vw,32px)',
-        padding: '24px 0', borderBottom: '1px solid #1f293b',
+        padding: '24px 0', borderBottom: '1px solid #1e293b',
         opacity: vis ? 1 : 0,
         transform: vis ? 'translateX(0)' : 'translateX(-12px)',
         transition: `all 0.5s ease ${index * 50}ms`,
@@ -613,7 +613,7 @@ function FeaturesSection() {
   return (
     <section style={{
       padding: '64px clamp(20px,4vw,48px) 80px',
-      borderTop: '1px solid #1f293b',
+      borderTop: '1px solid #1e293b',
       maxWidth: 720, margin: '0 auto',
     }}>
       <div style={{ fontFamily: MONO, fontSize: 10, color: A, letterSpacing: '0.12em', textTransform: 'uppercase', marginBottom: 40 }}>
@@ -647,7 +647,7 @@ function SetupSection() {
       </div>
 
       <div style={{
-        background: '#0a0a0c', border: `1px solid #1f293b`,
+        background: '#0a0a0c', border: `1px solid #1e293b`,
         borderRadius: 8, padding: '24px 28px', maxWidth: 480, width: '100%',
         textAlign: 'left', marginBottom: 32,
         fontFamily: MONO, fontSize: 13, lineHeight: 1.8,
@@ -712,7 +712,7 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
       ref={ref}
       style={{
         padding: '80px clamp(20px,4vw,48px)',
-        borderTop: '1px solid #1f293b',
+        borderTop: '1px solid #1e293b',
         opacity: vis ? 1 : 0,
         transform: vis ? 'translateY(0)' : 'translateY(24px)',
         transition: 'all 0.7s ease',
@@ -729,7 +729,7 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
           <div
             key={s.label}
             style={{
-              background: '#0a0a0c', border: `1px solid #1f293b`,
+              background: '#0a0a0c', border: `1px solid #1e293b`,
               borderRadius: 8, padding: '20px 20px 16px',
             }}
           >


### PR DESCRIPTION
## What this PR does

Targeted visual polish improvements to the existing landing page (no structural changes, no new dependencies, no component additions) and robust error/rate-limit handling for landing page repository statistics.

### Changes

**`src/components/landing/LandingPage.tsx`**
- Improved `MUTED` constant from `#555` → `#94a3b8` for better readability against dark background.
- Updated section divider borders from `#111` → `#1f293b` (visible but subtle).
- Added macOS-style terminal dots (🔴🟡🟢) to the Setup code block for visual clarity.
- Section labels (`FEATURES`, `SETUP`, `OPEN SOURCE`) now use the accent color instead of a dim grey.
- Stat tile suffix text contrast improved (`0.55em` → `0.75em` + accent color).
- Contributor overflow badge upgraded: brighter text (`#555` → `#cbd5e1`), richer background (`#181818` → `#1e293b`).

**`src/app/globals.css`**
- Upgraded `.lnd-cell` (bento cards) to glassmorphism: `backdrop-filter: blur(16px)`, subtle border, and inset highlight.
- Improved `.lnd-cell:hover` with an indigo glow shadow instead of a flat color swap.
- Added `body:has(.lnd-root)` rule to pin the landing page to a pure dark background.

**`src/components/Footer.tsx`**
- Made footer landing-page-aware via `usePathname`.
- On the `/` route: applies `bg-transparent` + `border-slate-900/40` so it blends seamlessly into the dark landing page background.
- All other pages: unchanged behavior.

**`src/app/page.tsx`**
- Added support for `GITHUB_TOKEN` env var to authenticate repository stats requests, raising the rate limit from 60/hr to 5000/hr in local development.
- Wrapped the Supabase sponsor lookup in a `try/catch` block. This prevents the entire stats fetch from crash-landing (returning all zeros) when running in environments where Supabase is not configured (such as local dev).

### What is NOT in this PR
- No `ParticleBackground` component
- No `CustomCursor` component  
- No structural changes to the landing page layout
- No new npm dependencies

 
### Old vs New Screenshots
1) Landing Page with Bento Card Polish Glow
<img width="1906" height="921" alt="image" src="https://github.com/user-attachments/assets/a4fbd2cf-3195-436f-834a-177824668523" />
<img width="1885" height="906" alt="image" src="https://github.com/user-attachments/assets/5ad000d5-b064-4a1c-8ebc-b77ea9ecb63d" />

2) Contribution graph
<img width="1898" height="915" alt="image" src="https://github.com/user-attachments/assets/386dca97-0886-4081-ba81-d84643eacb00" />
<img width="1889" height="914" alt="image" src="https://github.com/user-attachments/assets/8cdf3170-8990-4a79-9133-36ca59d5db5d" />

3) Features 
<img width="1907" height="908" alt="image" src="https://github.com/user-attachments/assets/f4a48623-4d20-43aa-bf5c-6dacb786fcae" />
<img width="1890" height="908" alt="image" src="https://github.com/user-attachments/assets/8c2fa0a6-71aa-4bd6-9933-583755050a6a" />

4) Git stars, Contributors counts etc.
<img width="1902" height="906" alt="image" src="https://github.com/user-attachments/assets/70632f2e-62c8-4638-915b-ea8a10d7b15b" />
<img width="1885" height="900" alt="image" src="https://github.com/user-attachments/assets/d8c536a8-973d-47a4-bc2b-a13f3d42f39e" />

5) Terminal block with 🔴🟡🟢 macOS dots at the top
<img width="1846" height="735" alt="image" src="https://github.com/user-attachments/assets/667e552d-c2bf-4de9-a988-625fcc2b58d5" />
<img width="1868" height="722" alt="image" src="https://github.com/user-attachments/assets/431a733f-84be-49c7-a6a5-22de0ef7ef76" />

6) Footer Blended with background
<img width="1901" height="540" alt="image" src="https://github.com/user-attachments/assets/6f233d23-dcb5-408d-92e1-d5958615f69f" />
<img width="1863" height="481" alt="image" src="https://github.com/user-attachments/assets/47683f4a-3f9d-4132-9aeb-5d59e7fc0783" />
