### PR TITLE
[FEAT] Persist dashboard date range choices selector values via localStorage #1483

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -96,6 +96,19 @@ export default function TopRepos() {
       .then((d) => setPinnedRepos(d.pinned_repos || []))
       .catch((err) => console.error("Failed to load pinned repos", err));
   }, []);
+  // --- PERSISTENCE LOGIC ---
+  // 1. Load initial preference from localStorage on mount
+  useEffect(() => {
+    const savedDays = localStorage.getItem("devtrack_dashboard_range");
+    if (savedDays) {
+      setDays(Number(savedDays));
+    }
+  }, []);
+
+  // 2. Save preference to localStorage whenever 'days' state changes
+  useEffect(() => {
+    localStorage.setItem("devtrack_dashboard_range", String(days));
+  }, [days]);
 
   const togglePin = async (repoFullName: string) => {
     const isPinned = pinnedRepos.includes(repoFullName);


### PR DESCRIPTION
Closes #1483

### Description
This PR implements persistent state management for the dashboard date range selector using `localStorage`. This ensures that user preferences for the activity filter range (7d, 30d, 90d) are remembered across browser refreshes.

### Changes
- Implemented a hydration-safe `useEffect` to retrieve the stored date range preference on initial component mount.
- Added a secondary `useEffect` to sync the state with `localStorage` whenever the range selection (`days`) is updated.
- Ensures a seamless user experience by maintaining the selected metrics scope persistently.

The implementation follows hydration-safe patterns to prevent server-client mismatch errors in the Next.js App Router.