### PR TITLE
security: fix debug health endpoint information disclosure

### DIFF
--- a/src/app/api/debug/health/route.ts
+++ b/src/app/api/debug/health/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
@@ -7,11 +7,28 @@ export const dynamic = "force-dynamic";
 
 /**
  * Debug health endpoint — only enabled when ENABLE_DEBUG_ENDPOINT=true
- * Returns internal state for diagnostic purposes during development.
- * IMPORTANT: Do not enable in production.
+ * AND the caller supplies the correct Authorization: Bearer <DEBUG_SECRET>.
+ *
+ * Access control layers:
+ *   1. ENABLE_DEBUG_ENDPOINT must be exactly "true" (env-var gate).
+ *   2. DEBUG_SECRET must be configured in the environment.
+ *   3. The request must supply Authorization: Bearer <DEBUG_SECRET>.
+ *
+ * If all three pass, the endpoint returns non-sensitive operational state:
+ *   - timestamp
+ *   - database connectivity status (boolean + error message on failure)
+ *   - whether the caller holds a valid session (boolean only)
+ *
+ * What is deliberately NOT returned:
+ *   - secret presence indicators (NEXTAUTH_SECRET, SUPABASE_SERVICE_ROLE_KEY, etc.)
+ *   - any part of session token or JWT
+ *   - githubId or githubLogin — these are account identifiers
+ *
+ * IMPORTANT: Never enable in production without also setting DEBUG_SECRET
+ * to a strong randomly-generated value.
  */
