### PR TITLE
fix(api): cleanly handle abort signals and controller state in SSE stream API

### DIFF
--- a/src/app/api/stream/route.ts
+++ b/src/app/api/stream/route.ts
@@ -52,9 +52,12 @@ export async function GET(req: NextRequest) {
   let lastCheckedSyncedAt: string | null = null;
   let lastCheckedUnreadCount: number | null = null;
 
+  let isClosed = false;
+
   const stream = new ReadableStream({
     start(controller) {
       const checkData = async () => {
+        if (isClosed) return;
         try {
           const { data: goals } = await supabaseAdmin
             .from("goals")
@@ -89,7 +92,7 @@ export async function GET(req: NextRequest) {
             lastCheckedUnreadCount = currentUnreadCount;
           }
 
-          if (hasChanges) {
+          if (hasChanges && !isClosed) {
             controller.enqueue(`data: ${JSON.stringify(payload)}\n\n`);
           }
         } catch (error) {
@@ -101,12 +104,17 @@ export async function GET(req: NextRequest) {
       // guaranteed to be in place before any async work begins. This prevents
       // a race where abort() fires before the listener is attached.
       const interval = setInterval(() => {
-        checkData();
+        if (!isClosed) checkData();
       }, POLL_INTERVAL_MS);
 
       req.signal.addEventListener("abort", () => {
+        isClosed = true;
         clearInterval(interval);
-        controller.close();
+        try {
+          controller.close();
+        } catch (e) {
+          // ignore already closed
+        }
 
         // Decrement the connection counter so the slot becomes available again.
         const remaining = activeStreamConnections.get(userId) ?? 1;

--- a/test/sse-stream-route.test.ts
+++ b/test/sse-stream-route.test.ts
@@ -21,16 +21,15 @@ vi.mock("@/lib/supabase", () => ({
 
 function makeRequest(): NextRequest {
   const controller = new AbortController();
-  return new NextRequest("http://localhost/api/stream", {
-    signal: controller.signal,
-  });
+  const req = new NextRequest("http://localhost/api/stream");
+  Object.defineProperty(req, 'signal', { value: controller.signal });
+  return req;
 }
 
 function makeAbortableRequest(): { req: NextRequest; abort: () => void } {
   const controller = new AbortController();
-  const req = new NextRequest("http://localhost/api/stream", {
-    signal: controller.signal,
-  });
+  const req = new NextRequest("http://localhost/api/stream");
+  Object.defineProperty(req, 'signal', { value: controller.signal });
   return { req, abort: () => controller.abort() };
 }
 


### PR DESCRIPTION
## Description
This PR addresses flakiness and memory leak issues in the Server-Sent Events (SSE) streaming API (`/api/stream`), as well as fixing the associated test suite which was failing completely.

Previously, if a client disconnected while the backend was waiting on an asynchronous database poll, the server would subsequently attempt to call `controller.enqueue()` on an already closed stream. This resulted in noisy `TypeError: Invalid state: Controller is already closed` exceptions and potential hanging promises. 

Additionally, the `test/sse-stream-route.test.ts` suite was completely failing due to a cross-environment Type mismatch where `NextRequest` rejected the Node-native `AbortSignal` constructed by Vitest.

## Resolved Issue
Resolves #1794 

## Changes Made
- **Safe SSE Teardown**: Introduced a robust `isClosed` flag to the SSE polling logic. The interval now immediately halts on abort, and any pending async database responses are safely discarded without attempting to enqueue into a dead stream.
- **Test Suite Resiliency**: Updated the test mocks to bypass strict `NextRequest` constructor validations by injecting the `AbortSignal` via `Object.defineProperty` post-instantiation.

## Impact
- **Backend Stability**: Prevents noisy console errors, resolves race conditions, and ensures clean teardown of resources when users close dashboard tabs.
- **Continuous Integration**: The SSE test suite is now fully unblocked and reliably passes all concurrency and memory-leak checks.

## Testing
- [x] Ran the full SSE test suite locally (`npm run test test/sse-stream-route.test.ts`).
- [x] Verified that all 15 concurrency and abort cleanup tests pass flawlessly with 0 console errors.
