### PR TITLE
feat(settings): add theme preset selection support

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 "use client";
 
+import ThemePresetPicker from "@/components/ThemePresetPicker";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
 import { redirect, useSearchParams } from "next/navigation";
@@ -640,11 +641,10 @@ function SettingsPageContent() {
 
         {statusMessage && (
           <div
-            className={`mb-6 rounded-xl border p-4 text-sm ${
-              statusMessage.kind === "success"
-                ? "border-[var(--success)]/30 bg-[var(--success)]/10 text-[var(--success)]"
-                : "border-[var(--error)]/30 bg-[var(--error)]/10 text-[var(--error)]"
-            }`}
+            className={`mb-6 rounded-xl border p-4 text-sm ${statusMessage.kind === "success"
+              ? "border-[var(--success)]/30 bg-[var(--success)]/10 text-[var(--success)]"
+              : "border-[var(--error)]/30 bg-[var(--error)]/10 text-[var(--error)]"
+              }`}
           >
             {statusMessage.message}
           </div>
@@ -740,13 +740,12 @@ function SettingsPageContent() {
                 {bioDraft.length === 0 && "Shown on your public /u/ page."}
               </p>
               <p
-                className={`text-xs font-medium tabular-nums transition-colors ${
-                  bioDraft.length >= BIO_MAX
-                    ? "text-[var(--destructive)]"
-                    : bioDraft.length >= Math.floor(BIO_MAX * 0.9)
+                className={`text-xs font-medium tabular-nums transition-colors ${bioDraft.length >= BIO_MAX
+                  ? "text-[var(--destructive)]"
+                  : bioDraft.length >= Math.floor(BIO_MAX * 0.9)
                     ? "text-yellow-500"
                     : "text-[var(--muted-foreground)]"
-                }`}
+                  }`}
               >
                 {bioDraft.length} / {BIO_MAX}
               </p>
@@ -812,11 +811,10 @@ function SettingsPageContent() {
 
             <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
               <span
-                className={`text-xs ${
-                  bioDraft.length > 500
-                    ? "text-[var(--error)]"
-                    : "text-[var(--muted-foreground)]"
-                }`}
+                className={`text-xs ${bioDraft.length > 500
+                  ? "text-[var(--error)]"
+                  : "text-[var(--muted-foreground)]"
+                  }`}
               >
                 {bioDraft.length}/500 characters
               </span>
@@ -904,6 +902,18 @@ function SettingsPageContent() {
         </div>
 
         <div className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-[var(--card-foreground)]">
+            Application Theme
+          </h2>
+
+          <p className="mt-1 text-sm text-[var(--muted-foreground)] mb-6">
+            Choose a theme for the DevTrack interface.
+          </p>
+
+          <ThemePresetPicker />
+        </div>
+
+        <div className="mt-6 rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
           <div className="flex items-start justify-between gap-4">
             <div>
               <h2 className="text-xl font-semibold text-[var(--card-foreground)]">
@@ -944,6 +954,7 @@ function SettingsPageContent() {
               Turning this on also enables your public profile so leaderboard
               rows can link to your DevTrack stats.
             </p>
+
           </div>
         </div>
 
@@ -1068,10 +1079,10 @@ function SettingsPageContent() {
                       !(settings.pinned_repos || []).includes(repoName) &&
                       repoName.toLowerCase().includes(repoSearchQuery.toLowerCase())
                   ).length === 0 && (
-                    <div className="text-center py-4 text-xs text-[var(--muted-foreground)]">
-                      No repositories available to pin.
-                    </div>
-                  )}
+                      <div className="text-center py-4 text-xs text-[var(--muted-foreground)]">
+                        No repositories available to pin.
+                      </div>
+                    )}
                 </div>
               )}
             </div>
@@ -1100,16 +1111,14 @@ function SettingsPageContent() {
                   className="sr-only"
                 />
                 <div
-                  className={`block h-6 w-10 rounded-full transition-colors ${
-                    settings.weekly_digest_opt_in
-                      ? "bg-[var(--accent)]"
-                      : "bg-[var(--control)]"
-                  }`}
+                  className={`block h-6 w-10 rounded-full transition-colors ${settings.weekly_digest_opt_in
+                    ? "bg-[var(--accent)]"
+                    : "bg-[var(--control)]"
+                    }`}
                 />
                 <div
-                  className={`absolute left-1 top-1 h-4 w-4 rounded-full bg-[var(--card)] transition-transform ${
-                    settings.weekly_digest_opt_in ? "translate-x-4" : ""
-                  }`}
+                  className={`absolute left-1 top-1 h-4 w-4 rounded-full bg-[var(--card)] transition-transform ${settings.weekly_digest_opt_in ? "translate-x-4" : ""
+                    }`}
                 />
               </div>
             </label>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -81,8 +81,117 @@ html {
   scroll-behavior: smooth;
 }
 
-html, body {
+html,
+body {
   overscroll-behavior: none;
+}
+
+.theme-dracula {
+  --background: #282a36;
+  --foreground: #f8f8f2;
+  --muted-foreground: #bd93f9;
+  --card: #343746;
+  --card-foreground: #f8f8f2;
+  --card-muted: #3b3f51;
+  --border: #44475a;
+  --accent: #bd93f9;
+  --accent-secondary: #ff79c6;
+  --focus-ring: #ff79c6;
+  --success: #50fa7b;
+  --warning: #f1fa8c;
+  --destructive: #ff5555;
+  --accent-soft: rgba(189, 147, 249, 0.18);
+  --accent-foreground: #ffffff;
+  --control: #3b3f51;
+  --control-hover: #4b5268;
+  --tooltip: #343746;
+  --tooltip-foreground: #f8f8f2;
+  --destructive-muted: rgba(255, 85, 85, 0.12);
+  --destructive-muted-border: rgba(255, 85, 85, 0.3);
+  --destructive-foreground: #ffffff;
+  --shadow-soft: 0 16px 34px -24px rgba(0, 0, 0, 0.7);
+  --shadow-medium: 0 24px 45px -28px rgba(0, 0, 0, 0.8);
+}
+
+.theme-nord {
+  --background: #2e3440;
+  --foreground: #eceff4;
+  --muted-foreground: #d8dee9;
+  --card: #3b4252;
+  --card-foreground: #eceff4;
+  --card-muted: #434c5e;
+  --border: #4c566a;
+  --accent: #88c0d0;
+  --accent-secondary: #5e81ac;
+  --focus-ring: #88c0d0;
+  --success: #a3be8c;
+  --warning: #ebcb8b;
+  --destructive: #bf616a;
+  --accent-soft: rgba(136, 192, 208, 0.18);
+  --accent-foreground: #ffffff;
+  --control: #434c5e;
+  --control-hover: #4c566a;
+  --tooltip: #3b4252;
+  --tooltip-foreground: #eceff4;
+  --destructive-muted: rgba(191, 97, 106, 0.12);
+  --destructive-muted-border: rgba(191, 97, 106, 0.3);
+  --destructive-foreground: #ffffff;
+  --shadow-soft: 0 16px 34px -24px rgba(15, 23, 42, 0.8);
+  --shadow-medium: 0 24px 45px -28px rgba(15, 23, 42, 0.9);
+}
+
+.theme-catppuccin-mocha {
+  --background: #1e1e2e;
+  --foreground: #cdd6f4;
+  --muted-foreground: #bac2de;
+  --card: #313244;
+  --card-foreground: #cdd6f4;
+  --card-muted: #45475a;
+  --border: #585b70;
+  --accent: #cba6f7;
+  --accent-secondary: #f5c2e7;
+  --focus-ring: #f5c2e7;
+  --success: #a6e3a1;
+  --warning: #f9e2af;
+  --destructive: #f38ba8;
+  --accent-soft: rgba(203, 166, 247, 0.18);
+  --accent-foreground: #ffffff;
+  --control: #45475a;
+  --control-hover: #585b70;
+  --tooltip: #313244;
+  --tooltip-foreground: #cdd6f4;
+  --destructive-muted: rgba(243, 139, 168, 0.12);
+  --destructive-muted-border: rgba(243, 139, 168, 0.3);
+  --destructive-foreground: #ffffff;
+  --shadow-soft: 0 16px 34px -24px rgba(0, 0, 0, 0.75);
+  --shadow-medium: 0 24px 45px -28px rgba(0, 0, 0, 0.85);
+}
+
+.theme-solarized-dark {
+  --background: #002b36;
+  --foreground: #eee8d5;
+  --muted-foreground: #93a1a1;
+  --card: #073642;
+  --card-foreground: #eee8d5;
+  --card-muted: #0b3b49;
+  --border: #586e75;
+  --accent: #2aa198;
+  --accent-secondary: #268bd2;
+  --focus-ring: #2aa198;
+  --success: #859900;
+  --warning: #b58900;
+  --destructive: #dc322f;
+  --accent-soft: rgba(42, 161, 152, 0.18);
+  --accent-foreground: #ffffff;
+  --control: #1b4d59;
+  --control-hover: #256472;
+  --tooltip: #073642;
+  --tooltip-foreground: #eee8d5;
+  --destructive-muted: rgba(220, 50, 47, 0.12);
+  --destructive-muted-border: rgba(220, 50, 47, 0.3);
+  --destructive-foreground: #ffffff;
+  --shadow-soft: 0 16px 34px -24px rgba(0, 0, 0, 0.75);
+  --shadow-medium: 0 24px 45px -28px rgba(0, 0, 0, 0.85);
 }
 
 /* Strip body background on landing page so the dark bg is visible */
@@ -204,25 +313,52 @@ body {
    ───────────────────────────────────────── */
 
 /* Staggered animation delays for child elements */
-.stagger-children > *:nth-child(1) { animation-delay: 0ms; }
-.stagger-children > *:nth-child(2) { animation-delay: 50ms; }
-.stagger-children > *:nth-child(3) { animation-delay: 100ms; }
-.stagger-children > *:nth-child(4) { animation-delay: 150ms; }
-.stagger-children > *:nth-child(5) { animation-delay: 200ms; }
-.stagger-children > *:nth-child(6) { animation-delay: 250ms; }
-.stagger-children > *:nth-child(7) { animation-delay: 300ms; }
-.stagger-children > *:nth-child(8) { animation-delay: 350ms; }
-.stagger-children > *:nth-child(9) { animation-delay: 400ms; }
-.stagger-children > *:nth-child(10) { animation-delay: 450ms; }
+.stagger-children>*:nth-child(1) {
+  animation-delay: 0ms;
+}
+
+.stagger-children>*:nth-child(2) {
+  animation-delay: 50ms;
+}
+
+.stagger-children>*:nth-child(3) {
+  animation-delay: 100ms;
+}
+
+.stagger-children>*:nth-child(4) {
+  animation-delay: 150ms;
+}
+
+.stagger-children>*:nth-child(5) {
+  animation-delay: 200ms;
+}
+
+.stagger-children>*:nth-child(6) {
+  animation-delay: 250ms;
+}
+
+.stagger-children>*:nth-child(7) {
+  animation-delay: 300ms;
+}
+
+.stagger-children>*:nth-child(8) {
+  animation-delay: 350ms;
+}
+
+.stagger-children>*:nth-child(9) {
+  animation-delay: 400ms;
+}
+
+.stagger-children>*:nth-child(10) {
+  animation-delay: 450ms;
+}
 
 /* Shimmer skeleton loading effect */
 .skeleton-shimmer {
-  background: linear-gradient(
-    90deg,
-    var(--card-muted) 0%,
-    color-mix(in srgb, var(--card-muted) 60%, var(--border) 40%) 50%,
-    var(--card-muted) 100%
-  );
+  background: linear-gradient(90deg,
+      var(--card-muted) 0%,
+      color-mix(in srgb, var(--card-muted) 60%, var(--border) 40%) 50%,
+      var(--card-muted) 100%);
   background-size: 200% 100%;
   animation: shimmer 1.8s ease-in-out infinite;
 }
@@ -231,6 +367,7 @@ body {
 .stat-cell {
   transition: transform 200ms ease, box-shadow 200ms ease, background-color 200ms ease, border-color 200ms ease;
 }
+
 .stat-cell:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 16px -4px rgba(96, 165, 250, 0.15);
@@ -241,6 +378,7 @@ body {
   transition: transform 200ms ease, background-color 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
   border-left: 3px solid transparent;
 }
+
 .list-item-hover:hover {
   transform: translateX(4px);
   border-left-color: var(--accent);
@@ -265,22 +403,48 @@ body {
   scrollbar-width: thin;
   scrollbar-color: #222 transparent;
 }
-.dark::-webkit-scrollbar       { width: 6px; height: 6px; }
-.dark::-webkit-scrollbar-track { background: transparent; }
-.dark::-webkit-scrollbar-thumb { background: #222; border-radius: 6px; }
-.dark::-webkit-scrollbar-thumb:hover { background: #9ca3af; }
+
+.dark::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.dark::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dark::-webkit-scrollbar-thumb {
+  background: #222;
+  border-radius: 6px;
+}
+
+.dark::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af;
+}
 
 /* ─────────────────────────────────────────
    LANDING PAGE
    ───────────────────────────────────────── */
 @keyframes lndHeroIn {
-  from { opacity: 0; transform: translateY(24px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes lndTicker {
-  0%   { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
+  0% {
+    transform: translateX(0);
+  }
+
+  100% {
+    transform: translateX(-50%);
+  }
 }
 
 .lnd-ticker {
@@ -303,7 +467,11 @@ body {
   border-radius: 5px;
   transition: all 0.2s;
 }
-.lnd-nav-link:hover { color: var(--foreground); border-color: var(--muted-foreground); }
+
+.lnd-nav-link:hover {
+  color: var(--foreground);
+  border-color: var(--muted-foreground);
+}
 
 .lnd-cta-primary {
   display: inline-flex;
@@ -319,6 +487,7 @@ body {
   text-decoration: none;
   transition: background 0.2s, transform 0.1s;
 }
+
 .lnd-cta-primary {
   transition: all 0.3s ease;
 }
@@ -369,25 +538,29 @@ body {
   padding: 18px 20px;
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  box-shadow: 
+  box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.05),
     var(--shadow-soft);
-  transition: 
+  transition:
     background 0.4s cubic-bezier(0.16, 1, 0.3, 1),
     border-color 0.4s cubic-bezier(0.16, 1, 0.3, 1),
     transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
     box-shadow 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
+
 .lnd-cell:hover {
   background: color-mix(in srgb, var(--card) 85%, transparent);
   border-color: var(--accent-secondary);
   transform: translateY(-2px);
-  box-shadow: 
+  box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
     var(--shadow-medium);
 }
 
-.lnd-heatmap-cell { cursor: crosshair; }
+.lnd-heatmap-cell {
+  cursor: crosshair;
+}
+
 .lnd-heatmap-cell:hover {
   transform: scale(1.6) !important;
   box-shadow: 0 0 8px #818cf8;
@@ -397,11 +570,14 @@ body {
 
 
 @media (max-width: 640px) {
-  .lnd-ticker { animation-duration: 20s !important; }
+  .lnd-ticker {
+    animation-duration: 20s !important;
+  }
 }
 
 /* --- Accessibility Fix: Respect prefers-reduced-motion (WCAG 2.3.3) --- */
 @media (prefers-reduced-motion: reduce) {
+
   *,
   *::before,
   *::after {

--- a/src/components/ThemeContext.tsx
+++ b/src/components/ThemeContext.tsx
@@ -2,10 +2,11 @@
 
 import React, { createContext, useContext, useEffect, useLayoutEffect, useState } from "react";
 
-type Theme = "light" | "dark";
+import { Theme, themes } from "@/lib/themes";
 
 interface ThemeContextType {
   theme: Theme | undefined;
+  setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
 }
 
@@ -22,7 +23,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useSafeLayoutEffect(() => {
     const storedTheme = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    if (storedTheme === "dark" || storedTheme === "light") {
+    if (storedTheme && storedTheme in themes) {
       setTheme(storedTheme);
       return;
     }
@@ -32,8 +33,27 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   useSafeLayoutEffect(() => {
     if (!theme) return;
 
-    document.documentElement.classList.toggle("dark", theme === "dark");
-    document.documentElement.style.colorScheme = theme;
+    const root = document.documentElement;
+
+    const themeClasses = [
+      "theme-dracula",
+      "theme-nord",
+      "theme-catppuccin-mocha",
+      "theme-solarized-dark",
+    ];
+
+    root.classList.remove(...themeClasses);
+
+    const currentTheme = themes[theme];
+    const isDarkTheme = currentTheme.mode === "dark";
+
+    root.classList.toggle("dark", isDarkTheme);
+
+    if (theme !== "light" && theme !== "dark") {
+      root.classList.add(`theme-${theme}`);
+    }
+
+    root.style.colorScheme = isDarkTheme ? "dark" : "light";
   }, [theme]);
 
   useEffect(() => {
@@ -46,7 +66,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   };
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/components/ThemePresetPicker.tsx
+++ b/src/components/ThemePresetPicker.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Theme, themes } from "@/lib/themes";
+import { useTheme } from "./ThemeContext";
+
+export default function ThemePresetPicker() {
+    const { theme, setTheme } = useTheme();
+
+    return (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {Object.entries(themes).map(([themeKey, config]) => {
+                const isActive = theme === themeKey;
+
+                return (
+                    <button
+                        key={themeKey}
+                        type="button"
+                        onClick={() => setTheme(themeKey as Theme)}
+                        className={`group rounded-2xl border p-4 text-left transition-colors duration-300 ${isActive
+                            ? "border-[var(--accent)] bg-[var(--accent-soft)] shadow-[var(--shadow-soft)]"
+                            : "border-[var(--border)] bg-[var(--card)] hover:bg-[var(--control)]"
+                            }`}
+                        aria-pressed={isActive}
+                    >
+                        <div className="mb-4 flex items-center justify-between">
+                            <div>
+                                <h4 className="text-sm font-semibold text-[var(--card-foreground)]">
+                                    {config.label}
+                                </h4>
+
+                                <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                                    {config.mode === "dark" ? "Dark Theme" : "Light Theme"}
+                                </p>
+                            </div>
+
+                            {isActive && (
+                                <div className="rounded-full bg-[var(--accent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--accent-foreground)]">
+                                    Active
+                                </div>
+                            )}
+                        </div>
+
+                        <div
+                            className="overflow-hidden rounded-xl border border-black/10"
+                            style={{
+                                backgroundColor: config.preview.background,
+                            }}
+                        >
+                            <div className="space-y-2 p-3">
+                                <div
+                                    className="h-3 w-2/3 rounded-md"
+                                    style={{
+                                        backgroundColor: config.preview.card,
+                                    }}
+                                />
+
+                                <div
+                                    className="h-3 w-1/2 rounded-md"
+                                    style={{
+                                        backgroundColor: config.preview.card,
+                                    }}
+                                />
+
+                                <div className="flex gap-2 pt-2">
+                                    <div
+                                        className="h-8 flex-1 rounded-lg"
+                                        style={{
+                                            backgroundColor: config.preview.card,
+                                        }}
+                                    />
+
+                                    <div
+                                        className="h-8 w-10 rounded-lg"
+                                        style={{
+                                            backgroundColor: config.preview.accent,
+                                        }}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,0 +1,81 @@
+export type Theme =
+    | "light"
+    | "dark"
+    | "dracula"
+    | "nord"
+    | "catppuccin-mocha"
+    | "solarized-dark";
+
+export type ThemeMode = "light" | "dark";
+
+export interface ThemeConfig {
+    label: string;
+    mode: ThemeMode;
+    preview: {
+        background: string;
+        accent: string;
+        card: string;
+    };
+}
+
+export const themes: Record<Theme, ThemeConfig> = {
+    light: {
+        label: "Default Light",
+        mode: "light",
+        preview: {
+            background: "#ffffff",
+            accent: "#3b82f6",
+            card: "#f8fafc",
+        },
+    },
+
+    dark: {
+        label: "Default Dark",
+        mode: "dark",
+        preview: {
+            background: "#0f172a",
+            accent: "#60a5fa",
+            card: "#1a2538",
+        },
+    },
+
+    dracula: {
+        label: "Dracula",
+        mode: "dark",
+        preview: {
+            background: "#282a36",
+            accent: "#bd93f9",
+            card: "#343746",
+        },
+    },
+
+    nord: {
+        label: "Nord",
+        mode: "dark",
+        preview: {
+            background: "#2e3440",
+            accent: "#88c0d0",
+            card: "#3b4252",
+        },
+    },
+
+    "catppuccin-mocha": {
+        label: "Catppuccin Mocha",
+        mode: "dark",
+        preview: {
+            background: "#1e1e2e",
+            accent: "#f5c2e7",
+            card: "#313244",
+        },
+    },
+
+    "solarized-dark": {
+        label: "Solarized Dark",
+        mode: "dark",
+        preview: {
+            background: "#002b36",
+            accent: "#b58900",
+            card: "#073642",
+        },
+    },
+};


### PR DESCRIPTION
## Summary

Adds theme preset selection support to the Settings page, allowing users to choose from multiple predefined themes while preserving existing theme functionality and user preferences.

Closes #252 

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Added centralized theme configuration in src/lib/themes.ts
-  Added ThemePresetPicker component for selecting theme presets
- Extended ThemeContext to support multiple theme options
- Added new theme variants:
- - Dracula
- - Nord
- - Catppuccin Mocha
- - Solarized Dark 
- Added corresponding theme CSS variables and styling
- Integrated theme preset selection into the Settings page
- Preserved existing light/dark theme behavior
- Added theme persistence using local storage

---

## How to Test

Steps for the reviewer to verify this works:

- Run the application locally
- Navigate to Settings
- Verify the theme preset selector is displayed
- Select each available theme preset
- Confirm UI colors update correctly
- Refresh the page and verify the selected theme persists
- Verify existing light/dark functionality continues to work as expected
- Verify the Settings page remains responsive on different screen sizes

---

## Screenshots (if UI change)

Custom Theme:
<img width="1920" height="1080" alt="Custom Theme" src="https://github.com/user-attachments/assets/1df06193-f472-483b-b1b5-dfb15056d69b" />

Light/Dark Theme:
<img width="1920" height="1080" alt="Light-Dark themes" src="https://github.com/user-attachments/assets/edc4cdee-888d-4fc2-83a9-ff1122104e3b" />

Theme Presets:
<img width="1920" height="1080" alt="Theme presets" src="https://github.com/user-attachments/assets/779b6f8d-681d-4c02-8bcc-91d2f289a303" />


---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally (pre-existing warnings remain)
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] Proper keyboard navigation tested
- [x] Responsive UI verified
- [x] Accessibility labels added where needed

---

## Additional Notes

npm run lint completes successfully. Existing repository warnings unrelated to this change remain and were not introduced by this PR.

This change only affects theme selection functionality and does not modify existing user settings, GitHub integrations, notification preferences, timezone settings, Discord webhook settings, pinned repositories, or weekly digest preferences.
