### PR TITLE
fix(ui): refine mobile responsiveness for heatmaps and comparison widgets

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -329,8 +329,8 @@ export default function ContributionHeatmap({
 };
 
   return (
-    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+    <div className="w-full overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-6 shadow-sm">
+      <div className="mb-4 flex flex-col sm:flex-row sm:flex-wrap items-start sm:items-center justify-between gap-4 sm:gap-2">
         <div>
           <h2 className="text-lg font-semibold text-[var(--card-foreground)] dark:text-white">Contribution Heatmap</h2>          
           <p className="text-sm text-[var(--muted-foreground)] dark:text-gray-300">
@@ -338,9 +338,9 @@ export default function ContributionHeatmap({
           </p>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-col sm:flex-row flex-wrap items-start sm:items-center gap-2">
           {/* Range buttons */}
-          <div className="flex gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1">
+          <div className="flex flex-wrap gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1">
             {PRESET_RANGES.map((r) => (
               <button
                 key={r.days}

--- a/src/components/FriendComparison.tsx
+++ b/src/components/FriendComparison.tsx
@@ -193,7 +193,7 @@ export default function FriendComparison() {
   };
 
   return (
-    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+    <div className="w-full overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-6 shadow-sm">
       <div className="mb-6 space-y-4">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
@@ -374,11 +374,11 @@ export default function FriendComparison() {
             />
           )}
 
-          <div className="flex justify-center items-center gap-3 pt-4">
+          <div className="flex flex-col sm:flex-row justify-center items-stretch sm:items-center gap-3 pt-4">
             <a
               href="#contribution-activity"
               onClick={handleCommitActivityClick}
-              className="rounded-full bg-[var(--control)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+              className="text-center rounded-full bg-[var(--control)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
             >
               View Commit Activity
             </a>


### PR DESCRIPTION
## Description
This PR addresses layout issues on smaller viewports where data-heavy components (like the contribution heatmap and friend comparison table) would either overflow the screen or cramp their flex layouts into illegible states. By refining our Tailwind breakpoints, these widgets now render cleanly on mobile devices.

## Resolved Issue
Resolves #1556 

### Key Changes
- **Root Containers**: Added `w-full overflow-hidden` and responsive padding (`p-4 sm:p-6`) to `ContributionHeatmap.tsx` and `FriendComparison.tsx`.
- **ContributionHeatmap**: Updated the header controls and range selectors to elegantly wrap and stack on narrow screens.
- **FriendComparison**: Updated the bottom action buttons ("View Commit Activity", "Clear Comparison") to stack vertically (`flex-col sm:flex-row`) so they remain easily tappable on mobile.
- **Scroll Areas**: Verified that the horizontal scrolling wrappers (`overflow-x-auto`) function correctly without breaking the parent layout.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] UI/UX Improvement

## How Has This Been Tested?
- [x] Tested with browser DevTools in responsive design mode (emulating 320px, 375px, and 414px width devices).
- [x] Verified that no horizontal page-level scrolling occurs when viewing large datasets.
- [x] Ensured form inputs and buttons remain legible and accessible when stacked vertically.
