### PR TITLE
feat: add dynamic scroll progress ring to Back to Top button

### DIFF
--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -5,15 +5,18 @@ import { ArrowUp } from "lucide-react";
 
 export default function BackToTopButton() {
   const [isVisible, setIsVisible] = useState(false);
+  const [scrollProgress, setScrollProgress] = useState(0);
 
-  // Show button when page is scrolled down
-  const toggleVisibility = () => {
+  const handleScroll = () => {
     if (typeof window !== "undefined") {
-      setIsVisible(window.scrollY > 300);
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const progress = docHeight > 0 ? Math.min(scrollTop / docHeight, 1) : 0;
+      setIsVisible(scrollTop > 300);
+      setScrollProgress(progress);
     }
   };
 
-  // Smooth scroll to top
   const scrollToTop = () => {
     if (typeof window !== "undefined") {
       window.scrollTo({
@@ -25,24 +28,61 @@ export default function BackToTopButton() {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
-      window.addEventListener("scroll", toggleVisibility);
+      window.addEventListener("scroll", handleScroll, { passive: true });
       return () => {
-        window.removeEventListener("scroll", toggleVisibility);
+        window.removeEventListener("scroll", handleScroll);
       };
     }
   }, []);
 
+  const radius = 24;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset = circumference * (1 - scrollProgress);
+
+  const ringColor = "#3b82f6";
+
   return (
     <>
       {isVisible && (
-        <button
-          onClick={scrollToTop}
-          type="button"
-          aria-label="Scroll to top"
-          className="fixed bottom-8 right-8 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--accent-foreground)] shadow-lg transition-all duration-300 hover:scale-110 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--background)]"
-        >
-          <ArrowUp size={24} aria-hidden="true" />
-        </button>
+        <div className="fixed bottom-8 right-8 z-50">
+          <div className="relative flex items-center justify-center">
+            <svg
+              className="absolute h-14 w-14 -rotate-90"
+              viewBox="0 0 56 56"
+            >
+              <circle
+                cx="28"
+                cy="28"
+                r={radius}
+                fill="none"
+                stroke={ringColor}
+                strokeWidth="4"
+                opacity="0.15"
+              />
+              <circle
+                cx="28"
+                cy="28"
+                r={radius}
+                fill="none"
+                stroke={ringColor}
+                strokeWidth="4"
+                strokeLinecap="round"
+                strokeDasharray={circumference}
+                strokeDashoffset={strokeDashoffset}
+                style={{ filter: "drop-shadow(0 0 6px rgba(59, 130, 246, 0.6))" }}
+                className="transition-[stroke-dashoffset] duration-100"
+              />
+            </svg>
+            <button
+              onClick={scrollToTop}
+              type="button"
+              aria-label="Scroll to top"
+              className="flex h-12 w-12 items-center justify-center rounded-full bg-black/50 backdrop-blur-md text-white shadow-lg transition-all duration-300 hover:scale-110 hover:shadow-xl hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-[#3b82f6] focus:ring-offset-2 focus:ring-offset-[var(--background)]"
+            >
+              <ArrowUp size={24} aria-hidden="true" className="text-white/90" />
+            </button>
+          </div>
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
## What does this PR do?
Enhances the Back to Top button by adding a dynamic circular SVG progress ring that fills up as the user scrolls down the page.

## Changes Made
- Added scroll progress tracking using JavaScript
- Added SVG circular ring around the Back to Top button
- Ring fills progressively based on scroll position
- Button background changed to dark/semi-transparent to match theme
- Kept existing click-to-scroll-top functionality intact

## Visual Reference
- Ring is blue to match DevTrack's accent color
- Dark background button matches the overall dark theme

## Type of Change
- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] UI Enhancement

## Screenshots
<img width="1910" height="1078" alt="image" src="https://github.com/user-attachments/assets/6c201a91-78df-448d-ba8e-c86d06c9b4df" />


## Related Issue
Closes #1649 

## Tested On
- [x] Desktop
- [x] Mobile