### PR TITLE
feat: add weekly email digest with AI productivity summary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,4 +109,9 @@ LEADERBOARD_USER_CONCURRENCY=5
 # Local development: set any non-empty value and pass the matching header when
 # calling a sync endpoint manually (e.g. curl -H "Authorization: Bearer ...").
 # Generate with: openssl rand -hex 32
-CRON_SECRET=your_cron_secret
+
+# Weekly Email Digest
+RESEND_API_KEY=re_xxxxxxxxxxxx
+RESEND_FROM_EMAIL=digest@yourdomain.com
+GEMINI_API_KEY=your_gemini_key_here
+CRON_SECRET=replace_with_long_random_string

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "react-markdown": "^10.1.0",
         "recharts": "^2.15.4",
         "rehype-sanitize": "^6.0.0",
+        "resend": "^6.12.4",
         "server-only": "^0.0.1",
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
@@ -193,6 +194,7 @@
     "node_modules/@babel/core": {
       "version": "7.29.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -628,7 +630,6 @@
       "version": "7.8.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -640,7 +641,6 @@
       "version": "7.8.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -652,7 +652,6 @@
       "version": "7.12.13",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
       },
@@ -664,7 +663,6 @@
       "version": "7.14.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -705,7 +703,6 @@
       "version": "7.10.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -717,7 +714,6 @@
       "version": "7.8.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -729,7 +725,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -744,7 +739,6 @@
       "version": "7.10.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -756,7 +750,6 @@
       "version": "7.8.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -768,7 +761,6 @@
       "version": "7.10.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -780,7 +772,6 @@
       "version": "7.8.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -792,7 +783,6 @@
       "version": "7.8.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -804,7 +794,6 @@
       "version": "7.8.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -816,7 +805,6 @@
       "version": "7.14.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -831,7 +819,6 @@
       "version": "7.14.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -846,7 +833,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1735,8 +1721,7 @@
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -1829,6 +1814,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1873,6 +1859,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1894,6 +1881,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2014,6 +2002,7 @@
     "node_modules/@ducanh2912/next-pwa/node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2067,6 +2056,7 @@
     "node_modules/@ducanh2912/next-pwa/node_modules/rollup": {
       "version": "2.80.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2360,6 +2350,7 @@
       "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -2369,8 +2360,9 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2665,6 +2657,28 @@
         "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
       "cpu": [
@@ -2674,6 +2688,102 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -2693,6 +2803,148 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
@@ -2717,11 +2969,130 @@
         "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
@@ -2737,7 +3108,6 @@
       "version": "1.0.10",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -2746,7 +3116,6 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -2759,7 +3128,6 @@
       "version": "3.14.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2772,7 +3140,6 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -2784,7 +3151,6 @@
       "version": "2.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -2799,7 +3165,6 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -2811,7 +3176,6 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2820,7 +3184,6 @@
       "version": "0.1.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2829,7 +3192,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.4.1",
         "@types/node": "*",
@@ -2846,7 +3208,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "30.4.1",
         "@jest/pattern": "30.4.0",
@@ -2893,7 +3254,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -2904,14 +3264,12 @@
     "node_modules/@jest/core/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jest/core/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2923,7 +3281,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
@@ -2973,7 +3330,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -2988,7 +3344,6 @@
       "version": "30.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2997,7 +3352,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "30.4.1",
         "@jest/types": "30.4.1",
@@ -3012,7 +3366,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expect": "30.4.1",
         "jest-snapshot": "30.4.1"
@@ -3025,7 +3378,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0"
       },
@@ -3037,7 +3389,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.4.1",
         "@sinonjs/fake-timers": "^15.4.0",
@@ -3054,7 +3405,6 @@
       "version": "30.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -3063,7 +3413,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.4.1",
         "@jest/expect": "30.4.1",
@@ -3078,7 +3427,6 @@
       "version": "30.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.4.0"
@@ -3091,7 +3439,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "30.4.1",
@@ -3133,7 +3480,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
@@ -3148,7 +3494,6 @@
       "version": "30.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "callsites": "^3.1.0",
@@ -3162,7 +3507,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "30.4.1",
         "@jest/types": "30.4.1",
@@ -3177,7 +3521,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.4.1",
         "graceful-fs": "^4.2.11",
@@ -3192,7 +3535,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.4.1",
@@ -3217,7 +3559,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.4.0",
         "@jest/schemas": "30.4.1",
@@ -3235,7 +3576,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -3246,8 +3586,7 @@
     "node_modules/@jest/types/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -3290,6 +3629,25 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@next/env": {
@@ -3508,6 +3866,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3529,6 +3888,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3544,6 +3904,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
       "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.214.0",
         "import-in-the-middle": "^3.0.0",
@@ -3577,6 +3938,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -3594,6 +3956,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3930,7 +4293,6 @@
       "version": "0.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
@@ -3942,6 +4304,7 @@
       "version": "1.60.0",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -3950,6 +4313,23 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
@@ -3962,6 +4342,263 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -4026,6 +4663,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4132,6 +4770,32 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.4",
       "cpu": [
@@ -4141,6 +4805,292 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@rtsao/scc": {
@@ -4601,7 +5551,6 @@
       "version": "3.0.1",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -4610,7 +5559,6 @@
       "version": "4.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4619,7 +5567,6 @@
       "version": "15.4.0",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -4731,6 +5678,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.1.tgz",
       "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.108.1",
         "@supabase/functions-js": "2.108.1",
@@ -5129,18 +6077,6 @@
         "tree-sitter": "=0.21.1",
         "tree-sitter-json": "=0.24.8",
         "web-tree-sitter": "=0.24.5"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/tree-sitter-json": {
@@ -5642,6 +6578,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
       "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -5759,6 +6696,17 @@
         }
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
@@ -5781,7 +6729,6 @@
       "version": "7.27.0",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -5790,7 +6737,6 @@
       "version": "7.4.4",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -5800,7 +6746,6 @@
       "version": "7.28.0",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
@@ -5915,14 +6860,12 @@
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -5931,7 +6874,6 @@
       "version": "3.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -5994,6 +6936,7 @@
     "node_modules/@types/react": {
       "version": "18.3.29",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -6003,6 +6946,7 @@
       "version": "18.3.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -6017,8 +6961,7 @@
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/swagger-ui-react": {
       "version": "5.18.0",
@@ -6044,7 +6987,6 @@
       "version": "17.0.35",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -6052,8 +6994,7 @@
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.0",
@@ -6098,6 +7039,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -6339,6 +7281,34 @@
       "version": "1.3.1",
       "license": "ISC"
     },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.12.2",
       "cpu": [
@@ -6349,6 +7319,311 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@upstash/redis": {
@@ -6573,7 +7848,6 @@
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -6581,23 +7855,19 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -6606,13 +7876,11 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6623,7 +7891,6 @@
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.13.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -6631,20 +7898,17 @@
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.13.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6659,7 +7923,6 @@
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -6671,7 +7934,6 @@
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -6682,7 +7944,6 @@
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -6695,7 +7956,6 @@
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -6703,17 +7963,16 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6733,7 +7992,6 @@
     "node_modules/acorn-import-phases": {
       "version": "1.0.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -6764,6 +8022,7 @@
     "node_modules/ajv": {
       "version": "6.15.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6819,7 +8078,6 @@
       "version": "4.3.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -6834,7 +8092,6 @@
       "version": "0.21.3",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7193,7 +8450,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "30.4.1",
         "@types/babel__core": "^7.20.5",
@@ -7251,7 +8507,6 @@
       "version": "7.0.1",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -7270,7 +8525,6 @@
       "version": "30.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/babel__core": "^7.20.5"
       },
@@ -7322,7 +8576,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -7348,7 +8601,6 @@
       "version": "30.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "30.4.0",
         "babel-preset-current-node-syntax": "^1.2.0"
@@ -7470,6 +8722,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7499,7 +8752,6 @@
       "version": "2.1.1",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
       }
@@ -7593,7 +8845,6 @@
       "version": "5.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7687,7 +8938,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7761,7 +9011,6 @@
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -7776,7 +9025,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7820,7 +9068,6 @@
       "version": "8.0.1",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -7833,14 +9080,12 @@
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7854,7 +9099,6 @@
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7878,7 +9122,6 @@
       "version": "4.6.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -7887,8 +9130,7 @@
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -8263,7 +9505,6 @@
       "version": "1.7.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -8411,7 +9652,6 @@
       "version": "3.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8525,7 +9765,6 @@
       "version": "0.13.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8548,7 +9787,6 @@
     "node_modules/enhanced-resolve": {
       "version": "5.22.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.3"
@@ -8572,7 +9810,6 @@
       "version": "1.3.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -8760,6 +9997,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8933,6 +10171,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9162,7 +10401,6 @@
       "version": "4.0.1",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -9229,7 +10467,6 @@
     "node_modules/events": {
       "version": "3.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -9238,7 +10475,6 @@
       "version": "0.2.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -9247,7 +10483,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
@@ -9371,7 +10606,6 @@
       "version": "2.0.2",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bser": "2.1.1"
       }
@@ -9634,7 +10868,6 @@
       "version": "2.0.5",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -9669,7 +10902,6 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -9739,8 +10971,7 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -10140,6 +11371,7 @@
     "node_modules/immutable": {
       "version": "3.8.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10180,7 +11412,6 @@
       "version": "3.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -10297,8 +11528,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -10447,7 +11677,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10456,7 +11685,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10744,7 +11972,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -10773,7 +12000,6 @@
       "version": "5.0.6",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.23",
         "debug": "^4.1.1",
@@ -10856,7 +12082,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "execa": "^5.1.1",
         "jest-util": "30.4.1",
@@ -10870,7 +12095,6 @@
       "version": "5.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -10893,7 +12117,6 @@
       "version": "6.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10905,7 +12128,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=10.17.0"
       }
@@ -10914,7 +12136,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -10926,7 +12147,6 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10935,7 +12155,6 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -10947,7 +12166,6 @@
       "version": "5.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -10961,14 +12179,12 @@
     "node_modules/jest-changed-files/node_modules/signal-exit": {
       "version": "3.0.7",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/jest-changed-files/node_modules/strip-final-newline": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10977,7 +12193,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.4.1",
         "@jest/expect": "30.4.1",
@@ -11008,7 +12223,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11019,14 +12233,12 @@
     "node_modules/jest-circus/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-circus/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11038,7 +12250,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11053,7 +12264,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/test-result": "30.4.1",
@@ -11085,7 +12295,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11096,14 +12305,12 @@
     "node_modules/jest-cli/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-cli/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11115,7 +12322,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
@@ -11165,7 +12371,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11180,7 +12385,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.4.0",
         "@jest/get-type": "30.1.0",
@@ -11195,7 +12399,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11206,14 +12409,12 @@
     "node_modules/jest-diff/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11225,7 +12426,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11240,7 +12440,6 @@
       "version": "30.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-newline": "^3.1.0"
       },
@@ -11252,7 +12451,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "@jest/types": "30.4.1",
@@ -11268,7 +12466,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11279,14 +12476,12 @@
     "node_modules/jest-each/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-each/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11298,7 +12493,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11313,7 +12507,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.4.1",
         "@jest/fake-timers": "30.4.1",
@@ -11331,7 +12524,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.4.1",
         "@types/node": "*",
@@ -11355,7 +12547,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11367,7 +12558,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "pretty-format": "30.4.1"
@@ -11380,7 +12570,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11391,14 +12580,12 @@
     "node_modules/jest-leak-detector/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-leak-detector/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11410,7 +12597,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11425,7 +12611,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
@@ -11440,7 +12625,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11451,14 +12635,12 @@
     "node_modules/jest-matcher-utils/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11470,7 +12652,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11485,7 +12666,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@jest/types": "30.4.1",
@@ -11506,7 +12686,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11517,14 +12696,12 @@
     "node_modules/jest-message-util/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-message-util/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11536,7 +12713,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11548,7 +12724,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11563,7 +12738,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.4.1",
         "@types/node": "*",
@@ -11577,7 +12751,6 @@
       "version": "1.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -11594,7 +12767,6 @@
       "version": "30.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -11603,7 +12775,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
@@ -11622,7 +12793,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jest-regex-util": "30.4.0",
         "jest-snapshot": "30.4.1"
@@ -11635,7 +12805,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "30.4.1",
         "@jest/environment": "30.4.1",
@@ -11668,7 +12837,6 @@
       "version": "30.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "30.4.1",
         "@jest/fake-timers": "30.4.1",
@@ -11701,7 +12869,6 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11710,7 +12877,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -11742,7 +12908,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11753,14 +12918,12 @@
     "node_modules/jest-snapshot/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11772,7 +12935,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11787,7 +12949,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.4.1",
         "@types/node": "*",
@@ -11804,7 +12965,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11816,7 +12976,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "@jest/types": "30.4.1",
@@ -11833,7 +12992,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -11844,14 +13002,12 @@
     "node_modules/jest-validate/node_modules/@sinclair/typebox": {
       "version": "0.34.49",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/ansi-styles": {
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11863,7 +13019,6 @@
       "version": "6.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11875,7 +13030,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
@@ -11890,7 +13044,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.4.1",
         "@jest/types": "30.4.1",
@@ -11909,7 +13062,6 @@
       "version": "30.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
@@ -11925,7 +13077,6 @@
       "version": "8.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -11940,6 +13091,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -12036,8 +13188,7 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -12092,6 +13243,7 @@
     "node_modules/jspdf": {
       "version": "4.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.6",
         "fast-png": "^6.2.0",
@@ -12198,6 +13350,27 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
       "cpu": [
@@ -12208,6 +13381,195 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -12236,7 +13598,6 @@
     "node_modules/loader-runner": {
       "version": "4.3.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -12399,7 +13760,6 @@
       "version": "1.0.12",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tmpl": "1.0.5"
       }
@@ -12978,7 +14338,6 @@
     "node_modules/mime-db": {
       "version": "1.54.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13124,6 +14483,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
       "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.9",
         "@swc/helpers": "0.5.15",
@@ -13418,8 +14778,7 @@
     "node_modules/node-int64": {
       "version": "0.4.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.46",
@@ -13715,7 +15074,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -13955,6 +15313,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "dev": true,
@@ -13973,6 +15337,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -14127,6 +15492,7 @@
     "node_modules/preact": {
       "version": "10.29.2",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -14224,8 +15590,7 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/qrcode.react": {
       "version": "4.2.0",
@@ -14269,6 +15634,7 @@
     "node_modules/ramda": {
       "version": "0.30.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -14309,6 +15675,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14341,6 +15708,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14383,15 +15751,13 @@
       "name": "react-is",
       "version": "18.3.1",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-is-19": {
       "name": "react-is",
       "version": "19.2.6",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -14549,7 +15915,8 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-immutable": {
       "version": "4.0.0",
@@ -14660,6 +16027,8 @@
     },
     "node_modules/rehype-sanitize": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -14731,7 +16100,6 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14764,6 +16132,27 @@
       "version": "5.2.0",
       "license": "MIT"
     },
+    "node_modules/resend": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
       "dev": true,
@@ -14790,7 +16179,6 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -14802,7 +16190,6 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -14883,6 +16270,7 @@
     "node_modules/rollup": {
       "version": "4.60.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -15279,7 +16667,6 @@
       "version": "4.1.0",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -15331,7 +16718,6 @@
       "version": "0.5.13",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -15362,7 +16748,6 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -15374,7 +16759,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15443,7 +16827,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
@@ -15577,7 +16960,6 @@
       "version": "6.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -15785,7 +17167,6 @@
       "version": "0.11.13",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.3.6"
       },
@@ -15819,6 +17200,7 @@
       "version": "3.4.19",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -15882,7 +17264,6 @@
     "node_modules/tapable": {
       "version": "2.3.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -16011,6 +17392,7 @@
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16094,7 +17476,6 @@
       "version": "6.0.0",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
@@ -16183,6 +17564,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16217,8 +17599,7 @@
     "node_modules/tmpl": {
       "version": "1.0.5",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -16275,6 +17656,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.3.0",
         "node-gyp-build": "^4.8.4"
@@ -16512,6 +17894,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16859,7 +18242,6 @@
       "version": "9.3.0",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -16917,6 +18299,7 @@
       "version": "8.0.16",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17004,6 +18387,7 @@
       "version": "4.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -17114,7 +18498,6 @@
       "version": "1.0.8",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "makeerror": "1.0.12"
       }
@@ -17122,7 +18505,6 @@
     "node_modules/watchpack": {
       "version": "2.5.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -17201,7 +18583,6 @@
     "node_modules/webpack-sources": {
       "version": "3.5.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -17224,7 +18605,6 @@
     "node_modules/webpack/node_modules/ajv-keywords": {
       "version": "5.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -17235,7 +18615,6 @@
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -17247,20 +18626,17 @@
     "node_modules/webpack/node_modules/estraverse": {
       "version": "4.3.0",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/webpack/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -17561,6 +18937,7 @@
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.20.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17621,6 +18998,7 @@
     "node_modules/workbox-build/node_modules/rollup": {
       "version": "2.80.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -17801,7 +19179,6 @@
       "version": "5.0.1",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -17838,7 +19215,6 @@
       "version": "5.0.8",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -17851,7 +19227,6 @@
       "version": "17.7.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -17876,14 +19251,12 @@
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -17913,6 +19286,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-markdown": "^10.1.0",
     "recharts": "^2.15.4",
     "rehype-sanitize": "^6.0.0",
+    "resend": "^6.12.4",
     "server-only": "^0.0.1",
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",

--- a/src/app/api/settings/digest/route.ts
+++ b/src/app/api/settings/digest/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+import { randomUUID } from "crypto";
+
+// GET — fetch current opt-in status
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("users")
+    .select("digest_enabled")
+    .eq("email", session.user.email)
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ enabled: data?.digest_enabled ?? false });
+}
+
+// POST — toggle opt-in/out
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const enabled: boolean = body.enabled;
+
+  const updates: Record<string, unknown> = { digest_enabled: enabled };
+
+  if (enabled) {
+    // Check if the user already has an unsubscribe token
+    const { data: existing } = await supabaseAdmin
+      .from("users")
+      .select("digest_unsubscribe_token")
+      .eq("email", session.user.email)
+      .single();
+
+    // Only generate a token if one doesn't exist yet
+    if (!existing?.digest_unsubscribe_token) {
+      updates.digest_unsubscribe_token = randomUUID();
+    }
+
+    // Store the email they want to receive digests at
+    updates.digest_email = session.user.email;
+  }
+
+  const { error } = await supabaseAdmin
+    .from("users")
+    .update(updates)
+    .eq("email", session.user.email);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, enabled });
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,24 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth";
+import DigestOptIn from "@/components/DigestOptIn";
+
+export const metadata = { title: "Settings — DevTrack" };
+
+export default async function SettingsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) redirect("/");
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-10">
+      <h1 className="mb-8 text-2xl font-bold text-gray-900">Settings</h1>
+
+      <section className="mb-8">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-widest text-gray-400">
+          Notifications
+        </h2>
+        <DigestOptIn />
+      </section>
+    </main>
+  );
+}

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { supabaseAdmin } from '@/lib/supabase';
+ 
+interface Props { searchParams: { token?: string } }
+ 
+export const metadata = { title: 'Unsubscribe — DevTrack' };
+ 
+export default async function UnsubscribePage({ searchParams }: Props) {
+  const { token } = searchParams;
+  let success = false;
+ 
+  if (token) {
+    const { error } = await supabaseAdmin
+      .from('users')
+      .update({ digest_enabled: false })
+      .eq('digest_unsubscribe_token', token);
+    if (!error) success = true;
+  }
+ 
+  return (
+    <main className='flex min-h-screen items-center justify-center
+                     bg-gray-50 px-4'>
+      <div className='w-full max-w-md rounded-xl border border-gray-200
+                      bg-white p-8 text-center shadow-sm'>
+        <div className='mb-4 text-4xl'>{success ? '✅' : '❌'}</div>
+        <h1 className='mb-2 text-lg font-semibold text-gray-900'>
+          {success ? 'You have been unsubscribed' : 'Invalid link'}
+        </h1>
+        <p className='mb-6 text-sm text-gray-500'>
+          {success
+            ? 'You will no longer receive weekly digest emails. Re-enable anytime in Settings.'
+            : 'This unsubscribe link is invalid or has already been used.'}
+        </p>
+        <Link href='/dashboard'
+          className='inline-block rounded-lg bg-blue-600 px-5 py-2.5
+                     text-sm font-medium text-white hover:bg-blue-700'>
+          Go to Dashboard
+        </Link>
+        {success && (
+          <p className='mt-4 text-xs text-gray-400'>
+            Changed your mind?{' '}
+            <Link href='/settings'
+              className='text-blue-600 hover:underline'>
+              Re-enable in Settings
+            </Link>
+          </p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -21,6 +21,7 @@ import { Moon, Sun } from "lucide-react";
 import { toast } from "sonner";
 import { useRealtimeSync } from "@/hooks/useRealtimeSync";
 import { Button, buttonVariants } from "@/components/ui/button";
+import Link from "next/link";
 
 type DashboardSyncContextValue = {
   lastSynced: Date | null;
@@ -286,7 +287,6 @@ export default function DashboardHeader() {
         </div>
 
         {/* Right Section */}
-        {/* Right Section */}
         <div className="w-full min-w-0 md:w-auto">
           <div className="flex w-full min-w-0 items-center gap-3 overflow-x-auto pb-1 md:w-auto md:justify-end md:overflow-visible md:pb-0">
             {isPublic === true && session?.githubLogin && (
@@ -316,6 +316,20 @@ export default function DashboardHeader() {
 
               <div className="transition-transform duration-200 hover:rotate-12">
                 <ThemeToggle />
+              </div>
+
+              {/* Settings link */}
+              <div className="transition-transform duration-200 hover:scale-[1.05]">
+                <Link
+                  href="/settings"
+                  title="Settings"
+                  className="flex items-center justify-center rounded-xl p-1.5 text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--card)] transition-colors duration-200"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                  </svg>
+                </Link>
               </div>
 
               <div className="transition-transform duration-200 hover:scale-[1.05]">
@@ -387,6 +401,20 @@ export default function DashboardHeader() {
 
             <div className="transition-transform duration-200 hover:rotate-12">
               <ThemeToggle />
+            </div>
+
+            {/* Settings link */}
+            <div className="transition-transform duration-200 hover:scale-[1.05]">
+              <Link
+                href="/settings"
+                title="Settings"
+                className="flex items-center justify-center rounded-xl p-1.5 text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--card)] transition-colors duration-200"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                </svg>
+              </Link>
             </div>
 
             <div className="transition-transform duration-200 hover:scale-[1.05]">

--- a/src/components/DigestOptIn.tsx
+++ b/src/components/DigestOptIn.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function DigestOptIn() {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving,  setSaving]  = useState(false);
+  const [error,   setError]   = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/settings/digest")
+      .then((r) => r.json())
+      .then((d) => { setEnabled(d.enabled ?? false); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, []);
+
+  const toggle = async () => {
+    setSaving(true);
+    setError(null);
+    const next = !enabled;
+
+    try {
+      const res = await fetch("/api/settings/digest", {
+        method:  "POST",
+        headers: { "Content-Type": "application/json" },
+        body:    JSON.stringify({ enabled: next }),
+      });
+      if (!res.ok) throw new Error("Failed to save");
+      setEnabled(next);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="h-16 rounded-lg bg-gray-100 animate-pulse" />;
+  }
+
+  return (
+    <div className="flex items-start justify-between gap-4 rounded-lg border border-gray-200 p-4">
+      <div className="flex-1">
+        <p className="text-sm font-medium text-gray-900">Weekly Email Digest</p>
+        <p className="mt-0.5 text-xs text-gray-500">
+          Get an AI-generated summary of your coding week every Monday at 9 AM UTC.
+        </p>
+        {error && (
+          <p className="mt-1 text-xs text-red-500">{error}</p>
+        )}
+        {enabled && !saving && (
+          <p className="mt-1 text-xs text-green-600">
+            ✓ You will receive your first digest next Monday
+          </p>
+        )}
+      </div>
+
+      {/* Accessible toggle switch */}
+      <button
+        role="switch"
+        aria-checked={enabled}
+        aria-label="Toggle weekly email digest"
+        onClick={toggle}
+        disabled={saving}
+        className={[
+          "relative flex-shrink-0 inline-flex h-6 w-11 items-center rounded-full",
+          "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+          enabled  ? "bg-blue-600"              : "bg-gray-300",
+          saving   ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+        ].join(" ")}
+      >
+        <span
+          className={[
+            "inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform",
+            enabled ? "translate-x-6" : "translate-x-1",
+          ].join(" ")}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/digest.ts
+++ b/src/lib/digest.ts
@@ -1,0 +1,142 @@
+export interface UserDigestData {
+  userName: string;
+  currentStreak: number;
+  longestStreak: number;
+  commitsThisWeek: number;
+  topRepo: string;
+  prsOpened: number;
+  prsMerged: number;
+}
+
+// Calls Gemini 1.5 Flash to generate a short personalized AI summary
+export async function generateAISummary(data: UserDigestData): Promise<string> {
+  try {
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${process.env.GEMINI_API_KEY}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{
+            parts: [{
+              text: `You are a friendly developer coach. Write a short, encouraging 2-3 sentence productivity summary for a developer based on their weekly GitHub stats. Plain paragraph text only.
+
+Stats for ${data.userName}:
+- Commits this week: ${data.commitsThisWeek}
+- Current streak: ${data.currentStreak} days
+- Longest streak ever: ${data.longestStreak} days
+- Most active repository: ${data.topRepo}
+- PRs opened: ${data.prsOpened}, merged: ${data.prsMerged}
+
+Return only the summary text.`
+            }]
+          }]
+        }),
+      }
+    );
+    const result = await response.json();
+    return result.candidates?.[0]?.content?.parts?.[0]?.text ??
+      `Great effort this week, ${data.userName} — every commit counts!`;
+  } catch {
+    return `${data.userName} had ${data.commitsThisWeek} commits this week with a ${data.currentStreak}-day streak. Keep it up!`;
+  }
+}
+
+// Builds the inline-styled HTML email body
+// All styles are inline — Gmail strips <style> blocks
+export function buildEmailHtml({
+  userName,
+  aiSummary,
+  unsubscribeToken,
+  appUrl,
+}: {
+  userName: string;
+  aiSummary: string;
+  unsubscribeToken: string;
+  appUrl: string;
+}): string {
+  const unsubscribeUrl = unsubscribeToken
+    ? `${appUrl}/unsubscribe?token=${unsubscribeToken}`
+    : null;
+
+  const weekLabel = new Date().toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0"
+    style="background-color:#f4f4f5;padding:32px 0;">
+    <tr><td align="center">
+      <table width="600" cellpadding="0" cellspacing="0" border="0"
+        style="background-color:#ffffff;border-radius:12px;
+               box-shadow:0 1px 4px rgba(0,0,0,0.08);overflow:hidden;">
+
+        <tr>
+          <td style="background-color:#1d4ed8;padding:28px 32px;">
+            <p style="margin:0;font-size:22px;font-weight:700;color:#ffffff;">
+              DevTrack
+            </p>
+            <p style="margin:4px 0 0;font-size:13px;color:#bfdbfe;">
+              Weekly Digest &nbsp;·&nbsp; ${weekLabel}
+            </p>
+          </td>
+        </tr>
+
+        <tr>
+          <td style="padding:28px 32px 0;">
+            <p style="margin:0 0 16px;font-size:15px;color:#374151;">
+              Hey <strong>${userName}</strong> 👋
+            </p>
+            <div style="background-color:#eff6ff;border-left:4px solid #2563eb;
+                 border-radius:0 8px 8px 0;padding:16px 20px;">
+              <p style="margin:0;font-size:14px;line-height:1.75;color:#1e40af;">
+                ${aiSummary}
+              </p>
+            </div>
+          </td>
+        </tr>
+
+        <tr>
+          <td style="padding:28px 32px;">
+            <a href="${appUrl}/dashboard"
+               style="display:inline-block;background-color:#1d4ed8;color:#ffffff;
+                      text-decoration:none;padding:12px 24px;border-radius:8px;
+                      font-size:14px;font-weight:600;">
+              View Full Dashboard →
+            </a>
+          </td>
+        </tr>
+
+        <tr>
+          <td style="background-color:#f9fafb;border-top:1px solid #f3f4f6;
+               padding:20px 32px;">
+            <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;
+               line-height:1.6;">
+              You are receiving this because you opted in to weekly digests on DevTrack.
+              ${
+                unsubscribeUrl
+                  ? `<br/><a href="${unsubscribeUrl}"
+                       style="color:#9ca3af;text-decoration:underline;">
+                       Unsubscribe
+                     </a>`
+                  : ""
+              }
+            </p>
+          </td>
+        </tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}

--- a/supabase/migrations/20260529000000_add_digest_settings.sql
+++ b/supabase/migrations/20260529000000_add_digest_settings.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users ADD digest_enabled BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE users ADD digest_email TEXT;
+ALTER TABLE users ADD digest_unsubscribe_token TEXT UNIQUE;
+
+CREATE INDEX idx_users_digest_enabled
+  ON users (digest_enabled);

--- a/test/weekly-digest-cron-auth.test.ts
+++ b/test/weekly-digest-cron-auth.test.ts
@@ -69,6 +69,28 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
     vi.clearAllMocks();
     vi.unstubAllEnvs();
     stubNoUsers();
+
+    // Smart default mock to prevent Gemini JSON parsing crashes while intercepting requests
+    mocks.resendFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("generativelanguage.googleapis.com")) {
+        return {
+          ok: true,
+          json: async () => ({
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "Mocked Gemini AI productivity summary text." }]
+                }
+              }
+            ]
+          })
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ id: "mock-email-id" })
+      };
+    });
   });
 
   // ── missing CRON_SECRET — fail closed ─────────────────────────────────────
@@ -92,7 +114,11 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
 
     expect(res.status).toBe(500);
     expect(mocks.supabaseFrom).not.toHaveBeenCalled();
-    expect(mocks.resendFetch).not.toHaveBeenCalled();
+    
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(0);
   });
 
   // ── wrong secret — reject ─────────────────────────────────────────────────
@@ -115,7 +141,11 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
 
     expect(res.status).toBe(401);
     expect(mocks.supabaseFrom).not.toHaveBeenCalled();
-    expect(mocks.resendFetch).not.toHaveBeenCalled();
+    
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(0);
   });
 
   it("returns 401 for a plaintext secret without the Bearer prefix", async () => {
@@ -137,7 +167,11 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.message).toBe("No users opted in");
-    expect(mocks.resendFetch).not.toHaveBeenCalled();
+    
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(0);
   });
 
   // ── email sending ─────────────────────────────────────────────────────────
