### PR TITLE
fix: generate .env.production for Next.js Edge Runtime in E2E tests (#1835)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,6 +36,19 @@ jobs:
       - name: Install app dependencies
         run: npm ci
 
+      - name: Generate .env.production for Edge Runtime
+        run: |
+          cat > .env.production << 'EOF'
+          NEXTAUTH_SECRET=${{ env.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL=${{ env.NEXTAUTH_URL }}
+          NEXT_PUBLIC_APP_URL=${{ env.NEXT_PUBLIC_APP_URL }}
+          GITHUB_ID=${{ env.GITHUB_ID }}
+          GITHUB_SECRET=${{ env.GITHUB_SECRET }}
+          NEXT_PUBLIC_SUPABASE_URL=${{ env.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ env.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY=${{ env.SUPABASE_SERVICE_ROLE_KEY }}
+          EOF
+
       - name: Build Next.js app
         run: npm run build
 


### PR DESCRIPTION
Closes #1835

## Problem
Next.js output: standalone does not inject OS environment variables into the Edge middleware sandbox, causing NEXTAUTH_SECRET to be undefined in middleware.ts. This makes Playwright E2E tests fail as the test runner gets redirected to / instead of accessing dashboard routes.

## Changes
- Added a step in .github/workflows/e2e.yml to generate .env.production before 
pm run build
- Next.js serializes .env.production during the build, making NEXTAUTH_SECRET available to both the Node.js server and Edge middleware