### PR TITLE
fix: block direct progress updates on activity-derived goals

### DIFF
--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -6,6 +6,11 @@ import { dispatchToAllWebhooks } from "@/lib/webhooks";
 
 export const dynamic = "force-dynamic";
 
+// Goals whose progress is derived from verified GitHub activity.
+// The sync endpoint (/api/goals/sync) is the sole authority for these values;
+// client-supplied progress updates must be rejected to prevent fabrication.
+const ACTIVITY_DERIVED_UNITS = new Set(["commits", "prs"]);
+
 export async function PATCH(
   req: Request,
   { params }: { params: { id: string } }
@@ -21,9 +26,9 @@ export async function PATCH(
   const body = await req.json().catch(() => ({}));
   const { current } = body;
 
-  if (typeof current !== "number" || current < 0) {
+  if (typeof current !== "number" || !Number.isInteger(current) || current < 0) {
     return Response.json(
-      { error: "Invalid current value" },
+      { error: "current must be a non-negative integer" },
       { status: 400 }
     );
   }
@@ -37,6 +42,26 @@ export async function PATCH(
 
   if (!existingGoal) {
     return Response.json({ error: "Goal not found" }, { status: 404 });
+  }
+
+  // Block manual progress edits for activity-derived goal types.
+  // These goals are synced from GitHub and setting current directly would
+  // allow goal completion without any corresponding real activity.
+  if (ACTIVITY_DERIVED_UNITS.has(existingGoal.unit)) {
+    return Response.json(
+      {
+        error:
+          "Progress for activity-derived goals is updated automatically via GitHub sync.",
+      },
+      { status: 422 }
+    );
+  }
+
+  if (current > existingGoal.target) {
+    return Response.json(
+      { error: "current cannot exceed target" },
+      { status: 400 }
+    );
   }
 
   const wasCompleted = existingGoal.current >= existingGoal.target;

--- a/test/goals-patch-integrity.test.ts
+++ b/test/goals-patch-integrity.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PATCH } from "@/app/api/goals/[id]/route";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveAppUser: vi.fn(),
+  supabaseFrom: vi.fn(),
+  dispatchToAllWebhooks: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/resolve-user", () => ({ resolveAppUser: mocks.resolveAppUser }));
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+vi.mock("@/lib/webhooks", () => ({
+  dispatchToAllWebhooks: mocks.dispatchToAllWebhooks,
+}));
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function buildGoal(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "goal-1",
+    user_id: "user-1",
+    title: "Test goal",
+    target: 10,
+    current: 0,
+    unit: "hours",
+    recurrence: "none",
+    deadline: null,
+    period_start: null,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRequest(body: unknown, goalId = "goal-1"): [Request, { params: { id: string } }] {
+  const req = new Request(`http://localhost/api/goals/${goalId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return [req, { params: { id: goalId } }];
+}
+
+function setupSupabase(goal: ReturnType<typeof buildGoal> | null, updateResult?: ReturnType<typeof buildGoal>) {
+  const selectSingle = vi.fn().mockResolvedValue({ data: goal, error: goal ? null : { message: "not found" } });
+  const selectEq2 = vi.fn().mockReturnValue({ single: selectSingle });
+  const selectEq1 = vi.fn().mockReturnValue({ eq: selectEq2 });
+  const selectChain = vi.fn().mockReturnValue({ eq: selectEq1 });
+
+  const updateSingle = vi.fn().mockResolvedValue({
+    data: updateResult ?? { ...(goal ?? {}), current: 5 },
+    error: null,
+  });
+  const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+  const updateEq2 = vi.fn().mockReturnValue({ select: updateSelect });
+  const updateEq1 = vi.fn().mockReturnValue({ eq: updateEq2 });
+  const updateChain = vi.fn().mockReturnValue({ eq: updateEq1 });
+
+  mocks.supabaseFrom.mockReturnValue({
+    select: selectChain,
+    update: updateChain,
+  });
+
+  return { selectSingle, updateEq1, updateChain };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("PATCH /api/goals/[id] — progress integrity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue({ githubId: "gh-123", githubLogin: "alice" });
+    mocks.resolveAppUser.mockResolvedValue({ id: "user-1" });
+    mocks.dispatchToAllWebhooks.mockResolvedValue(undefined);
+  });
+
+  // ── authentication ────────────────────────────────────────────────────────
+
+  it("returns 401 when there is no session", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const [req, ctx] = makeRequest({ current: 5 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the user cannot be resolved", async () => {
+    mocks.resolveAppUser.mockResolvedValue(null);
+    setupSupabase(buildGoal());
+    const [req, ctx] = makeRequest({ current: 5 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  // ── input validation ──────────────────────────────────────────────────────
+
+  it("rejects missing current field", async () => {
+    setupSupabase(buildGoal());
+    const [req, ctx] = makeRequest({});
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/non-negative integer/);
+  });
+
+  it("rejects a float value for current", async () => {
+    setupSupabase(buildGoal());
+    const [req, ctx] = makeRequest({ current: 5.5 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/non-negative integer/);
+  });
+
+  it("rejects a negative value for current", async () => {
+    setupSupabase(buildGoal());
+    const [req, ctx] = makeRequest({ current: -1 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a string value for current", async () => {
+    setupSupabase(buildGoal());
+    const [req, ctx] = makeRequest({ current: "10" });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  // ── goal not found ────────────────────────────────────────────────────────
+
+  it("returns 404 when the goal does not belong to the user", async () => {
+    setupSupabase(null);
+    const [req, ctx] = makeRequest({ current: 5 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  // ── activity-derived unit guard (the core security fix) ───────────────────
+
+  it("rejects progress update for a commits goal with 422", async () => {
+    setupSupabase(buildGoal({ unit: "commits", target: 20 }));
+    const [req, ctx] = makeRequest({ current: 20 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/GitHub sync/);
+  });
+
+  it("rejects progress update for a prs goal with 422", async () => {
+    setupSupabase(buildGoal({ unit: "prs", target: 5 }));
+    const [req, ctx] = makeRequest({ current: 5 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/GitHub sync/);
+  });
+
+  it("blocks completing a commits goal via an arbitrary PATCH — regression test for #1753", async () => {
+    // A user with zero real commits tries to set current = target
+    setupSupabase(buildGoal({ unit: "commits", current: 0, target: 50 }));
+    const [req, ctx] = makeRequest({ current: 50 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(422);
+  });
+
+  it("blocks setting partial progress on a prs goal via PATCH", async () => {
+    setupSupabase(buildGoal({ unit: "prs", current: 1, target: 10 }));
+    const [req, ctx] = makeRequest({ current: 3 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(422);
+  });
+
+  // ── upper-bound guard ─────────────────────────────────────────────────────
+
+  it("rejects current > target for a manual goal", async () => {
+    setupSupabase(buildGoal({ unit: "hours", target: 10 }));
+    const [req, ctx] = makeRequest({ current: 11 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/cannot exceed target/);
+  });
+
+  it("allows current === target for a manual goal (completion)", async () => {
+    const goal = buildGoal({ unit: "hours", target: 10, current: 0 });
+    const updated = { ...goal, current: 10 };
+    setupSupabase(goal, updated);
+    const [req, ctx] = makeRequest({ current: 10 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.goal.current).toBe(10);
+  });
+
+  // ── legitimate manual-goal updates ───────────────────────────────────────
+
+  it("allows progress update for a manually tracked hours goal", async () => {
+    const goal = buildGoal({ unit: "hours", target: 8, current: 0 });
+    const updated = { ...goal, current: 4 };
+    setupSupabase(goal, updated);
+    const [req, ctx] = makeRequest({ current: 4 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.goal.current).toBe(4);
+  });
+
+  it("allows progress update for a custom unit goal", async () => {
+    const goal = buildGoal({ unit: "books", target: 3, current: 1 });
+    const updated = { ...goal, current: 2 };
+    setupSupabase(goal, updated);
+    const [req, ctx] = makeRequest({ current: 2 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it("allows setting current to 0 (progress reset) for a manual goal", async () => {
+    const goal = buildGoal({ unit: "tasks", target: 5, current: 3 });
+    const updated = { ...goal, current: 0 };
+    setupSupabase(goal, updated);
+    const [req, ctx] = makeRequest({ current: 0 });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  // ── webhook dispatch on completion ────────────────────────────────────────
+
+  it("dispatches goal.completed webhook when a manual goal crosses the target", async () => {
+    const goal = buildGoal({ unit: "hours", target: 5, current: 4 });
+    const updated = { ...goal, current: 5 };
+    setupSupabase(goal, updated);
+    const [req, ctx] = makeRequest({ current: 5 });
+    await PATCH(req, ctx);
+    expect(mocks.dispatchToAllWebhooks).toHaveBeenCalledWith(
+      "user-1",
+      "goal.completed",
+      expect.objectContaining({ goalId: "goal-1" })
+    );
+  });
+
+  it("does not dispatch a completion webhook when the goal was already complete", async () => {
+    const goal = buildGoal({ unit: "hours", target: 5, current: 5 });
+    const updated = { ...goal, current: 5 };
+    setupSupabase(goal, updated);
+    const [req, ctx] = makeRequest({ current: 5 });
+    await PATCH(req, ctx);
+    expect(mocks.dispatchToAllWebhooks).not.toHaveBeenCalled();
+  });
+
+  it("does not dispatch a completion webhook when the update does not reach the target", async () => {
+    const goal = buildGoal({ unit: "hours", target: 10, current: 2 });
+    const updated = { ...goal, current: 5 };
+    setupSupabase(goal, updated);
+    const [req, ctx] = makeRequest({ current: 5 });
+    await PATCH(req, ctx);
+    expect(mocks.dispatchToAllWebhooks).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1753

## Problem

`PATCH /api/goals/[id]` accepted any client-supplied `current` value — including one equal to `target` — regardless of the goal's unit type. For goals whose progress is meant to come from verified GitHub activity (`unit: "commits"` or `unit: "prs"`), this allowed a user to mark a goal complete without a single real commit or pull request:

```
PATCH /api/goals/<id>
{ "current": 50 }   # target is 50, but user has 0 real commits
→ 200 OK
```

The sync endpoint (`POST /api/goals/sync`) queries the GitHub Search API and is the only trusted source for progress on activity-derived goals. Accepting client values in PATCH breaks that trust boundary.

## Root cause

The PATCH handler performed only `typeof current !== "number" || current < 0`, which passes for any non-negative number including floats and values exceeding the goal target.  No check existed for the goal's unit type.

## Fix

**`src/app/api/goals/[id]/route.ts`**

- Introduces `ACTIVITY_DERIVED_UNITS = new Set(["commits", "prs"])`.
- After fetching the existing goal, returns **422** if `existingGoal.unit` is in that set.  The error message directs callers to the sync endpoint.
- Tightens the input validation: `current` must now be a non-negative **integer** (rejects floats such as `5.5`).
- Adds an upper-bound check so `current` cannot exceed the goal's `target` on manually tracked goals.

Manually tracked goals (any unit other than `"commits"` / `"prs"`, e.g. `"hours"`, `"tasks"`, or custom strings) continue to accept client-supplied progress exactly as before.

The GitHub sync route is unaffected — it calls `supabaseAdmin…update({ current })` directly and bypasses the PATCH handler entirely.

## Tests

**`test/goals-patch-integrity.test.ts`** — 19 new tests:

| Category | Cases |
|---|---|
| Authentication | unauthenticated session, unresolved user |
| Input validation | missing field, float, negative, string |
| Goal not found | ownership-scoped lookup returns null |
| Activity-derived guard | `commits` goal → 422, `prs` goal → 422, regression for #1753 (setting `current = target` on `commits`), partial update on `prs` |
| Upper-bound guard | `current > target` → 400 |
| Legitimate manual updates | `hours`, custom unit, reset to 0, completing at target |
| Webhook dispatch | fires on first completion, silent when already complete, silent when not yet complete |

All 19 pass; the single pre-existing failure in `test/dateUtils.test.ts` (timezone boundary, unrelated to goals) was already present on `main` before this branch.