### PR TITLE
fix: add validation for empty githubLogin in supabase user lookup (closes #1591)

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -45,6 +45,9 @@ interface User {
 export async function getUserByUsername(
   username: string
 ): Promise<User | null> {
+  if (!username || !username.trim()) {
+    return null;
+  }
   try {
     const { data, error } = await supabaseAdmin
       .from("users")


### PR DESCRIPTION
## Summary:
Added an early return guard clause in getUserByUsername 
function in src/lib/supabase.ts to prevent unnecessary 
Supabase database queries when the username is empty or 
whitespace-only.

## Closes
 #1591
## Type of Change:
✅ Bug fix

## Changes Made:
- Added guard clause at the start of getUserByUsername 
  in src/lib/supabase.ts
- Function now returns null immediately if username is 
  empty or whitespace-only
- Prevents unnecessary Supabase database queries for 
  invalid input
- Improves performance by failing fast for obviously 
  invalid usernames
## How to Test:
1. Call getUserByUsername with an empty string ""
2. Verify it returns null immediately without hitting DB
3. Call getUserByUsername with whitespace only "   "
4. Verify it returns null immediately without hitting DB
5. Call getUserByUsername with valid username
6. Verify it still queries DB and returns correct result
## Screenshots:
N/A — backend validation fix, no UI changes
## Checklist:

✅ Linked issue in summary
✅ npm run lint passes locally
✅ No TypeScript errors (npm run type-check)
✅ Self-reviewed the diff
✅ No tests needed for this guard clause change

## Accessibility Checklist:

✅ No UI changes — not applicable