### PR TITLE
fix: cap SSE connections per user and lengthen poll interval

### DIFF
--- a/src/app/api/stream/route.ts
+++ b/src/app/api/stream/route.ts
@@ -3,8 +3,19 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
+import { activeStreamConnections } from "@/lib/sse";
 
 export const dynamic = "force-dynamic";
+
+// Maximum number of concurrent SSE connections allowed per authenticated user.
+// This prevents a single user's browser tabs from generating unbounded database
+// load: each connection independently polls two tables on every tick.
+const MAX_CONNECTIONS_PER_USER = 4;
+
+// How often each connection polls the database. 15 s is fast enough for the
+// data types involved (goal sync timestamps and unread notification counts)
+// while being 7.5x cheaper per connection than the previous 2 s interval.
+const POLL_INTERVAL_MS = 15_000;
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -17,17 +28,38 @@ export async function GET(req: NextRequest) {
     return new Response("User not found", { status: 404 });
   }
 
+  const userId = user.id;
+
+  // Enforce per-user connection cap before opening the stream.
+  const current = activeStreamConnections.get(userId) ?? 0;
+  if (current >= MAX_CONNECTIONS_PER_USER) {
+    return new Response(
+      JSON.stringify({ error: "Too many concurrent stream connections" }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": "30",
+        },
+      }
+    );
+  }
+
+  // Register this connection before the stream starts so that the count is
+  // accurate even if two requests race during the check above.
+  activeStreamConnections.set(userId, current + 1);
+
   let lastCheckedSyncedAt: string | null = null;
   let lastCheckedUnreadCount: number | null = null;
 
   const stream = new ReadableStream({
-    async start(controller) {
+    start(controller) {
       const checkData = async () => {
         try {
           const { data: goals } = await supabaseAdmin
             .from("goals")
             .select("last_synced_at")
-            .eq("user_id", user.id)
+            .eq("user_id", userId)
             .order("last_synced_at", { ascending: false })
             .limit(1);
 
@@ -36,7 +68,7 @@ export async function GET(req: NextRequest) {
           const { count } = await supabaseAdmin
             .from("notifications")
             .select("*", { count: "exact", head: true })
-            .eq("user_id", user.id)
+            .eq("user_id", userId)
             .eq("read", false);
 
           const currentUnreadCount = count ?? 0;
@@ -65,16 +97,28 @@ export async function GET(req: NextRequest) {
         }
       };
 
-      await checkData();
-
+      // Register the interval and abort handler synchronously so they are
+      // guaranteed to be in place before any async work begins. This prevents
+      // a race where abort() fires before the listener is attached.
       const interval = setInterval(() => {
         checkData();
-      }, 2000);
+      }, POLL_INTERVAL_MS);
 
       req.signal.addEventListener("abort", () => {
         clearInterval(interval);
         controller.close();
+
+        // Decrement the connection counter so the slot becomes available again.
+        const remaining = activeStreamConnections.get(userId) ?? 1;
+        if (remaining <= 1) {
+          activeStreamConnections.delete(userId);
+        } else {
+          activeStreamConnections.set(userId, remaining - 1);
+        }
       });
+
+      // Kick off the first poll immediately (non-blocking).
+      checkData();
     },
   });
 

--- a/src/lib/sse.ts
+++ b/src/lib/sse.ts
@@ -1,4 +1,11 @@
+// Per-user registry of SSE push controllers (one entry per user, last writer
+// wins). Used by server-side code (e.g. webhook dispatch) to push events to a
+// connected client without waiting for the next poll cycle.
 export const sseConnections = new Map<string, ReadableStreamDefaultController>();
+
+// Tracks the number of active /api/stream connections per user so the route
+// can enforce a cap and prevent unbounded database polling.
+export const activeStreamConnections = new Map<string, number>();
 
 export function sendSSEEvent(
   userId: string,

--- a/test/sse-stream-route.test.ts
+++ b/test/sse-stream-route.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { activeStreamConnections } from "@/lib/sse";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveAppUser: vi.fn(),
+  supabaseFrom: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/resolve-user", () => ({ resolveAppUser: mocks.resolveAppUser }));
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(): NextRequest {
+  const controller = new AbortController();
+  return new NextRequest("http://localhost/api/stream", {
+    signal: controller.signal,
+  });
+}
+
+function makeAbortableRequest(): { req: NextRequest; abort: () => void } {
+  const controller = new AbortController();
+  const req = new NextRequest("http://localhost/api/stream", {
+    signal: controller.signal,
+  });
+  return { req, abort: () => controller.abort() };
+}
+
+function setupSupabase(
+  goalSyncedAt: string | null = "2026-01-01T00:00:00Z",
+  unreadCount = 0
+) {
+  // goals query chain: .from("goals").select().eq().order().limit()
+  const goalsChain = {
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({
+      data: goalSyncedAt ? [{ last_synced_at: goalSyncedAt }] : [],
+      error: null,
+    }),
+  };
+  const goalsSelect = vi.fn().mockReturnValue(goalsChain);
+
+  // notifications query chain: .from("notifications").select().eq().eq()
+  const notifChain = {
+    eq: vi.fn().mockReturnThis(),
+    // final .eq() resolves with count
+    // we make the chain resolve at the second .eq call
+  };
+  // The notification query ends with two .eq() calls then awaits
+  const notifInnerEq = vi.fn().mockResolvedValue({ count: unreadCount, error: null });
+  const notifOuterEq = vi.fn().mockReturnValue({ eq: notifInnerEq });
+  const notifSelect = vi.fn().mockReturnValue({ eq: notifOuterEq });
+
+  mocks.supabaseFrom.mockImplementation((table: string) => {
+    if (table === "goals") return { select: goalsSelect };
+    if (table === "notifications") return { select: notifSelect };
+    return { select: vi.fn().mockReturnValue({ eq: vi.fn().mockReturnThis() }) };
+  });
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/stream — SSE stream route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activeStreamConnections.clear();
+
+    mocks.getServerSession.mockResolvedValue({
+      githubId: "gh-1",
+      githubLogin: "alice",
+    });
+    mocks.resolveAppUser.mockResolvedValue({ id: "user-1" });
+    setupSupabase();
+  });
+
+  // ── authentication ────────────────────────────────────────────────────────
+
+  it("returns 401 when there is no session", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/stream/route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when session has no githubId", async () => {
+    mocks.getServerSession.mockResolvedValue({ githubLogin: "alice" });
+    const { GET } = await import("@/app/api/stream/route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the user cannot be resolved", async () => {
+    mocks.resolveAppUser.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/stream/route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+  });
+
+  // ── single connection ────────────────────────────────────────────────────
+
+  it("returns a text/event-stream response for an authenticated user", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+  });
+
+  it("increments the connection counter when a stream is opened", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    await GET(makeRequest());
+    expect(activeStreamConnections.get("user-1")).toBe(1);
+  });
+
+  // ── connection limit enforcement (regression test for #1752) ─────────────
+
+  it("rejects a 5th connection from the same user with 429", async () => {
+    // Manually set the counter to the cap value (4)
+    activeStreamConnections.set("user-1", 4);
+    const { GET } = await import("@/app/api/stream/route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(429);
+  });
+
+  it("includes Retry-After header on 429 responses", async () => {
+    activeStreamConnections.set("user-1", 4);
+    const { GET } = await import("@/app/api/stream/route");
+    const res = await GET(makeRequest());
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("does not increment the counter when a connection is rejected", async () => {
+    activeStreamConnections.set("user-1", 4);
+    const { GET } = await import("@/app/api/stream/route");
+    await GET(makeRequest());
+    // Counter must remain at 4, not 5
+    expect(activeStreamConnections.get("user-1")).toBe(4);
+  });
+
+  it("allows exactly MAX_CONNECTIONS_PER_USER concurrent connections", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+
+    // Open 4 connections — all should succeed
+    const results: Response[] = [];
+    for (let i = 0; i < 4; i++) {
+      results.push(await GET(makeRequest()));
+    }
+    expect(results.every((r) => r.status === 200)).toBe(true);
+    expect(activeStreamConnections.get("user-1")).toBe(4);
+  });
+
+  it("allows different users to have independent connection slots", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+
+    // user-1 is at the cap
+    activeStreamConnections.set("user-1", 4);
+
+    // user-2 connects for the first time — must succeed
+    mocks.resolveAppUser.mockResolvedValue({ id: "user-2" });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    expect(activeStreamConnections.get("user-2")).toBe(1);
+  });
+
+  // ── connection cleanup ─────────────────────────────────────────────────
+
+  it("decrements the connection counter when the request is aborted", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    const { req, abort } = makeAbortableRequest();
+
+    await GET(req);
+    expect(activeStreamConnections.get("user-1")).toBe(1);
+
+    abort();
+    // Allow abort event listener to fire
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(activeStreamConnections.has("user-1")).toBe(false);
+  });
+
+  it("removes the user entry when the last connection closes", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    const { req, abort } = makeAbortableRequest();
+
+    await GET(req);
+    abort();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Entry should be fully removed, not set to 0
+    expect(activeStreamConnections.has("user-1")).toBe(false);
+  });
+
+  it("frees one slot when one of multiple connections closes", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+
+    // Open 3 connections — 2 fixed + 1 abortable
+    await GET(makeRequest());
+    await GET(makeRequest());
+    const { req, abort } = makeAbortableRequest();
+    await GET(req);
+
+    expect(activeStreamConnections.get("user-1")).toBe(3);
+
+    abort();
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Should drop back to 2, not 0
+    expect(activeStreamConnections.get("user-1")).toBe(2);
+  });
+
+  // ── response headers ──────────────────────────────────────────────────
+
+  it("includes Cache-Control: no-cache header", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    const res = await GET(makeRequest());
+    expect(res.headers.get("Cache-Control")).toContain("no-cache");
+  });
+
+  it("includes Connection: keep-alive header", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    const res = await GET(makeRequest());
+    expect(res.headers.get("Connection")).toBe("keep-alive");
+  });
+});


