### PR TITLE
fix(navigation): migrate standard HTML links to Next.js Link components for SPA routing

### DIFF
--- a/src/app/compare/[users]/page.tsx
+++ b/src/app/compare/[users]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import Link from "next/link";
 import { Scale, Trophy } from "lucide-react";
 import Image from "next/image";
 import { normalizeGitHubUsername } from "@/lib/validate-github-username";
@@ -110,12 +111,12 @@ export default async function PublicProfileComparePage({
               Shareable comparison built only from publicly visible DevTrack stats.
             </p>
           </div>
-          <a
+          <Link
             href={`/u/${encodeURIComponent(rightProfile.username)}`}
             className="secondary-button inline-flex rounded-lg px-4 py-2 text-sm font-medium"
           >
             View profile
-          </a>
+          </Link>
         </div>
 
         <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_auto_1fr] md:items-stretch">
@@ -201,9 +202,9 @@ function CompareUnavailable({
       <div className="surface-card max-w-md rounded-2xl p-8 text-center">
         <h1 className="mb-2 text-3xl font-bold">{title}</h1>
         <p className="mb-6 text-sm text-[var(--muted-foreground)]">{message}</p>
-        <a href="/" className="primary-button inline-block rounded-lg px-6 py-2">
+        <Link href="/" className="primary-button inline-block rounded-lg px-6 py-2">
           Back to Home
-        </a>
+        </Link>
       </div>
     </div>
   );
@@ -235,12 +236,12 @@ function ProfileHeader({
           className="h-14 w-14 rounded-full border border-[var(--border)]"
         />
         <div className="min-w-0">
-          <a
+          <Link
             href={`/u/${encodeURIComponent(profile.username)}`}
             className="truncate text-xl font-bold text-[var(--card-foreground)] hover:text-[var(--accent)]"
           >
             @{profile.username}
-          </a>
+          </Link>
           <p className="text-sm text-[var(--muted-foreground)]">
             {profile.streak.current} day streak - {profile.contributions.total} commits
           </p>

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1196,12 +1196,13 @@ function SettingsPageContent() {
               </p>
             </div>
 
-            <a
+            <Link
               href="/api/auth/link-github"
+              prefetch={false}
               className="inline-flex items-center justify-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-medium text-[var(--accent-foreground)] hover:opacity-90 transition-opacity"
             >
               Add GitHub Account
-            </a>
+            </Link>
           </div>
 
           {removeError && (

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { Metadata } from "next";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import BadgeSection from "@/components/BadgeSection";
@@ -98,20 +99,20 @@ export default async function PublicProfilePage({
           </p>
           <p className="text-sm text-[var(--muted-foreground)] mb-6">
             If this is your profile, go to{" "}
-            <a
+            <Link
               href="/dashboard/settings"
               className="text-[var(--accent)] underline hover:opacity-80"
             >
               Settings
-            </a>{" "}
+            </Link>{" "}
             and enable <strong>Public Profile</strong>.
           </p>
-          <a
+          <Link
             href="/"
             className="primary-button inline-block rounded-lg px-6 py-2"
           >
             Back to Home
-          </a>
+          </Link>
         </div>
       </div>
     );
@@ -149,20 +150,20 @@ export default async function PublicProfilePage({
             GitHub activity and coding stats
           </p>
           {compareHref && (
-            <a
+            <Link
               href={compareHref}
               className="primary-button mt-4 inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
             >
               Compare with me
-            </a>
+            </Link>
           )}
           {!loggedInUsername && (
-            <a
+            <Link
               href={signInToCompareHref}
               className="secondary-button mt-4 inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
             >
               Log in to compare
-            </a>
+            </Link>
           )}
         </div>
         {/* Download stats card button — client component */}

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import Image from "next/image";
+import Link from 'next/link';
 
 /* ═══════════════════════════════════════════════════════════
    PUBLIC TYPES
@@ -422,7 +423,7 @@ function HeroSection() {
 
         {/* CTAs */}
         <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
-          <a href="/api/auth/signin/github?callbackUrl=/dashboard" className="lnd-cta-primary" style={{
+          <Link href="/api/auth/signin/github?callbackUrl=/dashboard" prefetch={false} className="lnd-cta-primary" style={{
             boxShadow: '0 8px 24px rgba(129,140,248,0.3)',
             transition: 'transform 0.3s, box-shadow 0.3s',
             transform: 'translateY(0)',
@@ -439,7 +440,7 @@ function HeroSection() {
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
             </svg>
             Sign in with GitHub
-          </a>
+          </Link>
           <a
             href="https://github.com/Priyanshu-byte-coder/devtrack"
             target="_blank"
@@ -719,9 +720,9 @@ function SetupSection() {
       </div>
 
       <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', justifyContent: 'center' }}>
-        <a href="/api/auth/signin/github?callbackUrl=/dashboard" className="lnd-cta-primary">
+        <Link href="/api/auth/signin/github?callbackUrl=/dashboard" prefetch={false} className="lnd-cta-primary">
           Sign in with GitHub
-        </a>
+        </Link>
         <a
           href="https://github.com/Priyanshu-byte-coder/devtrack"
           target="_blank"


### PR DESCRIPTION
## Description
This PR replaces several standard HTML `<a>` tags used for internal navigation with `next/link` components. 

Previously, standard anchor tags were forcing full browser page reloads when users navigated between internal pages (e.g., from the public profile to the dashboard settings or compare pages). By upgrading to Next.js `<Link>` components, we restore proper client-side Single Page Application (SPA) routing.

## Resolved Issue
Resolves #1786 

## Changes Made
- **Routing Optimization**: Replaced `<a>` tags with `<Link>` components in the following files:
  - `src/app/compare/[users]/page.tsx`
  - `src/app/dashboard/settings/page.tsx`
  - `src/app/u/[username]/page.tsx`
  - `src/components/landing/LandingPage.tsx`
- **Auth Routes**: Used `prefetch={false}` on specific API route links (e.g., `/api/auth/link-github` and `/api/auth/signin/github`) to ensure NextAuth server-side redirects work seamlessly without unwanted client-side prefetching.
- **Linting**: Successfully resolved all instances of the `@next/next/no-html-link-for-pages` ESLint warnings.

## Impact
- **Performance**: Eliminates unnecessary full-page reloads, drastically reducing perceived latency during internal navigation.
- **User Experience**: State is properly preserved during transitions, leading to a much smoother, app-like experience.

## Testing
- [x] Verified that internal links (e.g., "Back to Home", "Settings", "Compare with me") navigate instantly via SPA routing.
- [x] Verified that GitHub authentication links still correctly redirect to NextAuth API endpoints.
- [x] Ran `npm run lint` and confirmed 0 `no-html-link-for-pages` errors.