@@ -149,7 +183,6 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
       { github_login: "alice", email: "alice@example.com" },
       { github_login: "bob", email: "bob@example.com" },
     ]);
-    mocks.resendFetch.mockResolvedValue({ ok: true });
 
     const res = await GET(makeRequest("Bearer s3cr3t"));
 
@@ -157,7 +190,7 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
     const body = await res.json();
     expect(body.sentCount).toBe(2);
     
-    // Filter out Gemini API calls and verify only Resend emails are counted
+    // Isolate email fetch executions from AI generation calls
     const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
       typeof call[0] === "string" && call[0].includes("api.resend.com")
     );
@@ -173,11 +206,9 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    // sentCount still increments so the response reflects how many users were
-    // eligible, but no external call is made
     expect(body.sentCount).toBe(1);
     
-    // Filter out Gemini API calls to ensure no Resend emails were dispatched
+    // Check that zero outbound emails went to Resend endpoints
     const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
       typeof call[0] === "string" && call[0].includes("api.resend.com")
     );
@@ -187,25 +218,31 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
   it("does not send emails when authentication fails even if opted-in users exist", async () => {
     vi.stubEnv("CRON_SECRET", "s3cr3t");
     vi.stubEnv("RESEND_API_KEY", "resend-key");
-    // Even if the DB would return users, the auth check fires first
     stubUsers([{ github_login: "eve", email: "eve@example.com" }]);
 
     const res = await GET(makeRequest("Bearer wrong"));
 
     expect(res.status).toBe(401);
-    expect(mocks.resendFetch).not.toHaveBeenCalled();
+    
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(0);
   });
 
   it("returns 500 and does not query the database when CRON_SECRET is absent regardless of user data", async () => {
     vi.stubEnv("CRON_SECRET", "");
-    // Even though the DB would return users, the config check fires first
     stubUsers([{ github_login: "mallory", email: "mallory@example.com" }]);
 
     const res = await GET(makeRequest("Bearer s3cr3t"));
 
     expect(res.status).toBe(500);
     expect(mocks.supabaseFrom).not.toHaveBeenCalled();
-    expect(mocks.resendFetch).not.toHaveBeenCalled();
+    
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(0);
   });
 
   // ── database error handling ───────────────────────────────────────────────