### PR DESCRIPTION
Closes #1752

## Problem

`GET /api/stream` creates an independent `setInterval` for every SSE connection. The interval fires every **2 seconds** and executes **2 Supabase queries** (one on the `goals` table, one on `notifications`) per tick. There is no limit on how many connections a single user can hold open simultaneously.

Concrete impact:

| Concurrent tabs | DB queries / second (per user) |
|---|---|
| 1 | 1 |
| 5 | 5 |
| 10 | 10 |
| N | N |

Resource usage scales linearly. A user with 10 browser tabs — or a browser that reconnects repeatedly due to network flaps — generates 10 polling loops and 20 DB queries per second attributed to a single account. This was confirmed by reading the production code in `src/app/api/stream/route.ts`.

## Root cause

Three compounding problems:

1. **No per-user connection tracking.** Every accepted `GET /api/stream` creates its own interval with no knowledge of how many other connections already exist for that user.
2. **2 s poll interval.** The data polled (goal sync timestamps and unread notification counts) does not change at sub-second granularity, so the frequency is unnecessary.
3. **Abort listener registered after an `await`.** The abort handler that cleans up the interval was registered after `await checkData()`, creating a race: if the request was aborted before that await resolved, the interval was never cleared (orphaned polling loop).

## Fix

**`src/app/api/stream/route.ts`**

