### PR TITLE
Add a Gists stat chip to the profile header

### DIFF
--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -124,6 +124,7 @@ export default async function PublicProfilePage({
 
   const avatarUrl = `https://avatars.githubusercontent.com/${profile.username}`;
   const topRepo = profile.repos[0]?.name ?? "";
+  const gistsUrl = `https://gist.github.com/${profile.username}`;
   const showCompareButton =
     loggedInUsername !== null &&
     loggedInUsername.toLowerCase() !== profile.username.toLowerCase();
@@ -148,6 +149,18 @@ export default async function PublicProfilePage({
           <p className="mt-2 text-[var(--muted-foreground)]">
             GitHub activity and coding stats
           </p>
+          {profile.publicGists > 0 && (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <a
+                href={gistsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center rounded-full border border-[var(--border)] bg-[var(--control)] px-3 py-1.5 text-sm font-medium text-[var(--card-foreground)] transition-colors hover:bg-[var(--control)]/80 hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/50"
+              >
+                {profile.publicGists} Gists
+              </a>
+            </div>
+          )}
           {compareHref && (
             <a
               href={compareHref}

--- a/src/lib/public-profile-data.ts
+++ b/src/lib/public-profile-data.ts
@@ -35,6 +35,7 @@ export interface PublicProfileData {
   username: string;
   bio: string | null;
   isSponsor: boolean;
+  publicGists: number;
   repos: TopRepo[];
   contributions: ContributionData;
   streak: StreakData;
@@ -51,6 +52,18 @@ async function ghFetch(url: string, token?: string): Promise<Response> {
   };
   if (token) headers.Authorization = `Bearer ${token}`;
   return fetch(url, { headers, cache: "no-store" });
+}
+
+export async function fetchPublicGists(
+  username: string,
+  token?: string
+): Promise<number> {
+  const res = await ghFetch(`${GITHUB_API}/users/${username}`, token);
+
+  if (!res.ok) return 0;
+
+  const data = (await res.json()) as { public_gists?: number };
+  return data.public_gists ?? 0;
 }
 
 export async function fetchPublicTopRepos(
@@ -250,6 +263,7 @@ export async function fetchPublicProfile(
 
   const githubToken = process.env.GITHUB_TOKEN;
   const [
+    publicGists,
     repos,
     contributions,
     streak,
@@ -258,6 +272,7 @@ export async function fetchPublicProfile(
     achievementsCache,
     spotlight,
   ] = await Promise.all([
+    fetchPublicGists(user.github_login, githubToken),
     fetchPublicTopRepos(user.github_login, githubToken, 30),
     fetchPublicContributions(user.github_login, githubToken, 30),
     fetchPublicStreak(user.github_login, githubToken),
@@ -281,6 +296,7 @@ export async function fetchPublicProfile(
     username: user.github_login,
     bio: user.bio ?? null,
     isSponsor: user.is_sponsor ?? false,
+    publicGists,
     repos,
     contributions,
     streak,

--- a/test/public-profile-data.test.ts
+++ b/test/public-profile-data.test.ts
@@ -4,6 +4,7 @@ import {
   fetchPublicContributions,
   fetchPublicStreak,
   fetchTopLanguage,
+  fetchPublicGists,
 } from "../src/lib/public-profile-data";
 
 describe("public-profile-data", () => {
@@ -43,6 +44,27 @@ describe("public-profile-data", () => {
 
       const repos = await fetchPublicTopRepos("user123");
       expect(repos).toEqual([]);
+    });
+  });
+
+  describe("fetchPublicGists", () => {
+    it("should return the public gist count on successful API response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ public_gists: 7 }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const gists = await fetchPublicGists("user123");
+      expect(gists).toBe(7);
+    });
+
+    it("should return zero on failed API response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const gists = await fetchPublicGists("user123");
+      expect(gists).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

Added GitHub gist count support to the public profile header so users with public gists now see a linked `N Gists` chip.

---
closes #212 
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Fetched `public_gists` from the GitHub REST `GET /users/{username}` endpoint
- Added `publicGists` to the public profile data model
- Rendered a conditional gist chip in the public profile header
- Linked the chip to the user's GitHub gists page
- Added unit tests for the new gist fetch helper

---

## How to Test

Steps for the reviewer to verify this works:

1. Open a public profile with at least one public gist
2. Verify a `N Gists` chip appears in the header
3. Click the chip and confirm it opens the user's GitHub gists page
4. Open a profile with zero public gists and confirm the chip is hidden

---



## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] Keyboard navigation works for the gist chip link
- [x] The link has a clear destination
- [x] The chip remains hidden when not applicable

---

## Additional Notes

The gist chip is only shown when `public_gists > 0` to keep the header clean for users without public gists.