### PR TITLE
fix: guard against zero percentage Other language generation

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -44,17 +44,19 @@ function getVisibleLanguages(languages: RepoLanguage[]): RepoLanguage[] {
   const sorted = [...languages].sort((a, b) => b.percentage - a.percentage);
 
   if (sorted.length <= 3) {
-    const total = sorted.reduce((sum, lang) => sum + lang.percentage, 0);
-    if (total < 100 && sorted.length > 0) {
-      return [
-        ...sorted,
-        {
-          name: "Other",
-          bytes: 0,
-          percentage: Math.round((100 - total) * 10) / 10,
-        },
-      ];
-    }
+   const total = sorted.reduce((sum, lang) => sum + lang.percentage, 0);
+const otherPercentage = Math.round((100 - total) * 10) / 10;
+
+if (total < 100 && sorted.length > 0 && otherPercentage > 0) {
+  return [
+    ...sorted,
+    {
+      name: "Other",
+      bytes: 0,
+      percentage: otherPercentage,
+    },
+  ];
+}
     return sorted;
   }
 


### PR DESCRIPTION
## Related Issues
Closes #1494
I am contributing to this project under GSSoC'26.

## Summary
Fixes an edge-case floating-point rounding bug in `TopRepos.tsx` where an empty "Other: 0%" badge is erroneously injected into the repository language layout array.

## Changes Made
- **Added Threshold Guard:** Implemented an explicit `otherPercentage > 0` condition inside `getVisibleLanguages` before appending the fallback "Other" object.
- **Optimized Metric Calculation:** Extracted the rounded percentage math to a clean, isolated constant (`otherPercentage`) for better readability.

## How to Test
1. Pass a mock language distribution array that sums up to an asymmetrical decimal close to 100% (e.g., 99.96%).
2. Verify that the component skips creating an "Other" badge entirely instead of rendering "Other (0%)".