### PR TITLE
Fix: optimize CI analytics repo limit from 5 to 3

### DIFF
--- a/src/lib/ci-analytics.ts
+++ b/src/lib/ci-analytics.ts
@@ -21,7 +21,7 @@ export async function fetchCIAnalyticsForAccount(token: string, githubLogin: str
   
   const repoMap = new Map<string, number>();
   for (const item of data.items) { const n = item.repository.full_name; repoMap.set(n, (repoMap.get(n) ?? 0) + 1); }
-  const repos = Array.from(repoMap.entries()).map(([name, commits]) => ({ name, commits })).sort((a, b) => b.commits - a.commits).slice(0, 5);
+  const repos = Array.from(repoMap.entries()).map(([name, commits]) => ({ name, commits })).sort((a, b) => b.commits - a.commits).slice(0, 3);
 
   const failedRepos: string[] = [];
   const runsByRepo = await Promise.all(repos.map(async (repo) => {


### PR DESCRIPTION
## Summary

Optimized CI analytics by reducing the number of top repositories fetched from 5 to 3. This improves performance and reduces unnecessary processing.

Closes #1611

---

## Type of Change

- [ ] Bug fix
- [x] Performance improvement
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Reduced repository limit from 5 to 3 in CI analytics
- Improved performance of analytics processing
- Reduced API/data processing overhead

---

## Testing

- [x] Tested locally
- [x] Verified output change in analytics result

---

## Checklist

- [x] Code is clean and minimal change
- [x] No breaking changes introduced
- [x] Self-reviewed the code