### PR TITLE
fix(data): include missing tables in account deletion handler

### DIFF
--- a/src/app/api/user/data-export/route.ts
+++ b/src/app/api/user/data-export/route.ts
@@ -301,17 +301,38 @@ export async function DELETE(req: NextRequest) {
   await writeAuditLog(user.id, "delete", req);
 
   // --- Data deletion ---------------------------------------------------
+  // Delete webhook_deliveries first — they reference webhook_configs via
+  // webhook_id (not user_id), so we must resolve the IDs before removing
+  // the parent webhook_configs rows.
+  const { data: userWebhooks } = await supabaseAdmin
+    .from("webhook_configs")
+    .select("id")
+    .eq("user_id", user.id);
+
+  const webhookIds = userWebhooks?.map((w) => w.id) ?? [];
+  if (webhookIds.length > 0) {
+    await supabaseAdmin
+      .from("webhook_deliveries")
+      .delete()
+      .in("webhook_id", webhookIds);
+  }
+
+  // Tables with a direct user_id foreign key, ordered to respect any
+  // potential FK constraints (children before parents).
   const tablesToDelete = [
-  "streak_freezes",
-  "streak_milestones",
-  "local_coding_sessions",
-  "local_coding_api_keys",
-  "jira_credentials",
-  "webhook_configs",
-  "user_github_accounts",
-  "goals",
-  "metric_snapshots",
-];
+    "notifications",
+    "ai_insights",
+    "data_export_audit",
+    "streak_freezes",
+    "streak_milestones",
+    "local_coding_sessions",
+    "local_coding_api_keys",
+    "jira_credentials",
+    "webhook_configs",
+    "user_github_accounts",
+    "goals",
+    "metric_snapshots",
+  ];
 
   for (const table of tablesToDelete) {
     await supabaseAdmin.from(table).delete().eq("user_id", user.id);


### PR DESCRIPTION
## Summary

The account deletion handler (`DELETE /api/user/data-export`) was missing 4 tables from its cleanup routine, leaving orphaned rows in the database after a user deleted their account.

Closes #1756

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Added `webhook_deliveries` deletion via `webhook_id` lookup (this table lacks a direct `user_id` column, so IDs are resolved from `webhook_configs` first)
- Added `notifications`, `ai_insights`, and `data_export_audit` to the direct-deletion list
- Reordered tables to respect foreign key constraints (children deleted before parents)
- Fixed inconsistent indentation on the `tablesToDelete` array

**Tables added:**
| Table | Relationship | Why it was missed |
|-------|-------------|-------------------|
| `notifications` | `user_id` FK | Not in original list |
| `ai_insights` | `user_id` FK | Not in original list |
| `data_export_audit` | `user_id` FK | Not in original list |
| `webhook_deliveries` | `webhook_id` FK → `webhook_configs` | Indirect relationship via parent table |

---

## How to Test

1. Create a test user account via GitHub OAuth sign-in
2. Generate some data: create goals, trigger notifications, use AI insights, configure a custom webhook
3. Navigate to Settings → Delete Account
4. Type "DELETE" and confirm
5. Verify in Supabase dashboard that no rows remain in `notifications`, `ai_insights`, `data_export_audit`, or `webhook_deliveries` for that user
6. Confirm the user row itself is also removed from `users`

---

## Screenshots (if UI change)

N/A — backend-only change.

---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

N/A — no UI changes.

---

## Additional Notes

The `webhook_deliveries` table uses `webhook_id` (not `user_id`) as its foreign key, so it cannot be deleted with a simple `.eq("user_id", ...)` call. The fix first queries `webhook_configs` for the user's webhook IDs, then deletes matching deliveries before removing the configs themselves. The `if (webhookIds.length > 0)` guard prevents an empty `.in()` call which could have unexpected behavior in some PostgREST versions.