@@ -220,7 +257,11 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
     const res = await GET(makeRequest("Bearer s3cr3t"));
 
     expect(res.status).toBe(500);
-    expect(mocks.resendFetch).not.toHaveBeenCalled();
+    
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(0);
   });
 
   // ── email personalisation ─────────────────────────────────────────────────
@@ -229,11 +270,9 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
     vi.stubEnv("CRON_SECRET", "s3cr3t");
     vi.stubEnv("RESEND_API_KEY", "resend-key");
     stubUsers([{ github_login: "devtracker", email: "devtracker@example.com" }]);
-    mocks.resendFetch.mockResolvedValue({ ok: true });
 
     await GET(makeRequest("Bearer s3cr3t"));
 
-    // Isolate the Resend email delivery call
     const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
       typeof call[0] === "string" && call[0].includes("api.resend.com")
     );

--- a/test/weekly-digest-cron-auth.test.ts
+++ b/test/weekly-digest-cron-auth.test.ts
@@ -6,9 +6,9 @@
  * ----------
  * The original guard used short-circuit AND evaluation:
  *
- *   if (process.env.CRON_SECRET && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
- *     return 401
- *   }
+ * if (process.env.CRON_SECRET && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+ * return 401
+ * }
  *
  * When CRON_SECRET is undefined, `undefined && ...` is falsy, so the entire
  * condition is skipped and the endpoint executes without any authentication.
