### PR TITLE
chore: add engines field for Node.js version support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "ts-jest": "^29.4.11",
     "typescript": "^5",
     "vitest": "^1.6.0"
+  },
+  "engines": {
+  "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Added an `engines` field to `package.json` to specify the supported Node.js version and improve environment consistency across contributors and deployment environments.

Closes #994

---

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [x] Developer Experience / Configuration improvement
* [ ] Refactor / code cleanup

---

## Changes Made

* Added an `engines` field to `package.json`
* Specified supported Node.js version (`>=20.0.0`)
* Improved consistency across local development and deployment environments
* Helps prevent version-related compatibility issues

---

## How to Test

1. Open `package.json`
2. Verify the following section exists:

```json
"engines": {
  "node": ">=20.0.0"
}
```

3. Run:

```bash
npm install
```

4. Confirm dependencies install successfully
5. Verify the project runs normally

---

## Screenshots (if UI change)

N/A

---

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable

---

## Additional Notes

This change helps contributors and deployment platforms use compatible Node.js versions, reducing setup and runtime issues caused by version mismatches.
