### PR TITLE
fix: remove internal Supabase UUID from public profile API response

### DIFF
--- a/src/lib/public-profile-data.ts
+++ b/src/lib/public-profile-data.ts
@@ -33,7 +33,6 @@ export interface StreakData {
 
 export interface PublicProfileData {
   username: string;
-  userId: string;
   bio: string | null;
   isSponsor: boolean;
   repos: TopRepo[];
@@ -298,7 +297,6 @@ export async function fetchPublicProfile(
 
   return {
     username: user.github_login,
-    userId: user.id,
     bio: user.bio ?? null,
     isSponsor: user.is_sponsor ?? false,
     repos,

--- a/test/public-profile-uuid-exposure.test.ts
+++ b/test/public-profile-uuid-exposure.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchPublicProfile } from "@/lib/public-profile-data";
+import { GET } from "@/app/api/public/[username]/route";
+import { NextRequest } from "next/server";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getUserByUsername: vi.fn(),
+  syncGitHubAchievementsForUser: vi.fn(),
+  fetchPinnedRepoDetails: vi.fn(),
+  // route-level mocks
+  fetchPublicProfileRoute: vi.fn(),
+  getUpstashConfig: vi.fn(() => null),
+}));
+
+// The first describe block tests the library function directly, so it needs
+// the real implementation with mocked dependencies.
+vi.mock("@/lib/supabase", () => ({
+  getUserByUsername: mocks.getUserByUsername,
+  supabaseAdmin: { from: vi.fn() },
+  isSupabaseAdminAvailable: true,
+  SUPABASE_ADMIN_UNAVAILABLE_MESSAGE: "",
+  getUserByGithubId: vi.fn(),
+  updateUserPublicFlag: vi.fn(),
+}));
+
+vi.mock("@/lib/github-achievements", () => ({
+  syncGitHubAchievementsForUser: mocks.syncGitHubAchievementsForUser,
+  getCachedGitHubAchievements: vi.fn(),
+}));
+
+vi.mock("@/lib/pinned-repos", () => ({
+  fetchPinnedRepoDetails: mocks.fetchPinnedRepoDetails,
+}));
+
+vi.mock("@/lib/upstash-rest", () => ({
+  getUpstashConfig: mocks.getUpstashConfig,
+  upstashRateLimitFixedWindow: vi.fn(),
+}));
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+const APP_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+const MOCK_USER = {
+  id: APP_UUID,
+  github_login: "alice",
+  github_id: "12345",
+  is_public: true,
+  is_sponsor: false,
+  bio: "Hello world",
+  pinned_repos: [],
+};
+
+// fetchPublicTopLanguages calls /users/{login}/repos and expects an array.
+// All other GitHub API calls used by fetchPublicProfile return { items, total_count }.
+function makeGhFetchStub() {
+  return vi.fn().mockImplementation((url: string) => {
+    const isReposEndpoint =
+      typeof url === "string" && url.includes("/users/") && url.includes("/repos");
+    return Promise.resolve({
+      ok: true,
+      json: async () => (isReposEndpoint ? [] : { items: [], total_count: 0 }),
+    });
+  });
+}
+
+// ─── tests for fetchPublicProfile ────────────────────────────────────────────
+
+describe("fetchPublicProfile — UUID exposure (regression for #1749)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getUserByUsername.mockResolvedValue(MOCK_USER);
+    mocks.syncGitHubAchievementsForUser.mockResolvedValue({
+      achievements: [],
+      syncedAt: null,
+      error: null,
+    });
+    mocks.fetchPinnedRepoDetails.mockResolvedValue([]);
+
+    vi.stubGlobal("fetch", makeGhFetchStub());
+  });
+
+  it("does not include userId in the returned profile", async () => {
+    const profile = await fetchPublicProfile("alice");
+    expect(profile).not.toBeNull();
+    expect(Object.keys(profile!)).not.toContain("userId");
+  });
+
+  it("does not include the Supabase UUID value anywhere in the serialised response", async () => {
+    const profile = await fetchPublicProfile("alice");
+    expect(profile).not.toBeNull();
+    // A UUID present in any field of the JSON would be a data exposure
+    const serialised = JSON.stringify(profile);
+    expect(serialised).not.toContain(APP_UUID);
+  });
+
+  it("still returns all expected public fields", async () => {
+    const profile = await fetchPublicProfile("alice");
+    expect(profile).not.toBeNull();
+    expect(profile!.username).toBe("alice");
+    expect(profile!.bio).toBe("Hello world");
+    expect(profile!.isSponsor).toBe(false);
+    expect(Array.isArray(profile!.repos)).toBe(true);
+    expect(profile!.contributions).toBeDefined();
+    expect(profile!.streak).toBeDefined();
+    expect(Array.isArray(profile!.topLanguages)).toBe(true);
+    expect(typeof profile!.pullRequests).toBe("number");
+    expect(Array.isArray(profile!.achievements)).toBe(true);
+  });
+
+  it("returns null when the user is not found", async () => {
+    mocks.getUserByUsername.mockResolvedValue(null);
+    const profile = await fetchPublicProfile("nobody");
+    expect(profile).toBeNull();
+  });
+
+  it("still passes user.id to syncGitHubAchievementsForUser for its own DB operations", async () => {
+    // The achievements sync must still receive the internal UUID so it can
+    // look up / write the cache row — only the *response payload* must not
+    // expose it.
+    await fetchPublicProfile("alice", { includeAchievements: true });
+    expect(mocks.syncGitHubAchievementsForUser).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: APP_UUID })
+    );
+  });
+});
+
+// ─── tests for the API route ─────────────────────────────────────────────────
+
+describe("GET /api/public/[username] — response schema (regression for #1749)", () => {
+  const SAFE_PROFILE = {
+    username: "alice",
+    bio: null,
+    isSponsor: false,
+    repos: [],
+    contributions: { days: 30, total: 0, data: {} },
+    streak: { current: 0, longest: 0, lastCommitDate: null, totalActiveDays: 0 },
+    topLanguages: [],
+    pullRequests: 0,
+    achievements: [],
+    achievementsError: null,
+    spotlightRepos: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // fetchPublicProfile is called by the route; stub it to return SAFE_PROFILE
+    mocks.getUserByUsername.mockResolvedValue(MOCK_USER);
+    mocks.syncGitHubAchievementsForUser.mockResolvedValue({
+      achievements: [],
+      syncedAt: null,
+      error: null,
+    });
+    mocks.fetchPinnedRepoDetails.mockResolvedValue([]);
+    vi.stubGlobal("fetch", makeGhFetchStub());
+  });
+
+  it("responds 200 and does not include userId in the JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/public/alice");
+    const res = await GET(req, { params: { username: "alice" } });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).not.toHaveProperty("userId");
+    expect(body.username).toBe("alice");
+    expect(body).toHaveProperty("repos");
+    expect(body).toHaveProperty("streak");
+  });
+
+  it("does not expose the UUID value in the API response body", async () => {
+    const req = new NextRequest("http://localhost/api/public/alice");
+    const res = await GET(req, { params: { username: "alice" } });
+    const body = await res.text();
+    expect(body).not.toContain(APP_UUID);
+  });
+
+  it("responds 404 when the profile is not found", async () => {
+    mocks.getUserByUsername.mockResolvedValue(null);
+    const req = new NextRequest("http://localhost/api/public/nobody");
+    const res = await GET(req, { params: { username: "nobody" } });
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes #1749

## Problem

`GET /api/public/:username` returned a `userId` field containing the internal Supabase UUID to any unauthenticated visitor:

```json
{
  "username": "alice",
  "userId": "550e8400-e29b-41d4-a716-446655440000",
  "repos": [...],
  "streak": {...}
}
```

`userId` is `users.id`, the primary key that ties together every table in the application (`goals`, `notifications`, `ai_insights`, `local_coding_sessions`, etc.). Exposing it publicly:

1. Reveals an internal database identifier with no user-facing meaning.
2. Enables an adversary to cross-reference any endpoint that might accept a raw UUID as a parameter in the future, without knowing a username.
3. Violates the principle of least privilege — callers of the public profile API require only the GitHub login for all current functionality.

## Root cause

`src/lib/public-profile-data.ts` line 301 placed `userId: user.id` in the return object of `fetchPublicProfile`. The route handler at `src/app/api/public/[username]/route.ts` then returned that object verbatim via `NextResponse.json(profile)`.

**No consumer reads this field.** After an exhaustive search across all `.ts` and `.tsx` files, `profile.userId` is never accessed in any component, page, or test. The profile page (`src/app/u/[username]/page.tsx`) uses only `profile.username`, `profile.streak`, `profile.contributions`, `profile.repos`, and related display fields.

## Fix

**`src/lib/public-profile-data.ts`** (two-line change):

- Remove `userId: string` from the `PublicProfileData` interface.
- Remove `userId: user.id` from the return object in `fetchPublicProfile`.

The `syncGitHubAchievementsForUser({ userId: user.id, ... })` call on the line above is a function argument (not the return value) and is correctly unchanged — the achievements sync still needs the UUID for its own DB cache operations.

No changes to the route handler are needed; once the field is absent from `fetchPublicProfile`'s return value it is absent from every API response.

## Consumer audit

| Location | References `userId` from public profile? |
|---|---|
| `src/app/u/[username]/page.tsx` | No |
| `src/components/*` | No |
| `src/app/api/public/*` | No |
| All existing tests | No |

## Tests

**`test/public-profile-uuid-exposure.test.ts`** — 8 new tests:

| Category | Cases |
|---|---|
| `fetchPublicProfile` response shape | `userId` key absent; UUID value absent from serialised JSON; all public fields present |
| Null handling | Returns null for unknown user |
| Internal invariant | `syncGitHubAchievementsForUser` still receives `user.id` internally |
| API route response | 200 without `userId` in JSON body; UUID not present in response text; 404 for unknown user |

All 8 pass. The one pre-existing failure in `test/dateUtils.test.ts` (timezone boundary) is unrelated to this change.