### PR TITLE
fix(cron): fail closed when CRON_SECRET is unset in weekly-digest route

### DIFF
--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -4,12 +4,16 @@ import { supabaseAdmin } from "@/lib/supabase";
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
-  // 1. Verify cron secret if provided
+  // 1. Verify cron secret - fail closed if not configured
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not configured" },
+      { status: 500 }
+    );
+  }
   const authHeader = request.headers.get("authorization");
-  if (
-    process.env.CRON_SECRET &&
-    authHeader !== `Bearer ${process.env.CRON_SECRET}`
-  ) {
+  if (authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 


### PR DESCRIPTION
## What and Why

Closes #1451

The `GET /api/cron/weekly-digest` route guarded itself with:

```ts
if (
  process.env.CRON_SECRET &&
  authHeader !== `Bearer ${process.env.CRON_SECRET}`
) {
  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
}
```

When `CRON_SECRET` is `undefined` (or empty), `process.env.CRON_SECRET` is falsy, the `&&` short-circuits, the `if` body is never entered, and the route proceeds to send emails to every opted-in user without any identity check. An unauthenticated attacker can trigger unlimited batch email sends, exhausting the Resend API quota and spamming users.

The same pattern is already handled correctly in `src/app/api/sponsors/sync/route.ts`.

## Fix

Apply the fail-closed pattern: return `500` when the secret is not configured at all, then check the `Authorization` header unconditionally.

```ts
const cronSecret = process.env.CRON_SECRET;
if (!cronSecret) {
  return NextResponse.json(
    { error: "CRON_SECRET is not configured" },
    { status: 500 }
  );
}
const authHeader = request.headers.get("authorization");
if (authHeader !== `Bearer ${cronSecret}`) {
  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
}
```

## Files Changed

- `src/app/api/cron/weekly-digest/route.ts` (auth guard block only)

## Test Plan

- [ ] With `CRON_SECRET` unset: `GET /api/cron/weekly-digest` returns `500 CRON_SECRET is not configured`.
- [ ] With `CRON_SECRET=abc` and no `Authorization` header: returns `401 Unauthorized`.
- [ ] With `CRON_SECRET=abc` and `Authorization: Bearer wrong`: returns `401 Unauthorized`.
- [ ] With `CRON_SECRET=abc` and `Authorization: Bearer abc`: proceeds to fetch users and send digests as before.

## GSSoC

program: gssoc