### PR TITLE
fix(ui): ensure dark mode coherence across charting components

### DIFF
--- a/src/components/ComparisonChart.tsx
+++ b/src/components/ComparisonChart.tsx
@@ -100,7 +100,7 @@ export default function ComparisonChart({
             wrapperStyle={{ fontSize: "12px", paddingTop: "10px" }}
           />
           <Bar dataKey="me" fill="var(--accent)" radius={[4, 4, 0, 0]} maxBarSize={28} />
-          <Bar dataKey="friend" fill="#6366f1" radius={[4, 4, 0, 0]} maxBarSize={28} />
+          <Bar dataKey="friend" fill="var(--accent-secondary)" radius={[4, 4, 0, 0]} maxBarSize={28} />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/MiniPRTrendChart.tsx
+++ b/src/components/MiniPRTrendChart.tsx
@@ -117,8 +117,8 @@ export default function MiniPRTrendChart() {
   }
 
   let strokeColor = "var(--accent)";
-  if (stats.trendText === "Improving") strokeColor = "#16a34a";
-  if (stats.trendText === "Degrading") strokeColor = "#dc2626";
+  if (stats.trendText === "Improving") strokeColor = "var(--success)";
+  if (stats.trendText === "Degrading") strokeColor = "var(--destructive)";
 
   return (
     <div className="mt-4 flex h-16 w-full items-center justify-between gap-4 rounded-lg bg-[var(--control)] p-3 border border-[var(--border)]">

--- a/src/components/PRBreakdownChart.tsx
+++ b/src/components/PRBreakdownChart.tsx
@@ -12,10 +12,10 @@ interface PRBreakdown {
 }
 
 const SLICES: { key: keyof PRBreakdown; label: string; color: string }[] = [
-  { key: "open",   label: "Open",   color: "#6366f1" },
-  { key: "merged", label: "Merged", color: "#34d399" },
-  { key: "closed", label: "Closed", color: "#fb923c" },
-  { key: "draft",  label: "Draft",  color: "#94a3b8" },
+  { key: "open",   label: "Open",   color: "var(--accent)" },
+  { key: "merged", label: "Merged", color: "var(--success)" },
+  { key: "closed", label: "Closed", color: "var(--warning)" },
+  { key: "draft",  label: "Draft",  color: "var(--muted-foreground)" },
 ];
 
 export default function PRBreakdownChart() {

--- a/src/components/repo-analytics/RepoTimelineChart.tsx
+++ b/src/components/repo-analytics/RepoTimelineChart.tsx
@@ -48,14 +48,14 @@ export default function RepoTimelineChart({ timeline }: { timeline: TimelinePoin
             <Line 
               type="monotone" 
               dataKey="prs" 
-              stroke="var(--chart-cyan)" 
+              stroke="var(--accent-secondary)" 
               strokeWidth={2} 
               dot={false}
             />
             <Line 
               type="monotone" 
               dataKey="issues" 
-              stroke="var(--chart-orange)" 
+              stroke="var(--warning)" 
               strokeWidth={2} 
               dot={false}
             />


### PR DESCRIPTION
## Description
This PR resolves an issue where third-party charting libraries (Recharts) used hardcoded hex colors, causing visual clashes when the dashboard was toggled into dark mode. By passing the semantic CSS variables defined in `globals.css` directly to the charting components, all data visualizations now adapt elegantly to the active theme.

## Resolved Issue
Resolves #1551 

### Key Changes
- **`PRBreakdownChart.tsx`**: Updated PR status slices to use semantic variables (`var(--accent)`, `var(--success)`, `var(--warning)`, `var(--muted-foreground)`).
- **`ComparisonChart.tsx`**: Updated the comparison bar graph to use `var(--accent-secondary)` instead of a hardcoded indigo hex value.
- **`MiniPRTrendChart.tsx`**: Swapped hardcoded green/red stroke colors for `var(--success)` and `var(--destructive)`.
- **`RepoTimelineChart.tsx`**: Replaced undefined chart CSS variables with `var(--accent-secondary)` and `var(--warning)`.
- **Audited**: Verified that `CodingTimeWidget`, `PRReviewTrendChart`, `CommitTimeChart`, and `PRStatusDonutChart` already correctly leverage theme tokens.
- **Design Decision**: Preserved standard GitHub branding colors (e.g., TypeScript blue, JavaScript yellow) to maintain language recognition.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] UI/UX Improvement

## How Has This Been Tested?
- [x] Toggled between Light and Dark mode to ensure text, axes, tooltips, and data series contrast properly in both themes.
- [x] Ran `npm run build` to verify that all modifications compile without type errors.