### PR TITLE
fix: validate repo parameter before cache and GitHub API calls

### DIFF
--- a/src/app/api/metrics/repo-analytics/route.ts
+++ b/src/app/api/metrics/repo-analytics/route.ts
@@ -10,34 +10,99 @@ const GITHUB_API = "https://api.github.com";
 
 const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"];
 
+// A valid GitHub repository identifier is exactly "owner/repo".
+//
+// owner rules (GitHub username / org name):
+//   - 1–39 characters
+//   - alphanumeric and hyphens only
+//   - cannot start or end with a hyphen
+//
+// repo rules (GitHub repository name):
+//   - 1–100 characters
+//   - alphanumeric, dots, hyphens, and underscores only
+//
+// The regex intentionally does NOT allow extra slashes, path traversal
+// segments, or any other characters so that malformed values such as
+// "octocat/Hello-World/issues", "../../../admin", or "%2F" tricks are
+// rejected before reaching the cache layer or any fetch() call.
+const REPO_IDENTIFIER_RE =
+  /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?)\/([a-zA-Z0-9._-]{1,100})$/;
+
+interface ParsedRepo {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Validates and parses a raw "owner/repo" string.
+ * Returns the split components on success, or null if the value is invalid.
+ */
+export function parseRepoParam(raw: string): ParsedRepo | null {
+  const trimmed = raw.trim();
+  const match = REPO_IDENTIFIER_RE.exec(trimmed);
+  if (!match) return null;
+
+  const [, owner, repo] = match;
+
+  // Exclude the special names "." and ".." even though they pass the
+  // character-set check, as they can be used for path traversal.
+  if (repo === "." || repo === "..") return null;
+
+  return { owner, repo };
+}
+
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const repoParam = req.nextUrl.searchParams.get("repo");
-  if (!repoParam) return Response.json({ error: "Missing repo parameter" }, { status: 400 });
+  const rawRepo = req.nextUrl.searchParams.get("repo");
+  if (!rawRepo) {
+    return Response.json({ error: "Missing repo parameter" }, { status: 400 });
+  }
 
+  // Validate and parse before touching the cache or calling fetch().
+  const parsed = parseRepoParam(rawRepo);
+  if (!parsed) {
+    return Response.json(
+      { error: "Invalid repo parameter. Expected format: owner/repo (e.g. octocat/Hello-World)" },
+      { status: 400 }
+    );
+  }
+
+  const { owner, repo } = parsed;
+
+  // Build the safe path used in all GitHub API URLs.
+  // encodeURIComponent is applied to each segment independently so that
+  // neither segment can introduce an extra slash or other special character
+  // into the constructed URL.
+  const safeRepoPath = `${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+
+  // Cache key uses the validated, normalised form — never the raw input.
   const bypass = isMetricsCacheBypassed(req);
-  const key = metricsCacheKey(session.githubId ?? session.githubLogin, `repo-analytics-${repoParam}` as any, { days: 30 });
+  const key = metricsCacheKey(
+    session.githubId ?? session.githubLogin,
+    `repo-analytics-${owner}/${repo}` as any,
+    { days: 30 }
+  );
 
   try {
     const data = await withMetricsCache({ bypass, key, ttlSeconds: 60 * 60 }, async () => {
-      const repoRes = await fetch(`${GITHUB_API}/repos/${repoParam}`, {
+      const repoRes = await fetch(`${GITHUB_API}/repos/${safeRepoPath}`, {
         headers: { Authorization: `Bearer ${session.accessToken}`, Accept: "application/vnd.github+json" },
         cache: "no-store",
       });
       if (!repoRes.ok) throw new Error("API error fetching repo overview");
       const repoData = await repoRes.json();
 
-      const contribRes = await fetch(`${GITHUB_API}/repos/${repoParam}/contributors?per_page=10`, {
+      const contribRes = await fetch(`${GITHUB_API}/repos/${safeRepoPath}/contributors?per_page=10`, {
         headers: { Authorization: `Bearer ${session.accessToken}`, Accept: "application/vnd.github+json" },
         cache: "no-store",
       });
       const contribData = contribRes.ok ? await contribRes.json() : [];
 
-      const langRes = await fetch(`${GITHUB_API}/repos/${repoParam}/languages`, {
+      const langRes = await fetch(`${GITHUB_API}/repos/${safeRepoPath}/languages`, {
         headers: { Authorization: `Bearer ${session.accessToken}`, Accept: "application/vnd.github+json" },
         cache: "no-store",
       });
@@ -54,11 +119,11 @@ export async function GET(req: NextRequest) {
 
       const primaryStack = languageBreakdown.slice(0, 3).map((l) => l.name);
 
-      const activityRes = await fetch(`${GITHUB_API}/repos/${repoParam}/stats/commit_activity`, {
+      const activityRes = await fetch(`${GITHUB_API}/repos/${safeRepoPath}/stats/commit_activity`, {
         headers: { Authorization: `Bearer ${session.accessToken}`, Accept: "application/vnd.github+json" },
         cache: "no-store",
       });
-      
+
       let timeline: { date: string; events: number }[] = [];
       if (activityRes.ok && activityRes.status === 200) {
         const activityData = await activityRes.json();
@@ -76,7 +141,7 @@ export async function GET(req: NextRequest) {
           }
         }
       }
-      
+
       if (timeline.length === 0) {
         for (let i = 6; i >= 0; i--) {
           const d = new Date();
@@ -92,7 +157,7 @@ export async function GET(req: NextRequest) {
         openIssuesCount: repoData.open_issues_count || 0,
         daysSinceLastCommit: 1,
       };
-      
+
       const health = computeHealthScore(repoData.name, healthSignals);
 
       const result: RepoAnalyticsResponse = {
@@ -120,7 +185,7 @@ export async function GET(req: NextRequest) {
 
       return result;
     });
-    
+
     return Response.json(data);
   } catch (error) {
     console.error(error);

--- a/test/repo-analytics-validation.test.ts
+++ b/test/repo-analytics-validation.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { parseRepoParam } from "@/app/api/metrics/repo-analytics/route";
+import { GET } from "@/app/api/metrics/repo-analytics/route";
+import { NextRequest } from "next/server";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  isMetricsCacheBypassed: vi.fn(() => false),
+  metricsCacheKey: vi.fn(() => "test-cache-key"),
+  withMetricsCache: vi.fn(),
+  computeHealthScore: vi.fn(() => ({ score: 90, grade: "A", signals: {} })),
+  fetch: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/metrics-cache", () => ({
+  isMetricsCacheBypassed: mocks.isMetricsCacheBypassed,
+  metricsCacheKey: mocks.metricsCacheKey,
+  withMetricsCache: mocks.withMetricsCache,
+}));
+vi.mock("@/lib/repo-health", () => ({
+  computeHealthScore: mocks.computeHealthScore,
+}));
+
+vi.stubGlobal("fetch", mocks.fetch);
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(repo?: string): NextRequest {
+  const url = repo
+    ? `http://localhost/api/metrics/repo-analytics?repo=${encodeURIComponent(repo)}`
+    : "http://localhost/api/metrics/repo-analytics";
+  return new NextRequest(url);
+}
+
+function authedSession() {
+  mocks.getServerSession.mockResolvedValue({
+    accessToken: "gh-token",
+    githubLogin: "alice",
+    githubId: "12345",
+  });
+}
+
+// ─── unit tests: parseRepoParam ──────────────────────────────────────────────
+
+describe("parseRepoParam — validation logic", () => {
+  // ── valid inputs ───────────────────────────────────────────────────────────
+
+  it("accepts a standard owner/repo", () => {
+    const result = parseRepoParam("octocat/Hello-World");
+    expect(result).toEqual({ owner: "octocat", repo: "Hello-World" });
+  });
+
+  it("accepts a single-char owner", () => {
+    const result = parseRepoParam("a/b");
+    expect(result).toEqual({ owner: "a", repo: "b" });
+  });
+
+  it("accepts dots and underscores in repo name", () => {
+    const result = parseRepoParam("torvalds/linux-2.6");
+    expect(result).toEqual({ owner: "torvalds", repo: "linux-2.6" });
+  });
+
+  it("accepts an org with hyphens", () => {
+    const result = parseRepoParam("my-org/my-repo");
+    expect(result).toEqual({ owner: "my-org", repo: "my-repo" });
+  });
+
+  it("accepts an owner at exactly 39 chars", () => {
+    const owner = "a" + "b".repeat(37) + "c"; // 39 chars
+    expect(owner.length).toBe(39);
+    const result = parseRepoParam(`${owner}/repo`);
+    expect(result).toEqual({ owner, repo: "repo" });
+  });
+
+  it("accepts a repo name at exactly 100 chars", () => {
+    const repo = "r".repeat(100);
+    const result = parseRepoParam(`owner/${repo}`);
+    expect(result).toEqual({ owner: "owner", repo });
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    const result = parseRepoParam("  octocat/Hello-World  ");
+    expect(result).toEqual({ owner: "octocat", repo: "Hello-World" });
+  });
+
+  // ── rejection: missing segments ───────────────────────────────────────────
+
+  it("rejects a value with no slash", () => {
+    expect(parseRepoParam("just-a-name")).toBeNull();
+  });
+
+  it("rejects an empty string", () => {
+    expect(parseRepoParam("")).toBeNull();
+  });
+
+  it("rejects whitespace-only input", () => {
+    expect(parseRepoParam("   ")).toBeNull();
+  });
+
+  it("rejects a trailing slash with no repo", () => {
+    expect(parseRepoParam("octocat/")).toBeNull();
+  });
+
+  it("rejects a leading slash with no owner", () => {
+    expect(parseRepoParam("/Hello-World")).toBeNull();
+  });
+
+  // ── rejection: extra path segments (the reported issue) ───────────────────
+
+  it("rejects three-segment path — regression for #1700", () => {
+    expect(parseRepoParam("octocat/Hello-World/issues")).toBeNull();
+  });
+
+  it("rejects four-segment path", () => {
+    expect(parseRepoParam("octocat/Hello-World/issues/123")).toBeNull();
+  });
+
+  it("rejects a path starting with extra slashes", () => {
+    expect(parseRepoParam("//etc/passwd")).toBeNull();
+  });
+
+  // ── rejection: path traversal attempts ───────────────────────────────────
+
+  it("rejects dot-dot traversal in the repo segment", () => {
+    expect(parseRepoParam("owner/..")).toBeNull();
+  });
+
+  it("rejects single-dot repo name", () => {
+    expect(parseRepoParam("owner/.")).toBeNull();
+  });
+
+  it("rejects classic path traversal pattern", () => {
+    expect(parseRepoParam("../../../admin")).toBeNull();
+  });
+
+  // ── rejection: invalid characters ─────────────────────────────────────────
+
+  it("rejects a space inside the value", () => {
+    expect(parseRepoParam("octo cat/Hello-World")).toBeNull();
+  });
+
+  it("rejects special characters in owner", () => {
+    expect(parseRepoParam("octo@cat/repo")).toBeNull();
+  });
+
+  it("rejects question marks (query confusion)", () => {
+    expect(parseRepoParam("owner/repo?foo=bar")).toBeNull();
+  });
+
+  it("rejects a null byte", () => {
+    expect(parseRepoParam("owner/repo\0extra")).toBeNull();
+  });
+
+  // ── rejection: length violations ──────────────────────────────────────────
+
+  it("rejects an owner longer than 39 chars", () => {
+    const owner = "a".repeat(40); // 40 chars — one over the limit
+    expect(parseRepoParam(`${owner}/repo`)).toBeNull();
+  });
+
+  it("rejects a repo name longer than 100 chars", () => {
+    const repo = "r".repeat(101);
+    expect(parseRepoParam(`owner/${repo}`)).toBeNull();
+  });
+
+  // ── rejection: owner hyphen rules ─────────────────────────────────────────
+
+  it("rejects an owner starting with a hyphen", () => {
+    expect(parseRepoParam("-bad-owner/repo")).toBeNull();
+  });
+
+  it("rejects an owner ending with a hyphen", () => {
+    expect(parseRepoParam("bad-owner-/repo")).toBeNull();
+  });
+});
+
+// ─── integration tests: GET route ────────────────────────────────────────────
+
+describe("GET /api/metrics/repo-analytics — validation integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authedSession();
+  });
+
+  // ── authentication ────────────────────────────────────────────────────────
+
+  it("returns 401 when there is no session", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const res = await GET(makeRequest("octocat/Hello-World"));
+    expect(res.status).toBe(401);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(mocks.withMetricsCache).not.toHaveBeenCalled();
+  });
+
+  // ── missing parameter ─────────────────────────────────────────────────────
+
+  it("returns 400 when the repo parameter is absent", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/missing/i);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(mocks.withMetricsCache).not.toHaveBeenCalled();
+  });
+
+  // ── malformed values return 400 before any cache or fetch ────────────────
+
+  it("returns 400 for extra path segments — regression for #1700", async () => {
+    const res = await GET(makeRequest("octocat/Hello-World/issues"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid/i);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(mocks.withMetricsCache).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a bare repository name without an owner", async () => {
+    const res = await GET(makeRequest("just-repo-name"));
+    expect(res.status).toBe(400);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(mocks.withMetricsCache).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a path-traversal attempt", async () => {
+    const res = await GET(makeRequest("owner/.."));
+    expect(res.status).toBe(400);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(mocks.withMetricsCache).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an owner starting with a hyphen", async () => {
+    const res = await GET(makeRequest("-org/repo"));
+    expect(res.status).toBe(400);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for special characters in the repo name", async () => {
+    const res = await GET(makeRequest("owner/repo?extra=segment"));
+    expect(res.status).toBe(400);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the repo value is whitespace only", async () => {
+    // The URL-encoded space becomes %20 — after decoding it's " "
+    const req = new NextRequest(
+      "http://localhost/api/metrics/repo-analytics?repo=%20%20"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    expect(mocks.fetch).not.toHaveBeenCalled();
+  });
+
+  // ── valid repo proceeds to cache and fetch ────────────────────────────────
+
+  it("reaches withMetricsCache for a valid owner/repo", async () => {
+    mocks.withMetricsCache.mockResolvedValue({ overview: {}, contributors: [], timeline: [], health: {}, primaryStack: [], languageBreakdown: [] });
+    const res = await GET(makeRequest("octocat/Hello-World"));
+    expect(res.status).toBe(200);
+    expect(mocks.withMetricsCache).toHaveBeenCalledOnce();
+  });
+
+  it("uses the validated repo in the cache key, not the raw input", async () => {
+    mocks.withMetricsCache.mockResolvedValue({ overview: {}, contributors: [], timeline: [], health: {}, primaryStack: [], languageBreakdown: [] });
+    await GET(makeRequest("  octocat/Hello-World  ")); // with whitespace
+    // metricsCacheKey should be called with the trimmed form
+    expect(mocks.metricsCacheKey).toHaveBeenCalledWith(
+      expect.anything(),
+      "repo-analytics-octocat/Hello-World",
+      expect.anything()
+    );
+  });
+
+  it("does not generate a cache entry for the invalid three-segment path", async () => {
+    await GET(makeRequest("octocat/Hello-World/issues"));
+    expect(mocks.metricsCacheKey).not.toHaveBeenCalled();
+    expect(mocks.withMetricsCache).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1700

## Problem

`GET /api/metrics/repo-analytics` accepted arbitrary values for the `?repo=` query parameter and interpolated them directly into GitHub API URL paths and cache keys with no format validation:

```
GET /api/metrics/repo-analytics?repo=octocat/Hello-World/issues
```

would silently construct and call:

```
GET https://api.github.com/repos/octocat/Hello-World/issues
GET https://api.github.com/repos/octocat/Hello-World/issues/contributors
GET https://api.github.com/repos/octocat/Hello-World/issues/languages
GET https://api.github.com/repos/octocat/Hello-World/issues/stats/commit_activity
```

These are entirely different GitHub API endpoints (issue lists, not repository metadata). The only guard was `if (!repoParam)`, which passes for any non-empty string.

**Consequences confirmed by code reading:**

1. **Extra path segments** reach unintended GitHub API endpoints (the reported case: `owner/repo/issues`)
2. **Path traversal patterns** such as `owner/..` are accepted and forwarded
3. **Cache pollution**: the raw value lands in the cache key (`repo-analytics-${repoParam}`), so malformed inputs create permanent cache entries for non-existent resources
4. **Unnecessary rate-limit consumption**: GitHub API quota is spent on requests that will always fail or return wrong data

## Root cause

Three lines in `src/app/api/metrics/repo-analytics/route.ts`:

```ts
// Line 23 — raw input in cache key
const key = metricsCacheKey(…, `repo-analytics-${repoParam}` as any, …);

// Lines 27, 34, 40, 57 — raw input in URL paths
fetch(`${GITHUB_API}/repos/${repoParam}`, …)
fetch(`${GITHUB_API}/repos/${repoParam}/contributors?per_page=10`, …)
fetch(`${GITHUB_API}/repos/${repoParam}/languages`, …)
fetch(`${GITHUB_API}/repos/${repoParam}/stats/commit_activity`, …)
```

## Fix

**`src/app/api/metrics/repo-analytics/route.ts`**

Introduces `parseRepoParam(raw)` — validates the raw string against a strict regex before any other processing:

```
REPO_IDENTIFIER_RE = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?)\/([a-zA-Z0-9._-]{1,100})$/
```

Rules enforced:
- **owner**: 1–39 chars, alphanumeric + hyphens, cannot start or end with a hyphen (mirrors GitHub's account name rules)
- **repo**: 1–100 chars, alphanumeric, dots, hyphens, underscores
- Exactly **one** slash between them — any extra segment is rejected
- `.` and `..` are explicitly excluded as repo names even though they match the character set

On validation failure → **400 Bad Request** is returned immediately, before the cache key is computed or any `fetch()` is called.

GitHub API URLs are then built from `encodeURIComponent(owner)/encodeURIComponent(repo)` so each path segment is individually URL-safe.

## Request lifecycle (after fix)

```
Request arrives
  → parseRepoParam()  ← new validation gate
      ├── invalid  →  400 (no cache key, no fetch)
      └── valid    →  metricsCacheKey()  →  withMetricsCache()  →  fetch()
```

## Tests

**`test/repo-analytics-validation.test.ts`** — 37 new tests:

| Category | Cases |
|---|---|
| Valid inputs | Standard, single-char, max-length owner (39), max-length repo (100), dots, hyphens, underscores, whitespace trimming |
| Missing segments | No slash, empty string, whitespace-only, trailing slash, leading slash |
| Extra path segments (regression) | Three-segment path (`owner/repo/issues`), four-segment path |
| Path traversal | `owner/..`, `owner/.`, `../../../admin`, double leading slash |
| Invalid characters | Spaces, `@`, `?`, null bytes |
| Length violations | Owner 40 chars, repo 101 chars |
| Hyphen rules | Owner starts with hyphen, owner ends with hyphen |
| Route 401/400 integration | No session, missing param, each malformed category |
| Fetch/cache not called | All 400 paths confirmed to skip `fetch()` and `withMetricsCache()` |
| Valid path proceeds | `withMetricsCache` is called; cache key uses validated, trimmed form |
| Cache key correctness | Raw whitespace-padded input maps to the same clean cache key |

All 37 pass. The one pre-existing failure in `test/dateUtils.test.ts` (timezone boundary) is unrelated to this change.