### PR TITLE
fix: make wrapped loading skeleton responsive

### DIFF
--- a/src/components/WrappedExperience.tsx
+++ b/src/components/WrappedExperience.tsx
@@ -220,8 +220,20 @@ export default function WrappedExperience() {
             aria-live="polite"
             aria-busy="true"
             className="grid flex-1 place-items-center py-16"
-          >
-            <div className="h-[520px] w-full max-w-4xl animate-pulse rounded-lg border border-white/10 bg-white/5" />
+          ><div
+            className="
+              w-full
+              max-w-4xl
+              animate-pulse
+              rounded-lg
+              border
+              border-white/10
+              bg-white/5
+              aspect-[4/3]
+              min-h-[250px]
+              max-h-[520px]
+            "
+          />
             <span className="sr-only">Loading your Year in Code</span>
           </section>
         ) : error ? (


### PR DESCRIPTION
## Summary

Fixed the loading skeleton on the Year in Code page by replacing the fixed-height implementation with a responsive layout that adapts to different screen sizes.

Closes #1708 

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

---

## Changes Made

* Removed the fixed-height loading skeleton.
* Added responsive sizing for mobile, tablet, and desktop screens.
* Reduced unnecessary scrolling on smaller devices.
* Preserved the existing loading experience on larger screens.
* Improved overall responsiveness of the loading state.

---

## How to Test

1. Open the Year in Code page.
2. Trigger the loading state.
3. Test on different screen sizes:

   * Mobile viewport
   * Tablet viewport
   * Desktop viewport
4. Verify that the skeleton adapts appropriately to the viewport size.
5. Confirm there is no excessive scrolling on smaller devices.

---

## Screenshots (if UI change)

### Before

(Add screenshot showing fixed-height skeleton on mobile)

### After

(Add screenshot showing responsive skeleton on mobile)

---

## Checklist

* [x] Linked the related issue
* [x] Self-reviewed the changes
* [ ] Added/updated tests if applicable

---

## Accessibility Checklist

* [x] Responsive behavior verified across screen sizes
* [x] No accessibility regressions introduced
* [x] Existing loading state functionality preserved

---

## Additional Notes

This fix improves the mobile user experience by preventing excessive vertical space usage during loading while maintaining the intended appearance on larger screens.
