### PR TITLE
fix(security): remove internal data from webhook POST response

### DIFF
--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -101,7 +101,7 @@ export async function POST(req: NextRequest) {
 
   const event = req.headers.get(GITHUB_EVENT_HEADER);
   if (event !== "push") {
-    return NextResponse.json({ received: true, ignored: true, event });
+    return NextResponse.json({ received: true });
   }
 
   let payload: GitHubPushPayload;
@@ -113,10 +113,7 @@ export async function POST(req: NextRequest) {
 
   const githubLogin = getPushActor(payload);
   if (!githubLogin) {
-    return NextResponse.json(
-      { received: true, userMatched: false, reason: "Missing GitHub actor" },
-      { status: 200 }
-    );
+    return NextResponse.json({ received: true }, { status: 200 });
   }
 
   let staleResult: Awaited<ReturnType<typeof markUserMetricsStale>>;
@@ -152,14 +149,5 @@ export async function POST(req: NextRequest) {
     revalidatePath("/dashboard");
   }
 
-  return NextResponse.json({
-    received: true,
-    userMatched: Boolean(staleResult),
-    accountType: staleResult?.accountType ?? null,
-    githubId: staleResult?.githubId ?? null,
-    githubLogin,
-    repository: payload.repository?.full_name ?? null,
-    after: payload.after ?? null,
-    commitCount: payload.commits?.length ?? 0,
-  });
+  return NextResponse.json({ received: true });
 }

--- a/test/webhook-response-shape.test.ts
+++ b/test/webhook-response-shape.test.ts
@@ -1,0 +1,124 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import crypto from "crypto";
+
+// Mock dependencies before importing the route
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: {
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            maybeSingle: vi.fn(() => ({
+              data: { id: "user-123", github_id: "456" },
+              error: null,
+            })),
+          })),
+        })),
+      })),
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => ({ data: null, error: null })),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/error-handler", () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("@/lib/sse", () => ({
+  sendSSEEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/metrics-cache", () => ({
+  invalidateUserMetricsCache: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import { POST } from "@/app/api/webhooks/github/route";
+
+const WEBHOOK_SECRET = "test-webhook-secret-1234";
+
+function signPayload(body: string): string {
+  return `sha256=${crypto.createHmac("sha256", WEBHOOK_SECRET).update(body).digest("hex")}`;
+}
+
+function createRequest(body: string, event = "push", signature?: string): Request {
+  return new Request("http://localhost:3000/api/webhooks/github", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-hub-signature-256": signature ?? signPayload(body),
+      "x-github-event": event,
+    },
+    body,
+  });
+}
+
+describe("webhook response shape — no internal data leakage", () => {
+  beforeEach(() => {
+    process.env.GITHUB_WEBHOOK_SECRET = WEBHOOK_SECRET;
+  });
+
+  const FORBIDDEN_FIELDS = [
+    "githubId",
+    "githubLogin",
+    "accountType",
+    "userMatched",
+    "repository",
+    "after",
+    "commitCount",
+    "reason",
+  ];
+
+  it("successful push response contains only { received: true }", async () => {
+    const body = JSON.stringify({
+      sender: { login: "testuser" },
+      repository: { full_name: "testuser/repo" },
+      commits: [{}],
+      after: "abc123",
+    });
+
+    const res = await POST(createRequest(body) as any);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ received: true });
+
+    for (const field of FORBIDDEN_FIELDS) {
+      expect(json).not.toHaveProperty(field);
+    }
+  });
+
+  it("non-push event response does not leak event type", async () => {
+    const body = JSON.stringify({ action: "created" });
+
+    const res = await POST(createRequest(body, "issues") as any);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ received: true });
+    expect(json).not.toHaveProperty("event");
+    expect(json).not.toHaveProperty("ignored");
+  });
+
+  it("missing actor response does not leak internal reason", async () => {
+    const body = JSON.stringify({
+      repository: { full_name: "org/repo" },
+      commits: [{}],
+    });
+
+    const res = await POST(createRequest(body) as any);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ received: true });
+    expect(json).not.toHaveProperty("reason");
+    expect(json).not.toHaveProperty("userMatched");
+  });
+});


### PR DESCRIPTION
## Summary

Remove verbose response payload from the GitHub webhook handler that exposed internal user IDs, account types, and system metadata to external callers via GitHub's webhook delivery logs.

Closes #1665

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Replaced the verbose webhook success response (which included `githubId`, `accountType`, `githubLogin`, `repository`, `after`, `commitCount`) with a minimal `{ received: true }` acknowledgment
- Removed `ignored: true` and `event` fields from the non-push event response
- Removed `userMatched: false` and `reason` fields from the missing-actor response
- All internal processing logic (cache invalidation, SSE events, path revalidation) remains unchanged
- Error responses (`401`, `400`, `500`) still return appropriate error messages without leaking user data
- Added regression tests asserting the response shape does not contain internal fields

---

## How to Test

1. Send a valid webhook POST request with a correct HMAC signature to `/api/webhooks/github`
2. Verify the response body is `{ "received": true }` regardless of whether the user was matched
3. Verify that non-push events return `{ "received": true }` without leaking the event type
4. Verify that cache invalidation, SSE events, and path revalidation still function correctly (internal logic is unchanged)
5. Confirm error responses (invalid signature, missing secret, bad JSON) still return appropriate error messages
6. Run `npx vitest run test/webhook-response-shape.test.ts` — all 3 assertions pass

---

## Screenshots (if UI change)

N/A — backend-only change.

---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable

---

## Accessibility Checklist

N/A — no UI changes.

---

## Additional Notes

The webhook endpoint previously returned internal system data (`githubId`, `accountType`, `userMatched`, `githubLogin`) in its response body. While the endpoint requires a valid HMAC signature to process requests, the response is visible in GitHub's webhook delivery UI to any repository administrator. This constitutes an information disclosure vulnerability (CWE-200) that enables user enumeration and leaks internal architecture details. The fix returns only the minimum acknowledgment needed by the caller.