### PR TITLE
feat: add fresh  copy success toast for badge markdown

### DIFF
--- a/src/components/BadgeSection.tsx
+++ b/src/components/BadgeSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 
 interface BadgeSectionProps {
@@ -33,9 +33,33 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
   const streakMarkdown = `![DevTrack Streak](${streakBadgeUrl})`;
   const commitsMarkdown = `![DevTrack Commits](${commitsBadgeUrl})`;
   const combinedMarkdown = `${streakMarkdown} ${commitsMarkdown}`;
+  const [toastVisible, setToastVisible] = useState(false);
+  const toastTimerRef = useRef<number | null>(null);
+
+  const showToast = () => {
+    setToastVisible(true);
+
+    if (toastTimerRef.current) {
+      window.clearTimeout(toastTimerRef.current);
+    }
+
+    toastTimerRef.current = window.setTimeout(() => {
+      setToastVisible(false);
+      toastTimerRef.current = null;
+    }, 2000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        window.clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
-    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+    <>
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
       <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
         📌 Get Your Badge
       </h2>
@@ -52,7 +76,7 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
           <div className="mb-2">
             <Image src={streakBadgePreviewUrl} alt="DevTrack Streak" width={150} height={20} className="w-auto h-auto" unoptimized />
           </div>
-          <CopyableCodeBlock code={streakMarkdown} />
+          <CopyableCodeBlock code={streakMarkdown} onCopySuccess={showToast} />
         </div>
 
         {/* Commits Badge */}
@@ -63,7 +87,7 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
           <div className="mb-2">
             <Image src={commitsBadgePreviewUrl} alt="DevTrack Commits" width={150} height={20} className="w-auto h-auto" unoptimized />
           </div>
-          <CopyableCodeBlock code={commitsMarkdown} />
+          <CopyableCodeBlock code={commitsMarkdown} onCopySuccess={showToast} />
         </div>
 
         {/* Combined */}
@@ -75,7 +99,7 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
             <Image src={streakBadgePreviewUrl} alt="DevTrack Streak" width={150} height={20} className="w-auto h-auto" unoptimized />
             <Image src={commitsBadgePreviewUrl} alt="DevTrack Commits" width={150} height={20} className="w-auto h-auto" unoptimized />
           </div>
-          <CopyableCodeBlock code={combinedMarkdown} />
+          <CopyableCodeBlock code={combinedMarkdown} onCopySuccess={showToast} />
         </div>
       </div>
 
@@ -85,19 +109,41 @@ export default function BadgeSection({ username }: BadgeSectionProps) {
         </p>
       </div>
     </div>
+
+      <Toast visible={toastVisible} />
+    </>
+  );
+}
+
+function Toast({ visible }: { visible: boolean }) {
+  return (
+    <div
+      aria-live="polite"
+      role="status"
+      className="pointer-events-none fixed inset-x-0 bottom-6 flex justify-center px-4 z-50"
+    >
+      <div
+        className={`max-w-md rounded-full bg-[var(--foreground)] text-[var(--background)] px-4 py-2 text-sm shadow-lg shadow-black/10 transition-all duration-200 ease-out ${
+          visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+        }`}
+      >
+        Badge markdown copied to clipboard
+      </div>
+    </div>
   );
 }
 
 /**
  * Copyable code block component
  */
-function CopyableCodeBlock({ code }: { code: string }) {
+function CopyableCodeBlock({ code, onCopySuccess }: { code: string; onCopySuccess?: () => void }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
+      onCopySuccess?.();
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       console.error("Failed to copy:", err);


### PR DESCRIPTION
## Summary

Added a toast/snackbar notification when badge markdown is copied from the Badge Section.

Closes #160 

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

---

## Changes Made

* Added a success toast notification for badge markdown copy actions
* Toast appears at the bottom of the screen after a successful clipboard write
* Toast automatically dismisses after approximately 2000ms
* Added accessibility support with `role="status"` and `aria-live="polite"`
* Preserved the existing inline `✓ Copied!` button state
* Ensured functionality works for all badge copy actions (streak, commits, combined)

---

## How to Test

1. Navigate to the Badge Section
2. Click the Streak badge copy button
3. Verify:

   * Badge markdown is copied to the clipboard
   * Existing `✓ Copied!` button state still appears
   * Toast appears at the bottom of the screen
4. Wait ~2 seconds and confirm the toast disappears
5. Repeat for:

   * Commits badge copy button
   * Combined badge copy button

---

## Screenshots (if UI change)



---

## Checklist

* [x] Linked issue in summary
* [x] Self-reviewed the diff
* [x] No unrelated files modified
* [x] Existing functionality preserved
* [ ] Added/updated tests if applicable

---

## Accessibility Checklist

* [x] `role="status"` added
* [x] `aria-live="polite"` added
* [x] Keyboard interaction remains unchanged
* [x] Existing UI behavior preserved

---

## Additional Notes

Implementation was intentionally limited to `src/components/BadgeSection.tsx` to keep the change focused and minimize merge conflict risk.