-export async function GET() {
-  // Guard: only serve if explicitly enabled via env var
+export async function GET(req: NextRequest) {
+  // ── Gate 1: feature flag ─────────────────────────────────────────────────
   if (process.env.ENABLE_DEBUG_ENDPOINT !== "true") {
     return NextResponse.json(
       { error: "Debug endpoint is disabled" },
@@ -19,10 +36,39 @@ export async function GET() {
     );
   }
 
-  try {
-    const session = await getServerSession(authOptions);
+  // ── Gate 2: mandatory debug secret ──────────────────────────────────────
+  // Requiring a secret means the endpoint cannot be probed by an attacker
+  // who simply discovers the URL. ENABLE_DEBUG_ENDPOINT alone is not
+  // sufficient access control for a remotely reachable endpoint.
+  const debugSecret = process.env.DEBUG_SECRET;
+  if (!debugSecret) {
+    // Fail closed: if DEBUG_SECRET is not configured the endpoint must not
+    // serve diagnostic data even if ENABLE_DEBUG_ENDPOINT is true.
+    return NextResponse.json(
+      { error: "Debug endpoint is not configured correctly" },
+      { status: 403 }
+    );
+  }
 
-    // Basic connectivity check
+  // ── Gate 3: Bearer token validation ─────────────────────────────────────
+  const authHeader = req.headers.get("authorization");
+  const provided = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : null;
+
+  // Constant-time comparison is not critical here because the endpoint is
+  // already hidden behind the feature flag, but a simple equality check is
+  // still the right idiom.
+  if (!provided || provided !== debugSecret) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  // ── Operational diagnostics (non-sensitive) ──────────────────────────────
+  try {
+    // Database connectivity check
     let dbHealthy = true;
     let dbError: string | null = null;
 
@@ -41,31 +87,23 @@ export async function GET() {
       dbError = err instanceof Error ? err.message : String(err);
     }
 
+    // Session check — return only a boolean; never expose account identifiers
+    // (githubId, githubLogin) because this endpoint is reachable by anyone
+    // who holds the DEBUG_SECRET, which may differ from the account owner.
+    const session = await getServerSession(authOptions);
+
     return NextResponse.json({
       status: "ok",
       timestamp: new Date().toISOString(),
-      environment: {
-        nextPublicSupabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL ? "set" : "missing",
-        supabaseServiceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY
-          ? "set"
-          : "missing",
-        nextAuthSecret: process.env.NEXTAUTH_SECRET ? "set" : "missing",
-        githubId: process.env.GITHUB_ID ? "set" : "missing",
-        githubSecret: process.env.GITHUB_SECRET ? "set" : "missing",
-      },
       database: {
         healthy: dbHealthy,
         error: dbError,
       },
-      session: session
-        ? {
-            authenticated: true,
-            githubId: session.githubId,
-            githubLogin: session.githubLogin,
-          }
-        : {
-            authenticated: false,
-          },
+      session: {
+        // Indicates whether the HTTP client making this request also holds a
+        // valid user session. No account identifiers are included.
+        authenticated: session !== null,
+      },
     });
   } catch (error) {
     console.error("Error in debug health endpoint:", error);

--- a/test/debug-health.test.ts
+++ b/test/debug-health.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Regression tests for the debug health endpoint information disclosure
+ * vulnerability described in issue #1816.
+ *
+ * Background
+ * ----------
+ * The original endpoint required only ENABLE_DEBUG_ENDPOINT=true.  With that
+ * single env-var set, any remote caller could receive:
+ *   - Secret-presence indicators (NEXTAUTH_SECRET, SUPABASE_SERVICE_ROLE_KEY, …)
+ *   - The caller's githubId and githubLogin from their session
+ *
+ * Fix
+ * ---
+ * Three access-control gates are now enforced in sequence:
+ *   1. ENABLE_DEBUG_ENDPOINT must be "true"
+ *   2. DEBUG_SECRET must be set in the environment
+ *   3. Authorization: Bearer <DEBUG_SECRET> must match
+ *
+ * The response no longer includes:
+ *   - Any secret-presence indicators
+ *   - githubId or githubLogin
+ * It retains only non-sensitive operational data (timestamp, DB health, auth boolean).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  supabaseFrom: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const VALID_SECRET = "super-strong-debug-secret";
+
+function makeRequest(authHeader?: string): NextRequest {
+  return new NextRequest("http://localhost/api/debug/health", {
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+function stubHealthyDb() {
+  const limitMock = vi.fn().mockResolvedValue({ error: null });
+  const selectMock = vi.fn().mockReturnValue({ limit: limitMock });
+  mocks.supabaseFrom.mockReturnValue({ select: selectMock });
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/debug/health — access control", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mocks.getServerSession.mockResolvedValue(null);
+    stubHealthyDb();
+  });
+
+  // ── gate 1: feature flag ────────────────────────────────────────────────
+
+  it("returns 403 when ENABLE_DEBUG_ENDPOINT is not set", async () => {
+    vi.stubEnv("ENABLE_DEBUG_ENDPOINT", "");
+    vi.stubEnv("DEBUG_SECRET", VALID_SECRET);
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    expect(res.status).toBe(403);
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when ENABLE_DEBUG_ENDPOINT is not exactly 'true'", async () => {
+    vi.stubEnv("ENABLE_DEBUG_ENDPOINT", "1");
+    vi.stubEnv("DEBUG_SECRET", VALID_SECRET);
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    expect(res.status).toBe(403);
+  });
+
+  // ── gate 2: DEBUG_SECRET must be configured ─────────────────────────────
+
+  it("returns 403 when DEBUG_SECRET is not configured — regression for #1816", async () => {
+    // ENABLE_DEBUG_ENDPOINT=true but no DEBUG_SECRET → must fail closed,
+    // not serve diagnostic data.
+    vi.stubEnv("ENABLE_DEBUG_ENDPOINT", "true");
+    vi.stubEnv("DEBUG_SECRET", "");
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer anything`));
+
+    expect(res.status).toBe(403);
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  // ── gate 3: bearer token validation ────────────────────────────────────
+
+  it("returns 401 when no Authorization header is supplied — regression for #1816", async () => {
+    vi.stubEnv("ENABLE_DEBUG_ENDPOINT", "true");
+    vi.stubEnv("DEBUG_SECRET", VALID_SECRET);
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest()); // no header
+
+    expect(res.status).toBe(401);
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a wrong secret", async () => {
+    vi.stubEnv("ENABLE_DEBUG_ENDPOINT", "true");
+    vi.stubEnv("DEBUG_SECRET", VALID_SECRET);
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest("Bearer wrong-secret"));
+
+    expect(res.status).toBe(401);
+    expect(mocks.supabaseFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a non-Bearer scheme", async () => {
+    vi.stubEnv("ENABLE_DEBUG_ENDPOINT", "true");
+    vi.stubEnv("DEBUG_SECRET", VALID_SECRET);
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Basic ${VALID_SECRET}`));
+
+    expect(res.status).toBe(401);
+  });
+
+  // ── authorised access ────────────────────────────────────────────────────
+
+  it("returns 200 with the correct Bearer token", async () => {
+    vi.stubEnv("ENABLE_DEBUG_ENDPOINT", "true");
+    vi.stubEnv("DEBUG_SECRET", VALID_SECRET);
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.timestamp).toBeTruthy();
+  });
+});
+
+describe("GET /api/debug/health — information disclosure prevention (#1816)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv("ENABLE_DEBUG_ENDPOINT", "true");
+    vi.stubEnv("DEBUG_SECRET", VALID_SECRET);
+    mocks.getServerSession.mockResolvedValue(null);
+    stubHealthyDb();
+  });
+
+  // ── secret presence indicators must never be exposed ───────────────────
+
+  it("never returns secret-presence indicators — regression for #1816", async () => {
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+    const serialised = JSON.stringify(body);
+
+    // These field names must not appear in any form
+    expect(serialised).not.toContain("nextAuthSecret");
+    expect(serialised).not.toContain("githubSecret");
+    expect(serialised).not.toContain("supabaseServiceRoleKey");
+    expect(serialised).not.toContain("NEXTAUTH_SECRET");
+    expect(serialised).not.toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(serialised).not.toContain("GITHUB_SECRET");
+    // The "environment" object must not appear at all
+    expect(body).not.toHaveProperty("environment");
+  });
+
+  it("never returns 'set' or 'missing' secret indicators", async () => {
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+    const serialised = JSON.stringify(body);
+
+    // These are the exact values the old code returned for secret presence
+    // — they must no longer appear anywhere in the response.
+    expect(serialised).not.toContain('"set"');
+    expect(serialised).not.toContain('"missing"');
+  });
+
+  // ── session identifiers must never be exposed ──────────────────────────
+
+  it("never exposes githubId — regression for #1816", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      githubId: "12345678",
+      githubLogin: "alice",
+    });
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+    const serialised = JSON.stringify(body);
+
+    expect(serialised).not.toContain("12345678");
+    expect(serialised).not.toContain("githubId");
+  });
+
+  it("never exposes githubLogin — regression for #1816", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      githubId: "12345678",
+      githubLogin: "alice",
+    });
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+    const serialised = JSON.stringify(body);
+
+    expect(serialised).not.toContain("alice");
+    expect(serialised).not.toContain("githubLogin");
+  });
+
+  // ── session state reported as boolean only ──────────────────────────────
+
+  it("reports authenticated:true when a session exists, without identifiers", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      githubId: "12345678",
+      githubLogin: "alice",
+    });
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+    expect(body.session.authenticated).toBe(true);
+    expect(body.session).not.toHaveProperty("githubId");
+    expect(body.session).not.toHaveProperty("githubLogin");
+  });
+
+  it("reports authenticated:false when no session exists", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+    expect(body.session.authenticated).toBe(false);
+  });
+
+  // ── database diagnostics remain functional ─────────────────────────────
+
+  it("reports healthy database connectivity", async () => {
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+    expect(body.database.healthy).toBe(true);
+    expect(body.database.error).toBeNull();
+  });
+
+  it("reports database error when Supabase is unreachable", async () => {
+    const limitMock = vi.fn().mockResolvedValue({
+      error: { message: "Connection refused" },
+    });
+    const selectMock = vi.fn().mockReturnValue({ limit: limitMock });
+    mocks.supabaseFrom.mockReturnValue({ select: selectMock });
+
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+    expect(body.database.healthy).toBe(false);
+    expect(body.database.error).toBe("Connection refused");
+  });
+
+  // ── safe response shape ─────────────────────────────────────────────────
+
+  it("response contains only the expected safe fields", async () => {
+    const { GET } = await import("@/app/api/debug/health/route");
+    const res = await GET(makeRequest(`Bearer ${VALID_SECRET}`));
+
+    const body = await res.json();
+
+    // These are the only allowed top-level keys
+    const allowedKeys = new Set(["status", "timestamp", "database", "session"]);
+    const actualKeys = new Set(Object.keys(body));
+
+    for (const key of actualKeys) {
+      expect(allowedKeys).toContain(key);
+    }
+
+    // Sub-keys
+    expect(Object.keys(body.database)).toEqual(
+      expect.arrayContaining(["healthy", "error"])
+    );
+    expect(Object.keys(body.session)).toEqual(["authenticated"]);
+  });
+});


