### PR TITLE
perf: replace timestamp-array badge rate limiter with sliding window counter

### DIFF
--- a/src/lib/badge-rate-limit.ts
+++ b/src/lib/badge-rate-limit.ts
@@ -6,7 +6,14 @@ const BADGE_LIMIT = 20;
 // NOTE: This rate limiter is separate from the API middleware rate limiting.
 // It applies per-IP limiting specifically for badge generation endpoints.
 
-const buckets = new Map<string, number[]>();
+// Sliding window counter entry — O(1) per client instead of O(N) timestamps.
+type Entry = {
+  prevCount: number;   // requests counted in the previous window
+  currCount: number;   // requests counted in the current window
+  windowStart: number; // epoch ms, quantized to WINDOW_MS boundaries
+};
+
+const store = new Map<string, Entry>();
 
 export type BadgeRateLimitResult = {
   allowed: boolean;
@@ -14,37 +21,61 @@ export type BadgeRateLimitResult = {
   reset: number;
 };
 
-function pruneBuckets(now: number) {
-  if (buckets.size < 500) return;
+function pruneStore(now: number): void {
+  if (store.size < 500) return;
+  // Entries whose window has fully elapsed contribute nothing and can be freed.
   const cutoff = now - WINDOW_MS;
-  for (const [key, timestamps] of Array.from(buckets.entries())) {
-    if (timestamps.every((t) => t <= cutoff)) buckets.delete(key);
+  for (const [key, entry] of store) {
+    if (entry.windowStart < cutoff) store.delete(key);
   }
 }
 
 export function checkBadgeRateLimit(ip: string): BadgeRateLimitResult {
   const now = Date.now();
-  pruneBuckets(now);
+  pruneStore(now);
 
   const key = `badge:${ip}`;
-  const cutoff = now - WINDOW_MS;
-  const active = (buckets.get(key) ?? []).filter((t) => t > cutoff);
-  const reset = Math.ceil(((active[0] ?? now) + WINDOW_MS) / 1000);
+  const windowStart = Math.floor(now / WINDOW_MS) * WINDOW_MS;
+  // Reset time is when the current fixed window boundary ends.
+  const reset = Math.ceil((windowStart + WINDOW_MS) / 1000);
 
-  if (active.length >= BADGE_LIMIT) {
-    buckets.set(key, active);
+  let entry = store.get(key);
+
+  if (!entry || entry.windowStart < windowStart - WINDOW_MS) {
+    // No history, or history is older than one full window — start fresh.
+    entry = { prevCount: 0, currCount: 0, windowStart };
+  } else if (entry.windowStart < windowStart) {
+    // Crossed a window boundary — promote current counts to previous.
+    entry = { prevCount: entry.currCount, currCount: 0, windowStart };
+  }
+  // else: same window — use entry as-is.
+
+  // Weighted contribution from the previous window based on how far into the
+  // current window we are.  At windowStart the previous window counts fully;
+  // at the end of the window its weight approaches zero.
+  const elapsed = now - windowStart;
+  const prevWeight = 1 - elapsed / WINDOW_MS;
+  const estimate = Math.floor(entry.prevCount * prevWeight) + entry.currCount;
+
+  if (estimate >= BADGE_LIMIT) {
+    store.set(key, entry);
     return { allowed: false, remaining: 0, reset };
   }
 
-  active.push(now);
-  buckets.set(key, active);
-  return { allowed: true, remaining: BADGE_LIMIT - active.length, reset };
+  entry = { ...entry, currCount: entry.currCount + 1 };
+  store.set(key, entry);
+  const remaining = Math.max(
+    0,
+    BADGE_LIMIT - Math.floor(entry.prevCount * prevWeight) - entry.currCount
+  );
+  return { allowed: true, remaining, reset };
 }
 
 export function getBadgeClientIp(req: NextRequest): string {
   return (
     req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
     req.headers.get("x-real-ip") ??
+    (req as NextRequest & { ip?: string }).ip ??
     "unknown"
   );
 }

--- a/test/badge-rate-limit.test.ts
+++ b/test/badge-rate-limit.test.ts
@@ -6,7 +6,6 @@ describe('badge-rate-limit', () => {
   describe('checkBadgeRateLimit', () => {
     beforeEach(() => {
       vi.useFakeTimers();
-      // Reset state indirectly or just use unique IPs for each test
     });
 
     afterEach(() => {
@@ -32,29 +31,117 @@ describe('badge-rate-limit', () => {
       expect(r2.remaining).toBe(18);
     });
 
-    it('verify reset time is calculated correctly', () => {
+    it('verify reset time points to the end of the current window', () => {
       const ip = '3.4.5.6';
-      vi.setSystemTime(new Date(1000)); // Set time to 1 second past epoch
+      // t=1000ms falls in the window [0, 60000), so it ends at 60000ms = epoch second 60.
+      vi.setSystemTime(new Date(1000));
       const result = checkBadgeRateLimit(ip);
-      // Window is 60s, so reset time should be exactly 61s from epoch
-      expect(result.reset).toBe(61);
+      expect(result.reset).toBe(60);
     });
 
     it('verify bucket pruning works when size exceeds 500', () => {
-      // Fill the buckets to exceed the 500 limit
+      // Fill the store to exceed the 500 limit.
       vi.setSystemTime(new Date(1000));
       for (let i = 0; i < 505; i++) {
         checkBadgeRateLimit(`prune-ip-${i}`);
       }
-      
-      // Advance time by 61 seconds so the previous 505 IPs are past the cutoff
+
+      // Advance time by 61 seconds so the 505 entries are in an expired window.
       vi.advanceTimersByTime(61000);
-      
-      // Make a new request. This should trigger pruneBuckets and clean up the old ones.
-      // Although we can't directly inspect the map size, we can ensure the logic 
-      // executes without errors.
+
+      // Next call triggers pruneStore and removes stale entries; should succeed.
       const result = checkBadgeRateLimit('new-ip');
       expect(result.allowed).toBe(true);
+    });
+
+    // ── sliding window counter semantics ────────────────────────────────────
+
+    it('allows all requests within the limit in a single window', () => {
+      const ip = 'single-window-ip';
+      vi.setSystemTime(new Date(0));
+      for (let i = 0; i < 20; i++) {
+        expect(checkBadgeRateLimit(ip).allowed).toBe(true);
+      }
+      expect(checkBadgeRateLimit(ip).allowed).toBe(false);
+    });
+
+    it('previous window requests reduce capacity in the new window (sliding effect)', () => {
+      const ip = 'sliding-ip';
+      // Fill 18 requests in window [0, 60000).
+      vi.setSystemTime(new Date(0));
+      for (let i = 0; i < 18; i++) {
+        checkBadgeRateLimit(ip);
+      }
+
+      // Advance to 30 s into the next window.
+      // prevWeight = 1 - 30000/60000 = 0.5; estimate from prev = floor(18*0.5) = 9.
+      vi.setSystemTime(new Date(90_000)); // windowStart=60000, elapsed=30000
+
+      // With estimate=9 from prev, capacity left = 20-9 = 11 more requests.
+      for (let i = 0; i < 11; i++) {
+        expect(checkBadgeRateLimit(ip).allowed).toBe(true);
+      }
+      // 12th would put currCount at 12, estimate=9+12=21 >= 20 → denied.
+      expect(checkBadgeRateLimit(ip).allowed).toBe(false);
+    });
+
+    it('requests from two or more windows ago do not count', () => {
+      const ip = 'two-window-ip';
+      // Max out in window 0.
+      vi.setSystemTime(new Date(0));
+      for (let i = 0; i < 20; i++) {
+        checkBadgeRateLimit(ip);
+      }
+
+      // Advance past two full windows — history is completely stale.
+      vi.setSystemTime(new Date(121_000)); // windowStart=120000
+      const result = checkBadgeRateLimit(ip);
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(19);
+    });
+
+    it('returns 429-compatible status (remaining 0) when limit is hit', () => {
+      const ip = 'block-check-ip';
+      vi.setSystemTime(new Date(0));
+      for (let i = 0; i < 20; i++) {
+        checkBadgeRateLimit(ip);
+      }
+      const blocked = checkBadgeRateLimit(ip);
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.remaining).toBe(0);
+      expect(blocked.reset).toBeGreaterThan(0);
+    });
+
+    it('reset field advances with the window boundary', () => {
+      const ip = 'reset-boundary-ip';
+      // Window [0, 60000) → reset = 60
+      vi.setSystemTime(new Date(1000));
+      const r1 = checkBadgeRateLimit(ip);
+      expect(r1.reset).toBe(60);
+
+      // Window [60000, 120000) → reset = 120
+      vi.setSystemTime(new Date(61_000));
+      const r2 = checkBadgeRateLimit(ip);
+      expect(r2.reset).toBe(120);
+    });
+
+    it('no timestamp arrays — entry stores only two counters and a window start', () => {
+      // Behavioural proxy: make requests spread across two windows and confirm
+      // the counter semantics hold (an array implementation would behave differently
+      // once timestamps fall outside the sliding window).
+      const ip = 'counter-shape-ip';
+      vi.setSystemTime(new Date(0));
+      for (let i = 0; i < 15; i++) {
+        checkBadgeRateLimit(ip);
+      }
+      // Start of a new window — prev 15 contribute with weight 1 initially.
+      vi.setSystemTime(new Date(60_000));
+      // elapsed=0, prevWeight=1, estimate=floor(15*1)+0=15 → 5 remaining.
+      for (let i = 0; i < 5; i++) {
+        expect(checkBadgeRateLimit(ip).allowed).toBe(true);
+      }
+      // 6th request: estimate=15+5=20 >= 20 → denied.
+      expect(checkBadgeRateLimit(ip).allowed).toBe(false);
     });
   });
 
@@ -65,7 +152,7 @@ describe('badge-rate-limit', () => {
           'x-forwarded-for': '192.168.1.1, 10.0.0.1'
         })
       } as unknown as NextRequest;
-      
+
       expect(getBadgeClientIp(req)).toBe('192.168.1.1');
     });
 
@@ -75,7 +162,7 @@ describe('badge-rate-limit', () => {
           'x-real-ip': '10.0.0.2'
         })
       } as unknown as NextRequest;
-      
+
       expect(getBadgeClientIp(req)).toBe('10.0.0.2');
     });
 
@@ -83,7 +170,7 @@ describe('badge-rate-limit', () => {
       const req = {
         headers: new Headers()
       } as unknown as NextRequest;
-      
+
       expect(getBadgeClientIp(req)).toBe('unknown');
     });
 
@@ -92,8 +179,19 @@ describe('badge-rate-limit', () => {
         ip: '172.16.0.1',
         headers: new Headers()
       } as unknown as NextRequest;
-      
+
       expect(getBadgeClientIp(req)).toBe('172.16.0.1');
+    });
+
+    it('x-forwarded-for takes precedence over req.ip', () => {
+      const req = {
+        ip: '10.0.0.99',
+        headers: new Headers({
+          'x-forwarded-for': '203.0.113.5'
+        })
+      } as unknown as NextRequest;
+
+      expect(getBadgeClientIp(req)).toBe('203.0.113.5');
     });
   });
 });


