### PR TITLE
fix: add webhook_url to user settings test assertions (#1833)

### DIFF
--- a/test/user-settings-api.test.ts
+++ b/test/user-settings-api.test.ts
@@ -145,6 +145,7 @@ describe("User Settings API Endpoints", () => {
         pinned_repos: ["repo-1"],
         has_wakatime_key: true,
         discord_webhook_url: null,
+        webhook_url: null,
         timezone: "UTC",
       });
     });
@@ -230,6 +231,7 @@ describe("User Settings API Endpoints", () => {
         pinned_repos: ["repo-1"],
         has_wakatime_key: true,
         discord_webhook_url: null,
+        webhook_url: null,
         timezone: "UTC",
       });
 
@@ -257,6 +259,7 @@ describe("User Settings API Endpoints", () => {
         pinned_repos: ["repo-2", "repo-3"],
         has_wakatime_key: true,
         discord_webhook_url: null,
+        webhook_url: null,
         timezone: "UTC",
       });
 


### PR DESCRIPTION
Closes #1833

## Problem
The /api/user/settings API returns webhook_url but the test assertions in test/user-settings-api.test.ts didn't expect it, causing deep equality test failures.

## Changes
- Added webhook_url: null to all GET and PATCH response assertions in test/user-settings-api.test.ts