### PR TITLE
Fix calculateWeeklyTrend bug by averaging sums (#1215)

### DIFF
--- a/src/lib/coding-activity-insights.ts
+++ b/src/lib/coding-activity-insights.ts
@@ -228,13 +228,13 @@ function calculateWeeklyTrend(
   direction: "up" | "down" | "stable";
   percentage: number;
 } {
-  const firstHalf = dayCounts
-    .slice(0, 3)
-    .reduce((sum, day) => sum + day.count, 0);
+  const firstHalfDays = dayCounts.slice(0, 3);
+  const firstHalfSum = firstHalfDays.reduce((sum, day) => sum + day.count, 0);
+  const firstHalf = firstHalfSum / firstHalfDays.length;
 
-  const secondHalf = dayCounts
-    .slice(3)
-    .reduce((sum, day) => sum + day.count, 0);
+  const secondHalfDays = dayCounts.slice(3);
+  const secondHalfSum = secondHalfDays.reduce((sum, day) => sum + day.count, 0);
+  const secondHalf = secondHalfSum / secondHalfDays.length;
 
   if (firstHalf === secondHalf) {
     return {


### PR DESCRIPTION
### Description
This PR resolves the math/logic error in the `calculateWeeklyTrend` function within `src/lib/coding-activity-insights.ts`. Previously, the function compared the raw sums of a 4-day period against a 3-day period, incorrectly resulting in an "up" trend for perfectly stable activity. The sums are now correctly divided by the number of days to yield a daily average before performing the trend comparison. 

Fixes #1215.

 