### PR TITLE
Fix/streak freeze unlimited stockpile

### DIFF
--- a/src/app/api/streak/freeze/route.ts
+++ b/src/app/api/streak/freeze/route.ts
@@ -70,6 +70,22 @@ export async function POST() {
 
   const today = todayStr();
 
+  // Prevent users from stockpiling unused freezes
+  const { count } = await supabaseAdmin
+    .from("streak_freezes")
+    .select("*", { count: "exact", head: true })
+    .eq("user_id", user.id)
+    .gte("freeze_date", today);
+
+  const MAX_PENDING_FREEZES = 1;
+
+  if (count !== null && count >= MAX_PENDING_FREEZES) {
+    return Response.json(
+      { error: "You already have a pending freeze." },
+      { status: 409 }
+    );
+  }
+
   const { data: existing } = await supabaseAdmin
     .from("streak_freezes")
     .select("id")
@@ -79,7 +95,10 @@ export async function POST() {
 
   const { data: freeze, error } = await supabaseAdmin
     .from("streak_freezes")
-    .upsert({ user_id: user.id, freeze_date: today }, { onConflict: "user_id,freeze_date" })
+    .upsert(
+      { user_id: user.id, freeze_date: today },
+      { onConflict: "user_id,freeze_date" }
+    )
     .select()
     .single();
 
@@ -89,7 +108,10 @@ export async function POST() {
 
   const alreadyExisted = existing !== null;
 
-  return Response.json({ freeze, already_existed: alreadyExisted }, { status: 201 });
+  return Response.json(
+    { freeze, already_existed: alreadyExisted },
+    { status: 201 }
+  );
 }
 
 // DELETE /api/streak/freeze
@@ -109,7 +131,8 @@ export async function DELETE() {
     .eq("user_id", user.id)
     .eq("freeze_date", todayStr());
 
-  if (error) return Response.json({ error: "Failed to cancel freeze" }, { status: 500 });
+  if (error)
+    return Response.json({ error: "Failed to cancel freeze" }, { status: 500 });
 
   return Response.json({ success: true });
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -80,9 +80,7 @@ function checkMemoryLimit(
   const active = (memoryBuckets.get(key) ?? []).filter(
     (timestamp) => timestamp > cutoff
   );
-  const reset = Math.ceil(
-    ((active[0] ?? now) + WINDOW_SECONDS * 1000) / 1000
-  );
+  const reset = Math.ceil(((active[0] ?? now) + WINDOW_SECONDS * 1000) / 1000);
 
   if (active.length >= limit) {
     memoryBuckets.set(key, active);
@@ -172,7 +170,7 @@ async function checkUpstashLimit(
     }
 
     const data = await response.json();
-    
+
     // Upstash REST eval response format: { result: [allowed_flag, current_count] }
     const [allowedFlag, currentCount] = data.result as [number, number];
     const isAllowed = allowedFlag === 1;
@@ -184,7 +182,10 @@ async function checkUpstashLimit(
       reset,
     };
   } catch (error) {
-    console.error("Rate-limiter cloud pipeline failure, falling back to local memory storage:", error);
+    console.error(
+      "Rate-limiter cloud pipeline failure, falling back to local memory storage:",
+      error
+    );
     return null;
   }
 }


### PR DESCRIPTION
Closes #1476

## Summary
Added a pending freeze count check before creating a new streak freeze.

## Changes
- Count existing pending freezes for the authenticated user
- Enforce a maximum of 1 pending freeze
- Return HTTP 409 when the limit is exceeded
- Prevent users from stockpiling unused freezes

## Result
Users can no longer accumulate unlimited pending freezes and are restricted to a single pending freeze at a time.