### PR TITLE
fix: fail closed when CRON_SECRET is absent in WakaTime sync endpoint

### DIFF
--- a/src/app/api/wakatime/sync/route.ts
+++ b/src/app/api/wakatime/sync/route.ts
@@ -5,9 +5,20 @@ import { decryptToken } from "@/lib/crypto";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
-  // To secure the cron job, check the authorization header
   const authHeader = req.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}` && process.env.NODE_ENV !== "development") {
+  const cronSecret = process.env.CRON_SECRET;
+
+  // Fail closed when CRON_SECRET is not configured.  Leaving it undefined
+  // causes `Bearer ${undefined}` → "Bearer undefined" to become the expected
+  // credential, which an attacker can trivially supply.
+  if (!cronSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not configured" },
+      { status: 500 }
+    );
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}` && process.env.NODE_ENV !== "development") {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/test/wakatime-sync-auth.test.ts
+++ b/test/wakatime-sync-auth.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "@/app/api/wakatime/sync/route";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  supabaseFrom: vi.fn(),
+  decryptToken: vi.fn(),
+  wakatimeFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+
+vi.mock("@/lib/crypto", () => ({
+  decryptToken: mocks.decryptToken,
+}));
+
+vi.stubGlobal("fetch", mocks.wakatimeFetch);
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(authHeader?: string): Request {
+  return new Request("http://localhost/api/wakatime/sync", {
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+/** Sets up Supabase to return zero users (no-op sync). */
+function stubEmptySync() {
+  mocks.supabaseFrom.mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      not: vi.fn().mockReturnValue({
+        not: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    }),
+  });
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/wakatime/sync — authentication hardening (#1746)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  // ── missing CRON_SECRET — fail closed ────────────────────────────────────
+
+  it("returns 500 when CRON_SECRET is not set — regression for #1746", async () => {
+    vi.stubEnv("CRON_SECRET", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    const res = await GET(makeRequest("Bearer anything"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/CRON_SECRET.*not configured/i);
+    // Sync must never run when the secret is absent
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  it("rejects Authorization: Bearer undefined when CRON_SECRET is absent — regression for #1746", async () => {
+    // This is the specific bypass described in the issue: when CRON_SECRET is
+    // undefined, `Bearer ${undefined}` evaluates to "Bearer undefined", so a
+    // caller who sends that literal string would previously pass the check.
+    vi.stubEnv("CRON_SECRET", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    const res = await GET(makeRequest("Bearer undefined"));
+    // Must NOT return 200; must not execute the sync.
+    expect(res.status).not.toBe(200);
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  // ── wrong secret — reject ─────────────────────────────────────────────────
+
+  it("returns 401 in production when the secret is present but the header is wrong", async () => {
+    vi.stubEnv("CRON_SECRET", "correct-secret");
+    vi.stubEnv("NODE_ENV", "production");
+
+    const res = await GET(makeRequest("Bearer wrong-secret"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 in production when no authorization header is provided", async () => {
+    vi.stubEnv("CRON_SECRET", "correct-secret");
+    vi.stubEnv("NODE_ENV", "production");
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 in production for a plaintext secret without the Bearer prefix", async () => {
+    vi.stubEnv("CRON_SECRET", "correct-secret");
+    vi.stubEnv("NODE_ENV", "production");
+
+    const res = await GET(makeRequest("correct-secret"));
+    expect(res.status).toBe(401);
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  // ── correct secret — allow ────────────────────────────────────────────────
+
+  it("proceeds with the sync when the correct Bearer token is supplied", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cr3t");
+    vi.stubEnv("NODE_ENV", "production");
+    stubEmptySync();
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("success");
+    expect(body).toHaveProperty("failure");
+  });
+
+  // ── development mode — intentional bypass for local testing ──────────────
+
+  it("allows any header in development mode (intentional bypass)", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cr3t");
+    vi.stubEnv("NODE_ENV", "development");
+    stubEmptySync();
+
+    // Any auth value should pass in dev (existing intentional behavior).
+    const res = await GET(makeRequest("Bearer totally-wrong"));
+    expect(res.status).toBe(200);
+  });
+
+  it("still returns 500 in development when CRON_SECRET is missing", async () => {
+    // CRON_SECRET must always be required — even in development we should
+    // not silently accept an absent secret configuration.
+    vi.stubEnv("CRON_SECRET", "");
+    vi.stubEnv("NODE_ENV", "development");
+
+    const res = await GET(makeRequest("Bearer undefined"));
+    expect(res.status).toBe(500);
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  // ── sync execution path ───────────────────────────────────────────────────
+
+  it("decrypts WakaTime keys and calls the WakaTime API for each user", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cr3t");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mocks.decryptToken.mockReturnValue("waka-api-key");
+    mocks.wakatimeFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            range: { date: "2026-05-01" },
+            grand_total: { total_seconds: 3600 },
+            languages: [{ name: "TypeScript", total_seconds: 1800, percent: 50 }],
+            projects: [{ name: "devtrack", total_seconds: 3600, percent: 100 }],
+          },
+        ],
+      }),
+    });
+
+    const upsertMock = vi.fn().mockResolvedValue({ error: null });
+    mocks.supabaseFrom.mockImplementation((table: string) => {
+      if (table === "users") {
+        return {
+          select: vi.fn().mockReturnValue({
+            not: vi.fn().mockReturnValue({
+              not: vi.fn().mockResolvedValue({
+                data: [
+                  { id: "user-1", wakatime_api_key_encrypted: "enc", wakatime_api_key_iv: "iv" },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "wakatime_stats") {
+        return { upsert: upsertMock };
+      }
+      return {};
+    });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(1);
+    expect(body.failure).toBe(0);
+    expect(mocks.decryptToken).toHaveBeenCalledWith("enc", "iv");
+    expect(mocks.wakatimeFetch).toHaveBeenCalledWith(
+      expect.stringContaining("wakatime.com"),
+      expect.any(Object)
+    );
+    expect(upsertMock).toHaveBeenCalledOnce();
+  });
+
+  it("counts a failure when WakaTime API key decryption fails", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cr3t");
+    vi.stubEnv("NODE_ENV", "production");
+
+    mocks.decryptToken.mockReturnValue(null); // decryption failed
+
+    mocks.supabaseFrom.mockImplementation((table: string) => {
+      if (table === "users") {
+        return {
+          select: vi.fn().mockReturnValue({
+            not: vi.fn().mockReturnValue({
+              not: vi.fn().mockResolvedValue({
+                data: [{ id: "user-1", wakatime_api_key_encrypted: "enc", wakatime_api_key_iv: "iv" }],
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.failure).toBe(1);
+    expect(body.success).toBe(0);
+    expect(mocks.wakatimeFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1746

## Problem

`GET /api/wakatime/sync` used `process.env.CRON_SECRET` directly inside a template literal without first checking whether the variable is defined:

```ts
if (authHeader !== `Bearer ${process.env.CRON_SECRET}` && process.env.NODE_ENV !== "development") {
```

When `CRON_SECRET` is not set, JavaScript coerces `undefined` to the string `"undefined"`, so the expected credential becomes the literal string `"Bearer undefined"`. Any caller who sends that header in production passes authentication and triggers:

1. A full query of all users with stored WakaTime keys
2. Decryption of every user's WakaTime API key
3. A WakaTime API call for every user
4. Database upserts for all results

## Endpoint comparison

Every other cron endpoint in the repository already follows the correct pattern:

| Endpoint | Pattern |
|---|---|
| `cron/weekly-digest` | ✅ `if (!cronSecret) return 500` then compare |
| `notifications/discord-sync` | ✅ `if (!cronSecret) return 500` then compare |
| `sponsors/sync` | ✅ `if (!cronSecret) return 500` then compare |
| **`wakatime/sync`** | ❌ inline `process.env.CRON_SECRET` without null check |

## Fix

Mirror the established pattern used by every other endpoint:

```ts
const cronSecret = process.env.CRON_SECRET;

// Fail closed — never allow "Bearer undefined" as a credential.
if (!cronSecret) {
  return NextResponse.json(
    { error: "CRON_SECRET is not configured" },
    { status: 500 }
  );
}

if (authHeader !== `Bearer ${cronSecret}` && process.env.NODE_ENV !== "development") {
  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
}
```

When `CRON_SECRET` is absent the endpoint now returns 500 *before any string comparison occurs*, so `Authorization: Bearer undefined` and every other header value are unconditionally rejected.

Development mode intentionally bypasses the header check (existing behavior, preserved); however, the `!cronSecret` guard now fires even in development, ensuring misconfigured environments are surfaced regardless of `NODE_ENV`.

## Tests — `test/wakatime-sync-auth.test.ts` (10 new tests)

| Test | Purpose |
|---|---|
| Missing `CRON_SECRET` → 500 | Fail-closed baseline |
| `Bearer undefined` with missing secret → non-200 | Direct regression for #1746 |
| Correct `Bearer <secret>` → 200 | Happy path |
| Wrong secret in production → 401 | Header rejection |
| No header in production → 401 | Missing header rejection |
| Plaintext secret without `Bearer` → 401 | Malformed header |
| Development: any header passes | Intentional bypass preserved |
| Missing `CRON_SECRET` in development → 500 | Fail closed even in dev |
| Decryption failure → counted as failure, not crash | Error handling |
| Full happy-path: decrypt → WakaTime call → upsert | Sync execution |

All 10 pass. The one pre-existing failure in `test/dateUtils.test.ts` is a timezone boundary issue unrelated to this change.