### PR TITLE
fix : added validation for empty githubLogin in supabase user lookup

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -45,6 +45,10 @@ interface User {
 export async function getUserByUsername(
   username: string
 ): Promise<User | null> {
+  if (!username || !username.trim()) {
+    return null;
+  }
+
   try {
     const { data, error } = await supabaseAdmin
       .from("users")


### PR DESCRIPTION
Refs #1591.

Summary of What Has Been Done:
Added guard clause to getUserByUsername function in src/lib/supabase.ts to return null early if username is empty or whitespace-only. This prevents unnecessary database queries for invalid input.

Changes Made:
- src/lib/supabase.ts: Added validation check at the beginning of getUserByUsername

Impact it Made:
- Prevents unnecessary database queries for invalid usernames
- Improves performance by failing fast for obviously invalid input
- Type-check and lint pass without errors