### PR TITLE
fix: make PR Breakdown tooltip consistent with PR Status Distribution

### DIFF
--- a/src/components/PRBreakdownChart.tsx
+++ b/src/components/PRBreakdownChart.tsx
@@ -119,18 +119,18 @@ export default function PRBreakdownChart() {
                   <Cell key={entry.name} fill={entry.color} />
                 ))}
               </Pie>
-              <Tooltip
+               <Tooltip
   contentStyle={{
-    backgroundColor: getCSSVariable('--card'),
+    backgroundColor: getCSSVariable('--tooltip'),
     border: `1px solid ${getCSSVariable('--border')}`,
     borderRadius: "10px",
-    color: getCSSVariable('--foreground'),
+    color: getCSSVariable('--tooltip-foreground'),
   }}
   itemStyle={{
-    color: getCSSVariable('--foreground'),
+    color: getCSSVariable('--tooltip-foreground'),
   }}
   labelStyle={{
-    color: getCSSVariable('--foreground'),
+    color: getCSSVariable('--tooltip-foreground'),
   }}
 />
             </PieChart>


### PR DESCRIPTION
## Related Issue

Closes #1514

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

---

## Summary

Updated the PR Breakdown chart tooltip to use the same theme-aware styling as the PR Status Distribution chart.

This fixes inconsistent tooltip appearance across dashboard donut charts and ensures proper styling in both light and dark mode.

---

## Changes Made

* Replaced tooltip styling with existing theme-aware CSS variables
* Used `--tooltip` for tooltip background
* Used `--tooltip-foreground` for tooltip text
* Aligned PR Breakdown tooltip appearance with PR Status Distribution
* Improved consistency across dashboard charts

---

## How to Test

1. Run the application locally
2. Navigate to the Dashboard
3. Hover over the PR Status Distribution chart
4. Hover over the PR Breakdown chart
5. Verify both tooltips use consistent styling in light mode
6. Switch to dark mode
7. Verify both tooltips still match

---



Tooltip appearance is now consistent with other dashboard donut charts in both light and dark themes.

---

## Checklist

* [x] Linked issue in summary
* [x] Self-reviewed the changes
* [x] Tested in light mode
* [x] Tested in dark mode
* [ ] Added/updated tests if applicable
