### PR TITLE
test : added unit tests for pinned-repos utilities

### DIFF
--- a/test/pinned-repos.test.ts
+++ b/test/pinned-repos.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("pinned-repos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("LANGUAGE_COLORS", () => {
+    it("maps TypeScript to correct color", async () => {
+      const { fetchPinnedRepoDetails } = await import("../src/lib/pinned-repos");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          description: "Test repo",
+          html_url: "https://github.com/test/repo",
+          stargazers_count: 100,
+          forks_count: 10,
+          language: "TypeScript",
+        }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await fetchPinnedRepoDetails("testuser", ["test/repo"], "fake-token");
+      expect(result).toHaveLength(1);
+      expect(result[0].primaryLanguage).toEqual({ name: "TypeScript", color: "#3178c6" });
+    });
+
+    it("handles unknown language with default color", async () => {
+      const { fetchPinnedRepoDetails } = await import("../src/lib/pinned-repos");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          description: "Test repo",
+          html_url: "https://github.com/test/repo",
+          stargazers_count: 100,
+          forks_count: 10,
+          language: "UnknownLang",
+        }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await fetchPinnedRepoDetails("testuser", ["test/repo"], "fake-token");
+      expect(result).toHaveLength(1);
+      expect(result[0].primaryLanguage).toEqual({ name: "UnknownLang", color: "#8b949e" });
+    });
+
+    it("handles null language", async () => {
+      const { fetchPinnedRepoDetails } = await import("../src/lib/pinned-repos");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          description: "Test repo",
+          html_url: "https://github.com/test/repo",
+          stargazers_count: 100,
+          forks_count: 10,
+          language: null,
+        }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await fetchPinnedRepoDetails("testuser", ["test/repo"], "fake-token");
+      expect(result).toHaveLength(1);
+      expect(result[0].primaryLanguage).toBeNull();
+    });
+
+    it("returns empty array for no pinned repos", async () => {
+      const { fetchPinnedRepoDetails } = await import("../src/lib/pinned-repos");
+      const result = await fetchPinnedRepoDetails("testuser", [], "fake-token");
+      expect(result).toHaveLength(0);
+    });
+
+    it("gracefully handles 404 response", async () => {
+      const { fetchPinnedRepoDetails } = await import("../src/lib/pinned-repos");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await fetchPinnedRepoDetails("testuser", ["private/repo"], "fake-token");
+      expect(result).toHaveLength(0);
+    });
+
+    it("gracefully handles 403 response", async () => {
+      const { fetchPinnedRepoDetails } = await import("../src/lib/pinned-repos");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await fetchPinnedRepoDetails("testuser", ["private/repo"], "fake-token");
+      expect(result).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Refs #1588.

Summary of What Has Been Done:
Added unit tests for the fetchPinnedRepoDetails function in src/lib/pinned-repos.ts. Created test/pinned-repos.test.ts with 6 tests covering language color mapping, unknown language handling, null language, empty repos array, and error handling for 404/403 responses.

Changes Made:
- test/pinned-repos.test.ts: Added 6 unit tests covering pinned-repos utilities

Impact it Made:
- Improved test coverage for repository spotlight features
- All 6 tests pass successfully
- Type-check and lint pass without errors