@@ -20,9 +20,9 @@
  * The guard was replaced with a fail-closed pattern that matches every other
  * cron endpoint in the codebase:
  *
- *   const cronSecret = process.env.CRON_SECRET;
- *   if (!cronSecret) return 500   // missing config
- *   if (authHeader !== `Bearer ${cronSecret}`) return 401
+ * const cronSecret = process.env.CRON_SECRET;
+ * if (!cronSecret) return 500   // missing config
+ * if (authHeader !== `Bearer ${cronSecret}`) return 401
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -156,8 +156,12 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.sentCount).toBe(2);
-    // One POST to Resend for each user
-    expect(mocks.resendFetch).toHaveBeenCalledTimes(2);
+    
+    // Filter out Gemini API calls and verify only Resend emails are counted
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(2);
   });
 
   it("counts sent emails even when RESEND_API_KEY is absent (no network call made)", async () => {
@@ -172,7 +176,12 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
     // sentCount still increments so the response reflects how many users were
     // eligible, but no external call is made
     expect(body.sentCount).toBe(1);
-    expect(mocks.resendFetch).not.toHaveBeenCalled();
+    
+    // Filter out Gemini API calls to ensure no Resend emails were dispatched
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(0);
   });
 
   it("does not send emails when authentication fails even if opted-in users exist", async () => {
@@ -224,9 +233,13 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
 
     await GET(makeRequest("Bearer s3cr3t"));
 
-    expect(mocks.resendFetch).toHaveBeenCalledOnce();
+    // Isolate the Resend email delivery call
+    const resendCalls = mocks.resendFetch.mock.calls.filter(call => 
+      typeof call[0] === "string" && call[0].includes("api.resend.com")
+    );
+    expect(resendCalls.length).toBe(1);
 
-    const [, callOptions] = mocks.resendFetch.mock.calls[0];
+    const [, callOptions] = resendCalls[0];
     const body = JSON.parse(callOptions.body);
 
     expect(body.to).toBe("devtracker@example.com");


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>[FEAT] Add weekly email digest with AI productivity summary</h1>
<p>Closes #937</p>
<h2>What this PR does</h2>
<p>Implements the weekly email digest feature. Opted-in users receive a Monday 9am UTC email with an AI-generated productivity summary, current streak, top repo, PR stats, and a trend badge.</p>
<h2>Changes</h2>

File | Description
-- | --
supabase/migrations/20260529000000_add_digest_settings.sql | Adds digest_unsubscribe_token to users table
src/lib/digest.ts | AI summary generator + email HTML builder
src/app/api/settings/digest/route.ts | GET/POST opt-in preference API
src/app/api/cron/weekly-digest/route.ts | Enhanced with AI summary + unsubscribe token
src/components/DigestOptIn.tsx | Toggle switch component
src/app/settings/page.tsx | New /settings page
src/app/unsubscribe/page.tsx | Token-based one-click unsubscribe
src/components/DashboardHeader.tsx | Gear icon linking to /settings
.env.example | Documents new env vars


<blockquote>
<p><code>vercel.json</code> already had the cron entry — no changes needed.</p>
</blockquote>
<h2>Acceptance Criteria</h2>
<ul>
<li>[x] User can opt in/out in Settings</li>
<li>[x] Cron triggers every Monday at 9am UTC</li>
<li>[x] Email compatible with Gmail, Outlook, Apple Mail</li>
<li>[x] Unsubscribe link in every email</li>
<li>[x] Unsubscribe works without login</li>
</ul>
<h2>Screenshots</h2>
<img width="598" height="227" alt="Screenshot 2026-05-30 173638" src="https://github.com/user-attachments/assets/3e03e7bb-8c45-4546-ba2f-bba94be28d89" />

<h2>Required before deploying</h2>
<ol>
<li>Run <code>supabase/migrations/20260529000000_add_digest_settings.sql</code> in Supabase SQL editor</li>
<li>Add env vars in Vercel: <code>RESEND_API_KEY</code>, <code>RESEND_FROM_EMAIL</code>, <code>GEMINI_API_KEY</code>, <code>CRON_SECRET</code></li>
</ol></body></html><!--EndFragment-->
</body>
</html>