### PR TITLE
Add Docker deployment health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ USER nextjs
 
 EXPOSE 3000
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
 ENV PORT 3000
 ENV HOSTNAME "0.0.0.0"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,4 +27,10 @@ services:
       - UPSTASH_REDIS_REST_URL=${UPSTASH_REDIS_REST_URL}
       - UPSTASH_REDIS_REST_TOKEN=${UPSTASH_REDIS_REST_TOKEN}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a Docker image health check for the production Next.js server
- add a matching docker-compose health check for local/self-hosted deployments
- keep the existing multi-stage standalone Next.js Docker build intact

Closes #1360

## Testing
- Docker build was not run in this sandbox.
