### PR TITLE
chore: add security warning to .env.example to prevent secret leaks (…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
+# ==============================================================================
+# 🚨 SECURITY WARNING 🚨 
+# NEVER PLACE REAL API KEYS, SECRETS, OR PASSWORDS IN THIS FILE!
+# This file is tracked by version control and is public to the entire internet.
+# Copy this file to '.env.local' and put your real keys there instead.
+# ==============================================================================
+
 # -------------------------------------------------------
 # Supabase
 # Project Settings → API → Project URL


### PR DESCRIPTION
chore: add security warning to .env.example to prevent secret leaks (fixes #1828)

## Summary

Added a strict security warning header to `.env.example` to ensure contributors do not commit real Supabase keys or GitHub OAuth credentials to version control. This prevents future occurrences of the secret leaks detailed in issue #1828.

Closes #1828

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update / Security
- [ ] Refactor / code cleanup

---

## Changes Made

- Added a massive, unmissable security warning to the top of `.env.example`.
- Reminded contributors to use `.env.local` for real credentials.

---

## How to Test

Steps for the reviewer to verify this works:

1. Open `.env.example`
2. Verify the security warning header is highly visible at the top of the file.

---

## Screenshots (if UI change)

N/A

---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

- [ ] Proper keyboard navigation tested
- [ ] Responsive UI verified
- [ ] Accessibility labels added where needed
*(N/A - This PR does not contain UI changes)*

---

## Additional Notes

**Important for Maintainers:** As documented in #1828, although the previously leaked keys were removed from this file in commit `73682c3`, they remain visible in the repository's Git history (originating in commit `a9a5ae1`). **An administrator must still manually revoke and rotate the Supabase and GitHub OAuth keys** to fully resolve the security incident.
