### PR TITLE
feat: add leaderboard filtering by language and time range

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,28 +1,31 @@
 // @ts-nocheck
 import { NextRequest, NextResponse } from "next/server";
-import { cacheGet, isMetricsCacheBypassed } from "@/lib/metrics-cache";
-import { pruneExpiredRateLimits, type RateLimitEntry } from "@/lib/leaderboard-cache";
+import { cacheGet, cacheSet, isMetricsCacheBypassed } from "@/lib/metrics-cache";
+import {
+  CACHE_STALE_SECONDS,
+  getLeaderboardCacheKey as getBaseLeaderboardCacheKey,
+  getLeaderboardData,
+  isFresh,
+  LEADERBOARD_BUILD_LOCK_KEY,
+  type LeaderboardPayload,
+  type LeaderboardPeriod,
+} from "@/lib/leaderboard";
+import {
+  pruneExpiredRateLimits,
+  type RateLimitEntry,
+} from "@/lib/leaderboard-cache";
 import {
   getUpstashConfig,
   upstashRateLimitFixedWindow,
   upstashTryAcquireLock,
 } from "@/lib/upstash-rest";
-import {
-  buildLeaderboard,
-  getMemoryCachedLeaderboard,
-  setMemoryCachedLeaderboard,
-  isFresh,
-  LEADERBOARD_CACHE_KEY,
-  LEADERBOARD_BUILD_LOCK_KEY,
-  CACHE_STALE_SECONDS,
-  type LeaderboardPayload,
-} from "@/lib/leaderboard";
-import { cacheSet } from "@/lib/metrics-cache";
 
 export const revalidate = 3600;
 
 const RATE_LIMIT_REQUESTS = 20;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const LANGUAGE_REPO_LIMIT = 8;
+
 const memoryRateLimits = new Map<string, RateLimitEntry>();
 
 function getRateLimitKey(req: NextRequest): string {
@@ -62,12 +65,130 @@ async function checkRateLimit(
       windowSeconds: Math.ceil(RATE_LIMIT_WINDOW_MS / 1000),
     });
   }
+
   return checkMemoryRateLimit(ip);
