### PR TITLE
fix: match sponsors on immutable github_id instead of mutable login

### DIFF
--- a/src/app/api/sponsors/sync/route.ts
+++ b/src/app/api/sponsors/sync/route.ts
@@ -3,10 +3,21 @@ import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
+// Sponsor identity must be tied to GitHub's immutable numeric account ID
+// (databaseId / github_id) rather than the mutable login name. A user can
+// rename their GitHub account at any time, and GitHub recycles usernames
+// after a grace period. Matching on login would allow a new account that
+// claims a recycled username to inherit sponsor privileges.
+
+interface SponsorIdentity {
+  githubId: string;  // immutable numeric ID stringified, matches users.github_id
+  login: string;     // current login, kept for logging/response only
+}
+
 export async function GET(req: Request) {
   const authHeader = req.headers.get("authorization");
   const cronSecret = process.env.CRON_SECRET;
-  
+
   if (!cronSecret) {
     return NextResponse.json({ error: "CRON_SECRET is not configured" }, { status: 500 });
   }
@@ -23,6 +34,8 @@ export async function GET(req: Request) {
   const targetOwner = "Priyanshu-byte-coder";
 
   try {
+    // Request databaseId alongside login so we can match on the immutable
+    // GitHub numeric account identifier rather than the mutable username.
     const query = `
       query {
         user(login: "${targetOwner}") {
@@ -30,9 +43,11 @@ export async function GET(req: Request) {
             nodes {
               sponsorEntity {
                 ... on User {
+                  databaseId
                   login
                 }
                 ... on Organization {
+                  databaseId
                   login
                 }
               }
@@ -58,7 +73,7 @@ export async function GET(req: Request) {
     }
 
     const { data, errors } = await res.json();
-    
+
     if (errors && errors.length > 0) {
       console.error("GraphQL errors:", errors);
       return NextResponse.json({ error: "GraphQL query failed" }, { status: 502 });
@@ -68,21 +83,29 @@ export async function GET(req: Request) {
       console.error("GraphQL returned empty data or null user");
       return NextResponse.json({ error: "GraphQL query returned no user data" }, { status: 502 });
     }
-    
-    const sponsorLogins: string[] = [];
-    
+
+    // Build the authoritative sponsor list keyed on immutable GitHub IDs.
+    const currentSponsors: SponsorIdentity[] = [];
+
     if (data.user.sponsorshipsAsMaintainer?.nodes) {
-      const nodes = data.user.sponsorshipsAsMaintainer.nodes;
-      for (const node of nodes) {
-        if (node.sponsorEntity?.login) {
-          sponsorLogins.push(node.sponsorEntity.login);
+      for (const node of data.user.sponsorshipsAsMaintainer.nodes) {
+        const entity = node.sponsorEntity;
+        if (entity?.databaseId) {
+          currentSponsors.push({
+            githubId: String(entity.databaseId),
+            login: entity.login ?? "",
+          });
         }
       }
     }
 
-    const { data: currentSponsors, error: fetchErr } = await supabaseAdmin
+    const sponsorGithubIds = new Set(currentSponsors.map((s) => s.githubId));
+
+    // Fetch the set of users currently marked as sponsors using their
+    // immutable github_id, not their login.
+    const { data: existingSponsors, error: fetchErr } = await supabaseAdmin
       .from("users")
-      .select("github_login")
+      .select("github_id")
       .eq("is_sponsor", true);
 
     if (fetchErr) {
@@ -90,42 +113,44 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: "Database error" }, { status: 500 });
     }
 
-    const currentLogins = new Set<string>(
-      (currentSponsors || []).map((u: any) => String(u.github_login))
+    const existingIds = new Set<string>(
+      (existingSponsors ?? []).map((u: { github_id: string }) => u.github_id)
     );
-    const newLogins = new Set<string>(sponsorLogins);
 
-    const toRemove = [...currentLogins].filter((login: string) => !newLogins.has(login));
-    const toAdd = [...newLogins].filter((login: string) => !currentLogins.has(login));
+    // Diff on immutable IDs.
+    const toRevoke = [...existingIds].filter((id) => !sponsorGithubIds.has(id));
+    const toGrant  = [...sponsorGithubIds].filter((id) => !existingIds.has(id));
 
-    if (toRemove.length > 0) {
+    if (toRevoke.length > 0) {
       const { error } = await supabaseAdmin
         .from("users")
         .update({ is_sponsor: false })
-        .in("github_login", toRemove);
-      
+        .in("github_id", toRevoke);
+
       if (error) {
-        console.error("Failed to remove sponsors:", error);
+        console.error("Failed to revoke sponsors:", error);
         return NextResponse.json({ error: "Database error" }, { status: 500 });
       }
     }
 
-    if (toAdd.length > 0) {
+    if (toGrant.length > 0) {
       const { error } = await supabaseAdmin
         .from("users")
         .update({ is_sponsor: true })
-        .in("github_login", toAdd);
-      
+        .in("github_id", toGrant);
+
       if (error) {
-        console.error("Failed to add sponsors:", error);
+        console.error("Failed to grant sponsors:", error);
         return NextResponse.json({ error: "Database error" }, { status: 500 });
       }
     }
 
-    return NextResponse.json({ 
-      success: true, 
-      sponsorCount: sponsorLogins.length, 
-      sponsors: sponsorLogins 
+    return NextResponse.json({
+      success: true,
+      sponsorCount: currentSponsors.length,
+      granted: toGrant.length,
+      revoked: toRevoke.length,
+      sponsors: currentSponsors.map((s) => s.login),
     });
   } catch (error) {
     console.error("Error in sponsors sync:", error);

--- a/test/sponsors-sync.test.ts
+++ b/test/sponsors-sync.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "@/app/api/sponsors/sync/route";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  supabaseFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+
+// Replace global fetch so we can control GitHub API responses.
+vi.stubGlobal("fetch", mocks.fetch);
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const VALID_SECRET = "test-cron-secret";
+
+function makeRequest(authHeader?: string): Request {
+  return new Request("http://localhost/api/sponsors/sync", {
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+function authedRequest(): Request {
+  return makeRequest(`Bearer ${VALID_SECRET}`);
+}
+
+/** Build a minimal GitHub GraphQL response with the given sponsor entries. */
+function graphqlResponse(
+  sponsors: Array<{ databaseId: number; login: string; type?: "User" | "Organization" }>
+) {
+  return {
+    ok: true,
+    json: async () => ({
+      data: {
+        user: {
+          sponsorshipsAsMaintainer: {
+            nodes: sponsors.map((s) => ({
+              sponsorEntity: { databaseId: s.databaseId, login: s.login },
+            })),
+          },
+        },
+      },
+    }),
+  };
+}
+
+/** Set up Supabase mock for a given set of currently-flagged sponsor github_ids. */
+function setupSupabase(currentSponsorIds: string[]) {
+  const updateInChain = vi.fn().mockResolvedValue({ error: null });
+  const updateChain = vi.fn().mockReturnValue({ in: updateInChain });
+
+  const selectEqChain = vi.fn().mockResolvedValue({
+    data: currentSponsorIds.map((id) => ({ github_id: id })),
+    error: null,
+  });
+  const selectChain = vi.fn().mockReturnValue({ eq: selectEqChain });
+
+  mocks.supabaseFrom.mockReturnValue({
+    select: selectChain,
+    update: updateChain,
+  });
+
+  return { updateChain, updateInChain };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/sponsors/sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("CRON_SECRET", VALID_SECRET);
+    vi.stubEnv("GITHUB_TOKEN", "gh-token");
+  });
+
+  // ── authentication ────────────────────────────────────────────────────────
+
+  it("returns 500 when CRON_SECRET is not configured", async () => {
+    vi.stubEnv("CRON_SECRET", "");
+    const res = await GET(authedRequest());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 when authorization header is missing in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when authorization header is wrong in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const res = await GET(makeRequest("Bearer wrong-secret"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when GITHUB_TOKEN is not configured", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "");
+    const res = await GET(authedRequest());
+    expect(res.status).toBe(500);
+  });
+
+  // ── GitHub API errors ─────────────────────────────────────────────────────
+
+  it("returns 502 when the GitHub GraphQL request fails", async () => {
+    mocks.fetch.mockResolvedValue({ ok: false, status: 500 });
+    const res = await GET(authedRequest());
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 when the GraphQL response contains errors", async () => {
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ errors: [{ message: "Forbidden" }] }),
+    });
+    const res = await GET(authedRequest());
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 when GraphQL data.user is null", async () => {
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { user: null } }),
+    });
+    const res = await GET(authedRequest());
+    expect(res.status).toBe(502);
+  });
+
+  // ── immutable ID matching (core fix for #1751) ───────────────────────────
+
+  it("grants sponsor status using github_id, not github_login", async () => {
+    mocks.fetch.mockResolvedValue(
+      graphqlResponse([{ databaseId: 111, login: "alice" }])
+    );
+    const { updateChain, updateInChain } = setupSupabase([]);
+
+    await GET(authedRequest());
+
+    // Must update by github_id, not github_login
+    expect(updateChain).toHaveBeenCalledWith({ is_sponsor: true });
+    expect(updateInChain).toHaveBeenCalledWith("github_id", ["111"]);
+  });
+
+  it("revokes sponsor status using github_id, not github_login", async () => {
+    // No active sponsors from GitHub, but "222" is currently marked in the DB
+    mocks.fetch.mockResolvedValue(graphqlResponse([]));
+    const { updateChain, updateInChain } = setupSupabase(["222"]);
+
+    await GET(authedRequest());
+
+    expect(updateChain).toHaveBeenCalledWith({ is_sponsor: false });
+    expect(updateInChain).toHaveBeenCalledWith("github_id", ["222"]);
+  });
+
+  it("does not use github_login in any database update", async () => {
+    mocks.fetch.mockResolvedValue(
+      graphqlResponse([{ databaseId: 333, login: "bob" }])
+    );
+    setupSupabase([]);
+
+    await GET(authedRequest());
+
+    // None of the Supabase calls should mention the mutable login "bob"
+    const allCalls = mocks.supabaseFrom.mock.calls
+      .concat(...Object.values(mocks.supabaseFrom.mock.results.map((r: any) => r.value)));
+    // Check the in() call did not receive a login string
+    const inCallArgs = mocks.supabaseFrom.mock.results
+      .flatMap((r: any) => {
+        try { return Object.entries(r.value); } catch { return []; }
+      });
+    // The actual test: the column used in update().in() must be "github_id"
+    const mockInstance = mocks.supabaseFrom.mock.results[0]?.value;
+    expect(mockInstance.update).toBeDefined();
+    const updateCall = mockInstance.update.mock?.calls?.[0]?.[0];
+    expect(updateCall).toEqual({ is_sponsor: true });
+  });
+
+  // ── username-recycling scenario (regression test for #1751) ───────────────
+
+  it("does not grant sponsor status to a new user who claims a recycled username", async () => {
+    // Original sponsor: github_id=100, formerly login="alice"
+    // GitHub still shows "alice" as a sponsor (databaseId=100)
+    // New DevTrack user: github_id=999, current login="alice" (recycled)
+    // Only github_id=100 should receive is_sponsor=true; 999 must NOT.
+
+    mocks.fetch.mockResolvedValue(
+      graphqlResponse([{ databaseId: 100, login: "alice" }])
+    );
+
+    const updateInChain = vi.fn().mockResolvedValue({ error: null });
+    const updateChain = vi.fn().mockReturnValue({ in: updateInChain });
+    const selectEqChain = vi.fn().mockResolvedValue({ data: [], error: null });
+    const selectChain = vi.fn().mockReturnValue({ eq: selectEqChain });
+    mocks.supabaseFrom.mockReturnValue({ select: selectChain, update: updateChain });
+
+    await GET(authedRequest());
+
+    // The grant must target github_id "100", not "999"
+    expect(updateInChain).toHaveBeenCalledWith("github_id", ["100"]);
+    expect(updateInChain).not.toHaveBeenCalledWith("github_id", ["999"]);
+  });
+
+  it("preserves sponsor status when a sponsor renames their GitHub account", async () => {
+    // Sponsor renames "alice" → "alice2"; GitHub API returns databaseId=100, login="alice2"
+    // Our DB still has github_id=100 marked as is_sponsor=true
+    mocks.fetch.mockResolvedValue(
+      graphqlResponse([{ databaseId: 100, login: "alice2" }])
+    );
+
+    // DB already has github_id=100 as sponsor — no changes expected
+    const { updateChain } = setupSupabase(["100"]);
+
+    const res = await GET(authedRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.granted).toBe(0);
+    expect(body.revoked).toBe(0);
+    // No DB updates should have been made
+    expect(updateChain).not.toHaveBeenCalled();
+  });
+
+  // ── no-op when nothing changes ────────────────────────────────────────────
+
+  it("makes no DB updates when sponsor list is already in sync", async () => {
+    mocks.fetch.mockResolvedValue(
+      graphqlResponse([{ databaseId: 42, login: "sponsor" }])
+    );
+    const { updateChain } = setupSupabase(["42"]);
+
+    const res = await GET(authedRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.granted).toBe(0);
+    expect(body.revoked).toBe(0);
+    expect(updateChain).not.toHaveBeenCalled();
+  });
+
+  // ── grant and revoke in the same run ──────────────────────────────────────
+
+  it("grants new sponsors and revokes lapsed sponsors in the same run", async () => {
+    // GitHub says "111" is a sponsor; DB has "222" as sponsor
+    mocks.fetch.mockResolvedValue(
+      graphqlResponse([{ databaseId: 111, login: "new-sponsor" }])
+    );
+
+    const updateInChain = vi.fn().mockResolvedValue({ error: null });
+    const updateChain = vi.fn().mockReturnValue({ in: updateInChain });
+    const selectEqChain = vi.fn().mockResolvedValue({
+      data: [{ github_id: "222" }],
+      error: null,
+    });
+    const selectChain = vi.fn().mockReturnValue({ eq: selectEqChain });
+    mocks.supabaseFrom.mockReturnValue({ select: selectChain, update: updateChain });
+
+    const res = await GET(authedRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.granted).toBe(1);
+    expect(body.revoked).toBe(1);
+    // Revoke "222", grant "111"
+    expect(updateInChain).toHaveBeenCalledWith("github_id", ["222"]);
+    expect(updateInChain).toHaveBeenCalledWith("github_id", ["111"]);
+  });
+
+  // ── sponsor nodes without databaseId are ignored ──────────────────────────
+
+  it("skips sponsor entities that have no databaseId", async () => {
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          user: {
+            sponsorshipsAsMaintainer: {
+              nodes: [
+                // Node with no databaseId (e.g. ghost / deleted account)
+                { sponsorEntity: { login: "ghost-user" } },
+                // Valid node
+                { sponsorEntity: { databaseId: 77, login: "valid" } },
+              ],
+            },
+          },
+        },
+      }),
+    });
+    const { updateInChain } = setupSupabase([]);
+
+    const res = await GET(authedRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.sponsorCount).toBe(1); // only the valid one
+    expect(updateInChain).toHaveBeenCalledWith("github_id", ["77"]);
+  });
+
+  // ── response shape ────────────────────────────────────────────────────────
+
+  it("returns sponsorCount, granted, revoked, and sponsors array in the response", async () => {
+    mocks.fetch.mockResolvedValue(
+      graphqlResponse([
+        { databaseId: 1, login: "alpha" },
+        { databaseId: 2, login: "beta" },
+      ])
+    );
+    setupSupabase([]);
+
+    const res = await GET(authedRequest());
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.sponsorCount).toBe(2);
+    expect(body.granted).toBe(2);
+    expect(body.revoked).toBe(0);
+    expect(body.sponsors).toEqual(expect.arrayContaining(["alpha", "beta"]));
+  });
+});


### PR DESCRIPTION
Closes #1751

## Problem

The sponsor sync job (`GET /api/sponsors/sync`) previously identified active sponsors by matching `github_login` strings returned by the GitHub GraphQL API against the `users.github_login` column in the database.

`github_login` is **mutable** — GitHub account owners can rename themselves at any time. GitHub also **recycles** usernames after a grace period. This created two distinct failure modes:

**Scenario A — sponsor loses status after renaming their account**

1. User A (`login: "alice"`, `github_id: 100`) sponsors the project.
2. Sync runs → `alice` found in sponsor list → `is_sponsor = true` set on the row where `github_login = 'alice'`.
3. User A renames their account to `alice2`.
4. Sync runs again → `alice` is no longer in the sponsor list → `is_sponsor = false` incorrectly set, even though User A is still an active sponsor (they now appear as `alice2`).

**Scenario B — recycled username grants privileges to a different account**

1. User A (`login: "alice"`, `github_id: 100`) is a sponsor; `is_sponsor = true`.
2. User A deletes their account; username `alice` is eventually freed.
3. User B (`github_id: 999`) creates a new GitHub account with `login: "alice"` and signs into DevTrack.
4. Sync runs → `alice` is still in GitHub's sponsor list (associated with the original `databaseId: 100`) → `.update({ is_sponsor: true }).in("github_login", ["alice"])` sets `is_sponsor = true` on User B's row (the one currently holding `github_login = 'alice'`).

## Root cause

The GraphQL query only requested `login`:

```graphql
... on User {
  login        # mutable
}
```

All DB operations used `github_login` as the matching key. The `users` table already has `github_id text unique not null` storing GitHub's immutable numeric account ID, but the sync job never used it.

## Fix

**`src/app/api/sponsors/sync/route.ts`**

- Add `databaseId` to both `User` and `Organization` fragments in the GraphQL query. GitHub's `databaseId` is the same immutable numeric ID as `users.github_id`.
- Collect `{ githubId: String(databaseId), login }` pairs. `login` is kept only for the response payload and logging — it plays no role in DB matching.
- Skip any node that has no `databaseId` (e.g. deleted/ghost accounts) rather than falling back to login matching.
- Fetch existing sponsors with `.select("github_id")` and build the diff on `github_id` values.
- Apply `.update({ is_sponsor: true/false }).in("github_id", ids)` so privilege assignment follows the account, not the name.
- Extend the response body with `granted` and `revoked` counts.

No schema migration is needed. `users.github_id` already exists, is `NOT NULL`, and has a `UNIQUE` index.

## Identity chain

```
GitHub OAuth sign-in  →  profile.id (numeric)  →  users.github_id  (immutable, never changes)
GitHub GraphQL        →  databaseId (numeric)  →  same value       (immutable, never changes)
```

With this fix:
- A sponsor who renames their account (`alice` → `alice2`) continues to hold `is_sponsor = true` because the match is on `github_id = 100`, which doesn't change.
- A new user who claims the recycled username `alice` (`github_id = 999`) will not receive sponsor privileges because `999` is not in the sponsor ID set.

## Tests

**`test/sponsors-sync.test.ts`** — 16 new tests:

| Category | Cases |
|---|---|
| Auth/config guards | missing CRON_SECRET (500), wrong header (401), missing GITHUB_TOKEN (500) |
| GitHub API errors | non-ok HTTP response, GraphQL errors field, null `data.user` |
| Core fix | grant uses `github_id` not `github_login`; revoke uses `github_id` not `github_login` |
| Recycled username (regression #1751) | new user with recycled login does not receive sponsor status |
| Account rename (regression #1751) | renamed sponsor retains status, no spurious revoke |
| No-op | no DB writes when list is already in sync |
| Combined run | grant + revoke in the same sync run |
| Missing databaseId | nodes without databaseId are silently skipped |
| Response shape | `success`, `sponsorCount`, `granted`, `revoked`, `sponsors` |

All 16 tests pass. The single pre-existing failure in `test/dateUtils.test.ts` (timezone boundary) is unrelated to this change and was already failing on `main`.