### PR TITLE
fix(local-coding): surface stats query errors

### DIFF
--- a/src/app/api/local-coding/stats/route.ts
+++ b/src/app/api/local-coding/stats/route.ts
@@ -32,12 +32,17 @@ export async function GET(req: NextRequest) {
   fromDate.setDate(fromDate.getDate() - days);
   const fromDateStr = fromDate.toISOString().slice(0, 10);
 
-  const { data: sessions } = await supabaseAdmin
+  const { data: sessions, error } = await supabaseAdmin
     .from("local_coding_sessions")
     .select("*")
     .eq("user_id", user.id)
     .gte("date", fromDateStr)
     .order("date", { ascending: false });
+
+  if (error) {
+    console.error("Failed to fetch local coding stats:", error);
+    return Response.json({ error: "Failed to fetch local coding stats" }, { status: 500 });
+  }
 
   if (!sessions || sessions.length === 0) {
     return Response.json({

--- a/test/local-coding-stats.test.ts
+++ b/test/local-coding-stats.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/local-coding/stats/route";
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveAppUser: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  gte: vi.fn(),
+  order: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.getServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: mocks.resolveAppUser,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}));
+
+function createRequest(days = 30) {
+  return new NextRequest(`http://localhost/api/local-coding/stats?days=${days}`);
+}
+
+describe("Local Coding Stats GET API Endpoint", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getServerSession.mockResolvedValue({
+      githubId: "12345",
+      githubLogin: "test-user",
+    });
+    mocks.resolveAppUser.mockResolvedValue({ id: "user-1" });
+
+    mocks.from.mockReturnValue({ select: mocks.select });
+    mocks.select.mockReturnValue({ eq: mocks.eq });
+    mocks.eq.mockReturnValue({ gte: mocks.gte });
+    mocks.gte.mockReturnValue({ order: mocks.order });
+    mocks.order.mockResolvedValue({ data: [], error: null });
+  });
+
+  it("returns empty stats when the query succeeds with no sessions", async () => {
+    const res = await GET(createRequest());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      dailyData: [],
+      totals: {
+        totalSeconds: 0,
+        totalDays: 0,
+        avgSecondsPerDay: 0,
+      },
+      hasData: false,
+    });
+  });
+
+  it("returns 500 when Supabase fails instead of hiding the error as empty stats", async () => {
+    const dbError = { message: "relation local_coding_sessions does not exist" };
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.order.mockResolvedValue({ data: null, error: dbError });
+
+    const res = await GET(createRequest());
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to fetch local coding stats" });
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to fetch local coding stats:", dbError);
+  });
+});


### PR DESCRIPTION
## Summary
- Handles Supabase query errors in `/api/local-coding/stats` instead of treating them as empty activity.
- Keeps the genuine no-session response unchanged.
- Adds focused route tests for both the empty-data path and the database-error path.

## Why
This fixes #1490 as part of GSSoC 2026. While checking the local coding stats route, I noticed the API only used `data` from the Supabase response. If the table/query failed, users would still get a successful empty stats response, which makes backend failures look like normal no-data states.

## Testing
- `npm run test -- test/local-coding-stats.test.ts`
- `npm run lint`
- `npm run type-check`
- `node scripts/check-deps.js`
- `npx -p node@20 -c 'node -v && npm run build'`

Closes #1490
