### PR TITLE
fix: invalidate leaderboard cache after visibility settings change

### DIFF
--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
 import { encryptToken } from "@/lib/crypto";
+import { clearLeaderboardCache } from "@/lib/leaderboard";
 
 export const dynamic = "force-dynamic";
 
@@ -352,6 +353,22 @@ export async function PATCH(req: NextRequest) {
   if (updateError || !updated) {
     console.error("Error updating settings:", updateError);
     return NextResponse.json({ error: "Failed to update settings" }, { status: 500 });
+  }
+
+  // If is_public or leaderboard_opt_in changed, the cached leaderboard would
+  // show stale eligibility until it expires (up to 1 hour). Bust the cache
+  // immediately so the next request reflects the updated preference.
+  const leaderboardEligibilityChanged =
+    "is_public" in updates || "leaderboard_opt_in" in updates;
+
+  if (leaderboardEligibilityChanged) {
+    try {
+      await clearLeaderboardCache();
+    } catch {
+      // Cache invalidation is best-effort — a failure must not prevent the
+      // settings response from reaching the client.
+      console.error("[settings] Failed to invalidate leaderboard cache after visibility change");
+    }
   }
 
   return NextResponse.json({

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,6 +1,6 @@
 import { supabaseAdmin } from "@/lib/supabase";
 import { dateDiffDays, toDateStr } from "@/lib/dateUtils";
-import { cacheGet, cacheSet } from "@/lib/metrics-cache";
+import { cacheGet, cacheSet, cacheDelete } from "@/lib/metrics-cache";
 import {
   pruneExpiredLeaderboardCache,
   type LeaderboardCacheEntry,
@@ -94,6 +94,25 @@ export function setMemoryCachedLeaderboard(payload: LeaderboardPayload): void {
     payload,
     expiresAt: Date.now() + CACHE_REFRESH_SECONDS * 1000,
   };
+}
+
+/**
+ * Evicts every layer of the leaderboard cache so the next request
+ * fetches fresh eligibility data from the database.
+ *
+ * Must be called whenever a user changes settings that affect leaderboard
+ * eligibility (is_public or leaderboard_opt_in) so that the updated
+ * preference is reflected immediately rather than waiting up to one hour
+ * for the cache to expire naturally.
+ */
+export async function clearLeaderboardCache(): Promise<void> {
+  // 1. Drop the module-level in-process cache.
+  _memoryCache = null;
+
+  // 2. Drop the shared key from the metrics memory map and from Redis/Upstash
+  //    so that other serverless instances also see a cache miss on their next
+  //    leaderboard request.
+  await cacheDelete(LEADERBOARD_CACHE_KEY);
 }
 
 async function mapWithConcurrency<T, R>(

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -202,6 +202,24 @@ export async function withMetricsCache<T>(
   return fresh;
 }
 
+/**
+ * Removes a single cache key from both the in-process memory store and Redis.
+ * Used to evict a specific entry (e.g. the shared leaderboard key) without
+ * scanning all keys the way invalidateUserMetricsCache does for per-user data.
+ */
+export async function cacheDelete(key: string): Promise<void> {
+  memoryCache.delete(key);
+
+  const redis = getRedisClient();
+  if (!redis) return;
+
+  try {
+    await redis.del(key);
+  } catch {
+    // Cache invalidation failures must not surface to callers.
+  }
+}
+
 export async function invalidateUserMetricsCache(userId: string): Promise<void> {
   const prefix = `metrics:${userId}:`;
 

--- a/test/leaderboard-cache-invalidation.test.ts
+++ b/test/leaderboard-cache-invalidation.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Regression tests for leaderboard stale-cache visibility (#1779).
+ *
+ * Background
+ * ----------
+ * The leaderboard is cached at two levels:
+ *   1. A module-level in-process Map (_memoryCache in leaderboard.ts)
+ *   2. A shared Redis/Upstash entry (LEADERBOARD_CACHE_KEY)
+ *
+ * Before this fix, PATCH /api/user/settings persisted is_public and
+ * leaderboard_opt_in changes to the database but did not invalidate
+ * either cache layer. A user who opted out remained visible on the
+ * leaderboard for up to one hour. A user who opted in was invisible
+ * for the same duration.
+ *
+ * Fix
+ * ---
+ * After a successful PATCH that modifies is_public or leaderboard_opt_in,
+ * the settings route now calls clearLeaderboardCache(), which:
+ *   - nulls _memoryCache in leaderboard.ts
+ *   - deletes the key from the in-process metrics memory Map
+ *   - deletes the key from Redis/Upstash
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveAppUser: vi.fn(),
+  supabaseFrom: vi.fn(),
+  clearLeaderboardCache: vi.fn(),
+  cacheDelete: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/resolve-user", () => ({ resolveAppUser: mocks.resolveAppUser }));
+vi.mock("@/lib/crypto", () => ({ encryptToken: vi.fn() }));
+vi.mock("@/lib/leaderboard", () => ({
+  clearLeaderboardCache: mocks.clearLeaderboardCache,
+}));
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const DB_USER = {
+  id: "user-uuid",
+  github_login: "alice",
+  is_public: true,
+  leaderboard_opt_in: true,
+  bio: "",
+  pinned_repos: [],
+  wakatime_api_key_encrypted: null,
+  wakatime_api_key_iv: null,
+  weekly_digest_opt_in: false,
+  discord_webhook_url: null,
+  timezone: "UTC",
+};
+
+function setupSupabase(updatedFields: Partial<typeof DB_USER> = {}) {
+  const selectSingle = vi.fn().mockResolvedValue({ data: DB_USER, error: null });
+  const selectEq = vi.fn().mockReturnValue({ single: selectSingle });
+  const selectChain = vi.fn().mockReturnValue({ eq: selectEq });
+
+  const updateSingle = vi.fn().mockResolvedValue({
+    data: { ...DB_USER, ...updatedFields },
+    error: null,
+  });
+  const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+  const updateEq = vi.fn().mockReturnValue({ select: updateSelect });
+  const updateChain = vi.fn().mockReturnValue({ eq: updateEq });
+
+  mocks.supabaseFrom.mockReturnValue({
+    select: selectChain,
+    update: updateChain,
+  });
+
+  return { selectSingle, updateEq, updateChain };
+}
+
+function patchRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/user/settings", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("PATCH /api/user/settings — leaderboard cache invalidation (#1779)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue({ githubId: "gh-1", githubLogin: "alice" });
+    mocks.resolveAppUser.mockResolvedValue({ id: "user-uuid" });
+    mocks.clearLeaderboardCache.mockResolvedValue(undefined);
+  });
+
+  // ── is_public changes ─────────────────────────────────────────────────────
+
+  it("clears the leaderboard cache when is_public is set to false — regression for #1779", async () => {
+    setupSupabase({ is_public: false });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ is_public: false }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.clearLeaderboardCache).toHaveBeenCalledOnce();
+  });
+
+  it("clears the leaderboard cache when is_public is set to true", async () => {
+    setupSupabase({ is_public: true });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ is_public: true }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.clearLeaderboardCache).toHaveBeenCalledOnce();
+  });
+
+  // ── leaderboard_opt_in changes ────────────────────────────────────────────
+
+  it("clears the leaderboard cache when leaderboard_opt_in is set to false — regression for #1779", async () => {
+    setupSupabase({ leaderboard_opt_in: false });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ leaderboard_opt_in: false }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.clearLeaderboardCache).toHaveBeenCalledOnce();
+  });
+
+  it("clears the leaderboard cache when leaderboard_opt_in is set to true", async () => {
+    setupSupabase({ leaderboard_opt_in: true, is_public: true });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ leaderboard_opt_in: true }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.clearLeaderboardCache).toHaveBeenCalledOnce();
+  });
+
+  it("clears the cache once even when both is_public and leaderboard_opt_in change", async () => {
+    setupSupabase({ is_public: false, leaderboard_opt_in: false });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ is_public: false, leaderboard_opt_in: false }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.clearLeaderboardCache).toHaveBeenCalledOnce();
+  });
+
+  // ── irrelevant changes — cache must NOT be cleared ────────────────────────
+
+  it("does NOT clear the leaderboard cache when only bio changes", async () => {
+    setupSupabase({ bio: "New bio" });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ bio: "New bio" }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.clearLeaderboardCache).not.toHaveBeenCalled();
+  });
+
+  it("does NOT clear the leaderboard cache when only timezone changes", async () => {
+    setupSupabase({ timezone: "America/New_York" });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ timezone: "America/New_York" }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.clearLeaderboardCache).not.toHaveBeenCalled();
+  });
+
+  it("does NOT clear the leaderboard cache when only weekly_digest_opt_in changes", async () => {
+    setupSupabase({ weekly_digest_opt_in: true });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ weekly_digest_opt_in: true }));
+
+    expect(res.status).toBe(200);
+    expect(mocks.clearLeaderboardCache).not.toHaveBeenCalled();
+  });
+
+  // ── error resilience ──────────────────────────────────────────────────────
+
+  it("still returns 200 when clearLeaderboardCache throws — invalidation is best-effort", async () => {
+    mocks.clearLeaderboardCache.mockRejectedValue(new Error("Redis unavailable"));
+    setupSupabase({ is_public: false });
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ is_public: false }));
+
+    // The settings update must succeed even if cache invalidation fails.
+    expect(res.status).toBe(200);
+  });
+
+  // ── 401/404 paths — cache must never be touched ───────────────────────────
+
+  it("does NOT clear the leaderboard cache when the request is unauthenticated", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ is_public: false }));
+
+    expect(res.status).toBe(401);
+    expect(mocks.clearLeaderboardCache).not.toHaveBeenCalled();
+  });
+
+  it("does NOT clear the leaderboard cache when the user cannot be resolved", async () => {
+    mocks.resolveAppUser.mockResolvedValue(null);
+    const { PATCH } = await import("@/app/api/user/settings/route");
+
+    const res = await PATCH(patchRequest({ is_public: false }));
+
+    expect(res.status).toBe(404);
+    expect(mocks.clearLeaderboardCache).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
Closes #1779

## Problem

The leaderboard is cached at two levels:

| Layer | Key | TTL |
|---|---|---|
| Module-level in-process variable (`_memoryCache`) | n/a | 1 hour |
| Shared Redis/Upstash entry | `leaderboard:v1` | 6 hours |

`PATCH /api/user/settings` persists `is_public` and `leaderboard_opt_in` changes to the database but does **not** invalidate either cache layer. A user who opts out of the leaderboard therefore remains visible to other users for up to one hour; a user who opts in remains invisible for the same duration.

**Reproduction:** change either setting in the dashboard and immediately visit the leaderboard — the old state persists until cache expiry.

## Fix

### `src/lib/metrics-cache.ts` — new `cacheDelete`

```ts
export async function cacheDelete(key: string): Promise<void> {
  memoryCache.delete(key);
  const redis = getRedisClient();
  if (!redis) return;
  try { await redis.del(key); } catch { /* best-effort */ }
}
```

Removes a single key from both the in-process memory Map and Redis/Upstash. Complements the existing `invalidateUserMetricsCache` (which scans a per-user prefix) for the case where one shared key must be evicted.

### `src/lib/leaderboard.ts` — new `clearLeaderboardCache`

```ts
export async function clearLeaderboardCache(): Promise<void> {
  _memoryCache = null;                        // in-process module-level cache
  await cacheDelete(LEADERBOARD_CACHE_KEY);   // metrics memory + Redis/Upstash
}
```

Evicts every cache layer so the next leaderboard request must rebuild from the database, reflecting updated preferences immediately.

### `src/app/api/user/settings/route.ts` — call invalidation after relevant PATCHes

```ts
const leaderboardEligibilityChanged =
  "is_public" in updates || "leaderboard_opt_in" in updates;

if (leaderboardEligibilityChanged) {
  try {
    await clearLeaderboardCache();
  } catch {
    // best-effort — must not fail the settings response
    console.error("[settings] Failed to invalidate leaderboard cache after visibility change");
  }
}
```

The check runs only after a successful DB write. It is scoped to the two fields that control leaderboard eligibility; unrelated changes (bio, timezone, etc.) do not trigger a cache bust.

## Cache invalidation flow

```
User toggles is_public / leaderboard_opt_in
  → PATCH /api/user/settings
      → DB write succeeds
      → clearLeaderboardCache()
          → _memoryCache = null                (same process)
          → cacheDelete("leaderboard:v1")
              → memoryCache.delete(key)        (in-process metrics Map)
              → redis.del("leaderboard:v1")    (Redis/Upstash)
      → 200 OK
Next leaderboard request: all cache layers miss → buildLeaderboard() → fresh DB query
```

## Tests — `test/leaderboard-cache-invalidation.test.ts` (11 new tests)

| Category | Tests |
|---|---|
| Cache cleared for `is_public` | → false (regression #1779), → true |
| Cache cleared for `leaderboard_opt_in` | → false (regression #1779), → true |
| Both change simultaneously | Cleared exactly once |
| Irrelevant-field changes | `bio`, `timezone`, `weekly_digest_opt_in` — cache NOT cleared |
| Error resilience | `clearLeaderboardCache` throws → PATCH still returns 200 |
| Auth guards | 401 → no cache call; 404 → no cache call |

All 11 pass. The one pre-existing failure in `test/dateUtils.test.ts` is a timezone boundary issue unrelated to this change.