### PR TITLE
perf(ui): optimize application images with next/image

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -132,6 +132,10 @@ const nextConfig = {
         protocol: "https",
         hostname: "avatars.githubusercontent.com",
       },
+      {
+        protocol: "https",
+        hostname: "github.githubassets.com",
+      },
     ],
   },
   async headers() {

--- a/src/app/compare/[users]/page.tsx
+++ b/src/app/compare/[users]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { Scale, Trophy } from "lucide-react";
+import Image from "next/image";
 import { normalizeGitHubUsername } from "@/lib/validate-github-username";
 import {
   fetchPublicProfile,
@@ -224,10 +225,11 @@ function ProfileHeader({
           align === "right" ? "md:flex-row-reverse" : ""
         }`}
       >
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
+        <Image
           src={`https://avatars.githubusercontent.com/${profile.username}`}
-          alt=""
+          alt={`${profile.username} avatar`}
+          width={56}
+          height={56}
           className="h-14 w-14 rounded-full border border-[var(--border)]"
         />
         <div className="min-w-0">

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import EmptyState from "@/components/EmptyState";
 import SponsorBadge from "@/components/SponsorBadge";
 
@@ -146,10 +147,11 @@ export default async function LeaderboardPage({
                     #{entry.rank}
                   </div>
                   <div className="flex min-w-0 items-center gap-3">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
+                    <Image
                       src={entry.avatarUrl}
-                      alt=""
+                      alt={`${entry.username} avatar`}
+                      width={40}
+                      height={40}
                       className="h-10 w-10 rounded-full border border-[var(--border)]"
                     />
                     <div className="min-w-0">

--- a/src/components/BadgeSection.tsx
+++ b/src/components/BadgeSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Image from "next/image";
 
 interface BadgeSectionProps {
   username: string;
@@ -49,8 +50,7 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
             Streak Badge
           </h3>
           <div className="mb-2">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={streakBadgePreviewUrl} alt="DevTrack Streak" />
+            <Image src={streakBadgePreviewUrl} alt="DevTrack Streak" width={150} height={20} className="w-auto h-auto" unoptimized />
           </div>
           <CopyableCodeBlock code={streakMarkdown} />
         </div>
@@ -61,8 +61,7 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
             Commits Badge
           </h3>
           <div className="mb-2">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={commitsBadgePreviewUrl} alt="DevTrack Commits" />
+            <Image src={commitsBadgePreviewUrl} alt="DevTrack Commits" width={150} height={20} className="w-auto h-auto" unoptimized />
           </div>
           <CopyableCodeBlock code={commitsMarkdown} />
         </div>
@@ -73,10 +72,8 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
             Combined (Both Badges)
           </h3>
           <div className="mb-2 flex gap-1">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={streakBadgePreviewUrl} alt="DevTrack Streak" />
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={commitsBadgePreviewUrl} alt="DevTrack Commits" />
+            <Image src={streakBadgePreviewUrl} alt="DevTrack Streak" width={150} height={20} className="w-auto h-auto" unoptimized />
+            <Image src={commitsBadgePreviewUrl} alt="DevTrack Commits" width={150} height={20} className="w-auto h-auto" unoptimized />
           </div>
           <CopyableCodeBlock code={combinedMarkdown} />
         </div>

--- a/src/components/FriendComparison.tsx
+++ b/src/components/FriendComparison.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
 import dynamic from "next/dynamic";
 
 const ComparisonChart = dynamic(() => import("./ComparisonChart"), { ssr: false });
@@ -265,10 +266,11 @@ export default function FriendComparison() {
                         : "hover:bg-[var(--control)]",
                     ].join(" ")}
                   >
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
+                    <Image
                       src={u.avatarUrl}
-                      alt=""
+                      alt={`${u.username} avatar`}
+                      width={20}
+                      height={20}
                       className="h-5 w-5 rounded-full"
                       loading="lazy"
                     />

--- a/src/components/GitHubAchievements.tsx
+++ b/src/components/GitHubAchievements.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import type { GitHubAchievement } from "@/lib/github-achievements";
 
 interface GitHubAchievementsProps {
@@ -52,10 +53,11 @@ export default function GitHubAchievements({
               title={achievement.description}
               className="group rounded-lg border border-[var(--border)] bg-[var(--control)] p-3 text-center transition-colors hover:border-[var(--accent)]"
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
+              <Image
                 src={achievement.imageUrl}
                 alt={`${achievement.title} GitHub achievement badge`}
+                width={56}
+                height={56}
                 className="mx-auto h-14 w-14 object-contain"
                 loading="lazy"
               />

--- a/src/components/WrappedExperience.tsx
+++ b/src/components/WrappedExperience.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import type { WrappedStats } from "@/lib/wrapped";
 
 const SLIDE_THEMES = [
@@ -306,11 +307,13 @@ export default function WrappedExperience() {
                   <p className="mt-1 text-sm text-slate-300">
                     Generated from your selected year.
                   </p>
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
+                  <Image
                     src={getOgImageUrl(stats)}
                     alt={`${stats.year} Year in Code share card for ${stats.username}`}
+                    width={1200}
+                    height={630}
                     className="mt-4 aspect-[1200/630] w-full rounded-md border border-white/10 object-cover"
+                    unoptimized
                   />
                   <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
                     <a

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import Image from "next/image";
 
 /* ═══════════════════════════════════════════════════════════
    PUBLIC TYPES
@@ -811,9 +812,8 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
                 el.style.zIndex = String(stats.contributors.length - i);
               }}
             >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={`${c.avatar_url}&s=76`}
+              <Image
+                src={c.avatar_url}
                 alt={c.login}
                 width={38}
                 height={38}


### PR DESCRIPTION
## Description
This PR addresses the major frontend performance enhancement by migrating the extensive use of standard HTML `<img>` tags to Next.js's native, optimized `<Image>` component. 

This change tackles frontend performance bottlenecks by enabling automatic WebP/AVIF compression, lazy loading out of the box, and enforcing explicit sizing to completely eliminate layout shifts as components render.

## Resolved Issue
Resolves #1545 

### Changes Made
- **Config Updates**: Added `github.githubassets.com` to `remotePatterns` in `next.config.mjs` to allow optimized achievement badges to be served.
- **Component Refactoring**: Integrated `next/image` into:
  - `src/components/BadgeSection.tsx`
  - `src/components/GitHubAchievements.tsx`
  - `src/components/FriendComparison.tsx`
  - `src/components/WrappedExperience.tsx`
  - `src/components/landing/LandingPage.tsx`
- **Page Refactoring**: Integrated `next/image` into:
  - `src/app/leaderboard/page.tsx`
  - `src/app/compare/[users]/page.tsx`
- **Exclusions**: `StatsCard.tsx` and `opengraph-image.tsx` were intentionally left using `<img>` to prevent breaking the `html-to-image` and `@vercel/og` libraries which require raw DOM images.

### Motivation and Context
Previously, large grids of contributor avatars, achievement badges, and OG preview cards were causing layout jumps (CLS) and heavily degrading the Largest Contentful Paint (LCP) times because the images were unoptimized original JPEGs/PNGs. This PR resolves those performance penalties.

### Testing Instructions
1. Pull down the branch and start the development server (`npm run dev`).
2. Navigate to the `/leaderboard` and `/compare` routes and verify that user avatars load correctly without any layout snapping.
3. Check the dashboard's "GitHub Achievements" section to ensure the badges are successfully loading from `github.githubassets.com`.
4. Run `npm run build` to ensure there are no unoptimized image warnings during the build step.