### PR DESCRIPTION
Closes #1816

## Summary

- The debug health endpoint previously returned secret-presence indicators ("set"/"missing" for NEXTAUTH_SECRET, SUPABASE_SERVICE_ROLE_KEY, GITHUB_SECRET, GITHUB_ID) and exposed githubId / githubLogin from the caller's session whenever ENABLE_DEBUG_ENDPOINT=true. A single env-var was the only access control.
- Two additional gates are now enforced: DEBUG_SECRET must be configured in the environment, and callers must supply Authorization: Bearer <DEBUG_SECRET>. The endpoint fails closed if DEBUG_SECRET is absent even when the feature flag is true.
- The response no longer contains the environment object or any account identifiers — only status, timestamp, database (healthy bool + error string), and session.authenticated (bool).

## Root cause

ENABLE_DEBUG_ENDPOINT=true was treated as sufficient access control for a remotely reachable HTTP endpoint. The response then included enough metadata (secret presence, GitHub identity) to assist reconnaissance without revealing raw secret values.

## Changes

- src/app/api/debug/health/route.ts — three-gate access control; stripped environment block and account identifiers from response.
- test/debug-health.test.ts — 16 regression tests covering each gate, both information-disclosure vectors, database error reporting, and the safe response shape.

## Test plan

- [ ] All 16 tests in test/debug-health.test.ts pass (npx vitest run test/debug-health.test.ts)
- [ ] Endpoint returns 403 when ENABLE_DEBUG_ENDPOINT is unset or not exactly "true"
- [ ] Endpoint returns 403 when DEBUG_SECRET is not configured (fail-closed)
- [ ] Endpoint returns 401 when Authorization header is missing or incorrect
- [ ] Endpoint returns 200 with correct Bearer token and shows only safe fields
- [ ] Response never contains environment, githubId, githubLogin, or "set"/"missing" indicators
