### PR TITLE
fix(dateUtils): use local timezone in toDateStr to fix streak date bug for UTC+ users

### DIFF
--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -17,7 +17,10 @@ function getUtcWeekStart(date: Date): Date {
 }
 
 export function toDateStr(d: Date): string {
-  return d.toISOString().slice(0, 10);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 export function dateDiffDays(a: string, b: string): number {


### PR DESCRIPTION
## Summary

Replace `toISOString().slice(0,10)` with `getFullYear/getMonth/getDate` so that commits made early morning in timezones ahead of UTC (IST, JST, AEDT, etc.) are logged on the correct local calendar date instead of the previous UTC date, which was breaking valid streaks.

gssoc26

Closes #928 

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---
*Testing*
--

- [✅]  Verified fix applies correctly to all call sites
- [✅] No TypeScript errors

- [✅]  Indentation consistent with codebase (2-space)

- [✅]  No other files modified

**Accessibility Checklist**
--
 No UI changes in this PR — purely a data/logic fix

## Root Cause

In `src/lib/dateUtils.ts`, the `toDateStr` function was using `Date.toISOString()` which always outputs a **UTC** date string. For users in timezones significantly ahead of UTC (e.g., IST +5:30, JST +9:00, AEDT +11:00), a commit made between midnight and their UTC offset would be logged as the **previous day**, silently breaking an otherwise valid streak.

**Before (broken):**
```ts
export function toDateStr(d: Date): string {
  return d.toISOString().slice(0, 10); // Always UTC — wrong for IST/JST/AEDT users
}

-----------------

> **After Fixed**

export function toDateStr(d: Date): string {
  const year = d.getFullYear();
  const month = String(d.getMonth() + 1).padStart(2, "0");
  const day = String(d.getDate()).padStart(2, "0");
  return `${year}-${month}-${day}`; // Local wall-clock date — matches GitHub's display
}
--

---
*