### PR TITLE
fix : redesign logout button to show text in the light mode

### DIFF
--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -51,11 +51,11 @@ export default function SignOutButton() {
             suppressHydrationWarning
             onClick={() => setConfirming(true)}
             aria-label="Sign out"
-            className="inline-flex h-10 items-center gap-2 rounded-full border border-[var(--destructive)]/50 bg-[var(--destructive)]/80 px-4 text-sm font-semibold text-[var(--destructive-foreground)] transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-70"
+            className="inline-flex h-10 items-center gap-2 rounded-full border border-[var(--destructive)]/50 bg-[var(--destructive)]/80 px-4 text-sm font-semibold text-[var(--foreground)] transition-colors hover:bg-[var(--destructive)] disabled:cursor-not-allowed disabled:opacity-70"
         >
             {signingOut && (
                 <svg
-                    className="h-4 w-4 animate-spin text-[var(--destructive-foreground)]"
+                    className="h-4 w-4 animate-spin text-[var(--foreground)]"
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"
                     viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
Redesigned the logout button to display text in light mode, as sometimes the "Sign Out" text appeared in white and was not visible. Explicitly specified the text color in the class to fix this issue.

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [] Documentation update
- [ ] Refactor / code cleanup



## Screenshots (if UI change)
before 
<img width="820" height="244" alt="Screenshot 2026-06-01 182036" src="https://github.com/user-attachments/assets/f96a73ad-3b64-44c2-8f34-b871d2f0c719" />


After
<img width="819" height="137" alt="image" src="https://github.com/user-attachments/assets/72dee771-466f-4a19-991a-314161808ba1" />


---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