### PR DESCRIPTION
Closes #1818

## Investigation findings

The badge rate limiter in `src/lib/badge-rate-limit.ts` stored a `Map<string, number[]>` (timestamp arrays). On every request it filtered the array to remove expired entries and appended the current timestamp — O(N) allocations and O(N) memory per client, where N is the request limit (20). The prune step scanned all 500+ entries only when the map grew large.

**Issue confirmed.**

## Implementation

Replaced the timestamp-array store with a sliding window counter. Each client entry now holds exactly three numbers:

```ts
type Entry = {
  prevCount: number;   // requests counted in the previous window
  currCount: number;   // requests counted in the current window
  windowStart: number; // epoch ms, quantized to WINDOW_MS boundaries
};
```

Rate estimate for any instant within the current window:

```
elapsed  = now - windowStart
estimate = floor(prevCount * (1 - elapsed / WINDOW_MS)) + currCount
```

When the clock crosses a window boundary, `currCount` is promoted to `prevCount` and a fresh `currCount` starts from zero. Entries whose window has fully elapsed are removed during the periodic prune (threshold still 500 entries, cutoff condition simplified to `entry.windowStart < now - WINDOW_MS`).

## Memory and performance improvement

| Metric | Before | After |
|--------|--------|-------|
| Memory per client | Up to 20 timestamp values | 3 numbers |
| Per-request allocations | Array filter + push | Counter increment |
| Per-request work | O(N) filter | O(1) |
| Prune scan work | O(entries × timestamps) | O(entries) |

## Behaviour preservation

- Same 20 req / 60 s limit enforced.
- `allowed`, `remaining`, and `reset` fields still returned on every call.
- 429 with `Retry-After` header still issued when the limit is exceeded.
- No new dependencies introduced.
- `reset` now points to the fixed window boundary (e.g. epoch second 60 for a request at t=1 s) rather than the oldest-timestamp expiry. The difference is at most one window period and makes the value more predictable for clients.

## Additional fix

`getBadgeClientIp` now falls back to `req.ip` (available in Next.js edge runtime) before returning `"unknown"`, which was the behaviour a pre-existing test expected but the old code never implemented.

## Files modified

- `src/lib/badge-rate-limit.ts` — sliding window counter implementation
- `test/badge-rate-limit.test.ts` — updated reset expectation; added 7 new tests

## Test plan

- [ ] `npx vitest run test/badge-rate-limit.test.ts` — all 15 tests pass
- [ ] 20 req/min limit still triggers at the correct boundary
- [ ] Requests are not blocked prematurely within a window
- [ ] Cross-window sliding effect correctly reduces capacity
- [ ] Two-window-old history contributes zero to the estimate
- [ ] `req.ip` fallback returns the correct IP address
