### PR TITLE
fix(weekly-summary): guard commitsRes.ok before .json() to prevent TypeError on rate limit

### DIFF
--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -176,16 +176,20 @@ export async function GET(req: NextRequest) {
         }
       );
 
-      // Note: commitsRes.ok is intentionally NOT checked here — if the commits
-      // Search call fails, commitsData.items will be undefined and all counts
-      // will fall back to 0 rather than throwing and returning a 502.
-      // This is a lenient design choice: partial data is shown over an error state.
-      const commitsData = (await commitsRes.json()) as {
+      // Guard against non-200 responses (e.g. 403 secondary rate limit) before
+      // calling .json(). Without this check, commitsData.items is undefined on a
+      // rate-limit response, causing the for-of loop below to throw
+      // "TypeError: undefined is not iterable" and wipe the entire widget.
+      // On failure we fall back to an empty items array so PRs and streak data
+      // remain visible even when the commits search is rate-limited.
+      const commitsData: {
         items: Array<{
           commit: { author: { date: string } };
           repository: { full_name: string };
         }>;
-      };
+      } = commitsRes.ok
+        ? await commitsRes.json()
+        : { items: [] };
 
       let commitsThisWeek = 0;
       let commitsPrevWeek = 0;


### PR DESCRIPTION
## Description

The `/api/metrics/weekly-summary` route fetches commits from the GitHub Search API but never checked `commitsRes.ok` before calling `.json()`. Every other API call in this handler (`searchRes` in `fetchActiveDates`, `prsRes`) already has an explicit `.ok` guard, but the commits fetch missed it.

**Root cause:** when GitHub returns a 403 secondary rate limit response, the body is an error object without an `items` array. The code cast it as `{ items: Array<...> }`, so `commitsData.items` was `undefined`. The `for...of` loop immediately threw `TypeError: undefined is not iterable`, which the outer `catch` block converted to a generic `502` and erased the entire weekly-summary widget, even though PR data and streak data were completely unaffected.

**Fix:** replace the unconditional `.json()` call with a conditional that falls back to `{ items: [] }` on any non-200 response. This delivers on the existing comment's stated intent ("partial data over error state") while actually making it work, keeping PRs, active days, and streak visible when the commits search is temporarily rate-limited.

## Related Issue

Closes #980

## Type of Change

- [x] Bug fix

## Changes Made

- `src/app/api/metrics/weekly-summary/route.ts`: replaced the unconditional `commitsRes.json()` call with a conditional expression that returns `{ items: [] }` when `commitsRes.ok` is false. Updated the surrounding comment to accurately describe the actual behavior. The type annotation was also moved to a proper variable declaration to avoid requiring an `as` cast on the conditional expression.

## Screenshots or Demo

Not applicable. This is a server-side fix with no visual change. The observable difference is that the weekly-summary widget continues to show PR counts, active days, and streak data during a commits rate-limit event, rather than returning a 502 and clearing the entire widget.

## Testing Done

1. Start the development server with `pnpm dev`.
2. Simulate a rate-limited commits response by temporarily modifying the commits fetch URL to one that returns a 403 (e.g. add a query parameter that triggers an error from a mock or use a revoked token for the commits call only).
3. Observe that the weekly-summary endpoint returns a 200 response with `commits.current = 0` and `commits.previous = 0`, while `prs`, `activeDays`, and `streak` are populated normally.
4. Restore the URL and verify normal operation returns correct commit counts.
5. Verify the TypeScript compiler reports no type errors: `pnpm tsc --noEmit`.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] I have read the CODE_OF_CONDUCT.md
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] All CI checks are passing
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with contribution tracking and scoring. Thank you!

program: gssoc