### PR TITLE
fix: No rate limiting on the API-key-authenticated local coding sync 

### DIFF
--- a/src/app/api/local-coding/sync/route.ts
+++ b/src/app/api/local-coding/sync/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
 import { createHash } from "crypto";
+import { getUpstashConfig, upstashRateLimitFixedWindow } from "@/lib/upstash-rest";
+
 
 export const dynamic = "force-dynamic";
 
@@ -9,6 +11,13 @@ const MAX_SESSIONS_PER_USER = 365;
 const ALLOWED_DAYS = [7, 30, 90];
 const DEFAULT_DAYS = 30;
 
+const RATE_LIMIT_REQUESTS = 20;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+type MemoryRateEntry = { count: number; resetAt: number };
+const memoryRateLimits = new Map<string, MemoryRateEntry>();
+
+
 function hashApiKey(key: string): string {
   return createHash("sha256").update(key).digest("hex");
 }
@@ -16,6 +25,7 @@ function hashApiKey(key: string): string {
 async function authenticateApiKey(apiKey: string): Promise<string | null> {
   const keyHash = hashApiKey(apiKey);
   const keyHashFilter = `api_key_hash.eq.${keyHash},api_key.eq.${keyHash}`;
+
 
   const { data: keyRecord } = await supabaseAdmin
     .from("local_coding_api_keys")
@@ -42,7 +52,49 @@ function validateDays(days: number): number {
   return DEFAULT_DAYS;
 }
 
+function getMemoryRateLimitKey(apiKeyHash: string): string {
+  return `local-coding-sync-rate-limit:${apiKeyHash}`;
+}
+
+function checkMemoryRateLimit(
+  key: string
+): { allowed: boolean; retryAfter?: number } {
+  const now = Date.now();
+  const record = memoryRateLimits.get(key);
+
+  if (!record || now > record.resetAt) {
+    memoryRateLimits.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { allowed: true };
+  }
+
+  if (record.count < RATE_LIMIT_REQUESTS) {
+    record.count += 1;
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    retryAfter: Math.ceil((record.resetAt - now) / 1000),
+  };
+}
+
+async function checkRateLimit(
+  key: string
+): Promise<{ allowed: boolean; retryAfter?: number }> {
+  const upstash = getUpstashConfig();
+  if (upstash) {
+    return upstashRateLimitFixedWindow({
+      key,
+      limit: RATE_LIMIT_REQUESTS,
+      windowSeconds: Math.ceil(RATE_LIMIT_WINDOW_MS / 1000),
+    });
+  }
+
+  return checkMemoryRateLimit(key);
+}
+
 interface SessionData {
+
   date: string;
   totalSeconds: number;
   fileCount: number;
@@ -57,13 +109,28 @@ export async function POST(req: NextRequest) {
   }
 
   const apiKey = authHeader.slice(7);
+  const apiKeyHash = hashApiKey(apiKey);
   const userId = await authenticateApiKey(apiKey);
 
   if (!userId) {
     return Response.json({ error: "Invalid API key" }, { status: 401 });
   }
 
+  const rateLimitKey = getMemoryRateLimitKey(apiKeyHash);
+  const rateLimit = await checkRateLimit(rateLimitKey);
+
+  if (!rateLimit.allowed) {
+    return Response.json(
+      { error: "Rate limit exceeded" },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rateLimit.retryAfter ?? 60) },
+      }
+    );
+  }
+
   let body: { sessions?: SessionData[] };
+
   try {
     body = await req.json();
   } catch (e) {

--- a/test/local-coding-sync.test.ts
+++ b/test/local-coding-sync.test.ts
@@ -1,4 +1,4 @@
-mport { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/local-coding/sync/route";
 import { NextRequest } from "next/server";
 import { createHash } from "crypto";

--- a/test/local-coding-sync.test.ts
+++ b/test/local-coding-sync.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+mport { describe, it, expect, vi, beforeEach } from "vitest";
 import { POST } from "@/app/api/local-coding/sync/route";
 import { NextRequest } from "next/server";
 import { createHash } from "crypto";
+
+vi.mock("@/lib/upstash-rest", () => ({
+  getUpstashConfig: () => null,
+  upstashRateLimitFixedWindow: vi.fn(),
+}));
+
 
 // Mock Supabase admin client methods
 const mockRpc = vi.fn();
@@ -326,4 +332,28 @@ describe("Local Coding Sync POST API Endpoint", () => {
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: "Failed to sync sessions" });
   });
+
+  it("rate limits POST requests per API key (21st request -> 429)", async () => {
+    const sessions = [{ date: "2026-05-27", totalSeconds: 120 }];
+
+    const req = new NextRequest("http://localhost/api/local-coding/sync", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-key",
+      },
+      body: JSON.stringify({ sessions }),
+    });
+
+    // First 20 requests should pass
+    for (let i = 0; i < 20; i++) {
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+    }
+
+    // 21st should be rate limited
+    const blocked = await POST(req);
+    expect(blocked.status).toBe(429);
+    expect(await blocked.json()).toEqual({ error: "Rate limit exceeded" });
+  });
 });
+


### PR DESCRIPTION
Rate limiting added to POST /api/local-coding/sync keyed by the sha256 hash of the bearer API key (fixed window: 20 requests per 60s). When exceeded, the endpoint now returns 429 with { error: "Rate limit exceeded" } and a Retry-After header.

Updated files:

src/app/api/local-coding/sync/route.ts (added in-memory + Upstash-backed limiter; applied only to POST)
test/local-coding-sync.test.ts (added test asserting 21st POST returns 429; mocked Upstash config to force in-memory)


closes #1690