### PR TITLE
fix: add client-side validation to prevent goal target of 0 or less (#929)

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -141,6 +141,12 @@ export function useGoalTracker() {
     setCreating(true);
     setCreateError(null);
 
+    if (target <= 0) {
+      setCreateError("Target must be greater than 0.");
+      setCreating(false);
+      return;
+    }
+
     try {
       const result = await submitGoalWithRefresh({
         payload: { title, target, unit, recurrence, deadline: deadline || null },

--- a/src/types/repo-health.ts
+++ b/src/types/repo-health.ts
@@ -16,4 +16,3 @@ export interface RepoHealthScore {
 export interface RepoHealthResponse {
   repos: RepoHealthScore[];
 }
-


### PR DESCRIPTION
## Summary
Closes #929

The progress bar NaN issue when target=0 was already guarded in the calculation, but users could still submit a goal with target=0. This PR adds explicit client-side validation that catches target ≤ 0 before the API call and shows a clear error message.

## Type of Change
- [x] Bug fix

## Changes Made
- Added client-side validation in `handleCreate` — returns early with error message if `target <= 0`
- Complements the existing `min={1}` attribute and division guard already in the codebase

## How to Test
1. Go to Goals section
2. Try creating a goal with target = 0
3. See error: "Target must be greater than 0."

## Checklist
- [x] Linked issue in summary
- [x] No TypeScript errors
- [x] Self-reviewed the diff