### PR TITLE
fix: replace tiny dropdown chevron with proper icon

### DIFF
--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
 
@@ -26,9 +27,17 @@ export default function WeeklySummaryCard() {
   const [error, setError] = useState<string | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(false);
 
-  const maxCommits = summary?.commits ? Math.max(summary.commits.current, summary.commits.previous, 1) : 1;
-  const maxPRs = summary?.prs ? Math.max(summary.prs.thisWeek.merged, summary.prs.lastWeek.merged, 1) : 1;
-  const maxActiveDays = summary?.activeDays ? Math.max(summary.activeDays.thisWeek, summary.activeDays.lastWeek, 1) : 1;
+const maxCommits = summary?.commits
+  ? Math.max(summary.commits.current, summary.commits.previous, 1)
+  : 1;
+
+const maxPRs = summary?.prs
+  ? Math.max(summary.prs.thisWeek.merged, summary.prs.lastWeek.merged, 1)
+  : 1;
+
+const maxActiveDays = summary?.activeDays
+  ? Math.max(summary.activeDays.thisWeek, summary.activeDays.lastWeek, 1)
+  : 1;
 
   const fetchSummary = useCallback(() => {
     setLoading(true);
@@ -72,7 +81,7 @@ export default function WeeklySummaryCard() {
           }
           suppressHydrationWarning
         >
-          {isCollapsed ? ">" : "v"}
+          <ChevronDown className="h-4 w-4" />
         </button>
       </div>
 
@@ -97,7 +106,11 @@ export default function WeeklySummaryCard() {
           <div className="mt-4 rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
             {error}
           </div>
+<<<<<<< HEAD
+        ) : (summary && summary.commits && summary.prs && summary.activeDays) ? (
+=======
         ) : summary && summary.commits && summary.prs && summary.activeDays ? (
+>>>>>>> 20107a0855dc410d6dfb4ad961eca16b1085bdf6
           <div className="mt-4 space-y-4">
             {/* Commits Comparison */}
             <div className="rounded-lg bg-[var(--control)] p-4">


### PR DESCRIPTION
## Changes Made
- Replaced the tiny text-based dropdown indicator (`v` / `>`) with a proper Lucide `ChevronDown` icon
- Improved dropdown visibility and UI clarity
- Enhanced accessibility and discoverability of the dropdown toggle

Fixes #1516