### PR TITLE
fix: show native share button on desktop browsers supporting Web Share API

### DIFF
--- a/src/components/ShareProfileSection.tsx
+++ b/src/components/ShareProfileSection.tsx
@@ -20,9 +20,7 @@ export default function ShareProfileSection({
   useEffect(() => {
     setCanUseNativeShare(
       typeof navigator !== "undefined" &&
-        "share" in navigator &&
-        typeof window !== "undefined" &&
-        window.matchMedia("(pointer: coarse)").matches
+        "share" in navigator
     );
   }, []);
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the native Share button was only displayed on devices with a coarse pointer (typically mobile devices).

The previous implementation required both Web Share API support and a coarse pointer device, which prevented the Share button from appearing on desktop browsers that already support `navigator.share()`.

### Changes Made

* Removed the `pointer: coarse` device check.
* Enabled the Share button whenever the browser supports the Web Share API.
* Ensured a consistent sharing experience across supported mobile and desktop browsers.

### Before

The Share button was hidden on desktop browsers even when `navigator.share()` was available.

### After

The Share button is displayed on any browser that supports the Web Share API, regardless of device type.

### Testing

* Verified that the Share button appears when `navigator.share()` is supported.
* Confirmed that existing sharing functionality continues to work as expected.

Fixes #1717 