+}
+
+function normalizeLanguage(value: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function normalizePeriod(value: string | null): LeaderboardPeriod {
+  if (value === "week" || value === "month" || value === "all") {
+    return value;
+  }
+
+  return "all";
+}
+
+function getLanguageCacheKey(filters: {
+  language: string;
+  period: LeaderboardPeriod;
+}): string {
+  return `${getBaseLeaderboardCacheKey(filters.period)}:${filters.language}`;
+}
+
+function getLeaderboardBuildLockCacheKey(cacheKey: string): string {
+  return `${LEADERBOARD_BUILD_LOCK_KEY}:${cacheKey}`;
+}
+
+async function fetchGitHubJson<T>(path: string): Promise<T | null> {
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const res = await fetch(`https://api.github.com${path}`, {
+      headers,
+      next: { revalidate: 3600 },
+    });
+
+    if (!res.ok) {
+      console.error("GitHub leaderboard request failed:", path, res.status);
+      return null;
+    }
+
+    return (await res.json()) as T;
+  } catch (error) {
+    console.error("GitHub leaderboard request error:", path, error);
+    return null;
+  }
+}
+
+async function fetchLanguageRepositories(
+  username: string,
+  language: string
+): Promise<string[]> {
+  const query = new URLSearchParams({
+    q: `user:${username} language:${language}`,
+    per_page: String(LANGUAGE_REPO_LIMIT),
+    sort: "updated",
+    order: "desc",
+  });
+
+  const data = await fetchGitHubJson<{
+    items: Array<{ full_name: string }>;
+  }>(`/search/repositories?${query.toString()}`);
+
+  return data?.items.map((repo) => repo.full_name) ?? [];
+}
+
+async function filterLeaderboardByLanguage(
+  leaderboard: LeaderboardPayload,
+  language: string
+): Promise<LeaderboardPayload> {
+  const normalizedLanguage = language.trim().toLowerCase();
+  if (!normalizedLanguage) {
+    return leaderboard;
+  }
+
+  const filterEntries = async (
+    entries: LeaderboardPayload["leaders"]["streak"]
+  ) => {
+    const matches = await Promise.all(
+      entries.map(async (entry) => {
+        const repos = await fetchLanguageRepositories(
+          entry.username,
+          normalizedLanguage
+        );
+        return repos.length > 0 ? entry : null;
+      })
+    );
+
+    return matches.filter(
+      (entry): entry is LeaderboardPayload["leaders"]["streak"][number] =>
+        entry !== null
+    );
+  };
+
+  return {
+    ...leaderboard,
+    leaders: {
+      streak: await filterEntries(leaderboard.leaders.streak),
+      commits: await filterEntries(leaderboard.leaders.commits),
+      prs: await filterEntries(leaderboard.leaders.prs),
+    },
+  };
 }
 
 export async function GET(req: NextRequest) {
   const ip = getRateLimitKey(req);
   const rateLimit = await checkRateLimit(ip);
+  const language = normalizeLanguage(req.nextUrl.searchParams.get("lang"));
+  const period = normalizePeriod(req.nextUrl.searchParams.get("period"));
+  const cacheKey = language
+    ? getLanguageCacheKey({ language, period })
+    : getBaseLeaderboardCacheKey(period);
 
   if (!rateLimit.allowed) {
     return NextResponse.json(
@@ -82,23 +203,16 @@ export async function GET(req: NextRequest) {
   const bypass = isMetricsCacheBypassed(req);
 
   if (!bypass) {
-    const mem = getMemoryCachedLeaderboard();
-    if (mem) {
-      return NextResponse.json(mem, {
+    const cached = await cacheGet<LeaderboardPayload>(cacheKey);
+    if (cached && isFresh(cached)) {
+      return NextResponse.json(cached, {
         headers: { "x-devtrack-leaderboard-cache": "memory" },
       });
     }
 
-    const cached = await cacheGet<LeaderboardPayload>(LEADERBOARD_CACHE_KEY);
-    if (cached && isFresh(cached)) {
-      setMemoryCachedLeaderboard(cached);
-      return NextResponse.json(cached);
-    }
-
-    // Avoid thundering herd on cache misses across serverless instances.
     if (getUpstashConfig()) {
       const locked = await upstashTryAcquireLock({
-        key: LEADERBOARD_BUILD_LOCK_KEY,
+        key: getLeaderboardBuildLockCacheKey(cacheKey),
         ttlSeconds: 5 * 60,
       });
 
@@ -108,6 +222,7 @@ export async function GET(req: NextRequest) {
             headers: { "x-devtrack-leaderboard-cache": "stale" },
           });
         }
+
         return NextResponse.json(
           { error: "Leaderboard is rebuilding. Please retry shortly." },
           { status: 503, headers: { "Retry-After": "5" } }
@@ -117,17 +232,42 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const payload = await buildLeaderboard();
-    await cacheSet(LEADERBOARD_CACHE_KEY, payload, CACHE_STALE_SECONDS);
-    setMemoryCachedLeaderboard(payload);
+    const baseLeaderboard = await getLeaderboardData(bypass, { period });
+
+    if (!baseLeaderboard) {
+      const stale = await cacheGet<LeaderboardPayload>(cacheKey);
+      if (stale) {
+        return NextResponse.json(stale, {
+          headers: { "x-devtrack-leaderboard-cache": "error-stale" },
+        });
+      }
+
+      return NextResponse.json(
+        { error: "Failed to build leaderboard" },
+        { status: 500 }
+      );
+    }
+
+    const payload = language
+      ? await filterLeaderboardByLanguage(baseLeaderboard, language)
+      : baseLeaderboard;
+
+    if (!bypass) {
+      await cacheSet(cacheKey, payload, CACHE_STALE_SECONDS);
+    }
+
     return NextResponse.json(payload);
-  } catch (e) {
-    const cached = await cacheGet<LeaderboardPayload>(LEADERBOARD_CACHE_KEY);
+  } catch (error) {
+    console.error("Leaderboard API Error:", error);
+    console.error("Stack:", error instanceof Error ? error.stack : error);
+
+    const cached = await cacheGet<LeaderboardPayload>(cacheKey);
     if (cached) {
       return NextResponse.json(cached, {
         headers: { "x-devtrack-leaderboard-cache": "error-stale" },
       });
     }
+
     return NextResponse.json(
       { error: "Failed to build leaderboard" },
       { status: 500 }

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,10 +1,13 @@
 import Link from "next/link";
 import Image from "next/image";
+import { Suspense } from "react";
 import EmptyState from "@/components/EmptyState";
+import LeaderboardFilters from "@/components/leaderboard/LeaderboardFilters";
 import SponsorBadge from "@/components/SponsorBadge";
-import { getLeaderboardData, type LeaderboardPayload } from "@/lib/leaderboard";
+import type { LeaderboardPayload } from "@/lib/leaderboard";
 
 type LeaderboardTab = "streak" | "commits" | "prs";
+type LeaderboardPeriod = "week" | "month" | "all";
 
 interface LeaderboardEntry {
   id: string;
@@ -21,9 +24,72 @@ interface LeaderboardEntry {
 
 const tabs: Array<{ id: LeaderboardTab; label: string; metric: string }> = [
   { id: "streak", label: "Streak", metric: "days" },
-  { id: "commits", label: "Commits", metric: "this month" },
-  { id: "prs", label: "PRs", metric: "this month" },
+  { id: "commits", label: "Commits", metric: "commits" },
+  { id: "prs", label: "PRs", metric: "pull requests" },
 ];
+
+const periods: Record<LeaderboardPeriod, string> = {
+  week: "this week",
+  month: "this month",
+  all: "all time",
+};
+
+function isLeaderboardPeriod(value: string | undefined): value is LeaderboardPeriod {
+  return value === "week" || value === "month" || value === "all";
+}
+
+function leaderboardHref(
+  tab: LeaderboardTab,
+  filters: { lang?: string; period: LeaderboardPeriod }
+): string {
+  const params = new URLSearchParams({ tab });
+
+  if (filters.lang) {
+    params.set("lang", filters.lang);
+  }
+
+  if (filters.period !== "all") {
+    params.set("period", filters.period);
+  }
+
+  return `/leaderboard?${params.toString()}`;
+}
+
+async function fetchLeaderboard(filters: {
+  lang?: string;
+  period: LeaderboardPeriod;
+}): Promise<LeaderboardPayload | null> {
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    "http://localhost:3000";
+  const params = new URLSearchParams();
+
+  if (filters.lang) {
+    params.set("lang", filters.lang);
+  }
+
+  if (filters.period !== "all") {
+    params.set("period", filters.period);
+  }
+
+  const query = params.toString();
+
+  try {
+    const res = await fetch(`${baseUrl}/api/leaderboard${query ? `?${query}` : ""}`, {
+      next: { revalidate: 3600 },
+    });
+
+    if (!res.ok) {
+      return null;
+    }
+
+    return (await res.json()) as LeaderboardPayload;
+  } catch (error) {
+    console.error("Failed to fetch leaderboard:", error);
+    return null;
+  }
+}
 
 function getMetricValue(entry: LeaderboardEntry, tab: LeaderboardTab): number {
   if (tab === "streak") return entry.streak;
@@ -34,22 +100,22 @@ function getMetricValue(entry: LeaderboardEntry, tab: LeaderboardTab): number {
 export default async function LeaderboardPage({
   searchParams,
 }: {
-  searchParams: Promise<{ tab?: string }>;
+  searchParams: { tab?: string; lang?: string; period?: string };
 }) {
   const resolvedSearchParams = await searchParams;
   const activeTab = tabs.some((tab) => tab.id === resolvedSearchParams.tab)
     ? (resolvedSearchParams.tab as LeaderboardTab)
     : "streak";
+  const period = isLeaderboardPeriod(resolvedSearchParams.period)
+    ? resolvedSearchParams.period
+    : "all";
+  const filters = { lang: resolvedSearchParams.lang, period };
+  const hasFilters = Boolean(filters.lang) || period !== "all";
 
-  let leaderboard: LeaderboardPayload | null = null;
-  try {
-    leaderboard = await getLeaderboardData();
-  } catch (err) {
-    console.error("[LeaderboardPage] Failed to load leaderboard data:", err);
-  }
-
+  const leaderboard = await fetchLeaderboard(filters);
   const activeMeta = tabs.find((tab) => tab.id === activeTab) ?? tabs[0];
   const rows = leaderboard?.leaders[activeTab] ?? [];
+  const metricLabel = activeTab === "streak" ? activeMeta.metric : periods[period];
 
   return (
     <main className="min-h-screen bg-[var(--background)] px-4 py-6 text-[var(--foreground)] md:px-8">
@@ -61,7 +127,7 @@ export default async function LeaderboardPage({
             </Link>
             <h1 className="mt-3 text-3xl font-bold text-[var(--foreground)] md:text-4xl">Public Leaderboard</h1>
             <p className="mt-2 max-w-2xl text-sm text-[var(--muted-foreground)] md:text-base">
-              Opted-in developers ranked by current streak, monthly commits, and monthly pull request activity.
+              Opted-in developers ranked by current streak, commits, and pull request activity.
             </p>
           </div>
           {leaderboard && (
@@ -77,7 +143,7 @@ export default async function LeaderboardPage({
             return (
               <Link
                 key={tab.id}
-                href={`/leaderboard?tab=${tab.id}`}
+                href={leaderboardHref(tab.id, filters)}
                 className={`rounded-lg border px-4 py-2 text-sm font-semibold transition-colors ${
                   active
                     ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-foreground)] shadow-sm"
@@ -90,6 +156,10 @@ export default async function LeaderboardPage({
           })}
         </div>
 
+        <Suspense fallback={null}>
+          <LeaderboardFilters />
+        </Suspense>
+
         <section className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-[var(--shadow-soft)]">
           {!leaderboard ? (
             <div className="px-4 py-12 text-center">
@@ -101,8 +171,16 @@ export default async function LeaderboardPage({
           ) : rows.length === 0 ? (
             <EmptyState
               icon="🏆"
-              title="No public profiles yet"
-              description="No public profiles yet - be the first to enable yours in Settings!"
+              title={
+                hasFilters
+                  ? "No leaderboard results for these filters"
+                  : "No public profiles yet"
+              }
+              description={
+                hasFilters
+                  ? "Try a broader language or time filter, or clear filters to view the full leaderboard."
+                  : "No public profiles yet - be the first to enable yours in Settings!"
+              }
               actionLabel="Go to Settings"
               actionHref="/dashboard/settings"
             />
@@ -127,6 +205,7 @@ export default async function LeaderboardPage({
                       alt={`${entry.username} avatar`}
                       width={40}
                       height={40}
+                      unoptimized
                       className="h-10 w-10 rounded-full border border-[var(--border)]"
                     />
                     <div className="min-w-0">
@@ -140,7 +219,7 @@ export default async function LeaderboardPage({
                   </div>
                   <div>
                     <div className="text-lg font-semibold text-[var(--card-foreground)]">{getMetricValue(entry, activeTab)}</div>
-                    <div className="text-xs text-[var(--muted-foreground)]">{activeMeta.metric}</div>
+                    <div className="text-xs text-[var(--muted-foreground)]">{metricLabel}</div>
                   </div>
                   <div className="hidden text-sm font-medium text-[var(--card-foreground)] md:block">{entry.score}</div>
                   <div>

--- a/src/components/leaderboard/LeaderboardFilters.tsx
+++ b/src/components/leaderboard/LeaderboardFilters.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type Period = "week" | "month" | "all";
+
+const STORAGE_KEY = "leaderboard-filters";
+
+const languages = [
+  { label: "TypeScript", value: "typescript" },
+  { label: "JavaScript", value: "javascript" },
+  { label: "Python", value: "python" },
+  { label: "Go", value: "go" },
+  { label: "Rust", value: "rust" },
+  { label: "Java", value: "java" },
+  { label: "C++", value: "c++" },
+  { label: "C", value: "c" },
+  { label: "C#", value: "c#" },
+  { label: "PHP", value: "php" },
+  { label: "Ruby", value: "ruby" },
+  { label: "Kotlin", value: "kotlin" },
+  { label: "Swift", value: "swift" },
+  { label: "Dart", value: "dart" },
+  { label: "Shell", value: "shell" },
+];
+
+const periods: Array<{ label: string; value: Period }> = [
+  { label: "This Week", value: "week" },
+  { label: "This Month", value: "month" },
+  { label: "All Time", value: "all" },
+];
+
+function isPeriod(value: string | null): value is Period {
+  return value === "week" || value === "month" || value === "all";
+}
+
+export default function LeaderboardFilters() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const language = searchParams.get("lang") ?? "";
+  const rawPeriod = searchParams.get("period");
+  const period: Period = isPeriod(rawPeriod) ? rawPeriod : "all";
+
+  const hasFilters = language !== "" || period !== "all";
+
+  const currentFilters = useMemo(
+    () => ({ lang: language, period }),
+    [language, period]
+  );
+
+  useEffect(() => {
+    const hasUrlFilters =
+      searchParams.has("lang") || searchParams.has("period");
+
+    if (!hasUrlFilters) {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stored) as {
+          lang?: string;
+          period?: string;
+        };
+        const nextParams = new URLSearchParams(searchParams.toString());
+
+        if (parsed.lang) {
+          nextParams.set("lang", parsed.lang);
+        }
+        const storedPeriod = parsed.period ?? null;
+        if (isPeriod(storedPeriod) && storedPeriod !== "all") {
+          nextParams.set("period", storedPeriod);
+        }
+
+        const query = nextParams.toString();
+        if (query) {
+          router.replace(`${pathname}?${query}`, { scroll: false });
+        }
+      } catch {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(currentFilters));
+  }, [currentFilters, pathname, router, searchParams]);
+
+  function updateFilters(next: Partial<{ lang: string; period: Period }>) {
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (next.lang !== undefined) {
+      if (next.lang) {
+        params.set("lang", next.lang);
+      } else {
+        params.delete("lang");
+      }
+    }
+
+    if (next.period !== undefined) {
+      if (next.period === "all") {
+        params.delete("period");
+      } else {
+        params.set("period", next.period);
+      }
+    }
+
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }
+
+  function clearFilters() {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("lang");
+    params.delete("period");
+    window.localStorage.removeItem(STORAGE_KEY);
+
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }
+
+  return (
+    <div className="mb-6 rounded-2xl border border-[var(--border)] bg-[var(--card)]/90 p-3 shadow-[var(--shadow-soft)]">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <label className="flex flex-col gap-2 text-sm font-medium text-[var(--card-foreground)] md:min-w-64">
+          Language
+          <select
+            value={language}
+            onChange={(event) => updateFilters({ lang: event.target.value })}
+            className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm text-[var(--card-foreground)] outline-none transition-colors hover:bg-[var(--control)] focus:border-[var(--accent)]"
+          >
+            <option value="">All languages</option>
+            {languages.map((item) => (
+              <option key={item.value} value={item.value}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="flex flex-col gap-2 text-sm font-medium text-[var(--card-foreground)]">
+          Time range
+          <div className="grid grid-cols-3 gap-1 rounded-lg border border-[var(--border)] bg-[var(--control)] p-1">
+            {periods.map((item) => {
+              const active = item.value === period;
+              return (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => updateFilters({ period: item.value })}
+                  className={`rounded-md px-3 py-2 text-xs font-semibold transition-colors sm:text-sm ${
+                    active
+                      ? "bg-[var(--accent)] text-[var(--accent-foreground)] shadow-sm"
+                      : "text-[var(--muted-foreground)] hover:bg-[var(--card)] hover:text-[var(--card-foreground)]"
+                  }`}
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={clearFilters}
+          disabled={!hasFilters}
+          className="secondary-button rounded-lg px-4 py-2 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Clear filters
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -132,7 +132,7 @@ export function setMemoryCachedLeaderboard(
  */
 export async function clearLeaderboardCache(): Promise<void> {
   // 1. Drop the module-level in-process cache.
-  _memoryCache = null;
+  _memoryCache.clear();
 
   // 2. Drop the shared key from the metrics memory map and from Redis/Upstash
   //    so that other serverless instances also see a cache miss on their next

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -82,7 +82,7 @@ const DEFAULT_PERIOD: LeaderboardPeriod = "month";
 
 // Module-level in-memory cache shared between the server component and API route
 // within the same Node.js process (standalone mode).
-const _memoryCache = new Map<string, LeaderboardCacheEntry<LeaderboardPayload>>();
+let _memoryCache = new Map<string, LeaderboardCacheEntry<LeaderboardPayload>>();
 
 export function isFresh(payload: LeaderboardPayload): boolean {
   const ts = Date.parse(payload.generatedAt);

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -14,6 +14,11 @@ export const LEADERBOARD_BUILD_LOCK_KEY = "leaderboard:build-lock:v1";
 const GITHUB_API = "https://api.github.com";
 
 export type LeaderboardMetric = "streak" | "commits" | "prs";
+export type LeaderboardPeriod = "week" | "month" | "all";
+
+export interface LeaderboardFilters {
+  period?: LeaderboardPeriod;
+}
 
 export interface PublicUser {
   id: string;
@@ -73,28 +78,47 @@ const USER_CONCURRENCY = validateUserConcurrency(
   process.env.LEADERBOARD_USER_CONCURRENCY
 );
 
+const DEFAULT_PERIOD: LeaderboardPeriod = "month";
+
 // Module-level in-memory cache shared between the server component and API route
 // within the same Node.js process (standalone mode).
-let _memoryCache: LeaderboardCacheEntry<LeaderboardPayload> | null = null;
+const _memoryCache = new Map<string, LeaderboardCacheEntry<LeaderboardPayload>>();
 
 export function isFresh(payload: LeaderboardPayload): boolean {
   const ts = Date.parse(payload.generatedAt);
   return Number.isFinite(ts) && Date.now() - ts < CACHE_REFRESH_SECONDS * 1000;
 }
 
-export function getMemoryCachedLeaderboard(): LeaderboardPayload | null {
-  _memoryCache = pruneExpiredLeaderboardCache(_memoryCache);
-  if (_memoryCache && isFresh(_memoryCache.payload)) {
-    return _memoryCache.payload;
+export function getLeaderboardCacheKey(period: LeaderboardPeriod = DEFAULT_PERIOD): string {
+  return `${LEADERBOARD_CACHE_KEY}:${period}`;
+}
+
+export function getMemoryCachedLeaderboard(
+  period: LeaderboardPeriod = DEFAULT_PERIOD
+): LeaderboardPayload | null {
+  const cacheKey = getLeaderboardCacheKey(period);
+  const cached = pruneExpiredLeaderboardCache(_memoryCache.get(cacheKey));
+
+  if (cached && isFresh(cached.payload)) {
+    return cached.payload;
   }
+
+  if (!cached) {
+    _memoryCache.delete(cacheKey);
+  }
+
   return null;
 }
 
-export function setMemoryCachedLeaderboard(payload: LeaderboardPayload): void {
-  _memoryCache = {
+export function setMemoryCachedLeaderboard(
+  payload: LeaderboardPayload,
+  period: LeaderboardPeriod = DEFAULT_PERIOD
+): void {
+  const cacheKey = getLeaderboardCacheKey(period);
+  _memoryCache.set(cacheKey, {
     payload,
     expiresAt: Date.now() + CACHE_REFRESH_SECONDS * 1000,
-  };
+  });
 }
 
 /**
@@ -189,9 +213,23 @@ function calculateCurrentStreak(commitDates: string[]): number {
   return latest.end === today || latest.end === yesterday ? latest.length : 0;
 }
 
-async function fetchCommitStats(username: string, since: string) {
+function getPeriodSince(period: LeaderboardPeriod): string | undefined {
+  if (period === "all") {
+    return undefined;
+  }
+
+  const days = period === "week" ? 7 : 30;
+  return toDateStr(new Date(Date.now() - days * 86400000));
+}
+
+async function fetchCommitStats(username: string, since?: string) {
   const query = new URLSearchParams({
-    q: `author:${username} author-date:>=${since}`,
+    q: [
+      `author:${username}`,
+      since ? `author-date:>=${since}` : "",
+    ]
+      .filter(Boolean)
+      .join(" "),
     per_page: "100",
     sort: "author-date",
     order: "desc",
@@ -202,9 +240,15 @@ async function fetchCommitStats(username: string, since: string) {
   }>(`/search/commits?${query}`);
 }
 
-async function fetchPrCount(username: string, since: string): Promise<number> {
+async function fetchPrCount(username: string, since?: string): Promise<number> {
   const query = new URLSearchParams({
-    q: `author:${username} type:pr created:>=${since}`,
+    q: [
+      `author:${username}`,
+      "type:pr",
+      since ? `created:>=${since}` : "",
+    ]
+      .filter(Boolean)
+      .join(" "),
     per_page: "1",
   });
   const data = await fetchGitHubJson<{ total_count: number }>(
@@ -213,7 +257,11 @@ async function fetchPrCount(username: string, since: string): Promise<number> {
   return data?.total_count ?? 0;
 }
 
-export async function buildLeaderboard(): Promise<LeaderboardPayload> {
+export async function buildLeaderboard(
+  filters: LeaderboardFilters = {}
+): Promise<LeaderboardPayload> {
+  const period = filters.period ?? DEFAULT_PERIOD;
+  const periodStart = getPeriodSince(period);
   const { data: users, error } = await supabaseAdmin
     .from("users")
     .select("id, github_login, is_sponsor")
@@ -227,9 +275,6 @@ export async function buildLeaderboard(): Promise<LeaderboardPayload> {
   }
 
   const now = new Date();
-  const monthStart = toDateStr(
-    new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
-  );
   const streakStart = toDateStr(new Date(Date.now() - 90 * 86400000));
   const safeUsers = (users ?? []) as PublicUser[];
 
@@ -238,9 +283,9 @@ export async function buildLeaderboard(): Promise<LeaderboardPayload> {
     USER_CONCURRENCY,
     async (user) => {
       const [monthlyCommits, streakCommits, prs] = await Promise.all([
-        fetchCommitStats(user.github_login, monthStart),
+        fetchCommitStats(user.github_login, periodStart),
         fetchCommitStats(user.github_login, streakStart),
-        fetchPrCount(user.github_login, monthStart),
+        fetchPrCount(user.github_login, periodStart),
       ]);
 
       const streak = calculateCurrentStreak(
@@ -288,28 +333,31 @@ export async function buildLeaderboard(): Promise<LeaderboardPayload> {
  * where multiple serverless instances may race.
  */
 export async function getLeaderboardData(
-  bypass = false
+  bypass = false,
+  filters: LeaderboardFilters = {}
 ): Promise<LeaderboardPayload | null> {
+  const period = filters.period ?? DEFAULT_PERIOD;
   if (!bypass) {
-    const mem = getMemoryCachedLeaderboard();
+    const mem = getMemoryCachedLeaderboard(period);
     if (mem) return mem;
 
-    const cached = await cacheGet<LeaderboardPayload>(LEADERBOARD_CACHE_KEY);
+    const cached = await cacheGet<LeaderboardPayload>(getLeaderboardCacheKey(period));
     if (cached && isFresh(cached)) {
-      setMemoryCachedLeaderboard(cached);
+      setMemoryCachedLeaderboard(cached, period);
       return cached;
     }
   }
 
   try {
-    const payload = await buildLeaderboard();
-    await cacheSet(LEADERBOARD_CACHE_KEY, payload, CACHE_STALE_SECONDS);
-    setMemoryCachedLeaderboard(payload);
+    const payload = await buildLeaderboard(filters);
+    const cacheKey = getLeaderboardCacheKey(period);
+    await cacheSet(cacheKey, payload, CACHE_STALE_SECONDS);
+    setMemoryCachedLeaderboard(payload, period);
     return payload;
   } catch (err) {
     console.error("[Leaderboard] Build failed:", err);
     // Return stale data rather than null when the fresh build fails.
-    const stale = await cacheGet<LeaderboardPayload>(LEADERBOARD_CACHE_KEY);
+    const stale = await cacheGet<LeaderboardPayload>(getLeaderboardCacheKey(period));
     return stale ?? null;
   }
 }


### PR DESCRIPTION
## Summary

Implements leaderboard filtering by language and time range for the DevTrack leaderboard.

### Features Added

* Language dropdown filtering
* Time range filtering:

  * This Week
  * This Month
  * All Time
* URL query parameter synchronization
* localStorage persistence for filters
* Clear filters functionality
* Mobile responsive filter UI
* Filter-aware leaderboard API query handling
* Defensive filtering for missing language data

### API Updates

Supports leaderboard queries like:

```txt id="u3m8rc"
/api/leaderboard?lang=python&period=month
```

---

## Screenshots
<img width="1358" height="579" alt="image" src="https://github.com/user-attachments/assets/347a0204-250e-48d8-8cdc-dce35decd604" />

---

## Verification

Tested:

* `/leaderboard`
* `/leaderboard?lang=python`
* `/leaderboard?tab=commits&period=month`
* `/leaderboard?tab=streak&lang=typescript`

Verified:

* rankings render correctly
* filters update without page reload
* URL reflects active filters
* leaderboard remains stable
* mobile responsiveness works
* `npm run lint` passes

---

## Notes

Local development database currently contains only one public leaderboard user, so local filtered leaderboard views may show limited results. The filtering system itself works correctly against the available dataset.

Closes #1045
