### PR TITLE
"feat: validate package subpath exports in check-deps"

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -94,6 +94,40 @@ function loadInternalAliases(rootDir) {
 
   return aliases;
 }
+function isValidPackageSubpath(pkgName, mod, cwd) {
+  try {
+    const pkgJsonPath = require.resolve(
+      `${pkgName}/package.json`,
+      { paths: [cwd] }
+    );
+
+    const pkgJson = JSON.parse(
+      fs.readFileSync(pkgJsonPath, "utf8")
+    );
+
+    const exportsField = pkgJson.exports;
+
+    if (!exportsField) return true;
+
+    const subpath = mod.slice(pkgName.length);
+
+    if (!subpath) return true;
+
+    const exportKey =
+      "." + (subpath.startsWith("/") ? subpath : "/" + subpath);
+
+    if (typeof exportsField === "string") {
+      return exportKey === ".";
+    }
+
+    return (
+      exportKey in exportsField ||
+      "./*" in exportsField
+    );
+  } catch {
+    return true;
+  }
+}
 function collectMissingDeps(files, allDeps, cwd = process.cwd()) {
   const missing = new Map(); // pkgName → Set of files
   // Load Aliases 
@@ -123,7 +157,20 @@ function collectMissingDeps(files, allDeps, cwd = process.cwd()) {
       ) {
         continue;
       }
-      if (allDeps.has(pkgName)) continue;
+      if (allDeps.has(pkgName)) {
+        if (
+          mod !== pkgName &&
+          !isValidPackageSubpath(pkgName, mod, cwd)
+      ) {
+        if (!missing.has(mod)) {
+          missing.set(mod, new Set());
+        }
+
+        missing.get(mod).add(rel);
+      }
+
+       continue;
+     }
 
       if (!missing.has(pkgName)) missing.set(pkgName, new Set());
       missing.get(pkgName).add(rel);


### PR DESCRIPTION
Summary

Adds validation for package subpath imports in "check-deps.js".

Previously, the dependency checker only verified that the base package existed in "package.json". This change adds an additional check for package subpath imports and reports imports that are not exposed through the package's "exports" field.

Example:

import helper from "some-package/internal/helper";

If "some-package/internal/helper" is not exported by the package, the checker will now report it.

Changes Made

- Added "isValidPackageSubpath()" helper function
- Added validation for package subpath imports
- Updated dependency checking logic in "collectMissingDeps()"
- Reports invalid package subpath imports as missing dependencies

Why

This helps catch invalid imports earlier and prevents build-time or runtime failures caused by importing private package internals.

Testing

- Verified existing dependency checks continue to work
- Verified package subpath imports are validated before being accepted
- Confirmed no changes to relative imports, aliases, framework aliases, or Node built-in modules

Closes #1712 