### PR TITLE
fix(local-coding): align API key hash storage

### DIFF
--- a/src/app/api/local-coding/keys/route.ts
+++ b/src/app/api/local-coding/keys/route.ts
@@ -72,6 +72,7 @@ export async function POST(req: NextRequest) {
     .insert({
       user_id: user.id,
       api_key: apiKeyHash,
+      api_key_hash: apiKeyHash,
       name,
     })
     .select("id, name, last_used_at, created_at")

--- a/src/app/api/local-coding/sync/route.ts
+++ b/src/app/api/local-coding/sync/route.ts
@@ -15,11 +15,12 @@ function hashApiKey(key: string): string {
 
 async function authenticateApiKey(apiKey: string): Promise<string | null> {
   const keyHash = hashApiKey(apiKey);
+  const keyHashFilter = `api_key_hash.eq.${keyHash},api_key.eq.${keyHash}`;
 
   const { data: keyRecord } = await supabaseAdmin
     .from("local_coding_api_keys")
     .select("user_id")
-    .eq("api_key_hash", keyHash)
+    .or(keyHashFilter)
     .single();
 
   if (!keyRecord) {
@@ -29,7 +30,7 @@ async function authenticateApiKey(apiKey: string): Promise<string | null> {
   await supabaseAdmin
     .from("local_coding_api_keys")
     .update({ last_used_at: new Date().toISOString() })
-    .eq("api_key_hash", keyHash);
+    .or(keyHashFilter);
 
   return keyRecord.user_id;
 }

--- a/test/local-coding-keys.test.ts
+++ b/test/local-coding-keys.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { createHash } from "crypto";
+import { POST } from "@/app/api/local-coding/keys/route";
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveAppUser: vi.fn(),
+  from: vi.fn(),
+  countEq: vi.fn(),
+  insert: vi.fn(),
+  insertSelect: vi.fn(),
+  insertSingle: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: mocks.getServerSession,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: mocks.resolveAppUser,
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: {
+    from: mocks.from,
+  },
+}));
+
+function createRequest(name: string) {
+  return new NextRequest("http://localhost/api/local-coding/keys", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+}
+
+describe("Local Coding Keys POST API Endpoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getServerSession.mockResolvedValue({
+      githubId: "12345",
+      githubLogin: "test-user",
+    });
+    mocks.resolveAppUser.mockResolvedValue({ id: "user-1" });
+    mocks.countEq.mockResolvedValue({ count: 0, error: null });
+    mocks.insertSingle.mockResolvedValue({
+      data: {
+        id: "key-1",
+        name: "Laptop",
+        last_used_at: null,
+        created_at: "2026-05-29T00:00:00.000Z",
+      },
+      error: null,
+    });
+
+    mocks.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({ eq: mocks.countEq }),
+      insert: mocks.insert,
+    });
+    mocks.insert.mockReturnValue({ select: mocks.insertSelect });
+    mocks.insertSelect.mockReturnValue({ single: mocks.insertSingle });
+  });
+
+  it("stores the generated hash in both API key hash columns", async () => {
+    const res = await POST(createRequest("  Laptop  "));
+    const body = await res.json();
+    const returnedApiKey = body.key.api_key;
+    const expectedHash = createHash("sha256").update(returnedApiKey).digest("hex");
+
+    expect(res.status).toBe(200);
+    expect(mocks.insert).toHaveBeenCalledWith({
+      user_id: "user-1",
+      api_key: expectedHash,
+      api_key_hash: expectedHash,
+      name: "Laptop",
+    });
+    expect(body.message).toContain("Store this API key securely");
+  });
+});

--- a/test/local-coding-sync.test.ts
+++ b/test/local-coding-sync.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/local-coding/sync/route";
 import { NextRequest } from "next/server";
+import { createHash } from "crypto";
 
 // Mock Supabase admin client methods
 const mockRpc = vi.fn();
 const mockSingle = vi.fn();
 const mockEq = vi.fn().mockReturnValue({ single: mockSingle });
 const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
-const mockUpdate = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+const mockKeyLookupOr = vi.fn().mockReturnValue({ single: mockSingle });
+const mockUpdateOr = vi.fn().mockResolvedValue({ error: null });
+const mockUpdate = vi.fn().mockReturnValue({ or: mockUpdateOr });
 const mockFrom = vi.fn().mockReturnValue({
   select: mockSelect,
   update: mockUpdate,
@@ -34,12 +37,10 @@ describe("Local Coding Sync POST API Endpoint", () => {
       if (table === "local_coding_api_keys") {
         return {
           select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              single: mockSingle,
-            }),
+            or: mockKeyLookupOr,
           }),
           update: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ error: null }),
+            or: mockUpdateOr,
           }),
         };
       }
@@ -164,7 +165,7 @@ describe("Local Coding Sync POST API Endpoint", () => {
       if (table === "local_coding_api_keys") {
         return {
           select: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
+            or: vi.fn().mockReturnValue({
               single: mockSingle.mockResolvedValue({
                 data: { user_id: "test-user-id" },
                 error: null,
@@ -172,7 +173,7 @@ describe("Local Coding Sync POST API Endpoint", () => {
             }),
           }),
           update: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ error: null }),
+            or: vi.fn().mockResolvedValue({ error: null }),
           }),
         };
       }
@@ -237,6 +238,25 @@ describe("Local Coding Sync POST API Endpoint", () => {
         },
       ],
     });
+  });
+
+  it("authenticates against both api_key_hash and legacy api_key columns", async () => {
+    const sessions = [{ date: "2026-05-27", totalSeconds: 3600, fileCount: 2, projectCount: 1 }];
+    const req = new NextRequest("http://localhost/api/local-coding/sync", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-key",
+      },
+      body: JSON.stringify({ sessions }),
+    });
+
+    const res = await POST(req);
+    const keyHash = createHash("sha256").update("test-key").digest("hex");
+    const expectedFilter = `api_key_hash.eq.${keyHash},api_key.eq.${keyHash}`;
+
+    expect(res.status).toBe(200);
+    expect(mockKeyLookupOr).toHaveBeenCalledWith(expectedFilter);
+    expect(mockUpdateOr).toHaveBeenCalledWith(expectedFilter);
   });
 
   it("returns 500 error if batch_upsert_sessions RPC fails", async () => {


### PR DESCRIPTION
## Summary
- Store newly generated local coding API key hashes in `api_key_hash` as well as the existing `api_key` column.
- Let sync authentication match either `api_key_hash` or the legacy `api_key` column so existing rows keep working.
- Add regression coverage for key creation storage and sync authentication lookup behavior.

## Why
This fixes #1524 as part of GSSoC 2026. The key creation route was writing the generated hash into `api_key`, while the sync route authenticated against `api_key_hash`. That made a freshly generated key look valid in the UI but fail later with `401 Invalid API key` during sync.

## Testing
- `npm run test -- test/local-coding-keys.test.ts test/local-coding-sync.test.ts`
- `npm run lint`
- `npm run type-check`
- `node scripts/check-deps.js`
- `npm ci --dry-run`
- `npx -p node@20 -c 'node -v && npm run build'`

Closes #1524
