### PR TITLE
Fix E2E test timeout by adding Playwright retriesFix E2E test timeout by adding Playwright retries

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,8 +42,8 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: npx playwright test
-
+        run: npx playwright test --retries=2
+        
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary

Added retry support for Playwright E2E tests to improve CI stability.

Closes #1107

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

## Changes Made

- Updated `.github/workflows/e2e.yml`
- Added `--retries=2` to Playwright test execution
- Improves resilience against intermittent E2E failures

## How to Test

1. Run GitHub Actions workflow
2. Verify Playwright tests execute with retry support
3. Confirm workflow completes successfully

## Additional Notes

This change only affects CI test execution and does not modify application behavior.