### PR TITLE
chore: add prominent security warning to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,18 @@
+# ╔══════════════════════════════════════════════════════════════════════════╗
+# ║                        ⚠️  SECURITY WARNING  ⚠️                         ║
+# ║                                                                          ║
+# ║  This file is tracked by Git. NEVER insert real secrets, API keys,       ║
+# ║  tokens, or passwords here. Any real credential committed to this file   ║
+# ║  will be exposed in the Git history forever — even if removed later.      ║
+# ║                                                                          ║
+# ║  Instead:                                                                 ║
+# ║    1. Copy this file to .env.local (already in .gitignore)               ║
+# ║    2. Fill in your actual values there                                   ║
+# ║    3. Keep .env.example as a reference template with placeholder values  ║
+# ║                                                                          ║
+# ║  ✦ If you have accidentally committed a real key, rotate it immediately ✦ ║
+# ╚══════════════════════════════════════════════════════════════════════════╝
+
 # -------------------------------------------------------
 # Supabase
 # Project Settings → API → Project URL


### PR DESCRIPTION
Adds a prominent security banner at the top of .env.example warning contributors not to place real secrets in the tracked template file. Instructs to use .env.local instead and to rotate any leaked keys.

Closes #1828