### PR TITLE
fix(api): propagate database errors correctly in local-coding stats endpoint

### DIFF
--- a/src/app/api/local-coding/stats/route.ts
+++ b/src/app/api/local-coding/stats/route.ts
@@ -40,12 +40,11 @@ export async function GET(req: NextRequest) {
     .order("date", { ascending: false });
 
   if (error) {
-    // Table may not exist in all deployments — degrade gracefully
-    return Response.json({
-      dailyData: [],
-      totals: { totalSeconds: 0, totalDays: 0, avgSecondsPerDay: 0 },
-      hasData: false,
-    });
+    console.error("Failed to fetch local coding stats:", error);
+    return Response.json(
+      { error: "Failed to fetch local coding stats" },
+      { status: 500 }
+    );
   }
 
   if (!sessions || sessions.length === 0) {


### PR DESCRIPTION
## Description
This PR addresses a silent failure issue in the backend where critical database connection or query errors were being intentionally swallowed by the API.

Previously, the `/api/local-coding/stats` route caught database query failures (e.g., if the Supabase instance was down or unreachable) and "gracefully degraded" by returning an empty, mock data object alongside a `200 OK` status. This masked underlying infrastructure issues, broke frontend error handling (since the `fetch` API assumed success), and made debugging significantly more difficult.

## Resolved Issue
Resolves #1792 

## Changes Made
- **Error Propagation**: Removed the fallback mechanism in `src/app/api/local-coding/stats/route.ts`. The endpoint now correctly catches database errors, logs them to the server console, and halts execution by returning a standard `500 Internal Server Error` status with an appropriate error message.

## Impact
- **Observability**: Backend database failures are now immediately visible to the frontend, enabling proper fallback states, retry logic, or user-facing error messages instead of displaying mysteriously empty charts.

## Testing
- [x] Ran the unit test suite (`npm run test test/local-coding-stats.test.ts`).
- [x] Verified that the test asserting the endpoint "returns 500 when Supabase fails instead of hiding the error as empty stats" now completely passes.
