### PR TITLE
feat(search): add clear text button for repository search

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -270,16 +270,29 @@ export default function TopRepos() {
         <p className="text-sm text-[var(--muted-foreground)]">No commits in the last {days} days.</p>
       ) : (
       <>
-        {repos.length > 10 && (
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search repositories…"
-            aria-label="Search repositories"
-            className="mb-3 w-full rounded-lg border border-[var(--border)] bg-[var(--control)] px-3 py-1.5 text-sm text-[var(--card-foreground)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:border-[var(--accent)]"
-          />
-        )}
+      {repos.length > 10 && (
+  <div className="relative mb-3">
+    <input
+      type="text"
+      value={searchQuery}
+      onChange={(e) => setSearchQuery(e.target.value)}
+      placeholder="Search repositories…"
+      aria-label="Search repositories"
+      className="w-full rounded-lg border border-[var(--border)] bg-[var(--control)] px-3 py-1.5 pr-10 text-sm text-[var(--card-foreground)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:border-[var(--accent)]"
+    />
+
+    {searchQuery.length > 0 && (
+      <button
+        type="button"
+        onClick={() => setSearchQuery("")}
+        aria-label="Clear search"
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)] hover:text-[var(--card-foreground)]"
+      >
+        ✕
+      </button>
+    )}
+  </div>
+)}
         <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)] mb-2 px-0">
           <button
             type="button"


### PR DESCRIPTION
## Summary

Added a clear text button to the repository search input in the Top Repositories widget.

Closes #1472

## Type of Change

- [x] New feature

## Changes Made

- Added a clear (✕) button inside the repository search input
- Button appears only when the search field contains text
- Clicking the button clears the search query
- Button disappears when the input is empty

## How to Test

1. Run `npm test`
2. Run `npm run lint`
3. Open the Top Repositories section
4. Type text into the repository search field
5. Verify the clear button appears
6. Click the button and verify the input is cleared

## Screenshots (if UI change)

N/A

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] Self-reviewed the diff
- [x] Tested locally