- Adds `MAX_CONNECTIONS_PER_USER = 4`. Before opening a stream the handler checks `activeStreamConnections` and returns **429 + `Retry-After: 30`** if the cap is reached.  Four slots cover normal multi-tab usage while eliminating unbounded accumulation.
- Increments the counter on accept, decrements it in the `abort` listener. When the count reaches zero the map entry is deleted so memory is reclaimed.
- Increases `POLL_INTERVAL_MS` from `2 000` ms to `15 000` ms — a **7.5× reduction** in per-connection query frequency for data types that don't need second-level freshness.
- Moves both `setInterval` and `req.signal.addEventListener("abort", …)` to the **synchronous** portion of the `ReadableStream` `start` callback (before any `await`). This closes the race where abort fired before the listener was attached, which previously left intervals running indefinitely.

**`src/lib/sse.ts`**

- Exports `activeStreamConnections: Map<string, number>` alongside the existing `sseConnections` push registry. The two maps serve distinct purposes and are kept separate so `sendSSEEvent` (used by webhook dispatch) is unaffected.

## Worst-case DB load comparison

| Scenario | Before | After |
|---|---|---|
| 1 tab | 1 q/s | 0.13 q/s |
| 4 tabs (cap) | 4 q/s | 0.53 q/s |
| 5th tab | 5 q/s | **rejected (429)** |
| N tabs | N q/s | ≤ 0.53 q/s |

## Tests

**`test/sse-stream-route.test.ts`** — 15 new tests:

| Category | Cases |
|---|---|
| Auth guards | no session, missing githubId, unresolved user |
| Single connection | 200 + SSE headers, counter incremented to 1 |
| Connection-limit enforcement | 5th connection → 429, Retry-After header present, counter stays at 4 |
| Cross-user isolation | cap on user-1 does not block user-2 |
| Cleanup | abort decrements counter; last-connection close removes map entry; partial close leaves remaining count |
| Response headers | Content-Type, Cache-Control, Connection |

All 15 new tests and all 7 existing `test/sse.test.ts` tests pass. The only failing test in the suite (`test/dateUtils.test.ts` — timezone boundary) is pre-existing and unrelated to this change.