### PR TITLE
feat: add a Back to home button on sign in page

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -3,7 +3,7 @@
 import { signIn } from "next-auth/react";
 import { Suspense, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
-
+import Link from "next/link";
 
 const A = "#818cf8";
 const ERR = "#f87171";
@@ -143,6 +143,31 @@ function SignInContent() {
           alignItems: "center",
         }}
       >
+
+         {/* BACK TO HOME */}
+      <div
+        style={{
+    width: "100%",
+    display: "flex",
+    justifyContent: "flex-start",
+    alignItems:"center",
+    marginBottom: 20,
+  }}
+      >
+        <Link
+          href="/"
+          style={{
+            fontFamily: MONO,
+    color: "#e8e8e8",
+    textDecoration: "none",
+  fontSize:12 }}
+        >
+           ← Back to home
+        </Link>
+      </div>
+
+
+        
         <div style={{ marginBottom: 36 }}>
           <span
             style={{


### PR DESCRIPTION
## Summary

Added a Back to Home button to the Sign In page, allowing users to easily navigate back to the homepage without relying on browser navigation controls.

Closes #1509 

---

## Type of Change

- [X] New feature

---

## Changes Made

- Added Back to home button on sign in page
- The button redirects on the home page

---

## How to Test

Steps for the reviewer to verify this works:

1. Open the website
2. Navigate to sign in page
3. Click on the Back to home button
4. It redirects on the home page

---

## Screenshots (if UI change)
<img width="1909" height="975" alt="Screenshot 2026-05-29 183639" src="https://github.com/user-attachments/assets/00a543c9-4ba1-4179-8c91-4d1acf28daa5" />


---

## Checklist

- [x] Linked issue in summary
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff

---

## Accessibility Checklist

- [x] Responsive UI verified
- [x] Accessibility labels added where needed
