### PR TITLE
fix(stream/goals): prevent unbounded SSE polling load and preserve recurring goal history

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,14 @@ NEXTAUTH_URL=http://localhost:3000
 # Must not have a trailing slash.
 # NEXT_PUBLIC_APP_URL=https://devtrack-delta.vercel.app
 
+# -------------------------------------------------------
+# CSRF protection — allowed origins for state-changing API requests
+# (optional — NEXTAUTH_URL is always included automatically)
+# Comma-separated list of additional origins permitted to make authenticated
+# mutations. Add preview / staging deployments here.
+# Example: ALLOWED_ORIGINS=https://staging.devtrack.app,https://preview.devtrack.app
+# ALLOWED_ORIGINS=
+
 # Generate with: openssl rand -base64 32
 NEXTAUTH_SECRET=your_nextauth_secret
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -663,65 +663,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-async-generators": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-bigint": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-properties": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-static-block": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
@@ -742,186 +683,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
       "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-meta": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-json-strings": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
-      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-private-property-in-object": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-top-level-await": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
-      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1914,14 +1675,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -3189,604 +2942,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
-      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/console": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
-      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/core": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
-      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/pattern": "30.4.0",
-        "@jest/reporters": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "exit-x": "^0.2.2",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.4.1",
-        "jest-config": "30.4.2",
-        "jest-haste-map": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-resolve-dependencies": "30.4.2",
-        "jest-runner": "30.4.2",
-        "jest-runtime": "30.4.2",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "jest-watcher": "30.4.1",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/core/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@jest/core/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/core/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/jest-config": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
-      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/get-type": "30.1.0",
-        "@jest/pattern": "30.4.0",
-        "@jest/test-sequencer": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-jest": "30.4.1",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "deepmerge": "^4.3.1",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "jest-circus": "30.4.2",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-runner": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "parse-json": "^5.2.0",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "esbuild-register": ">=3.4.0",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "esbuild-register": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/core/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/core/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "expect": "30.4.1",
-        "jest-snapshot": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@sinonjs/fake-timers": "^15.4.0",
-        "@types/node": "*",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/globals": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
-      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/types": "30.4.1",
-        "jest-mock": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/reporters": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
-      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "collect-v8-coverage": "^1.0.2",
-        "exit-x": "^0.2.2",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^6.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^5.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.2",
-        "v8-to-istanbul": "^9.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -3799,142 +2954,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/@jest/snapshot-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
-      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "natural-compare": "^1.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/source-map": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
-      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "callsites": "^3.1.0",
-        "graceful-fs": "^4.2.11"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/test-result": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
-      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "collect-v8-coverage": "^1.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
-      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/test-result": "30.4.1",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/transform": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
-      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
-        "chalk": "^4.1.2",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "pirates": "^4.0.7",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -4219,25 +3238,11 @@
         "node": ">=14"
       }
     },
-    "node_modules/@pkgr/core": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
-      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pkgr"
-      }
-    },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0"
@@ -4742,39 +3747,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/commons/node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
-      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
     "node_modules/@supabase/auth-js": {
       "version": "2.106.2",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.106.2.tgz",
@@ -5071,55 +4043,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -5236,36 +4159,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5319,6 +4212,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/raf": {
@@ -5332,6 +4226,7 @@
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -5357,14 +4252,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -5376,25 +4263,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.0",
@@ -6259,181 +5127,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/wasm-gen": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/helper-wasm-section": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-opt": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1",
-        "@webassemblyjs/wast-printer": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xtuc/ieee754": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/@xtuc/long": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -6444,19 +5137,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -6544,37 +5224,6 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -6937,29 +5586,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/babel-jest": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
-      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/transform": "30.4.1",
-        "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.4.0",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-0"
-      }
-    },
     "node_modules/babel-loader": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.4.1.tgz",
@@ -7001,41 +5627,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/babel-plugin-istanbul": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "workspaces": [
-        "test/babel-8"
-      ],
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-instrument": "^6.0.2",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
-      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/babel__core": "^7.20.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -7084,52 +5675,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5",
-        "@babel/plugin-syntax-import-attributes": "^7.24.7",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-        "@babel/plugin-syntax-top-level-await": "^7.14.5"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/babel-preset-jest": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
-      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "babel-plugin-jest-hoist": "30.4.0",
-        "babel-preset-current-node-syntax": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
     "node_modules/bail": {
@@ -7270,17 +5815,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/bser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "node-int64": "^0.4.0"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -7373,17 +5907,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7484,17 +6007,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/char-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -7586,41 +6098,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chrome-trace-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -7654,65 +6131,6 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -7721,26 +6139,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/collect-v8-coverage": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
-      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -8170,22 +6568,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dedent": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
-      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -8356,17 +6738,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/detect-newline": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -8497,20 +6868,6 @@
       "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "license": "ISC"
     },
-    "node_modules/emittery": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -8527,20 +6884,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/enhanced-resolve": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
-      "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
@@ -8552,17 +6895,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -8678,13 +7010,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -9188,21 +7513,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -9220,6 +7530,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -9232,6 +7543,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -9272,16 +7584,6 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -9304,36 +7606,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/exit-x": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
-      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/extend": {
@@ -9432,17 +7704,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fb-watchman": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "bser": "2.1.1"
       }
     },
     "node_modules/fflate": {
@@ -9723,17 +7984,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -9773,17 +8023,6 @@
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
       "license": "ISC"
-    },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
@@ -9877,13 +8116,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.1.1",
@@ -10165,14 +8397,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/html-to-image": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
@@ -10255,27 +8479,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-local": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
-      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "pkg-dir": "^4.2.0",
-        "resolve-cwd": "^3.0.0"
-      },
-      "bin": {
-        "import-local-fixture": "fixtures/cli.js"
-      },
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10393,14 +8596,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -10577,17 +8772,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-generator-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-generator-function": {
@@ -10928,82 +9112,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/parser": "^7.23.9",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -11056,1404 +9164,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jest": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
-      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/core": "30.4.2",
-        "@jest/types": "30.4.1",
-        "import-local": "^3.2.0",
-        "jest-cli": "30.4.2"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-changed-files": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
-      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "execa": "^5.1.1",
-        "jest-util": "30.4.1",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/jest-changed-files/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jest-circus": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
-      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "co": "^4.6.0",
-        "dedent": "^1.6.0",
-        "is-generator-fn": "^2.1.0",
-        "jest-each": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-runtime": "30.4.2",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "p-limit": "^3.1.0",
-        "pretty-format": "30.4.1",
-        "pure-rand": "^7.0.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-circus/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-circus/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-cli": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
-      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/core": "30.4.2",
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "exit-x": "^0.2.2",
-        "import-local": "^3.2.0",
-        "jest-config": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-cli/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-cli/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-cli/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-config": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
-      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/get-type": "30.1.0",
-        "@jest/pattern": "30.4.0",
-        "@jest/test-sequencer": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-jest": "30.4.1",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "deepmerge": "^4.3.1",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "jest-circus": "30.4.2",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-runner": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "parse-json": "^5.2.0",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "esbuild-register": ">=3.4.0",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "esbuild-register": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-cli/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-cli/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-diff/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-docblock": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
-      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "detect-newline": "^3.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-each": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
-      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-each/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-each/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-each/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-each/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-environment-node": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
-      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-haste-map": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
-      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "anymatch": "^3.1.3",
-        "fb-watchman": "^2.0.2",
-        "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
-        "picomatch": "^4.0.3",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-leak-detector": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
-      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-leak-detector/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-leak-detector/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-leak-detector/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-message-util/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-mock": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-pnp-resolver": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "jest-resolve": "*"
-      },
-      "peerDependenciesMeta": {
-        "jest-resolve": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-resolve": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
-      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "slash": "^3.0.0",
-        "unrs-resolver": "^1.7.11"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-resolve-dependencies": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
-      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "jest-regex-util": "30.4.0",
-        "jest-snapshot": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runner": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
-      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/environment": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "emittery": "^0.13.1",
-        "exit-x": "^0.2.2",
-        "graceful-fs": "^4.2.11",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-haste-map": "30.4.1",
-        "jest-leak-detector": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-resolve": "30.4.1",
-        "jest-runtime": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-watcher": "30.4.1",
-        "jest-worker": "30.4.1",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runtime": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
-      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/globals": "30.4.1",
-        "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "cjs-module-lexer": "^2.1.0",
-        "collect-v8-coverage": "^1.0.2",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-snapshot": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
-      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@babel/generator": "^7.27.5",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.27.1",
-        "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-preset-current-node-syntax": "^1.2.0",
-        "chalk": "^4.1.2",
-        "expect": "30.4.1",
-        "graceful-fs": "^4.2.11",
-        "jest-diff": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1",
-        "semver": "^7.7.2",
-        "synckit": "^0.11.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-snapshot/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-validate": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
-      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.1",
-        "camelcase": "^6.3.0",
-        "chalk": "^4.1.2",
-        "leven": "^3.1.0",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/jest-validate/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-validate/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-validate/node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-watcher": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
-      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "emittery": "^0.13.1",
-        "jest-util": "30.4.1",
-        "string-length": "^4.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-worker": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
-      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.4.1",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/jiti": {
@@ -12563,14 +9273,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -12733,20 +9435,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loader-runner": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
     },
     "node_modules/loader-utils": {
       "version": "2.0.4",
@@ -12912,40 +9600,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/makeerror": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "tmpl": "1.0.5"
-      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -13586,16 +10246,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -13734,6 +10384,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/next": {
@@ -13907,14 +10558,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.46",
@@ -14232,14 +10875,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "peer": true
-    },
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -14283,26 +10918,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -14560,7 +11175,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -14579,7 +11194,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14877,24 +11492,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pure-rand": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
-      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -14964,24 +11561,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/react-is-18": {
-      "name": "react-is",
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/react-is-19": {
-      "name": "react-is",
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -15266,17 +11845,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -15308,31 +11876,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-cwd": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-cwd/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -15418,7 +11961,7 @@
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -15463,7 +12006,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -15842,18 +12385,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
@@ -15871,45 +12402,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -15954,21 +12452,6 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "char-regex": "^1.0.2",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/string-width": {
@@ -16388,23 +12871,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/synckit": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
-      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@pkgr/core": "^0.3.6"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/synckit"
-      }
-    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -16496,20 +12962,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/temp-dir": {
@@ -16739,45 +13191,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -16918,14 +13331,6 @@
       "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -17550,22 +13955,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/v8-to-istanbul": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -17778,31 +14167,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/walker": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -17811,144 +14175,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/webpack": {
-      "version": "5.107.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
-      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.0",
-        "es-module-lexer": "^2.1.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.2",
-        "mime-db": "^1.54.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.5.0",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.5.0"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-sources": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
-      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/whatwg-mimetype": {
@@ -18698,21 +14924,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
-    "node_modules/write-file-atomic": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -18730,42 +14941,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
@@ -18775,30 +14955,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -37,10 +37,11 @@ export async function GET(request: Request) {
     // 3. For each user, send the email
     // Minimal template logic to prevent timeouts and keep implementation clean
     let sentCount = 0;
-    
+    let failedCount = 0;
+
     for (const user of users) {
       if (!user.email) continue;
-      
+
       const htmlBody = `
         <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
           <h2>Your Weekly DevTrack Digest</h2>
@@ -55,24 +56,42 @@ export async function GET(request: Request) {
       `;
 
       if (process.env.RESEND_API_KEY) {
-        await fetch("https://api.resend.com/emails", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-          },
-          body: JSON.stringify({
-            from: "DevTrack <digest@devtrack.com>",
-            to: user.email,
-            subject: "Your Weekly DevTrack Digest",
-            html: htmlBody,
-          }),
-        });
+        try {
+          const sendRes = await fetch("https://api.resend.com/emails", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+            },
+            body: JSON.stringify({
+              from: "DevTrack <digest@devtrack.com>",
+              to: user.email,
+              subject: "Your Weekly DevTrack Digest",
+              html: htmlBody,
+            }),
+          });
+
+          if (sendRes.ok) {
+            sentCount++;
+          } else {
+            failedCount++;
+            const errorText = await sendRes.text().catch(() => "");
+            console.error(
+              `Digest send failed for ${user.github_login}: HTTP ${sendRes.status}`,
+              errorText,
+            );
+          }
+        } catch (err) {
+          failedCount++;
+          console.error(
+            `Digest send failed for ${user.github_login}: network error`,
+            err,
+          );
+        }
       }
-      sentCount++;
     }
 
-    return NextResponse.json({ success: true, sentCount });
+    return NextResponse.json({ success: true, sentCount, failedCount });
   } catch (err) {
     console.error("Cron weekly-digest failed:", err);
     return NextResponse.json({ error: "Failed to process digests" }, { status: 500 });

--- a/src/app/api/daily-focus/route.ts
+++ b/src/app/api/daily-focus/route.ts
@@ -1,0 +1,152 @@
+import { getServerSession } from "next-auth";
+import { type NextRequest, NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
+import { validateTextInput } from "@/lib/sanitize";
+
+export const dynamic = "force-dynamic";
+
+const MAX_GOAL_TEXT_LEN = 280;
+
+export interface DailyFocusRecord {
+  id: string;
+  user_id: string;
+  focus_date: string;
+  goal_text: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function todayDateString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function isValidDateString(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && !isNaN(Date.parse(value));
+}
+
+// ── GET /api/daily-focus?date=YYYY-MM-DD (defaults to today) ─────────────────
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.githubId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const dateParam = req.nextUrl.searchParams.get("date");
+  const focusDate =
+    dateParam && isValidDateString(dateParam) ? dateParam : todayDateString();
+
+  const { data, error } = await supabaseAdmin
+    .from("daily_focus")
+    .select("*")
+    .eq("user_id", user.id)
+    .eq("focus_date", focusDate)
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch focus" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ focus: (data as DailyFocusRecord | null) ?? null });
+}
+
+// ── PUT /api/daily-focus — upsert (create or update) ─────────────────────────
+
+export async function PUT(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.githubId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { goal_text, focus_date } = body as Record<string, unknown>;
+
+  const validation = validateTextInput(goal_text, "goal_text", MAX_GOAL_TEXT_LEN);
+  if (!validation.ok) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+
+  let safeDate = todayDateString();
+  if (typeof focus_date === "string" && isValidDateString(focus_date)) {
+    safeDate = focus_date;
+  }
+
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const now = new Date().toISOString();
+  const { data, error } = await supabaseAdmin
+    .from("daily_focus")
+    .upsert(
+      {
+        user_id: user.id,
+        focus_date: safeDate,
+        goal_text: validation.value,
+        updated_at: now,
+      },
+      { onConflict: "user_id,focus_date" }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: "Failed to save focus" }, { status: 500 });
+  }
+
+  return NextResponse.json({ focus: data as DailyFocusRecord });
+}
+
+// ── DELETE /api/daily-focus?date=YYYY-MM-DD (defaults to today) ──────────────
+
+export async function DELETE(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.githubId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const dateParam = req.nextUrl.searchParams.get("date");
+  const focusDate =
+    dateParam && isValidDateString(dateParam) ? dateParam : todayDateString();
+
+  const { error } = await supabaseAdmin
+    .from("daily_focus")
+    .delete()
+    .eq("user_id", user.id)
+    .eq("focus_date", focusDate);
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to delete focus" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -81,15 +81,13 @@ export async function PATCH(
     updates.recurrence = recurrence;
   }
 
-  if (current !== undefined) {
-    if (typeof current !== "number" || current < 0) {
-      return Response.json(
-        { error: "Invalid current value" },
-        { status: 400 }
-      );
-    }
-    updates.current = current;
+  if (typeof current !== "number" || !Number.isInteger(current) || current < 0) {
+    return Response.json(
+      { error: "current must be a non-negative integer" },
+      { status: 400 }
+    );
   }
+  updates.current = current;
 
   const { data: existingGoal } = await supabaseAdmin
     .from("goals")

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -20,6 +20,14 @@ interface Goal {
   created_at: string;
 }
 
+interface LastPeriodSummary {
+  period_start: string;
+  period_end: string;
+  target: number;
+  achieved_value: number;
+  completed: boolean;
+}
+
 type Recurrence = "none" | "weekly" | "monthly";
 
 const VALID_RECURRENCES = ["none", "weekly", "monthly"] as const;
@@ -76,6 +84,24 @@ export async function GET() {
         : new Date(0);
 
       if (storedPeriodStart < periodStart) {
+        // Archive the expiring period before zeroing current.
+        // Uses upsert with ignoreDuplicates so concurrent resets are idempotent.
+        const periodEnd = new Date(periodStart.getTime() - 1);
+        await supabaseAdmin
+          .from("goal_history")
+          .upsert(
+            {
+              goal_id: goal.id,
+              user_id: goal.user_id,
+              period_start: storedPeriodStart.toISOString(),
+              period_end: periodEnd.toISOString(),
+              target: goal.target,
+              achieved_value: goal.current,
+              completed: goal.current >= goal.target,
+            },
+            { onConflict: "goal_id,period_start", ignoreDuplicates: true }
+          );
+
         const { data: updated } = await supabaseAdmin
           .from("goals")
           .update({ current: 0, period_start: periodStart.toISOString() })
@@ -98,7 +124,40 @@ export async function GET() {
     })
   );
 
-  return Response.json({ goals: processedGoals });
+  // Fetch the most recent archived period for each recurring goal so the UI
+  // can display last-period progress without a separate request.
+  const recurringIds = (processedGoals as Goal[])
+    .filter((g) => g.recurrence !== "none")
+    .map((g) => g.id);
+
+  const lastPeriodByGoal = new Map<string, LastPeriodSummary>();
+
+  if (recurringIds.length > 0) {
+    const { data: history } = await supabaseAdmin
+      .from("goal_history")
+      .select("goal_id, period_start, period_end, target, achieved_value, completed")
+      .in("goal_id", recurringIds)
+      .order("period_start", { ascending: false });
+
+    for (const row of history ?? []) {
+      if (!lastPeriodByGoal.has(row.goal_id)) {
+        lastPeriodByGoal.set(row.goal_id, {
+          period_start: row.period_start,
+          period_end: row.period_end,
+          target: row.target,
+          achieved_value: row.achieved_value,
+          completed: row.completed,
+        });
+      }
+    }
+  }
+
+  const goalsWithHistory = (processedGoals as Goal[]).map((g) => ({
+    ...g,
+    last_period: lastPeriodByGoal.get(g.id) ?? null,
+  }));
+
+  return Response.json({ goals: goalsWithHistory });
 }
 
 export async function POST(req: Request) {

--- a/src/app/api/local-coding/stats/route.ts
+++ b/src/app/api/local-coding/stats/route.ts
@@ -40,12 +40,8 @@ export async function GET(req: NextRequest) {
     .order("date", { ascending: false });
 
   if (error) {
-    // Table may not exist in all deployments — degrade gracefully
-    return Response.json({
-      dailyData: [],
-      totals: { totalSeconds: 0, totalDays: 0, avgSecondsPerDay: 0 },
-      hasData: false,
-    });
+    console.error("Failed to fetch local coding stats:", error);
+    return Response.json({ error: "Failed to fetch local coding stats" }, { status: 500 });
   }
 
   if (!sessions || sessions.length === 0) {

--- a/src/app/api/metrics/achievements/route.ts
+++ b/src/app/api/metrics/achievements/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import { isMetricsCacheBypassed } from "@/lib/metrics-cache";
 import { resolveAppUser } from "@/lib/resolve-user";
 import { syncGitHubAchievementsForUser } from "@/lib/github-achievements";
@@ -12,6 +13,9 @@ export async function GET(req: NextRequest) {
 
   if (!session?.accessToken || !session.githubId || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
   }
 
   const user = await resolveAppUser(session.githubId, session.githubLogin);

--- a/src/app/api/metrics/activity/route.ts
+++ b/src/app/api/metrics/activity/route.ts
@@ -2,7 +2,8 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { getAccountToken, getAllAccounts } from "@/lib/github-accounts";
-import { GITHUB_API, fetchUserEvents } from "@/lib/github";
+import { GITHUB_API, GitHubAuthError, fetchUserEvents } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -47,6 +48,7 @@ async function fetchPublicEvents(
   );
 
   if (!response.ok) {
+    if (response.status === 401) throw new GitHubAuthError();
     throw new Error("GitHub API error");
   }
 
@@ -81,6 +83,9 @@ export async function GET(req: NextRequest) {
 
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
   }
 
   const accessToken: string = session.accessToken;
@@ -209,6 +214,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(result);
   } catch (error) {
+    if (error instanceof GitHubAuthError) return githubAuthErrorResponse();
     if (error instanceof Error) {
       if (error.message === "Unauthorized") {
         return Response.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/metrics/ci/route.ts
+++ b/src/app/api/metrics/ci/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { getAccountToken, getAllAccounts, mergeMetrics } from "@/lib/github-accounts";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
 import { isMetricsCacheBypassed, metricsCacheKey, withMetricsCache } from "@/lib/metrics-cache";
@@ -12,6 +13,7 @@ export const dynamic = "force-dynamic";
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (session.error === "TokenRevoked") return githubAuthErrorResponse();
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -45,6 +47,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(data);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/coding-activity-insights/route.ts
+++ b/src/app/api/metrics/coding-activity-insights/route.ts
@@ -144,6 +144,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const timeZone = getRequestedTimeZone(req);

--- a/src/app/api/metrics/coding-activity-insights/route.ts
+++ b/src/app/api/metrics/coding-activity-insights/route.ts
@@ -164,6 +164,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(data);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -247,6 +248,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(data);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/coding-activity-insights/route.ts
+++ b/src/app/api/metrics/coding-activity-insights/route.ts
@@ -6,6 +6,7 @@ import {
   getAllAccounts,
 } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -83,6 +84,7 @@ async function fetchCommitTimestampsForAccount(
         );
 
         if (!response.ok) {
+          if (response.status === 401) throw new GitHubAuthError();
           if ((response.status === 403 || response.status === 429) && timestamps.length > 0) {
             break;
           }

--- a/src/app/api/metrics/contributions/daily/route.ts
+++ b/src/app/api/metrics/contributions/daily/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -21,6 +22,9 @@ export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
   }
 
   const date = req.nextUrl.searchParams.get("date");
@@ -54,7 +58,10 @@ export async function GET(req: NextRequest) {
           }
         );
 
-        if (!searchRes.ok) throw new Error("GitHub API error");
+        if (!searchRes.ok) {
+          if (searchRes.status === 401) throw new GitHubAuthError();
+          throw new Error("GitHub API error");
+        }
 
         const data = (await searchRes.json()) as {
           items: Array<{
@@ -81,6 +88,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(result);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/contributions/hourly/route.ts
+++ b/src/app/api/metrics/contributions/hourly/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -15,6 +16,9 @@ export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
   }
 
   const days = Number(req.nextUrl.searchParams.get("days")) || 30;
@@ -51,7 +55,10 @@ export async function GET(req: NextRequest) {
               cache: "no-store",
             }
           );
-          if (!searchRes.ok) throw new Error("GitHub API error");
+          if (!searchRes.ok) {
+            if (searchRes.status === 401) throw new GitHubAuthError();
+            throw new Error("GitHub API error");
+          }
           const data = (await searchRes.json()) as {
             items: Array<{ commit: { author: { date: string } } }>;
           };
@@ -82,6 +89,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(result);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -16,6 +16,7 @@ import {
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
 import { normalizeGitHubUsername } from "@/lib/validate-github-username";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 
 export const dynamic = "force-dynamic";
 
@@ -144,6 +145,9 @@ async function fetchContributionsForAccount(
         );
 
         if (!searchRes.ok) {
+          // 401: token revoked or invalid — surface as auth error immediately
+          if (searchRes.status === 401) throw new GitHubAuthError();
+
           // If we're being rate limited or hit a secondary rate limit/permission error,
           // return partial results collected so far instead of failing the whole request.
           if (searchRes.status === 429 || searchRes.status === 403) {
@@ -323,6 +327,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const fromParam = req.nextUrl.searchParams.get("from");
   const toParam = req.nextUrl.searchParams.get("to");
@@ -368,6 +375,7 @@ export async function GET(req: NextRequest) {
       );
       return Response.json(result);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -395,6 +403,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(merged);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -482,6 +491,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(merged);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -514,6 +524,7 @@ export async function GET(req: NextRequest) {
     );
     return Response.json(result);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/discussions/route.ts
+++ b/src/app/api/metrics/discussions/route.ts
@@ -6,6 +6,7 @@ import {
   getAllAccounts,
   mergeMetrics,
 } from "@/lib/github-accounts";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -69,6 +70,7 @@ async function fetchDiscussionsMetrics(
       });
 
       if (!response.ok) {
+        if (response.status === 401) throw new GitHubAuthError();
         throw new Error("GitHub API error");
       }
 
@@ -115,6 +117,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -128,6 +133,7 @@ export async function GET(req: NextRequest) {
       });
       return Response.json(formatDiscussionsMetrics(result));
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -186,6 +192,7 @@ export async function GET(req: NextRequest) {
     });
     return Response.json(formatDiscussionsMetrics(result));
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/inactive-repos/route.ts
+++ b/src/app/api/metrics/inactive-repos/route.ts
@@ -2,7 +2,8 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { getAccountToken, getAllAccounts, mergeMetrics } from "@/lib/github-accounts";
-import { fetchUserRepos, type GitHubRepo } from "@/lib/github";
+import { fetchUserRepos, GitHubAuthError, type GitHubRepo } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -131,6 +132,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const thresholdDays = parseThreshold(req.nextUrl.searchParams.get("days"));
   const accountId = req.nextUrl.searchParams.get("accountId");
@@ -147,6 +151,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(result);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -203,6 +208,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(result);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -234,6 +240,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(result);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/issues/route.ts
+++ b/src/app/api/metrics/issues/route.ts
@@ -1,7 +1,8 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
-import { fetchIssuesMetrics } from "@/lib/github";
+import { GitHubAuthError, fetchIssuesMetrics } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -17,6 +18,9 @@ export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
   }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
@@ -50,6 +54,7 @@ export async function GET(req: NextRequest) {
     );
     return Response.json(metrics);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/languages/route.ts
+++ b/src/app/api/metrics/languages/route.ts
@@ -1,6 +1,8 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import { GitHubAuthError } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import { isMetricsCacheBypassed, metricsCacheKey, withMetricsCache, METRICS_CACHE_TTL_SECONDS} from "@/lib/metrics-cache";
 import { getAccountToken } from "@/lib/github-accounts";
 import { supabaseAdmin } from "@/lib/supabase";
@@ -12,6 +14,7 @@ const GITHUB_API = "https://api.github.com";
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (session.error === "TokenRevoked") return githubAuthErrorResponse();
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -62,7 +65,10 @@ export async function GET(req: NextRequest) {
         `${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${since.toISOString().slice(0, 10)}&per_page=100&sort=author-date&order=desc`,
         { headers, cache: "no-store" }
       );
-      if (!searchRes.ok) throw new Error("API Error");
+      if (!searchRes.ok) {
+        if (searchRes.status === 401) throw new GitHubAuthError();
+        throw new Error("API Error");
+      }
 
       const raw = await searchRes.json();
       const repoNames = Array.from(new Set<string>(raw.items.map((i: any) => i.repository.full_name)));
@@ -112,6 +118,7 @@ export async function GET(req: NextRequest) {
     });
     return Response.json(data);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/pinned-repos/route.ts
+++ b/src/app/api/metrics/pinned-repos/route.ts
@@ -1,5 +1,6 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 
 export const dynamic = "force-dynamic";
 
@@ -39,6 +40,9 @@ export async function GET() {
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   try {
     const response = await fetch("https://api.github.com/graphql", {
@@ -52,6 +56,7 @@ export async function GET() {
     });
 
     if (!response.ok) {
+      if (response.status === 401) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
 

--- a/src/app/api/metrics/pr-breakdown/route.ts
+++ b/src/app/api/metrics/pr-breakdown/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import { isMetricsCacheBypassed, metricsCacheKey, withMetricsCache } from "@/lib/metrics-cache";
 import { getAccountToken } from "@/lib/github-accounts";
 import { resolveAppUser } from "@/lib/resolve-user";
@@ -13,6 +14,7 @@ interface PRItem { state: string; draft?: boolean; pull_request?: { merged_at: s
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (session.error === "TokenRevoked") return githubAuthErrorResponse();
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -44,7 +46,10 @@ export async function GET(req: NextRequest) {
         headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
         cache: "no-store",
       });
-      if (!res.ok) throw new Error("API Error");
+      if (!res.ok) {
+        if (res.status === 401) throw new GitHubAuthError();
+        throw new Error("API Error");
+      }
 
       const raw = (await res.json()) as { items: PRItem[] };
       let draft = 0, open = 0, merged = 0, closed = 0;
@@ -59,6 +64,7 @@ export async function GET(req: NextRequest) {
     });
     return Response.json(data);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/pr-review-time/route.ts
+++ b/src/app/api/metrics/pr-review-time/route.ts
@@ -6,7 +6,8 @@ import {
   getAllAccounts,
   mergeMetrics,
 } from "@/lib/github-accounts";
-import { GITHUB_API } from "@/lib/github";
+import { GITHUB_API, GitHubAuthError } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -128,6 +129,7 @@ async function fetchPRReviewTrendForAccount(
       );
 
       if (!mergedRes.ok) {
+        if (mergedRes.status === 401) throw new GitHubAuthError();
         throw new Error("GitHub API error");
       }
 
@@ -233,6 +235,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -246,6 +251,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(formatTrendWeeks(result));
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -305,6 +311,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(formatTrendWeeks(result));
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/productive-hours/route.ts
+++ b/src/app/api/metrics/productive-hours/route.ts
@@ -336,7 +336,8 @@ export async function GET(req: NextRequest) {
       repoParam
     );
     return Response.json(result);
-  } catch {
+  } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/productive-hours/route.ts
+++ b/src/app/api/metrics/productive-hours/route.ts
@@ -6,7 +6,8 @@ import {
   getAllAccounts,
   mergeMetrics,
 } from "@/lib/github-accounts";
-import { GITHUB_API, GitHubCommitSearchItem } from "@/lib/github";
+import { GITHUB_API, GitHubCommitSearchItem, GitHubAuthError } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -89,6 +90,7 @@ async function fetchProductiveHoursForAccount(
         });
 
         if (!searchRes.ok) {
+          if (searchRes.status === 401) throw new GitHubAuthError();
           // Graceful degradation on rate-limit — return partial data already collected.
           if (searchRes.status === 429 || searchRes.status === 403) {
             if (allItems.length === 0) {
@@ -196,6 +198,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const searchParams = req.nextUrl.searchParams;
 
@@ -236,7 +241,8 @@ export async function GET(req: NextRequest) {
         repoParam
       );
       return Response.json(result);
-    } catch {
+    } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -296,7 +302,8 @@ export async function GET(req: NextRequest) {
         repoParam
       );
       return Response.json(result);
-    } catch {
+    } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }

--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { getAccountToken, getAllAccounts } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -164,7 +165,10 @@ async function fetchPRMetrics(token: string): Promise<PRMetricsBase> {
     }
   );
 
-  if (!searchRes.ok) throw new Error("GitHub API error");
+  if (!searchRes.ok) {
+    if (searchRes.status === 401) throw new GitHubAuthError();
+    throw new Error("GitHub API error");
+  }
 
   const data = (await searchRes.json()) as {
     total_count: number;
@@ -440,7 +444,10 @@ async function fetchReviewMetrics(token: string): Promise<ReviewMetrics> {
     cache: "no-store",
   });
 
-  if (!res.ok) throw new Error("GitHub GraphQL error");
+  if (!res.ok) {
+    if (res.status === 401) throw new GitHubAuthError();
+    throw new Error("GitHub GraphQL error");
+  }
 
   const json = await res.json();
   const nodes = json?.data?.viewer?.contributionsCollection?.pullRequestReviewContributions?.nodes ?? [];
@@ -476,6 +483,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const gitlabToken = typeof session.gitlabToken === "string" ? session.gitlabToken : undefined;
   const accountId = req.nextUrl.searchParams.get("accountId");
@@ -499,9 +509,8 @@ export async function GET(req: NextRequest) {
       ]);
       
       return Response.json({ ...formatPRMetricsResponse(result, gitlab), reviews });
-    } catch {
-      // Catches errors from fetchCachedPRMetrics (GitHub Search API failures).
-      // Returns 502 so the client knows the data is unavailable, not just empty.
+    } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -594,7 +603,8 @@ export async function GET(req: NextRequest) {
       ]);
       
       return Response.json({ ...formatPRMetricsResponse(combinedMetrics, gitlab), reviews });
-    } catch {
+    } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "Failed to compile combined profile metrics" }, { status: 502 });
     }
   }
@@ -618,6 +628,7 @@ export async function GET(req: NextRequest) {
     
     return Response.json({ ...formatPRMetricsResponse(result, gitlab), reviews });
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/repo-explorer/route.ts
+++ b/src/app/api/metrics/repo-explorer/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import { isMetricsCacheBypassed, metricsCacheKey, withMetricsCache } from "@/lib/metrics-cache";
 import { ExplorerRepoCardData } from "@/lib/repoAnalytics";
 
@@ -11,6 +12,9 @@ export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
   }
 
   const bypass = isMetricsCacheBypassed(req);
@@ -24,7 +28,10 @@ export async function GET(req: NextRequest) {
         cache: "no-store",
       });
       
-      if (!reposRes.ok) throw new Error("API error fetching repos");
+      if (!reposRes.ok) {
+        if (reposRes.status === 401) throw new GitHubAuthError();
+        throw new Error("API error fetching repos");
+      }
       const repos = await reposRes.json();
 
       // 2. Fetch last 30 days of commits across all repos for the user
@@ -37,8 +44,10 @@ export async function GET(req: NextRequest) {
         cache: "no-store",
       });
 
+      if (!searchRes.ok && searchRes.status === 401) throw new GitHubAuthError();
+
       const repoCommits: Record<string, any[]> = {};
-      
+
       if (searchRes.ok) {
         const searchData = await searchRes.json();
         const items = searchData.items || [];
@@ -97,6 +106,7 @@ export async function GET(req: NextRequest) {
     });
     return Response.json(data);
   } catch (error) {
+    if (error instanceof GitHubAuthError) return githubAuthErrorResponse();
     console.error(error);
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }

--- a/src/app/api/metrics/repos/route.ts
+++ b/src/app/api/metrics/repos/route.ts
@@ -6,7 +6,8 @@ import {
   getAllAccounts,
   mergeMetrics,
 } from "@/lib/github-accounts";
-import { GITHUB_API } from "@/lib/github";
+import { GITHUB_API, GitHubAuthError } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -161,11 +162,11 @@ async function fetchReposForAccount(
         }
       );
 
+      // HTTP 401 = token revoked — throw auth error so caller can surface reconnect.
       // HTTP 403 = Search API rate limit exceeded for this token.
       // HTTP 422 = malformed query (e.g. invalid date format or username characters).
-      // Both throw here so the GET handler returns HTTP 502, and the client
-      // falls back to showing an error state rather than an empty repos list.
       if (!searchRes.ok) {
+        if (searchRes.status === 401) throw new GitHubAuthError();
         throw new Error("GitHub API error");
       }
 
@@ -218,6 +219,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const daysParam = req.nextUrl.searchParams.get("days");
   const parsedDays = daysParam ? parseInt(daysParam, 10) : NaN;
@@ -237,8 +241,7 @@ export async function GET(req: NextRequest) {
       );
       return Response.json(result);
     } catch (e) {
-      // fetchReposForAccount throws on GitHub API errors (rate limit, network failure).
-      // Return 502 so the client shows an error state rather than an empty repos widget.
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -300,6 +303,7 @@ export async function GET(req: NextRequest) {
       );
       return Response.json(result);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -331,6 +335,7 @@ export async function GET(req: NextRequest) {
     );
     return Response.json(result);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/streak/route.ts
+++ b/src/app/api/metrics/streak/route.ts
@@ -2,7 +2,8 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { getAccountToken, getAllAccounts } from "@/lib/github-accounts";
-import { GITHUB_API } from "@/lib/github";
+import { GITHUB_API, GitHubAuthError } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -75,6 +76,7 @@ async function fetchActiveDates(
         // Both are thrown here so the outer GET handler returns HTTP 502 to the client,
         // which shows an error state rather than a misleading 0-day streak.
         if (!searchRes.ok) {
+          if (searchRes.status === 401) throw new GitHubAuthError();
           throw new Error("GitHub API error");
         }
 
@@ -241,6 +243,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin || !session.githubId) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -304,9 +309,8 @@ export async function GET(req: NextRequest) {
       }
 
       return Response.json(streakData);
-    } catch {
-      // fetchActiveDates throws on GitHub API errors (rate limit, network failure).
-      // Return 502 so the client shows an error state rather than a false 0-day streak.
+    } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -398,7 +402,8 @@ export async function GET(req: NextRequest) {
     }
 
     return Response.json(streakData);
-  } catch {
+  } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -96,6 +96,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -285,8 +288,7 @@ export async function GET(req: NextRequest) {
     });
     return Response.json(data);
   } catch (e) {
-    // Catches errors thrown by the PR Search call or fetchActiveDates (rate limit, network).
-    // Returns 502 so the client shows an error state rather than stale/empty summary data.
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import { isMetricsCacheBypassed, metricsCacheKey, withMetricsCache } from "@/lib/metrics-cache";
 import { getAccountToken } from "@/lib/github-accounts";
 import { supabaseAdmin } from "@/lib/supabase";
@@ -65,10 +66,12 @@ async function fetchActiveDates(githubLogin: string, token: string): Promise<Set
       }
     );
 
-    // HTTP 403 = Search API rate limit exceeded ("API rate limit exceeded" in body).
-    // Throws here so withMetricsCache propagates the error to the GET handler,
-    // which returns HTTP 502 to the client.
-    if (!searchRes.ok) throw new Error("GitHub API error");
+    // HTTP 401 = token revoked/invalid. HTTP 403 = rate limit.
+    // Both throw so the outer GET handler can distinguish auth failures.
+    if (!searchRes.ok) {
+      if (searchRes.status === 401) throw new GitHubAuthError();
+      throw new Error("GitHub API error");
+    }
 
     const data = (await searchRes.json()) as { items: Array<{ commit: { author: { date: string } } }> };
 
@@ -159,12 +162,10 @@ export async function GET(req: NextRequest) {
         }
       );
 
-      // Guard against non-200 responses (e.g. 403 secondary rate limit) before
-      // calling .json(). Without this check, commitsData.items is undefined on a
-      // rate-limit response, causing the for-of loop below to throw
-      // "TypeError: undefined is not iterable" and wipe the entire widget.
-      // On failure we fall back to an empty items array so PRs and streak data
-      // remain visible even when the commits search is rate-limited.
+      // 401 = token revoked — surface immediately so the banner appears.
+      // Other non-ok responses (403 rate limit, 5xx) fall back to empty items
+      // so the PRs and streak sections still render on rate-limit transients.
+      if (!commitsRes.ok && commitsRes.status === 401) throw new GitHubAuthError();
       const commitsData: {
         items: Array<{
           commit: { author: { date: string } };
@@ -220,9 +221,8 @@ export async function GET(req: NextRequest) {
         }
       );
 
-      // Unlike commitsRes, a PR Search failure throws and returns 502 —
-      // PR data is more critical to the weekly summary widget than commit counts.
       if (!prsRes.ok) {
+        if (prsRes.status === 401) throw new GitHubAuthError();
         throw new Error("GitHub API error");
       }
 

--- a/src/app/api/stream/route.ts
+++ b/src/app/api/stream/route.ts
@@ -17,6 +17,22 @@ const MAX_CONNECTIONS_PER_USER = 4;
 // while being 7.5x cheaper per connection than the previous 2 s interval.
 const POLL_INTERVAL_MS = 15_000;
 
+// Keepalive comment sent to prevent proxies from closing the connection on
+// their idle timeout. Also provides an early signal if the client is gone
+// (enqueue throws when the controller is already closed).
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+
+// Close connections where no real data has been delivered for this long.
+// This recycles slots occupied by zombie connections (tabs closed via network
+// interruption, proxies that dropped the TCP stream without notifying the
+// server, etc.). The browser EventSource reconnects within seconds.
+export const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+// Hard ceiling on how long a single stream connection may remain open,
+// regardless of activity. Forces a clean reconnect and prevents state from
+// accumulating in very long-lived connections.
+export const MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
+
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.githubId || !session.githubLogin) {
@@ -51,11 +67,47 @@ export async function GET(req: NextRequest) {
 
   let lastCheckedSyncedAt: string | null = null;
   let lastCheckedUnreadCount: number | null = null;
-
+  let lastDataSentAt = Date.now();
   let isClosed = false;
 
   const stream = new ReadableStream({
     start(controller) {
+      // Declare handles up-front so closeStream can clear them regardless of
+      // which close path fires first (abort, idle, max-age).
+      let pollInterval: ReturnType<typeof setInterval>;
+      let heartbeatInterval: ReturnType<typeof setInterval>;
+      let idleCheckInterval: ReturnType<typeof setInterval>;
+      let maxAgeTimer: ReturnType<typeof setTimeout>;
+
+      // Guard: ensures the connection slot is decremented exactly once even if
+      // multiple close paths race (e.g. abort fires while idle timeout fires).
+      let cleanedUp = false;
+      function releaseSlot() {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        const remaining = activeStreamConnections.get(userId) ?? 1;
+        if (remaining <= 1) {
+          activeStreamConnections.delete(userId);
+        } else {
+          activeStreamConnections.set(userId, remaining - 1);
+        }
+      }
+
+      function closeStream() {
+        if (isClosed) return;
+        isClosed = true;
+        clearInterval(pollInterval);
+        clearInterval(heartbeatInterval);
+        clearInterval(idleCheckInterval);
+        clearTimeout(maxAgeTimer);
+        try {
+          controller.close();
+        } catch (_) {
+          // already closed
+        }
+        releaseSlot();
+      }
+
       const checkData = async () => {
         if (isClosed) return;
         try {
@@ -94,36 +146,45 @@ export async function GET(req: NextRequest) {
 
           if (hasChanges && !isClosed) {
             controller.enqueue(`data: ${JSON.stringify(payload)}\n\n`);
+            lastDataSentAt = Date.now();
           }
         } catch (error) {
           console.error("SSE Polling Error:", error);
         }
       };
 
-      // Register the interval and abort handler synchronously so they are
-      // guaranteed to be in place before any async work begins. This prevents
-      // a race where abort() fires before the listener is attached.
-      const interval = setInterval(() => {
+      // Register all timers and the abort listener synchronously so they are
+      // in place before any async work begins. This prevents a race where
+      // abort() fires before the listener is attached.
+      pollInterval = setInterval(() => {
         if (!isClosed) checkData();
       }, POLL_INTERVAL_MS);
 
-      req.signal.addEventListener("abort", () => {
-        isClosed = true;
-        clearInterval(interval);
+      // Keepalive comment — invisible to message handlers, keeps the TCP
+      // stream alive through intermediate proxies.
+      heartbeatInterval = setInterval(() => {
+        if (isClosed) return;
         try {
-          controller.close();
-        } catch (e) {
-          // ignore already closed
+          controller.enqueue(": heartbeat\n\n");
+        } catch (_) {
+          // If enqueue throws the controller is already closed; clean up.
+          closeStream();
         }
+      }, HEARTBEAT_INTERVAL_MS);
 
-        // Decrement the connection counter so the slot becomes available again.
-        const remaining = activeStreamConnections.get(userId) ?? 1;
-        if (remaining <= 1) {
-          activeStreamConnections.delete(userId);
-        } else {
-          activeStreamConnections.set(userId, remaining - 1);
+      // Idle timeout — close connections that have sent no real data for
+      // IDLE_TIMEOUT_MS. Frees slots held by zombie connections.
+      idleCheckInterval = setInterval(() => {
+        if (isClosed) return;
+        if (Date.now() - lastDataSentAt > IDLE_TIMEOUT_MS) {
+          closeStream();
         }
-      });
+      }, 60_000);
+
+      // Max-age ceiling — forcibly recycle the connection after MAX_AGE_MS.
+      maxAgeTimer = setTimeout(closeStream, MAX_AGE_MS);
+
+      req.signal.addEventListener("abort", closeStream);
 
       // Kick off the first poll immediately (non-blocking).
       checkData();

--- a/src/app/api/user/data-export/route.ts
+++ b/src/app/api/user/data-export/route.ts
@@ -197,9 +197,17 @@ export async function GET(req: NextRequest) {
 
   const { data: goals } = await supabaseAdmin
     .from("goals")
-    .select("id, user_id, title, description, status, created_at, updated_at")
+    .select("id, user_id, title, target, current, unit, recurrence, deadline, period_start, created_at")
     .eq("user_id", user.id);
   sections.goals = goals || [];
+
+  const { data: goalHistory } = await supabaseAdmin
+    .from("goal_history")
+    .select("id, goal_id, user_id, period_start, period_end, target, achieved_value, completed, created_at")
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false })
+    .limit(1000);
+  sections.goalHistory = goalHistory || [];
 
   const { data: snapshots } = await supabaseAdmin
     .from("metric_snapshots")
@@ -258,6 +266,14 @@ export async function GET(req: NextRequest) {
     .order("date", { ascending: false })
     .limit(365);
   sections.localCodingSessions = localCodingSessions || [];
+
+  const { data: dailyFocusRecords } = await supabaseAdmin
+    .from("daily_focus")
+    .select("id, user_id, focus_date, goal_text, created_at, updated_at")
+    .eq("user_id", user.id)
+    .order("focus_date", { ascending: false })
+    .limit(365);
+  sections.dailyFocus = dailyFocusRecords || [];
 
   // --- Redact any sensitive fields that slipped through the column selects --
   const redactedSections = redactSensitiveFields(sections) as Record<string, unknown>;
@@ -334,7 +350,9 @@ export async function DELETE(req: NextRequest) {
     "jira_credentials",
     "webhook_configs",
     "user_github_accounts",
+    "goal_history",
     "goals",
+    "daily_focus",
     "metric_snapshots",
   ];
 

--- a/src/app/api/user/github-accounts/route.ts
+++ b/src/app/api/user/github-accounts/route.ts
@@ -38,8 +38,8 @@ export async function GET() {
       .order("added_at", { ascending: true });
 
     if (error) {
-      // Table may not exist in all deployments — return empty accounts
-      return NextResponse.json({ accounts: [] });
+      console.error("Failed to fetch github accounts:", error);
+      return NextResponse.json({ error: "Failed to fetch accounts" }, { status: 500 });
     }
 
     return NextResponse.json({

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -33,6 +33,22 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
       const response = await originalFetch(...args);
       if (response.status === 401) {
         const cloned = response.clone();
+
+        // Check if this is a token_expired response from a metrics route.
+        // These mean the GitHub OAuth token was revoked — the NextAuth session
+        // itself is still valid, so we dispatch an event for the reconnect
+        // banner rather than signing out.
+        let body: Record<string, unknown> | null = null;
+        try {
+          body = await response.clone().json();
+        } catch {
+          // Non-JSON 401 — fall through to session check.
+        }
+        if (body?.error === "token_expired") {
+          window.dispatchEvent(new CustomEvent("github-token-expired"));
+          return cloned;
+        }
+
         const sessionStillActive = await hasActiveSession(originalFetch);
 
         if (!sessionStillActive) {

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -243,7 +243,7 @@ export default function ContributionGraph() {
       try {
         const r = await fetch(url);
         const body = await r.json().catch(() => null);
-        if (body?.error === "github_auth_invalid") {
+        if (body?.error === "token_expired") {
           if (active) {
             setGithubAuthInvalid(true);
             setLoading(false);

--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -125,6 +125,7 @@ export default function ContributionGraph() {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
   const [commits, setCommits] = useState<CommitItem[]>([]);
   const [usesTouchTooltip, setUsesTouchTooltip] = useState(false);
   const [repo, setRepo] = useState<string>("all");
@@ -234,14 +235,23 @@ export default function ContributionGraph() {
         // No cache: show standard loading
         setLoading(true);
         setError(null);
+        setGithubAuthInvalid(false);
         setCommits([]);
       }
 
       // 2. Perform background sync / standard fetch
       try {
         const r = await fetch(url);
+        const body = await r.json().catch(() => null);
+        if (body?.error === "github_auth_invalid") {
+          if (active) {
+            setGithubAuthInvalid(true);
+            setLoading(false);
+          }
+          return;
+        }
         if (!r.ok) throw new Error("API error");
-        const res: ContributionResponse = await r.json();
+        const res: ContributionResponse = body;
         
         if (!active) return;
 
@@ -620,6 +630,18 @@ export default function ContributionGraph() {
             aria-hidden="true"
             className="h-[220px] rounded border border-[var(--border)] bg-[var(--background)] animate-pulse"
           />
+        </div>
+      ) : githubAuthInvalid ? (
+        <div className="flex h-[220px] flex-col items-center justify-center gap-3 rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 text-center">
+          <p className="text-sm text-[var(--muted-foreground)]">
+            Your GitHub connection is no longer valid. Reconnect your GitHub account to continue syncing data.
+          </p>
+          <a
+            href="/api/auth/signin?callbackUrl=/dashboard"
+            className="rounded-md bg-[var(--accent)] px-4 py-2 text-sm font-medium text-[var(--background)] hover:opacity-90 transition-opacity"
+          >
+            Reconnect GitHub
+          </a>
         </div>
       ) : error ? (
         <div className="flex h-[220px] items-center rounded-lg border border-[var(--border)] bg-[var(--background)] px-4">

--- a/src/components/DashboardWidgets.tsx
+++ b/src/components/DashboardWidgets.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 
-
+import GitHubTokenExpiredBanner from "@/components/GitHubTokenExpiredBanner";
 import ContributionGraph from "@/components/ContributionGraph";
 import ContributionHeatmap from "@/components/ContributionHeatmap";
 import PRMetrics from "@/components/PRMetrics";
@@ -25,6 +25,8 @@ import WidgetErrorBoundary from "@/components/WidgetErrorBoundary";
 export default function DashboardWidgets() {
   return (
     <>
+      <GitHubTokenExpiredBanner />
+
       <WidgetErrorBoundary>
         <DashboardHeader />
       </WidgetErrorBoundary>

--- a/src/components/DiscussionsWidget.tsx
+++ b/src/components/DiscussionsWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { signOut } from "next-auth/react";
 
 interface DiscussionData {
   discussionsStarted: number;
@@ -12,16 +13,26 @@ export default function DiscussionsWidget() {
   const [data, setData] = useState<DiscussionData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
 
   const fetchData = useCallback(() => {
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
     fetch("/api/metrics/discussions")
-      .then((r) => {
+      .then(async (r) => {
+        const body = await r.json();
+        if (body?.error === "token_expired") {
+          setGithubAuthInvalid(true);
+          return null;
+        }
         if (!r.ok) throw new Error("API error");
-        return r.json();
+        return body as DiscussionData;
       })
-      .then((d: DiscussionData) => setData(d))
+      .then((d) => {
+        if (!d) return;
+        setData(d);
+      })
       .catch(() =>
         setError("We couldn't load your discussion metrics right now.")
       )
@@ -66,6 +77,24 @@ export default function DiscussionsWidget() {
               className="h-20 rounded-lg skeleton-shimmer"
             />
           ))}
+        </div>
+      ) : githubAuthInvalid ? (
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center space-y-3">
+          <p className="text-sm text-[var(--muted-foreground)]">
+            Your GitHub connection is no longer valid. Reconnect your GitHub
+            account to continue syncing data.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              void signOut({ redirect: false }).then(() => {
+                window.location.href = "/api/auth/signin/github?callbackUrl=/dashboard";
+              });
+            }}
+            className="inline-flex items-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+          >
+            Reconnect GitHub
+          </button>
         </div>
       ) : error ? (
         <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">

--- a/src/components/GitHubTokenExpiredBanner.tsx
+++ b/src/components/GitHubTokenExpiredBanner.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession, signOut } from "next-auth/react";
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Renders a full-width reconnect banner when the stored GitHub token is no
+ * longer valid. Triggered by two sources:
+ *   1. session.error === "TokenRevoked" — set by the 24-hour liveness check in
+ *      the NextAuth JWT callback after GitHub returns 401 on /user.
+ *   2. A "github-token-expired" custom event dispatched by the dashboard layout
+ *      fetch interceptor when any metrics API returns { error: "token_expired" }.
+ */
+export default function GitHubTokenExpiredBanner() {
+  const { data: session } = useSession();
+  const [visible, setVisible] = useState(false);
+
+  // Show immediately when the session is already flagged.
+  useEffect(() => {
+    if (session?.error === "TokenRevoked") {
+      setVisible(true);
+    }
+  }, [session?.error]);
+
+  // Also show when a metrics route surfaces a live 401 during this page view.
+  useEffect(() => {
+    function handleEvent() {
+      setVisible(true);
+    }
+    window.addEventListener("github-token-expired", handleEvent);
+    return () => window.removeEventListener("github-token-expired", handleEvent);
+  }, []);
+
+  if (!visible) return null;
+
+  async function handleReconnect() {
+    await signOut({ redirect: false });
+    window.location.href = "/api/auth/signin/github?callbackUrl=/dashboard";
+  }
+
+  return (
+    <div
+      role="alert"
+      className="mb-6 flex flex-col gap-3 rounded-xl border border-[var(--warning-border,#f59e0b)] bg-[var(--warning-muted,#fef3c7)] px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-[var(--warning,#d97706)]" />
+        <p className="text-sm text-[var(--foreground)]">
+          <span className="font-semibold">GitHub connection lost.</span>{" "}
+          Your GitHub connection is no longer valid. Please reconnect your GitHub
+          account to continue syncing data.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => void handleReconnect()}
+        className="shrink-0 rounded-lg bg-[var(--warning,#d97706)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+      >
+        Reconnect GitHub
+      </button>
+    </div>
+  );
+}

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -6,6 +6,14 @@ import ConfirmModal from "@/components/ConfirmModal"; // 🎯 Imported the nativ
 
 type Recurrence = "none" | "weekly" | "monthly";
 
+interface LastPeriod {
+  period_start: string;
+  period_end: string;
+  target: number;
+  achieved_value: number;
+  completed: boolean;
+}
+
 interface Goal {
   id: string;
   title: string;
@@ -16,6 +24,7 @@ interface Goal {
   deadline: string | null;
   period_start: string;
   last_synced_at: string | null;
+  last_period?: LastPeriod | null;
 }
 
 const RECURRENCE_LABELS: Record<Recurrence, string> = {
@@ -446,6 +455,13 @@ export default function GoalTracker() {
                         {completionLabel}
                       </span>
                     ) : null}
+                    {goal.recurrence !== "none" && goal.last_period && (
+                      <span className="text-xs text-[var(--muted-foreground)]">
+                        {goal.last_period.completed
+                          ? `✓ ${goal.last_period.achieved_value} / ${goal.last_period.target} last period`
+                          : `✗ ${goal.last_period.achieved_value} / ${goal.last_period.target} last period`}
+                      </span>
+                    )}
                   </div>
 
                   <div className="flex items-center gap-2">

--- a/src/components/InactiveRepositoriesCard.tsx
+++ b/src/components/InactiveRepositoriesCard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { signOut } from "next-auth/react";
 import type { InactiveRepo } from "@/types/inactive-repos";
 
 const THRESHOLDS = [30, 60, 90] as const;
@@ -39,10 +40,12 @@ export default function InactiveRepositoriesCard() {
   const [repos, setRepos] = useState<InactiveRepo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
 
   const fetchInactiveRepos = useCallback(() => {
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
 
     const accountParam =
       selectedAccount !== null
@@ -50,14 +53,19 @@ export default function InactiveRepositoriesCard() {
         : "";
 
     fetch(`/api/metrics/inactive-repos?days=${thresholdDays}${accountParam}`)
-      .then((response) => {
+      .then(async (response) => {
+        const payload = await response.json();
+        if (payload?.error === "token_expired") {
+          setGithubAuthInvalid(true);
+          return null;
+        }
         if (!response.ok) {
           throw new Error("API error");
         }
-
-        return response.json();
+        return payload as { repos?: InactiveRepo[] };
       })
-      .then((payload: { repos?: InactiveRepo[] }) => {
+      .then((payload) => {
+        if (!payload) return;
         setRepos(payload.repos ?? []);
       })
       .catch(() => {
@@ -120,6 +128,24 @@ export default function InactiveRepositoriesCard() {
                 className="h-20 rounded-lg skeleton-shimmer"
               />
             ))}
+          </div>
+        ) : githubAuthInvalid ? (
+          <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center space-y-3">
+            <p className="text-sm text-[var(--muted-foreground)]">
+              Your GitHub connection is no longer valid. Reconnect your GitHub
+              account to continue syncing data.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                void signOut({ redirect: false }).then(() => {
+                  window.location.href = "/api/auth/signin/github?callbackUrl=/dashboard";
+                });
+              }}
+              className="inline-flex items-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+            >
+              Reconnect GitHub
+            </button>
           </div>
         ) : error ? (
           <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">

--- a/src/components/IssueMetrics.tsx
+++ b/src/components/IssueMetrics.tsx
@@ -31,7 +31,7 @@ export default function IssueMetrics() {
     fetch(url)
       .then(async (r) => {
         const data = await r.json();
-        if (data?.error === "github_auth_invalid") {
+        if (data?.error === "token_expired") {
           setGithubAuthInvalid(true);
           return null;
         }

--- a/src/components/IssueMetrics.tsx
+++ b/src/components/IssueMetrics.tsx
@@ -17,18 +17,31 @@ export default function IssueMetrics() {
   const [metrics, setMetrics] = useState<IssueData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
 
   const fetchMetrics = useCallback(() => {
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
 
     const url = selectedAccount !== null
       ? `/api/metrics/issues?accountId=${encodeURIComponent(selectedAccount)}`
       : "/api/metrics/issues";
 
     fetch(url)
-      .then((r) => r.json())
-      .then((data: IssueData) => setMetrics(data))
+      .then(async (r) => {
+        const data = await r.json();
+        if (data?.error === "github_auth_invalid") {
+          setGithubAuthInvalid(true);
+          return null;
+        }
+        if (!r.ok) throw new Error("API error");
+        return data as IssueData;
+      })
+      .then((data) => {
+        if (!data) return;
+        setMetrics(data);
+      })
       .catch(() =>
         setError(
           "We couldn't load your Issues analytics right now. Please try again in a moment."
@@ -81,6 +94,18 @@ export default function IssueMetrics() {
               className="h-20 rounded-lg skeleton-shimmer"
             />
           ))}
+        </div>
+      ) : githubAuthInvalid ? (
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center space-y-3">
+          <p className="text-sm text-[var(--muted-foreground)]">
+            Your GitHub connection is no longer valid. Reconnect your GitHub account to continue syncing data.
+          </p>
+          <a
+            href="/api/auth/signin?callbackUrl=/dashboard"
+            className="inline-block rounded-md bg-[var(--accent)] px-4 py-2 text-sm font-medium text-[var(--background)] hover:opacity-90 transition-opacity"
+          >
+            Reconnect GitHub
+          </a>
         </div>
       ) : error ? (
         <div className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -68,7 +68,7 @@ export default function PRMetrics() {
     fetch(url)
       .then(async (r) => {
         const data = await r.json();
-        if (data?.error === "github_auth_invalid") {
+        if (data?.error === "token_expired") {
           setGithubAuthInvalid(true);
           return null;
         }

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -50,6 +50,7 @@ export default function PRMetrics() {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
   const [activeTab, setActiveTab] = useState<"authored" | "reviews">("authored");
   const [prFilter, setPrFilter] = useState<"all" | "merged" | "open">("all");
   const [staleThresholdDays, setStaleThresholdDays] = useState(14);
@@ -57,6 +58,7 @@ export default function PRMetrics() {
   const fetchMetrics = useCallback(() => {
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
 
     const url =
       selectedAccount !== null
@@ -64,11 +66,17 @@ export default function PRMetrics() {
         : "/api/metrics/prs";
 
     fetch(url)
-      .then((r) => {
+      .then(async (r) => {
+        const data = await r.json();
+        if (data?.error === "github_auth_invalid") {
+          setGithubAuthInvalid(true);
+          return null;
+        }
         if (!r.ok) throw new Error("API error");
-        return r.json();
+        return data as PRData;
       })
-      .then((data: PRData) => {
+      .then((data) => {
+        if (!data) return;
         setMetrics(data);
         setLastUpdated(new Date());
         setMinutesAgo(0);
@@ -212,6 +220,18 @@ export default function PRMetrics() {
               <div key={i} className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse" />
             ))}
           </div>
+        </div>
+      ) : githubAuthInvalid ? (
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center space-y-3">
+          <p className="text-sm text-[var(--muted-foreground)]">
+            Your GitHub connection is no longer valid. Reconnect your GitHub account to continue syncing data.
+          </p>
+          <a
+            href="/api/auth/signin?callbackUrl=/dashboard"
+            className="inline-block rounded-md bg-[var(--accent)] px-4 py-2 text-sm font-medium text-[var(--background)] hover:opacity-90 transition-opacity"
+          >
+            Reconnect GitHub
+          </a>
         </div>
       ) : error ? (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">

--- a/src/components/PRReviewTrendChart.tsx
+++ b/src/components/PRReviewTrendChart.tsx
@@ -186,6 +186,26 @@ export default function PRReviewTrendChart() {
           </div>
           <div className="h-[280px] animate-pulse rounded-lg bg-[var(--card-muted)]" />
         </div>
+      ) : githubAuthInvalid ? (
+        <div className="flex h-[360px] items-center justify-center">
+          <div className="max-w-sm rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center space-y-3">
+            <p className="text-sm text-[var(--muted-foreground)]">
+              Your GitHub connection is no longer valid. Reconnect your GitHub
+              account to continue syncing data.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                void signOut({ redirect: false }).then(() => {
+                  window.location.href = "/api/auth/signin/github?callbackUrl=/dashboard";
+                });
+              }}
+              className="inline-flex items-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+            >
+              Reconnect GitHub
+            </button>
+          </div>
+        </div>
       ) : error ? (
         <div className="flex h-[360px] items-center justify-center">
           <div className="max-w-sm rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-5 text-center">

--- a/src/components/PRReviewTrendChart.tsx
+++ b/src/components/PRReviewTrendChart.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { signOut } from "next-auth/react";
 import {
   CartesianGrid,
   Line,
@@ -76,10 +77,12 @@ export default function PRReviewTrendChart() {
   const [data, setData] = useState<PRReviewTrendPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
 
   const fetchTrend = useCallback(() => {
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
 
     const url =
       selectedAccount !== null
@@ -89,11 +92,17 @@ export default function PRReviewTrendChart() {
         : "/api/metrics/pr-review-time";
 
     fetch(url)
-      .then((r) => {
+      .then(async (r) => {
+        const body = await r.json();
+        if (body?.error === "token_expired") {
+          setGithubAuthInvalid(true);
+          return null;
+        }
         if (!r.ok) throw new Error("API error");
-        return r.json();
+        return body as PRReviewTrendResponse;
       })
-      .then((res: PRReviewTrendResponse) => {
+      .then((res) => {
+        if (!res) return;
         setData(res.weeks ?? []);
       })
       .catch(() => {

--- a/src/components/ProductiveHoursWidget.tsx
+++ b/src/components/ProductiveHoursWidget.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHeatmapTheme } from "@/hooks/useHeatmapTheme";
+import { signOut } from "next-auth/react";
 
 const DEFAULT_DAYS = 90;
 
@@ -61,6 +62,7 @@ export default function ProductiveHoursWidget() {
   const [totalCommits, setTotal]    = useState(0);
   const [loading, setLoading]       = useState(true);
   const [error, setError]           = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
 
@@ -182,6 +184,7 @@ export default function ProductiveHoursWidget() {
     let active = true;
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
 
     const tz     = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const params = new URLSearchParams({
@@ -191,12 +194,17 @@ export default function ProductiveHoursWidget() {
     });
 
     fetch(`/api/metrics/productive-hours?${params.toString()}`)
-      .then((res) => {
+      .then(async (res) => {
+        const data = await res.json();
+        if (data?.error === "token_expired") {
+          if (active) setGithubAuthInvalid(true);
+          return null;
+        }
         if (!res.ok) throw new Error("API error");
-        return res.json();
+        return data as ProductiveHoursResponse;
       })
-      .then((data: ProductiveHoursResponse) => {
-        if (!active) return;
+      .then((data: ProductiveHoursResponse | null) => {
+        if (!active || !data) return;
         setGrid(data.grid ?? []);
         setPeak(data.peak ?? null);
         setTotal(data.total ?? 0);
@@ -413,6 +421,24 @@ export default function ProductiveHoursWidget() {
 
       {loading ? (
         <div className="h-[140px] animate-pulse rounded-lg bg-[var(--card-muted)]" />
+      ) : githubAuthInvalid ? (
+        <div className="flex h-[140px] flex-col items-center justify-center gap-3 rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center">
+          <p className="text-sm text-[var(--muted-foreground)]">
+            Your GitHub connection is no longer valid. Reconnect your GitHub
+            account to continue syncing data.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              void signOut({ redirect: false }).then(() => {
+                window.location.href = "/api/auth/signin/github?callbackUrl=/dashboard";
+              });
+            }}
+            className="inline-flex items-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+          >
+            Reconnect GitHub
+          </button>
+        </div>
       ) : error ? (
         <div className="flex h-[140px] items-center rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-4">
           <p className="text-sm text-[var(--destructive)]">

--- a/src/components/TodayFocusHero.tsx
+++ b/src/components/TodayFocusHero.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { DailyFocusRecord } from "@/app/api/daily-focus/route";
 
 type TodayFocusHeroProps = {
   userName?: string | null;
@@ -14,13 +15,21 @@ const PROMPTS = [
   "Make one part of your project better today.",
 ];
 
+// Legacy localStorage key prefix — used only for migration on first load.
 const STORAGE_PREFIX = "devtrack_today_goal_";
 
 function getTodayKey(date = new Date()): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${STORAGE_PREFIX}${year}-${month}-${day}`;
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${STORAGE_PREFIX}${y}-${m}-${d}`;
+}
+
+function getTodayDate(date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 function getGreeting(hour: number): "morning" | "afternoon" | "evening" {
@@ -39,9 +48,17 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
   const [inputValue, setInputValue] = useState("");
   const [isEditing, setIsEditing] = useState(false);
   const [prompt, setPrompt] = useState(PROMPTS[0]);
-  const [greeting, setGreeting] = useState<"morning" | "afternoon" | "evening">("morning");
-  const [todayKey, setTodayKey] = useState("");
+  const [greeting, setGreeting] = useState<"morning" | "afternoon" | "evening">(
+    "morning"
+  );
   const [isMounted, setIsMounted] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  // Stable refs so async callbacks never capture stale values.
+  const todayDate = useRef("");
+  const todayKey = useRef("");
 
   const greetingLabel = useMemo(() => {
     const base =
@@ -53,50 +70,224 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
     return userName?.trim() ? `${base}, ${userName.trim()}` : base;
   }, [greeting, userName]);
 
+  // Migrate an existing localStorage entry to the server.
+  // Only removes the localStorage copy after a confirmed successful PUT.
+  const migrateLocalStorage = useCallback(
+    async (stored: string, date: string, key: string): Promise<boolean> => {
+      try {
+        const res = await fetch("/api/daily-focus", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ goal_text: stored, focus_date: date }),
+        });
+        if (res.ok) {
+          try {
+            window.localStorage.removeItem(key);
+          } catch {
+            // Removing is best-effort.
+          }
+          return true;
+        }
+      } catch {
+        // Network failure — keep localStorage as-is.
+      }
+      return false;
+    },
+    []
+  );
+
+  const loadFocus = useCallback(
+    async (date: string, key: string) => {
+      setIsLoading(true);
+      setServerError(null);
+      try {
+        const res = await fetch(`/api/daily-focus?date=${date}`);
+
+        if (!res.ok) {
+          if (res.status === 401) {
+            // Not signed in — use localStorage only (read-only mode).
+            try {
+              const stored = window.localStorage.getItem(key)?.trim() ?? "";
+              setGoal(stored);
+              setInputValue(stored);
+              setIsEditing(stored.length === 0);
+            } catch {
+              setIsEditing(true);
+            }
+            return;
+          }
+          setServerError("Failed to load today's focus.");
+          return;
+        }
+
+        const json = (await res.json()) as {
+          focus: DailyFocusRecord | null;
+        };
+
+        if (json.focus) {
+          // Server is the source of truth — discard any leftover localStorage copy.
+          setGoal(json.focus.goal_text);
+          setInputValue(json.focus.goal_text);
+          setIsEditing(false);
+          try {
+            window.localStorage.removeItem(key);
+          } catch {
+            // Best-effort cleanup.
+          }
+        } else {
+          // No server record — check for a localStorage value to migrate.
+          try {
+            const stored = window.localStorage.getItem(key)?.trim() ?? "";
+            if (stored) {
+              await migrateLocalStorage(stored, date, key);
+              setGoal(stored);
+              setInputValue(stored);
+              setIsEditing(false);
+            } else {
+              setGoal("");
+              setInputValue("");
+              setIsEditing(true);
+            }
+          } catch {
+            setGoal("");
+            setInputValue("");
+            setIsEditing(true);
+          }
+        }
+      } catch {
+        // Network failure — fall back to localStorage.
+        try {
+          const stored = window.localStorage.getItem(key)?.trim() ?? "";
+          setGoal(stored);
+          setInputValue(stored);
+          setIsEditing(stored.length === 0);
+        } catch {
+          setGoal("");
+          setInputValue("");
+          setIsEditing(true);
+        }
+        setServerError(
+          "Could not reach the server. Changes may not sync across devices."
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [migrateLocalStorage]
+  );
+
   useEffect(() => {
     const now = new Date();
-    const nextKey = getTodayKey(now);
-    setTodayKey(nextKey);
+    todayDate.current = getTodayDate(now);
+    todayKey.current = getTodayKey(now);
     setGreeting(getGreeting(now.getHours()));
     setPrompt(getDailyPrompt(now));
-
-    try {
-      const storedGoal = window.localStorage.getItem(nextKey)?.trim() ?? "";
-      setGoal(storedGoal);
-      setInputValue(storedGoal);
-      setIsEditing(storedGoal.length === 0);
-    } catch (e) {
-      setGoal("");
-      setInputValue("");
-      setIsEditing(true);
-    }
-
     setIsMounted(true);
-  }, []);
+    void loadFocus(todayDate.current, todayKey.current);
+  }, [loadFocus]);
 
-  function handleSave() {
-    const trimmedGoal = inputValue.trim();
-    if (!trimmedGoal || !todayKey) return;
+  async function handleSave() {
+    const trimmed = inputValue.trim();
+    const date = todayDate.current;
+    const key = todayKey.current;
+    if (!trimmed || !date) return;
+
+    // Optimistic update.
+    const prevGoal = goal;
+    setGoal(trimmed);
+    setInputValue(trimmed);
+    setIsEditing(false);
+    setIsSaving(true);
+    setServerError(null);
 
     try {
-      window.localStorage.setItem(todayKey, trimmedGoal);
-    } catch (e) {}
+      const res = await fetch("/api/daily-focus", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ goal_text: trimmed, focus_date: date }),
+      });
 
-    setGoal(trimmedGoal);
-    setInputValue(trimmedGoal);
-    setIsEditing(false);
+      if (!res.ok) {
+        // Roll back on server error.
+        setGoal(prevGoal);
+        setInputValue(trimmed);
+        setIsEditing(true);
+        setServerError("Failed to save. Please try again.");
+        // Keep a localStorage fallback so data is not lost.
+        try {
+          window.localStorage.setItem(key, trimmed);
+        } catch {
+          // Storage write failed.
+        }
+        return;
+      }
+
+      // Successfully persisted — remove any stale localStorage copy.
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // Best-effort cleanup.
+      }
+    } catch {
+      // Network failure — keep the optimistic state and save locally.
+      try {
+        window.localStorage.setItem(key, trimmed);
+      } catch {
+        // Storage write failed.
+      }
+      setServerError(
+        "Saved locally. Will sync when your connection is restored."
+      );
+    } finally {
+      setIsSaving(false);
+    }
   }
 
-  function handleClear() {
-    if (!todayKey) return;
+  async function handleClear() {
+    const date = todayDate.current;
+    const key = todayKey.current;
+    if (!date) return;
 
-    try {
-      window.localStorage.removeItem(todayKey);
-    } catch (e) {}
-
+    // Optimistic update.
+    const prevGoal = goal;
     setGoal("");
     setInputValue("");
     setIsEditing(true);
+    setIsSaving(true);
+    setServerError(null);
+
+    try {
+      const res = await fetch(`/api/daily-focus?date=${date}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        // Roll back.
+        setGoal(prevGoal);
+        setInputValue(prevGoal);
+        setIsEditing(false);
+        setServerError("Failed to clear. Please try again.");
+        return;
+      }
+
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // Best-effort cleanup.
+      }
+    } catch {
+      // Network failure — keep the optimistic cleared state.
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // Best-effort cleanup.
+      }
+      setServerError(
+        "Cleared locally. Will sync when your connection is restored."
+      );
+    } finally {
+      setIsSaving(false);
+    }
   }
 
   function handleEdit() {
@@ -104,6 +295,7 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
     setIsEditing(true);
   }
 
+  // SSR skeleton — identical to the original to avoid layout shift.
   if (!isMounted) {
     return (
       <section className="surface-card fade-up relative overflow-hidden rounded-3xl border border-[var(--border)] px-5 py-6 shadow-sm md:px-8 md:py-8">
@@ -150,7 +342,12 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
         </div>
 
         <div className="rounded-2xl border border-[var(--border)] bg-[color-mix(in_srgb,var(--card)_92%,white_8%)] p-4 shadow-[0_14px_34px_-26px_rgba(15,23,42,0.35)] sm:p-5">
-          {goal && !isEditing ? (
+          {isLoading ? (
+            <div className="flex h-full flex-col gap-3">
+              <div className="h-4 w-32 rounded skeleton-shimmer" />
+              <div className="h-12 w-full rounded-xl skeleton-shimmer" />
+            </div>
+          ) : goal && !isEditing ? (
             <div className="flex h-full flex-col justify-between gap-4">
               <div className="space-y-2">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
@@ -161,20 +358,30 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
                 </p>
               </div>
 
+              {serverError ? (
+                <p role="alert" className="text-xs text-[var(--destructive)]">
+                  {serverError}
+                </p>
+              ) : null}
+
               <div className="flex flex-col gap-3 sm:flex-row">
                 <button
                   type="button"
                   onClick={handleEdit}
-                  className="secondary-button inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-medium sm:w-auto"
+                  disabled={isSaving}
+                  className="secondary-button inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-medium disabled:opacity-60 sm:w-auto"
                 >
                   Edit
                 </button>
                 <button
                   type="button"
-                  onClick={handleClear}
-                  className="inline-flex w-full items-center justify-center rounded-xl border border-[var(--destructive-muted-border)] bg-[var(--destructive-muted)] px-4 py-3 text-sm font-medium text-[var(--destructive)] transition hover:opacity-90 sm:w-auto"
+                  onClick={() => {
+                    void handleClear();
+                  }}
+                  disabled={isSaving}
+                  className="inline-flex w-full items-center justify-center rounded-xl border border-[var(--destructive-muted-border)] bg-[var(--destructive-muted)] px-4 py-3 text-sm font-medium text-[var(--destructive)] transition hover:opacity-90 disabled:opacity-60 sm:w-auto"
                 >
-                  Clear
+                  {isSaving ? "Clearing…" : "Clear"}
                 </button>
               </div>
             </div>
@@ -189,12 +396,25 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
                 </p>
               </div>
 
+              {serverError ? (
+                <p role="alert" className="text-xs text-[var(--destructive)]">
+                  {serverError}
+                </p>
+              ) : null}
+
               <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
                 <label className="block">
-                  <span className="sr-only">Write your main dev goal for today</span>
+                  <span className="sr-only">
+                    Write your main dev goal for today
+                  </span>
                   <input
                     value={inputValue}
                     onChange={(event) => setInputValue(event.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && inputValue.trim()) {
+                        void handleSave();
+                      }
+                    }}
                     placeholder="Write your main dev goal for today..."
                     className="w-full rounded-xl border border-[var(--border)] bg-[var(--background)] px-4 py-3 text-sm text-[var(--foreground)] shadow-sm transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)] focus-visible:outline-none"
                   />
@@ -203,17 +423,22 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
                 <div className="flex flex-col gap-3 sm:flex-row lg:flex-col xl:flex-row">
                   <button
                     type="button"
-                    onClick={handleSave}
-                    disabled={!inputValue.trim()}
+                    onClick={() => {
+                      void handleSave();
+                    }}
+                    disabled={!inputValue.trim() || isSaving}
                     className="primary-button inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto lg:w-full xl:w-auto"
                   >
-                    Save
+                    {isSaving ? "Saving…" : "Save"}
                   </button>
                   {goal ? (
                     <button
                       type="button"
-                      onClick={handleClear}
-                      className="secondary-button inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-medium sm:w-auto lg:w-full xl:w-auto"
+                      onClick={() => {
+                        void handleClear();
+                      }}
+                      disabled={isSaving}
+                      className="secondary-button inline-flex w-full items-center justify-center rounded-xl px-4 py-3 text-sm font-medium disabled:opacity-60 sm:w-auto lg:w-full xl:w-auto"
                     >
                       Clear
                     </button>

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { signOut } from "next-auth/react";
 
 interface WeeklySummaryData {
   commits: {
@@ -25,6 +26,7 @@ export default function WeeklySummaryCard() {
   const [summary, setSummary] = useState<WeeklySummaryData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const maxCommits = summary?.commits
@@ -42,17 +44,26 @@ export default function WeeklySummaryCard() {
   const fetchSummary = useCallback(() => {
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
 
     const url = selectedAccount !== null
       ? `/api/metrics/weekly-summary?accountId=${encodeURIComponent(selectedAccount)}`
       : "/api/metrics/weekly-summary";
 
     fetch(url)
-      .then((r) => {
+      .then(async (r) => {
+        const data = await r.json();
+        if (data?.error === "token_expired") {
+          setGithubAuthInvalid(true);
+          return null;
+        }
         if (!r.ok) throw new Error("API error");
-        return r.json();
+        return data as WeeklySummaryData;
       })
-      .then((data: WeeklySummaryData) => setSummary(data))
+      .then((data) => {
+        if (!data) return;
+        setSummary(data);
+      })
       .catch(() =>
         setError(
           "We couldn't load your weekly summary right now. Please try again in a moment."

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -113,6 +113,24 @@ export default function WeeklySummaryCard() {
               />
             ))}
           </div>
+        ) : githubAuthInvalid ? (
+          <div className="mt-4 rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center space-y-3">
+            <p className="text-sm text-[var(--muted-foreground)]">
+              Your GitHub connection is no longer valid. Reconnect your GitHub
+              account to continue syncing data.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                void signOut({ redirect: false }).then(() => {
+                  window.location.href = "/api/auth/signin/github?callbackUrl=/dashboard";
+                });
+              }}
+              className="inline-flex items-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+            >
+              Reconnect GitHub
+            </button>
+          </div>
         ) : error ? (
           <div className="mt-4 rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
             {error}

--- a/src/lib/ci-analytics.ts
+++ b/src/lib/ci-analytics.ts
@@ -1,4 +1,5 @@
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError } from "@/lib/github-fetch";
 
 interface TopRepo { name: string; commits: number; }
 interface WorkflowRun { conclusion: string | null; created_at: string; name: string | null; updated_at: string; }
@@ -16,7 +17,10 @@ export function mergeCIAnalytics(a: CIAnalyticsResponse, b: CIAnalyticsResponse)
 
 export async function fetchCIAnalyticsForAccount(token: string, githubLogin: string): Promise<CIAnalyticsResponse> {
   const searchRes = await fetch(`${GITHUB_API}/search/commits?q=author:${githubLogin}+author-date:>=${toIsoDate(30)}&per_page=100&sort=author-date&order=desc`, { headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" }, cache: "no-store" });
-  if (!searchRes.ok) throw new Error("API error");
+  if (!searchRes.ok) {
+    if (searchRes.status === 401) throw new GitHubAuthError();
+    throw new Error("API error");
+  }
   const data = await searchRes.json();
   
   const repoMap = new Map<string, number>();

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,1 @@
+export { toDateStr, dateDiffDays, dateDiff, getThisWeekRange, getLastWeekRange } from './dateUtils';

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -27,6 +27,8 @@ export function dateDiffDays(a: string, b: string): number {
   return (new Date(b).getTime() - new Date(a).getTime()) / 86400000;
 }
 
+export const dateDiff = dateDiffDays;
+
 export function getThisWeekRange(): { start: string; end: string } {
   const now = new Date();
   const weekStart = getUtcWeekStart(now);

--- a/src/lib/github-fetch.ts
+++ b/src/lib/github-fetch.ts
@@ -5,9 +5,9 @@
  * repeat the same ~10-line pattern.
  */
 
-import { GITHUB_API } from "@/lib/github";
+import { GITHUB_API, GitHubAuthError } from "@/lib/github";
 
-export { GITHUB_API };
+export { GITHUB_API, GitHubAuthError };
 
 export class GitHubRateLimitError extends Error {
   constructor(
@@ -24,6 +24,16 @@ export class GitHubApiError extends Error {
     super(`GitHub API error: ${status}`);
     this.name = "GitHubApiError";
   }
+}
+
+/**
+ * Returns a structured JSON response for GitHub credential failures.
+ * All metrics routes should use this instead of a generic 502 when GitHub
+ * returns 401, so the frontend can distinguish auth failures from other errors
+ * and offer a reconnect action.
+ */
+export function githubAuthErrorResponse(): Response {
+  return Response.json({ error: "github_auth_invalid" }, { status: 401 });
 }
 
 function extractRateLimitInfo(headers: Headers): {
@@ -54,7 +64,12 @@ function isSecondaryRateLimitBody(body: unknown): boolean {
 
 async function buildGitHubError(
   res: Response,
-): Promise<GitHubRateLimitError | GitHubApiError> {
+): Promise<GitHubAuthError | GitHubRateLimitError | GitHubApiError> {
+  // 401: invalid or revoked credential — surface as auth error, not generic API error
+  if (res.status === 401) {
+    return new GitHubAuthError();
+  }
+
   const { resetAt, retryAfter, remaining } = extractRateLimitInfo(res.headers);
 
   // 429: always a rate limit

--- a/src/lib/github-fetch.ts
+++ b/src/lib/github-fetch.ts
@@ -1,7 +1,7 @@
 /**
  * Typed GitHub API fetch helper.
  * Centralises Authorization headers, Accept header, ok-check,
- * and 403/429 rate-limit error handling so metric routes don't
+ * and rate-limit error handling so metric routes don't
  * repeat the same ~10-line pattern.
  */
 
@@ -10,7 +10,10 @@ import { GITHUB_API } from "@/lib/github";
 export { GITHUB_API };
 
 export class GitHubRateLimitError extends Error {
-  constructor(public resetAt: Date | null) {
+  constructor(
+    public resetAt: Date | null,
+    public retryAfter: number | null = null,
+  ) {
     super("GitHub API rate limit exceeded");
     this.name = "GitHubRateLimitError";
   }
@@ -23,9 +26,79 @@ export class GitHubApiError extends Error {
   }
 }
 
+function extractRateLimitInfo(headers: Headers): {
+  resetAt: Date | null;
+  retryAfter: number | null;
+  remaining: number | null;
+} {
+  const resetHeader = headers.get("X-RateLimit-Reset");
+  const retryAfterHeader = headers.get("Retry-After");
+  const remainingHeader = headers.get("X-RateLimit-Remaining");
+
+  return {
+    resetAt: resetHeader ? new Date(Number(resetHeader) * 1000) : null,
+    retryAfter: retryAfterHeader !== null ? Number(retryAfterHeader) : null,
+    remaining: remainingHeader !== null ? Number(remainingHeader) : null,
+  };
+}
+
+function isSecondaryRateLimitBody(body: unknown): boolean {
+  if (typeof body !== "object" || body === null) return false;
+  const message = ((body as { message?: string }).message ?? "").toLowerCase();
+  return (
+    message.includes("secondary rate limit") ||
+    message.includes("rate limit exceeded") ||
+    message.includes("exceeded a secondary")
+  );
+}
+
+async function buildGitHubError(
+  res: Response,
+): Promise<GitHubRateLimitError | GitHubApiError> {
+  const { resetAt, retryAfter, remaining } = extractRateLimitInfo(res.headers);
+
+  // 429: always a rate limit
+  if (res.status === 429) {
+    return new GitHubRateLimitError(resetAt, retryAfter);
+  }
+
+  if (res.status === 403) {
+    // Primary rate limit: quota exhausted
+    if (remaining === 0) {
+      return new GitHubRateLimitError(resetAt, retryAfter);
+    }
+
+    // Secondary rate limit: Retry-After header signals required backoff
+    if (retryAfter !== null) {
+      return new GitHubRateLimitError(resetAt, retryAfter);
+    }
+
+    // Secondary rate limit: body message indicates rate limiting
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // Body not JSON or stream already consumed
+    }
+    if (isSecondaryRateLimitBody(body)) {
+      return new GitHubRateLimitError(resetAt, retryAfter);
+    }
+
+    // Authorization failure: invalid token, insufficient scope, permissions
+    return new GitHubApiError(res.status);
+  }
+
+  return new GitHubApiError(res.status);
+}
+
 /**
  * Fetch a GitHub API endpoint with standard headers.
- * Throws GitHubRateLimitError on 403/429, GitHubApiError on other non-ok responses.
+ * Throws GitHubRateLimitError when response headers or body indicate actual rate limiting:
+ * - 429 responses
+ * - 403 with X-RateLimit-Remaining: 0 (primary rate limit)
+ * - 403 with Retry-After header (secondary rate limit)
+ * - 403 with rate-limit message in response body (secondary rate limit)
+ * Authorization failures (invalid token, insufficient scope, permissions) throw GitHubApiError.
  */
 export async function githubFetch<T>(
   url: string,
@@ -42,14 +115,8 @@ export async function githubFetch<T>(
     cache: (options.cache as RequestCache) ?? "no-store",
   });
 
-  if (res.status === 403 || res.status === 429) {
-    const resetHeader = res.headers.get("X-RateLimit-Reset");
-    const resetAt = resetHeader ? new Date(Number(resetHeader) * 1000) : null;
-    throw new GitHubRateLimitError(resetAt);
-  }
-
   if (!res.ok) {
-    throw new GitHubApiError(res.status);
+    throw await buildGitHubError(res);
   }
 
   return res.json() as Promise<T>;
@@ -72,14 +139,8 @@ export async function githubGraphQL<T>(
     cache: "no-store",
   });
 
-  if (res.status === 403 || res.status === 429) {
-    const resetHeader = res.headers.get("X-RateLimit-Reset");
-    const resetAt = resetHeader ? new Date(Number(resetHeader) * 1000) : null;
-    throw new GitHubRateLimitError(resetAt);
-  }
-
   if (!res.ok) {
-    throw new GitHubApiError(res.status);
+    throw await buildGitHubError(res);
   }
 
   const json = await res.json();

--- a/src/lib/github-fetch.ts
+++ b/src/lib/github-fetch.ts
@@ -33,7 +33,7 @@ export class GitHubApiError extends Error {
  * and offer a reconnect action.
  */
 export function githubAuthErrorResponse(): Response {
-  return Response.json({ error: "github_auth_invalid" }, { status: 401 });
+  return Response.json({ error: "token_expired" }, { status: 401 });
 }
 
 function extractRateLimitInfo(headers: Headers): {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,19 @@
 export const GITHUB_API = "https://api.github.com";
 
 /**
+ * Thrown when GitHub returns HTTP 401 — the stored OAuth token has been
+ * revoked or is otherwise invalid. Callers should surface a reauthentication
+ * prompt rather than a generic API error.
+ */
+export class GitHubAuthError extends Error {
+  readonly status = 401;
+  constructor() {
+    super("GitHub authentication failed: token is invalid or has been revoked");
+    this.name = "GitHubAuthError";
+  }
+}
+
+/**
  * Fetch wrapper with AbortController-based timeout for GitHub API calls.
  * Prevents hanging requests under slow/stalled network conditions.
  */
@@ -26,7 +39,10 @@ export async function fetchUserEvents(token: string): Promise<GitHubEvent[]> {
       Accept: "application/vnd.github+json",
     },
   });
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+  if (!res.ok) {
+    if (res.status === 401) throw new GitHubAuthError();
+    throw new Error(`GitHub API error: ${res.status}`);
+  }
   return res.json();
 }
 
@@ -54,7 +70,10 @@ export async function fetchUserRepos(
       }
     );
 
-    if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+    if (!res.ok) {
+      if (res.status === 401) throw new GitHubAuthError();
+      throw new Error(`GitHub API error: ${res.status}`);
+    }
 
     const pageRepos = (await res.json()) as GitHubRepo[];
     repos.push(...pageRepos);
@@ -140,7 +159,10 @@ export async function fetchIssuesMetrics(
     `https://api.github.com/search/issues?q=type:issue+author:@me+created:>=${since30d.toISOString().slice(0, 10)}&per_page=100`,
     { headers, cache: "no-store" }
   );
-  if (!searchRes.ok) throw new Error(`GitHub API error: ${searchRes.status}`);
+  if (!searchRes.ok) {
+    if (searchRes.status === 401) throw new GitHubAuthError();
+    throw new Error(`GitHub API error: ${searchRes.status}`);
+  }
 
   const searchData = (await searchRes.json()) as { items: GitHubIssueItem[] };
   const items = searchData.items;

--- a/src/lib/security/csrf.ts
+++ b/src/lib/security/csrf.ts
@@ -1,0 +1,117 @@
+/**
+ * CSRF protection utilities — Origin/Referer-based validation for
+ * state-changing requests authenticated via NextAuth session cookies.
+ *
+ * Design rationale
+ * ----------------
+ * NextAuth sets SameSite=Lax cookies by default, which blocks cross-site
+ * form-submission attacks but does not cover same-registered-domain
+ * subdomain attacks or certain browser edge cases. Origin validation adds
+ * an explicit server-side check that is independent of cookie attributes.
+ *
+ * Exemptions
+ * ----------
+ * Routes that authenticate via their own out-of-band mechanism (HMAC
+ * signatures, bearer secrets) are not subject to this check:
+ *
+ *   /api/webhooks/github    — x-hub-signature-256 HMAC verification
+ *   /api/webhooks/dispatch  — WEBHOOK_DISPATCH_SECRET bearer token
+ *   /api/cron/              — CRON_SECRET bearer token
+ *   /api/auth/              — NextAuth internals (callbacks, sign-out)
+ *
+ * Requests that carry an Authorization: Bearer header are also exempted
+ * because they are API clients (e.g. the local-coding CLI) rather than
+ * browser sessions and are not susceptible to CSRF.
+ */
+
+export const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+const CSRF_EXEMPT_PREFIXES = [
+  "/api/webhooks/github",
+  "/api/webhooks/dispatch",
+  "/api/cron/",
+  "/api/auth/",
+] as const;
+
+/**
+ * Returns true for paths that authenticate via their own mechanism and
+ * must not be gated by Origin validation.
+ */
+export function isCsrfExemptPath(pathname: string): boolean {
+  return CSRF_EXEMPT_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(prefix)
+  );
+}
+
+function extractOrigin(url: string): string | null {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Builds the set of origins that are permitted to make authenticated
+ * state-changing requests.
+ *
+ * Sources (both are merged):
+ *   NEXTAUTH_URL      — the canonical application origin; required by NextAuth
+ *   ALLOWED_ORIGINS   — comma-separated list of additional allowed origins
+ *                       (useful for staging / preview deployments)
+ *
+ * If neither variable is set the returned set is empty, which causes the
+ * CSRF check in middleware to skip enforcement and log a warning instead.
+ */
+export function buildAllowedOrigins(): Set<string> {
+  const origins = new Set<string>();
+
+  const nextAuthUrl = process.env.NEXTAUTH_URL;
+  if (nextAuthUrl) {
+    const o = extractOrigin(nextAuthUrl);
+    if (o) origins.add(o);
+  }
+
+  const extra = process.env.ALLOWED_ORIGINS;
+  if (extra) {
+    for (const raw of extra.split(",")) {
+      const trimmed = raw.trim();
+      if (!trimmed) continue;
+      const o = extractOrigin(trimmed);
+      if (o) origins.add(o);
+    }
+  }
+
+  return origins;
+}
+
+/**
+ * Extracts the request origin from the Origin header, falling back to the
+ * Referer header when Origin is absent (some browsers omit it for same-site
+ * navigations).
+ *
+ * Returns null when neither header is present.
+ */
+export function getRequestOrigin(
+  headers: { get(name: string): string | null }
+): string | null {
+  const origin = headers.get("origin");
+  if (origin) return origin.trim();
+
+  const referer = headers.get("referer");
+  if (referer) return extractOrigin(referer);
+
+  return null;
+}
+
+/**
+ * Returns true if the supplied requestOrigin is in the allowed set.
+ * The comparison is exact and case-sensitive (origins are always lowercase
+ * per RFC 6454 when produced by a conforming browser).
+ */
+export function isOriginAllowed(
+  requestOrigin: string,
+  allowedOrigins: Set<string>
+): boolean {
+  return allowedOrigins.has(requestOrigin);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,13 @@
 import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
 import { createMemoryFixedWindowRateLimiter, getClientIp } from "@/lib/rate-limit";
+import {
+  SAFE_METHODS,
+  buildAllowedOrigins,
+  getRequestOrigin,
+  isCsrfExemptPath,
+  isOriginAllowed,
+} from "@/lib/security/csrf";
 
 export const runtime = "nodejs";
 
@@ -200,6 +207,52 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
+  // ── CSRF protection ──────────────────────────────────────────────────────────
+  // Applies to all state-changing API requests from authenticated browser
+  // sessions. Requests that carry their own authentication mechanism (bearer
+  // tokens, HMAC signatures) are exempted.
+  if (
+    token &&
+    pathname.startsWith("/api/") &&
+    !SAFE_METHODS.has(req.method) &&
+    !isCsrfExemptPath(pathname)
+  ) {
+    // API clients authenticate via Authorization: Bearer — they are not
+    // susceptible to CSRF and must not be blocked.
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      const allowedOrigins = buildAllowedOrigins();
+
+      if (allowedOrigins.size > 0) {
+        const requestOrigin = getRequestOrigin(req.headers);
+
+        if (!requestOrigin || !isOriginAllowed(requestOrigin, allowedOrigins)) {
+          return NextResponse.json(
+            { error: "Forbidden: cross-origin request blocked" },
+            { status: 403 }
+          );
+        }
+      } else {
+        // NEXTAUTH_URL and ALLOWED_ORIGINS are both unset. The application is
+        // not fully configured; skip enforcement rather than block all traffic,
+        // but surface a warning so operators can detect the misconfiguration.
+        console.warn(
+          "[csrf] NEXTAUTH_URL and ALLOWED_ORIGINS are both unset; " +
+          "CSRF origin validation is disabled. Set at least NEXTAUTH_URL."
+        );
+      }
+    }
+  }
+  // ── end CSRF protection ──────────────────────────────────────────────────────
+
+  // Rate limiting is scoped to metrics and contact endpoints only.
+  const isRateLimitTarget =
+    pathname.startsWith("/api/metrics/") || pathname.startsWith("/api/contact");
+
+  if (!isRateLimitTarget) {
+    return NextResponse.next();
+  }
+
   const githubId = typeof token?.githubId === "string" ? token.githubId : null;
   const identifier = githubId ? `user:${githubId}` : `ip:${getIp(req)}`;
 
@@ -255,7 +308,6 @@ export const config = {
     "/dashboard/:path*",
     "/settings",
     "/settings/:path*",
-    "/api/metrics/:path*",
-    "/api/contact",
+    "/api/:path*",
   ],
 };

--- a/supabase/migrations/20260602000000_add_daily_focus.sql
+++ b/supabase/migrations/20260602000000_add_daily_focus.sql
@@ -1,0 +1,38 @@
+-- Migration: Add daily_focus table for server-side persistence of Today's Focus
+-- Created: 2026-06-02
+
+create table if not exists daily_focus (
+  id          text        primary key default gen_random_uuid()::text,
+  user_id     text        not null references users(id) on delete cascade,
+  focus_date  date        not null,
+  goal_text   text        not null,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now(),
+
+  unique (user_id, focus_date)
+);
+
+create index if not exists daily_focus_user_id
+  on daily_focus (user_id);
+
+create index if not exists daily_focus_user_date
+  on daily_focus (user_id, focus_date);
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+alter table daily_focus enable row level security;
+
+create policy "daily_focus_select_own"
+  on daily_focus for select
+  using (user_id = auth.uid()::text);
+
+create policy "daily_focus_insert_own"
+  on daily_focus for insert
+  with check (user_id = auth.uid()::text);
+
+create policy "daily_focus_update_own"
+  on daily_focus for update
+  using (user_id = auth.uid()::text);
+
+create policy "daily_focus_delete_own"
+  on daily_focus for delete
+  using (user_id = auth.uid()::text);

--- a/supabase/migrations/20260602000000_add_goal_history.sql
+++ b/supabase/migrations/20260602000000_add_goal_history.sql
@@ -1,0 +1,28 @@
+-- Migration: create goal_history table for recurring goal period archival
+--
+-- Every time a recurring goal's period resets, the previous period's
+-- achievement data is written here before current is zeroed. This
+-- preserves both successful and unsuccessful periods permanently.
+
+create table if not exists goal_history (
+  id             uuid        primary key default gen_random_uuid(),
+  goal_id        uuid        not null references goals(id) on delete cascade,
+  user_id        uuid        not null references users(id) on delete cascade,
+  period_start   timestamptz not null,
+  period_end     timestamptz not null,
+  target         integer     not null check (target > 0),
+  achieved_value integer     not null check (achieved_value >= 0),
+  completed      boolean     not null,
+  created_at     timestamptz not null default now(),
+
+  -- one row per goal per period; prevents double-inserts on concurrent resets
+  unique (goal_id, period_start)
+);
+
+-- fast lookup for the most recent period of each goal
+create index if not exists goal_history_goal_period_idx
+  on goal_history (goal_id, period_start desc);
+
+-- fast lookup for all history belonging to a user
+create index if not exists goal_history_user_created_idx
+  on goal_history (user_id, created_at desc);

--- a/test/csrf.test.ts
+++ b/test/csrf.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  SAFE_METHODS,
+  isCsrfExemptPath,
+  buildAllowedOrigins,
+  getRequestOrigin,
+  isOriginAllowed,
+} from "@/lib/security/csrf";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function fakeHeaders(entries: Record<string, string>) {
+  return {
+    get(name: string): string | null {
+      return entries[name.toLowerCase()] ?? null;
+    },
+  };
+}
+
+// ── SAFE_METHODS ──────────────────────────────────────────────────────────────
+
+describe("SAFE_METHODS", () => {
+  it("contains GET, HEAD, and OPTIONS", () => {
+    expect(SAFE_METHODS.has("GET")).toBe(true);
+    expect(SAFE_METHODS.has("HEAD")).toBe(true);
+    expect(SAFE_METHODS.has("OPTIONS")).toBe(true);
+  });
+
+  it("does not contain state-changing methods", () => {
+    expect(SAFE_METHODS.has("POST")).toBe(false);
+    expect(SAFE_METHODS.has("PUT")).toBe(false);
+    expect(SAFE_METHODS.has("PATCH")).toBe(false);
+    expect(SAFE_METHODS.has("DELETE")).toBe(false);
+  });
+});
+
+// ── isCsrfExemptPath ──────────────────────────────────────────────────────────
+
+describe("isCsrfExemptPath", () => {
+  // Webhook endpoints use their own authentication mechanisms
+  it("exempts /api/webhooks/github (HMAC signature auth)", () => {
+    expect(isCsrfExemptPath("/api/webhooks/github")).toBe(true);
+  });
+
+  it("exempts /api/webhooks/dispatch (bearer secret auth)", () => {
+    expect(isCsrfExemptPath("/api/webhooks/dispatch")).toBe(true);
+  });
+
+  // Cron endpoints use CRON_SECRET bearer tokens
+  it("exempts /api/cron/ prefix", () => {
+    expect(isCsrfExemptPath("/api/cron/")).toBe(true);
+    expect(isCsrfExemptPath("/api/cron/weekly-digest")).toBe(true);
+    expect(isCsrfExemptPath("/api/cron/any-future-cron-job")).toBe(true);
+  });
+
+  // NextAuth internals must never be blocked
+  it("exempts /api/auth/ prefix", () => {
+    expect(isCsrfExemptPath("/api/auth/callback/github")).toBe(true);
+    expect(isCsrfExemptPath("/api/auth/signout")).toBe(true);
+    expect(isCsrfExemptPath("/api/auth/session")).toBe(true);
+  });
+
+  // Custom webhook management routes are browser-session-authenticated → not exempt
+  it("does not exempt /api/webhooks/custom (session-authenticated)", () => {
+    expect(isCsrfExemptPath("/api/webhooks/custom")).toBe(false);
+    expect(isCsrfExemptPath("/api/webhooks/custom/abc123")).toBe(false);
+  });
+
+  // Standard application routes must be protected
+  it("does not exempt regular session-authenticated routes", () => {
+    expect(isCsrfExemptPath("/api/goals")).toBe(false);
+    expect(isCsrfExemptPath("/api/goals/some-id")).toBe(false);
+    expect(isCsrfExemptPath("/api/user/settings")).toBe(false);
+    expect(isCsrfExemptPath("/api/streak/freeze")).toBe(false);
+    expect(isCsrfExemptPath("/api/daily-note")).toBe(false);
+    expect(isCsrfExemptPath("/api/notifications/some-id")).toBe(false);
+    expect(isCsrfExemptPath("/api/rooms")).toBe(false);
+    expect(isCsrfExemptPath("/api/local-coding/keys")).toBe(false);
+  });
+});
+
+// ── buildAllowedOrigins ───────────────────────────────────────────────────────
+
+describe("buildAllowedOrigins", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("includes the origin from NEXTAUTH_URL", () => {
+    vi.stubEnv("NEXTAUTH_URL", "http://localhost:3000");
+    vi.stubEnv("ALLOWED_ORIGINS", "");
+    const origins = buildAllowedOrigins();
+    expect(origins.has("http://localhost:3000")).toBe(true);
+  });
+
+  it("strips path components from NEXTAUTH_URL — only the origin is stored", () => {
+    vi.stubEnv("NEXTAUTH_URL", "https://app.example.com/some/path?q=1");
+    vi.stubEnv("ALLOWED_ORIGINS", "");
+    const origins = buildAllowedOrigins();
+    expect(origins.has("https://app.example.com")).toBe(true);
+    expect(origins.has("https://app.example.com/some/path")).toBe(false);
+  });
+
+  it("includes all origins from ALLOWED_ORIGINS (comma-separated)", () => {
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv(
+      "ALLOWED_ORIGINS",
+      "https://staging.example.com,https://preview.example.com"
+    );
+    const origins = buildAllowedOrigins();
+    expect(origins.has("https://staging.example.com")).toBe(true);
+    expect(origins.has("https://preview.example.com")).toBe(true);
+  });
+
+  it("combines NEXTAUTH_URL and ALLOWED_ORIGINS without duplicates", () => {
+    vi.stubEnv("NEXTAUTH_URL", "https://app.example.com");
+    vi.stubEnv("ALLOWED_ORIGINS", "https://staging.example.com,https://app.example.com");
+    const origins = buildAllowedOrigins();
+    expect(origins.has("https://app.example.com")).toBe(true);
+    expect(origins.has("https://staging.example.com")).toBe(true);
+    expect(origins.size).toBe(2);
+  });
+
+  it("tolerates extra whitespace around entries in ALLOWED_ORIGINS", () => {
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("ALLOWED_ORIGINS", "  https://a.example.com  , https://b.example.com ");
+    const origins = buildAllowedOrigins();
+    expect(origins.has("https://a.example.com")).toBe(true);
+    expect(origins.has("https://b.example.com")).toBe(true);
+  });
+
+  it("returns an empty set when neither variable is set", () => {
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("ALLOWED_ORIGINS", "");
+    expect(buildAllowedOrigins().size).toBe(0);
+  });
+
+  it("ignores empty entries in ALLOWED_ORIGINS", () => {
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("ALLOWED_ORIGINS", ",,,https://valid.example.com,,,");
+    const origins = buildAllowedOrigins();
+    expect(origins.has("https://valid.example.com")).toBe(true);
+    expect(origins.size).toBe(1);
+  });
+});
+
+// ── getRequestOrigin ──────────────────────────────────────────────────────────
+
+describe("getRequestOrigin", () => {
+  it("returns the Origin header value when present", () => {
+    const h = fakeHeaders({ origin: "https://app.example.com" });
+    expect(getRequestOrigin(h)).toBe("https://app.example.com");
+  });
+
+  it("extracts the origin from the Referer header when Origin is absent", () => {
+    const h = fakeHeaders({ referer: "https://app.example.com/dashboard" });
+    expect(getRequestOrigin(h)).toBe("https://app.example.com");
+  });
+
+  it("returns null when neither Origin nor Referer is present", () => {
+    expect(getRequestOrigin(fakeHeaders({}))).toBeNull();
+  });
+
+  it("prefers Origin over Referer when both are present", () => {
+    const h = fakeHeaders({
+      origin: "https://app.example.com",
+      referer: "https://other.example.com/page",
+    });
+    expect(getRequestOrigin(h)).toBe("https://app.example.com");
+  });
+
+  it("returns null for a malformed Referer that cannot be parsed", () => {
+    const h = fakeHeaders({ referer: "not-a-url" });
+    expect(getRequestOrigin(h)).toBeNull();
+  });
+
+  it("trims whitespace from the Origin header value", () => {
+    const h = fakeHeaders({ origin: "  https://app.example.com  " });
+    expect(getRequestOrigin(h)).toBe("https://app.example.com");
+  });
+});
+
+// ── isOriginAllowed ───────────────────────────────────────────────────────────
+
+describe("isOriginAllowed", () => {
+  const allowed = new Set([
+    "https://app.example.com",
+    "http://localhost:3000",
+  ]);
+
+  it("accepts a known origin (valid origin accepted)", () => {
+    expect(isOriginAllowed("https://app.example.com", allowed)).toBe(true);
+    expect(isOriginAllowed("http://localhost:3000", allowed)).toBe(true);
+  });
+
+  it("rejects an unknown origin (invalid origin rejected)", () => {
+    expect(isOriginAllowed("https://evil.attacker.net", allowed)).toBe(false);
+    expect(isOriginAllowed("https://app.example.com.evil.net", allowed)).toBe(false);
+  });
+
+  it("rejects an origin that differs only in scheme", () => {
+    expect(isOriginAllowed("http://app.example.com", allowed)).toBe(false);
+  });
+
+  it("rejects an origin that differs only in port", () => {
+    expect(isOriginAllowed("https://app.example.com:8443", allowed)).toBe(false);
+  });
+
+  it("is case-sensitive — uppercase origin is rejected", () => {
+    expect(isOriginAllowed("HTTPS://APP.EXAMPLE.COM", allowed)).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isOriginAllowed("", allowed)).toBe(false);
+  });
+});
+
+// ── Middleware CSRF behaviour (integration) ───────────────────────────────────
+//
+// These tests exercise the CSRF logic as it runs inside the middleware by
+// importing the middleware directly and constructing NextRequest objects.
+// next-auth/jwt is mocked so no real JWT decoding occurs.
+
+const mockGetToken = vi.fn();
+vi.mock("next-auth/jwt", () => ({ getToken: mockGetToken }));
+
+// Suppress rate-limiter construction side-effects in the module scope.
+vi.mock("@/lib/rate-limit", () => ({
+  createMemoryFixedWindowRateLimiter: vi.fn(() => ({
+    check: vi.fn(() => ({ allowed: true, remaining: 99, reset: 0 })),
+  })),
+  getClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+describe("middleware CSRF enforcement", () => {
+  let middleware: (req: import("next/server").NextRequest) => Promise<import("next/server").NextResponse>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv("NEXTAUTH_SECRET", "test-secret");
+    vi.stubEnv("NEXTAUTH_URL", "http://localhost:3000");
+    vi.stubEnv("ALLOWED_ORIGINS", "");
+
+    // Re-import so the module picks up the stubbed env vars.
+    vi.resetModules();
+    const mod = await import("@/middleware");
+    middleware = mod.middleware as typeof middleware;
+  });
+
+  function makeRequest(
+    method: string,
+    path: string,
+    headers: Record<string, string> = {}
+  ) {
+    const { NextRequest } = require("next/server");
+    return new NextRequest(`http://localhost:3000${path}`, { method, headers });
+  }
+
+  // ── authenticated browser requests with valid origin ──────────────────────
+
+  it("allows an authenticated POST with a matching Origin header", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("POST", "/api/goals", { origin: "http://localhost:3000" });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  it("allows an authenticated PATCH with a matching Origin header", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("PATCH", "/api/user/settings", { origin: "http://localhost:3000" });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  it("allows an authenticated DELETE with a matching Origin header", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("DELETE", "/api/goals/some-id", { origin: "http://localhost:3000" });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  it("allows an authenticated PUT with a matching Origin header", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("PUT", "/api/goals/some-id", { origin: "http://localhost:3000" });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  // ── authenticated browser requests with invalid/missing origin ────────────
+
+  it("blocks an authenticated POST from a cross-origin attacker (invalid origin rejected)", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("POST", "/api/goals", { origin: "https://evil.attacker.net" });
+    const res = await middleware(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks an authenticated DELETE with a cross-origin Referer (invalid origin rejected)", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("DELETE", "/api/streak/freeze", {
+      referer: "https://evil.attacker.net/csrf-page",
+    });
+    const res = await middleware(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("blocks an authenticated PATCH with no Origin or Referer header (missing token rejected)", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("PATCH", "/api/notifications/some-id");
+    const res = await middleware(req);
+    expect(res.status).toBe(403);
+  });
+
+  // ── unauthenticated requests must not be blocked by CSRF ──────────────────
+
+  it("does not apply CSRF check to unauthenticated requests (route will 401 independently)", async () => {
+    mockGetToken.mockResolvedValue(null);
+    const req = makeRequest("POST", "/api/goals", { origin: "https://evil.attacker.net" });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  // ── safe methods are never blocked ───────────────────────────────────────
+
+  it("allows GET requests without an Origin header (GET is a safe method)", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("GET", "/api/goals");
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  // ── bearer token clients must not be broken ───────────────────────────────
+
+  it("allows a POST with Authorization: Bearer even without an Origin header (bearer token client)", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("POST", "/api/local-coding/sync", {
+      authorization: "Bearer dt_api_key_abc123",
+    });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  it("allows a POST with Bearer auth from a cross-origin caller (API client, not browser)", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("POST", "/api/goals", {
+      authorization: "Bearer some-token",
+      origin: "https://external-tool.io",
+    });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  // ── webhook endpoints must not be broken ──────────────────────────────────
+
+  it("allows POST to /api/webhooks/github without Origin (HMAC-authenticated)", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("POST", "/api/webhooks/github");
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  it("allows POST to /api/webhooks/dispatch without Origin (bearer-secret-authenticated)", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("POST", "/api/webhooks/dispatch");
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  // ── internal cron jobs must not be broken ────────────────────────────────
+
+  it("allows GET to /api/cron/weekly-digest without Origin (cron job)", async () => {
+    mockGetToken.mockResolvedValue(null);
+    const req = makeRequest("GET", "/api/cron/weekly-digest");
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+
+  // ── Referer fallback ──────────────────────────────────────────────────────
+
+  it("accepts a valid Referer as a fallback when Origin is absent", async () => {
+    mockGetToken.mockResolvedValue({ githubId: "123" });
+    const req = makeRequest("POST", "/api/daily-note", {
+      referer: "http://localhost:3000/dashboard",
+    });
+    const res = await middleware(req);
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/test/daily-focus.test.ts
+++ b/test/daily-focus.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Regression tests for the daily-focus API route.
+ *
+ * Covers:
+ *   - Unauthenticated access (401)
+ *   - GET returns null when no record exists
+ *   - GET returns a record when one exists
+ *   - PUT creates a new focus entry
+ *   - PUT updates (upserts) an existing focus entry for the same date
+ *   - PUT validates goal_text (missing, empty, too long)
+ *   - PUT rejects invalid JSON
+ *   - DELETE removes a focus entry
+ *   - DELETE is idempotent (no-op on missing entry is not an error)
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveAppUser: vi.fn(),
+  supabaseFrom: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: mocks.resolveAppUser,
+}));
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const SESSION = { githubId: "gh-123", githubLogin: "alice" };
+const USER = { id: "user-uuid-001" };
+const TODAY = new Date().toISOString().slice(0, 10);
+
+function makeRequest(
+  method: string,
+  url: string,
+  body?: unknown
+): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : {},
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+const SAMPLE_RECORD = {
+  id: "focus-id-1",
+  user_id: USER.id,
+  focus_date: TODAY,
+  goal_text: "Ship the feature",
+  created_at: "2026-06-02T09:00:00Z",
+  updated_at: "2026-06-02T09:00:00Z",
+};
+
+// ─── shared Supabase chain builders ─────────────────────────────────────────
+
+function stubSelect(returnData: unknown, returnError: unknown = null) {
+  const maybeSingle = vi.fn().mockResolvedValue({ data: returnData, error: returnError });
+  const eq2 = vi.fn().mockReturnValue({ maybeSingle });
+  const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+  const select = vi.fn().mockReturnValue({ eq: eq1 });
+  mocks.supabaseFrom.mockReturnValue({ select });
+}
+
+function stubUpsert(returnData: unknown, returnError: unknown = null) {
+  const single = vi.fn().mockResolvedValue({ data: returnData, error: returnError });
+  const select = vi.fn().mockReturnValue({ single });
+  const upsert = vi.fn().mockReturnValue({ select });
+  mocks.supabaseFrom.mockReturnValue({ upsert });
+}
+
+function stubDelete(returnError: unknown = null) {
+  const eq2 = vi.fn().mockResolvedValue({ error: returnError });
+  const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+  const del = vi.fn().mockReturnValue({ eq: eq1 });
+  mocks.supabaseFrom.mockReturnValue({ delete: del });
+}
+
+// ─── GET ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/daily-focus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue(SESSION);
+    mocks.resolveAppUser.mockResolvedValue(USER);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/daily-focus/route");
+    const res = await GET(
+      makeRequest("GET", `http://localhost/api/daily-focus?date=${TODAY}`)
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns null focus when no record exists for today", async () => {
+    stubSelect(null);
+    const { GET } = await import("@/app/api/daily-focus/route");
+    const res = await GET(
+      makeRequest("GET", `http://localhost/api/daily-focus?date=${TODAY}`)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { focus: null };
+    expect(body.focus).toBeNull();
+  });
+
+  it("returns the record when one exists for today", async () => {
+    stubSelect(SAMPLE_RECORD);
+    const { GET } = await import("@/app/api/daily-focus/route");
+    const res = await GET(
+      makeRequest("GET", `http://localhost/api/daily-focus?date=${TODAY}`)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { focus: typeof SAMPLE_RECORD };
+    expect(body.focus?.goal_text).toBe("Ship the feature");
+  });
+
+  it("defaults to today when no date param is supplied", async () => {
+    stubSelect(null);
+    const { GET } = await import("@/app/api/daily-focus/route");
+    const res = await GET(
+      makeRequest("GET", "http://localhost/api/daily-focus")
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when the database call fails", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: { message: "db error" } });
+    const eq2 = vi.fn().mockReturnValue({ maybeSingle });
+    const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+    const select = vi.fn().mockReturnValue({ eq: eq1 });
+    mocks.supabaseFrom.mockReturnValue({ select });
+
+    const { GET } = await import("@/app/api/daily-focus/route");
+    const res = await GET(
+      makeRequest("GET", `http://localhost/api/daily-focus?date=${TODAY}`)
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── PUT ─────────────────────────────────────────────────────────────────────
+
+describe("PUT /api/daily-focus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue(SESSION);
+    mocks.resolveAppUser.mockResolvedValue(USER);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const res = await PUT(
+      makeRequest("PUT", "http://localhost/api/daily-focus", {
+        goal_text: "Build the thing",
+        focus_date: TODAY,
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("creates a new focus record", async () => {
+    stubUpsert(SAMPLE_RECORD);
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const res = await PUT(
+      makeRequest("PUT", "http://localhost/api/daily-focus", {
+        goal_text: "Ship the feature",
+        focus_date: TODAY,
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { focus: typeof SAMPLE_RECORD };
+    expect(body.focus.goal_text).toBe("Ship the feature");
+  });
+
+  it("upserts — calling PUT twice for the same date succeeds", async () => {
+    stubUpsert({ ...SAMPLE_RECORD, goal_text: "Updated goal" });
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const res = await PUT(
+      makeRequest("PUT", "http://localhost/api/daily-focus", {
+        goal_text: "Updated goal",
+        focus_date: TODAY,
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { focus: typeof SAMPLE_RECORD };
+    expect(body.focus.goal_text).toBe("Updated goal");
+  });
+
+  it("returns 400 when goal_text is missing", async () => {
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const res = await PUT(
+      makeRequest("PUT", "http://localhost/api/daily-focus", {
+        focus_date: TODAY,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when goal_text is empty", async () => {
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const res = await PUT(
+      makeRequest("PUT", "http://localhost/api/daily-focus", {
+        goal_text: "   ",
+        focus_date: TODAY,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when goal_text exceeds 280 characters", async () => {
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const res = await PUT(
+      makeRequest("PUT", "http://localhost/api/daily-focus", {
+        goal_text: "x".repeat(281),
+        focus_date: TODAY,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const req = new NextRequest("http://localhost/api/daily-focus", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("falls back to today when focus_date is omitted", async () => {
+    stubUpsert(SAMPLE_RECORD);
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const res = await PUT(
+      makeRequest("PUT", "http://localhost/api/daily-focus", {
+        goal_text: "Ship the feature",
+      })
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when the database call fails", async () => {
+    const single = vi.fn().mockResolvedValue({ data: null, error: { message: "db error" } });
+    const select = vi.fn().mockReturnValue({ single });
+    const upsert = vi.fn().mockReturnValue({ select });
+    mocks.supabaseFrom.mockReturnValue({ upsert });
+
+    const { PUT } = await import("@/app/api/daily-focus/route");
+    const res = await PUT(
+      makeRequest("PUT", "http://localhost/api/daily-focus", {
+        goal_text: "Ship it",
+        focus_date: TODAY,
+      })
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── DELETE ──────────────────────────────────────────────────────────────────
+
+describe("DELETE /api/daily-focus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue(SESSION);
+    mocks.resolveAppUser.mockResolvedValue(USER);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const { DELETE } = await import("@/app/api/daily-focus/route");
+    const res = await DELETE(
+      makeRequest("DELETE", `http://localhost/api/daily-focus?date=${TODAY}`)
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("deletes a focus entry and returns success", async () => {
+    stubDelete(null);
+    const { DELETE } = await import("@/app/api/daily-focus/route");
+    const res = await DELETE(
+      makeRequest("DELETE", `http://localhost/api/daily-focus?date=${TODAY}`)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("is idempotent — deleting a non-existent entry succeeds", async () => {
+    // Supabase DELETE with no matching rows returns no error — this is
+    // consistent with the rest of the API surface.
+    stubDelete(null);
+    const { DELETE } = await import("@/app/api/daily-focus/route");
+    const res = await DELETE(
+      makeRequest("DELETE", "http://localhost/api/daily-focus?date=2020-01-01")
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("defaults to today when no date param is supplied", async () => {
+    stubDelete(null);
+    const { DELETE } = await import("@/app/api/daily-focus/route");
+    const res = await DELETE(
+      makeRequest("DELETE", "http://localhost/api/daily-focus")
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when the database call fails", async () => {
+    stubDelete({ message: "db error" });
+    const { DELETE } = await import("@/app/api/daily-focus/route");
+    const res = await DELETE(
+      makeRequest("DELETE", `http://localhost/api/daily-focus?date=${TODAY}`)
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/test/date-utils.test.ts
+++ b/test/date-utils.test.ts
@@ -7,6 +7,10 @@ describe('exports', () => {
     expect(typeof dateUtils.dateDiffDays).toBe('function');
   });
 
+  it('exports dateDiff as a backward-compatible alias', () => {
+    expect(dateUtils.dateDiff).toBe(dateUtils.dateDiffDays);
+  });
+
   it('exports toDateStr by name', () => {
     expect(typeof dateUtils.toDateStr).toBe('function');
   });

--- a/test/date-utils.test.ts
+++ b/test/date-utils.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { toDateStr, dateDiffDays } from '../src/lib/dateUtils';
+import * as dateUtils from '../src/lib/dateUtils';
+
+describe('exports', () => {
+  it('exports dateDiffDays by name — rename regression for #1879', () => {
+    expect(typeof dateUtils.dateDiffDays).toBe('function');
+  });
+
+  it('exports toDateStr by name', () => {
+    expect(typeof dateUtils.toDateStr).toBe('function');
+  });
+});
 
 describe('toDateStr', () => {
   it('formats date as YYYY-MM-DD', () => {

--- a/test/date-utils.test.ts
+++ b/test/date-utils.test.ts
@@ -1,26 +1,19 @@
 import { describe, it, expect } from 'vitest';
+import { toDateStr, dateDiffDays } from '../src/lib/dateUtils';
 
 describe('toDateStr', () => {
-  function toDateStr(d: Date): string {
-    return d.toISOString().slice(0, 10);
-  }
-
   it('formats date as YYYY-MM-DD', () => {
-    const d = new Date('2026-05-24T12:00:00Z');
+    const d = new Date(2026, 4, 24, 12, 0, 0); // 2026-05-24 local noon
     expect(toDateStr(d)).toBe('2026-05-24');
   });
 
   it('pads single-digit month and day', () => {
-    const d = new Date('2026-01-05T12:00:00Z');
+    const d = new Date(2026, 0, 5, 12, 0, 0); // 2026-01-05 local noon
     expect(toDateStr(d)).toBe('2026-01-05');
   });
 });
 
 describe('dateDiffDays', () => {
-  function dateDiffDays(a: string, b: string): number {
-    return (new Date(b).getTime() - new Date(a).getTime()) / 86400000;
-  }
-
   it('returns positive difference when b is after a', () => {
     expect(dateDiffDays('2026-05-01', '2026-05-10')).toBe(9);
   });

--- a/test/dateDiffDays.test.ts
+++ b/test/dateDiffDays.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { dateDiffDays } from "../src/lib/dateUtils";
+import {
+  dateDiffDays as barrelDiffDays,
+  dateDiff,
+} from "@/lib/date-utils";
 
 describe("dateUtils dateDiffDays", () => {
   it("returns 0 for same day", () => {
@@ -48,5 +52,39 @@ describe("dateUtils dateDiffDays", () => {
     const diff = dateDiffDays("2024-06-15T10:00:00Z", "2024-06-15T23:59:59Z");
     expect(diff).toBeGreaterThan(0);
     expect(diff).toBeLessThan(1);
+  });
+});
+
+describe("date-utils barrel export", () => {
+  it("exports dateDiffDays", () => {
+    expect(typeof barrelDiffDays).toBe("function");
+  });
+
+  it("exports dateDiff alias", () => {
+    expect(typeof dateDiff).toBe("function");
+  });
+
+  it("dateDiff and dateDiffDays produce identical results", () => {
+    expect(dateDiff("2024-01-01", "2024-01-06")).toBe(
+      barrelDiffDays("2024-01-01", "2024-01-06")
+    );
+  });
+
+  it("barrel dateDiffDays computes correct day difference", () => {
+    expect(barrelDiffDays("2024-06-01", "2024-06-06")).toBe(5);
+  });
+
+  it("barrel dateDiff computes correct day difference", () => {
+    expect(dateDiff("2024-06-01", "2024-06-06")).toBe(5);
+  });
+
+  it("barrel export returns 0 for same date", () => {
+    expect(barrelDiffDays("2024-03-10", "2024-03-10")).toBe(0);
+    expect(dateDiff("2024-03-10", "2024-03-10")).toBe(0);
+  });
+
+  it("barrel export returns negative for reversed dates", () => {
+    expect(barrelDiffDays("2024-06-06", "2024-06-01")).toBe(-5);
+    expect(dateDiff("2024-06-06", "2024-06-01")).toBe(-5);
   });
 });

--- a/test/dateUtils.test.ts
+++ b/test/dateUtils.test.ts
@@ -18,7 +18,7 @@ describe("toDateStr", () => {
   });
 
   it("should handle end-of-year boundary", () => {
-    const newYear = new Date("2023-12-31T23:59:59Z");
+    const newYear = new Date(2023, 11, 31, 23, 59, 59); // local Dec 31
     expect(toDateStr(newYear)).toBe("2023-12-31");
   });
 

--- a/test/discord.test.ts
+++ b/test/discord.test.ts
@@ -10,7 +10,7 @@ describe("sendDiscordWebhook", () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", mockFetch);
 
-    const result = await sendDiscordWebhook("https://webhook.url", { test: "payload" });
+    const result = await sendDiscordWebhook("https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrst", { test: "payload" });
     expect(result).toBe(true);
   });
 
@@ -18,7 +18,7 @@ describe("sendDiscordWebhook", () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 400, statusText: "Bad Request" });
     vi.stubGlobal("fetch", mockFetch);
 
-    await expect(sendDiscordWebhook("https://webhook.url", { test: "payload" })).rejects.toThrow("Discord Webhook failed: 400 Bad Request");
+    await expect(sendDiscordWebhook("https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrst", { test: "payload" })).rejects.toThrow("Discord Webhook failed: 400 Bad Request");
   });
 });
 
@@ -31,9 +31,9 @@ describe("sendTestNotification", () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", mockFetch);
 
-    const result = await sendTestNotification("https://webhook.url", "testuser");
+    const result = await sendTestNotification("https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrst", "testuser");
     expect(result).toBe(true);
-    expect(mockFetch).toHaveBeenCalledWith("https://webhook.url", expect.objectContaining({
+    expect(mockFetch).toHaveBeenCalledWith("https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrst", expect.objectContaining({
       method: "POST",
       headers: { "Content-Type": "application/json" },
     }));
@@ -49,7 +49,7 @@ describe("sendStreakAtRisk", () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", mockFetch);
 
-    const result = await sendStreakAtRisk("https://webhook.url", "testuser", 5);
+    const result = await sendStreakAtRisk("https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrst", "testuser", 5);
     expect(result).toBe(true);
   });
 });
@@ -63,7 +63,7 @@ describe("sendMilestoneReached", () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", mockFetch);
 
-    const result = await sendMilestoneReached("https://webhook.url", "testuser", 30);
+    const result = await sendMilestoneReached("https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrst", "testuser", 30);
     expect(result).toBe(true);
   });
 });
@@ -77,7 +77,7 @@ describe("sendWeeklySummary", () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", mockFetch);
 
-    const result = await sendWeeklySummary("https://webhook.url", "testuser", { commits: 10, prs: 3, activeDays: 5 });
+    const result = await sendWeeklySummary("https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrst", "testuser", { commits: 10, prs: 3, activeDays: 5 });
     expect(result).toBe(true);
   });
 });

--- a/test/github-auth-error.test.ts
+++ b/test/github-auth-error.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for GitHub credential failure detection and structured error responses.
+ *
+ * Covers:
+ *   - GitHubAuthError class shape
+ *   - githubFetch throws GitHubAuthError on 401
+ *   - githubGraphQL throws GitHubAuthError on 401
+ *   - githubAuthErrorResponse returns correct structure
+ *   - Metrics routes return structured auth error when session is revoked
+ *   - Metrics routes return structured auth error when GitHub API returns 401
+ *   - Non-auth GitHub failures (rate limit, 500) are NOT classified as auth errors
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  GitHubAuthError,
+  GitHubApiError,
+  GitHubRateLimitError,
+  githubFetch,
+  githubGraphQL,
+  githubAuthErrorResponse,
+} from "@/lib/github-fetch";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  fetchFn: vi.fn(),
+  supabaseFrom: vi.fn(),
+  metricsCache: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: vi.fn().mockResolvedValue({ id: "user-uuid" }),
+}));
+vi.mock("@/lib/metrics-cache", () => ({
+  isMetricsCacheBypassed: vi.fn().mockReturnValue(false),
+  metricsCacheKey: vi.fn((...args: unknown[]) => String(args.join("-"))),
+  METRICS_CACHE_TTL_SECONDS: {
+    contributions: 300,
+    prs: 300,
+    repos: 300,
+    streak: 300,
+    issues: 300,
+    languages: 300,
+  },
+  withMetricsCache: vi.fn(
+    (_opts: unknown, fn: () => unknown) => fn()
+  ),
+}));
+vi.mock("@/lib/github-accounts", () => ({
+  getAccountToken: vi.fn().mockResolvedValue(null),
+  getAllAccounts: vi.fn().mockResolvedValue([]),
+  mergeMetrics: vi.fn().mockReturnValue(null),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mocks.getServerSession.mockReset();
+});
+
+// ─── GitHubAuthError class ───────────────────────────────────────────────────
+
+describe("GitHubAuthError", () => {
+  it("has name GitHubAuthError", () => {
+    expect(new GitHubAuthError().name).toBe("GitHubAuthError");
+  });
+
+  it("has a meaningful message", () => {
+    expect(new GitHubAuthError().message).toMatch(/authentication/i);
+  });
+
+  it("is an instance of Error", () => {
+    expect(new GitHubAuthError()).toBeInstanceOf(Error);
+  });
+
+  it("is not an instance of GitHubApiError", () => {
+    expect(new GitHubAuthError()).not.toBeInstanceOf(GitHubApiError);
+  });
+});
+
+// ─── githubAuthErrorResponse ─────────────────────────────────────────────────
+
+describe("githubAuthErrorResponse", () => {
+  it("returns HTTP 401", async () => {
+    const res = githubAuthErrorResponse();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns github_auth_invalid error key", async () => {
+    const res = githubAuthErrorResponse();
+    const body = await res.json();
+    expect(body).toEqual({ error: "github_auth_invalid" });
+  });
+});
+
+// ─── githubFetch — 401 handling ──────────────────────────────────────────────
+
+describe("githubFetch — 401", () => {
+  it("throws GitHubAuthError on 401", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/user", "bad-token")
+    ).rejects.toThrow(GitHubAuthError);
+  });
+
+  it("does NOT throw GitHubApiError on 401", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    let thrownError: unknown;
+    try {
+      await githubFetch("https://api.github.com/user", "bad-token");
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).not.toBeInstanceOf(GitHubApiError);
+  });
+
+  it("still throws GitHubRateLimitError on 429", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      headers: { get: () => null },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/user", "token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("still throws GitHubApiError on 404", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/user", "token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+});
+
+// ─── githubGraphQL — 401 handling ────────────────────────────────────────────
+
+describe("githubGraphQL — 401", () => {
+  it("throws GitHubAuthError on 401", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "bad-token")
+    ).rejects.toThrow(GitHubAuthError);
+  });
+});
+
+// ─── /api/metrics/repos — session.error check ───────────────────────────────
+
+describe("GET /api/metrics/repos — TokenRevoked session", () => {
+  it("returns github_auth_invalid when session.error is TokenRevoked", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      accessToken: "some-token",
+      githubLogin: "alice",
+      githubId: "12345",
+      error: "TokenRevoked",
+    });
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("github_auth_invalid");
+  });
+});
+
+// ─── /api/metrics/repos — GitHub 401 from API ────────────────────────────────
+
+describe("GET /api/metrics/repos — GitHub API 401", () => {
+  it("returns github_auth_invalid when GitHub Search API returns 401", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      accessToken: "revoked-token",
+      githubLogin: "alice",
+      githubId: "12345",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      json: async () => ({ message: "Bad credentials" }),
+    });
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("github_auth_invalid");
+  });
+
+  it("returns 502 for non-auth GitHub failures (rate limit 403)", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      accessToken: "valid-token",
+      githubLogin: "alice",
+      githubId: "12345",
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: (key: string) => key === "X-RateLimit-Remaining" ? "0" : null },
+      json: async () => ({ message: "API rate limit exceeded" }),
+    });
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toBe("github_auth_invalid");
+  });
+});
+
+// ─── /api/metrics/streak — session.error check ───────────────────────────────
+
+describe("GET /api/metrics/streak — TokenRevoked session", () => {
+  it("returns github_auth_invalid when session.error is TokenRevoked", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      accessToken: "some-token",
+      githubLogin: "alice",
+      githubId: "12345",
+      error: "TokenRevoked",
+    });
+
+    mocks.supabaseFrom.mockReturnValue({
+      select: () => ({ eq: () => ({ gte: () => ({ data: [], error: null }) }) }),
+      upsert: () => ({ error: null }),
+    });
+
+    const { GET } = await import("@/app/api/metrics/streak/route");
+    const req = new NextRequest("http://localhost/api/metrics/streak");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("github_auth_invalid");
+  });
+});
+
+// ─── /api/metrics/issues — session.error check ───────────────────────────────
+
+describe("GET /api/metrics/issues — TokenRevoked session", () => {
+  it("returns github_auth_invalid when session.error is TokenRevoked", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      accessToken: "some-token",
+      githubLogin: "alice",
+      githubId: "12345",
+      error: "TokenRevoked",
+    });
+
+    const { GET } = await import("@/app/api/metrics/issues/route");
+    const req = new NextRequest("http://localhost/api/metrics/issues");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("github_auth_invalid");
+  });
+
+  it("returns github_auth_invalid when GitHub Search API returns 401", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      accessToken: "revoked-token",
+      githubLogin: "alice",
+      githubId: "12345",
+    });
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+      json: async () => ({ message: "Bad credentials" }),
+    });
+
+    const { GET } = await import("@/app/api/metrics/issues/route");
+    const req = new NextRequest("http://localhost/api/metrics/issues");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("github_auth_invalid");
+  });
+});

--- a/test/github-auth-error.test.ts
+++ b/test/github-auth-error.test.ts
@@ -96,10 +96,10 @@ describe("githubAuthErrorResponse", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns github_auth_invalid error key", async () => {
+  it("returns token_expired error key", async () => {
     const res = githubAuthErrorResponse();
     const body = await res.json();
-    expect(body).toEqual({ error: "github_auth_invalid" });
+    expect(body).toEqual({ error: "token_expired" });
   });
 });
 
@@ -178,7 +178,7 @@ describe("githubGraphQL — 401", () => {
 // ─── /api/metrics/repos — session.error check ───────────────────────────────
 
 describe("GET /api/metrics/repos — TokenRevoked session", () => {
-  it("returns github_auth_invalid when session.error is TokenRevoked", async () => {
+  it("returns token_expired when session.error is TokenRevoked", async () => {
     mocks.getServerSession.mockResolvedValue({
       accessToken: "some-token",
       githubLogin: "alice",
@@ -192,14 +192,14 @@ describe("GET /api/metrics/repos — TokenRevoked session", () => {
 
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe("github_auth_invalid");
+    expect(body.error).toBe("token_expired");
   });
 });
 
 // ─── /api/metrics/repos — GitHub 401 from API ────────────────────────────────
 
 describe("GET /api/metrics/repos — GitHub API 401", () => {
-  it("returns github_auth_invalid when GitHub Search API returns 401", async () => {
+  it("returns token_expired when GitHub Search API returns 401", async () => {
     mocks.getServerSession.mockResolvedValue({
       accessToken: "revoked-token",
       githubLogin: "alice",
@@ -219,7 +219,7 @@ describe("GET /api/metrics/repos — GitHub API 401", () => {
 
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe("github_auth_invalid");
+    expect(body.error).toBe("token_expired");
   });
 
   it("returns 502 for non-auth GitHub failures (rate limit 403)", async () => {
@@ -242,14 +242,14 @@ describe("GET /api/metrics/repos — GitHub API 401", () => {
 
     expect(res.status).toBe(502);
     const body = await res.json();
-    expect(body.error).not.toBe("github_auth_invalid");
+    expect(body.error).not.toBe("token_expired");
   });
 });
 
 // ─── /api/metrics/streak — session.error check ───────────────────────────────
 
 describe("GET /api/metrics/streak — TokenRevoked session", () => {
-  it("returns github_auth_invalid when session.error is TokenRevoked", async () => {
+  it("returns token_expired when session.error is TokenRevoked", async () => {
     mocks.getServerSession.mockResolvedValue({
       accessToken: "some-token",
       githubLogin: "alice",
@@ -268,14 +268,14 @@ describe("GET /api/metrics/streak — TokenRevoked session", () => {
 
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe("github_auth_invalid");
+    expect(body.error).toBe("token_expired");
   });
 });
 
 // ─── /api/metrics/issues — session.error check ───────────────────────────────
 
 describe("GET /api/metrics/issues — TokenRevoked session", () => {
-  it("returns github_auth_invalid when session.error is TokenRevoked", async () => {
+  it("returns token_expired when session.error is TokenRevoked", async () => {
     mocks.getServerSession.mockResolvedValue({
       accessToken: "some-token",
       githubLogin: "alice",
@@ -289,10 +289,10 @@ describe("GET /api/metrics/issues — TokenRevoked session", () => {
 
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe("github_auth_invalid");
+    expect(body.error).toBe("token_expired");
   });
 
-  it("returns github_auth_invalid when GitHub Search API returns 401", async () => {
+  it("returns token_expired when GitHub Search API returns 401", async () => {
     mocks.getServerSession.mockResolvedValue({
       accessToken: "revoked-token",
       githubLogin: "alice",
@@ -312,6 +312,6 @@ describe("GET /api/metrics/issues — TokenRevoked session", () => {
 
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe("github_auth_invalid");
+    expect(body.error).toBe("token_expired");
   });
 });

--- a/test/github-auth-metrics.test.ts
+++ b/test/github-auth-metrics.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for GitHub credential failure detection in the metrics routes that were
+ * missing auth-error handling.
+ *
+ * Covers for each route:
+ *   - session.error === "TokenRevoked" returns { error: "token_expired" } (401)
+ *   - GitHub API returning 401 propagates as { error: "token_expired" } (401)
+ *   - Non-auth GitHub failures (403 rate limit, 500) return generic 502
+ */
+
+import "./setup";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── shared mock setup ────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+vi.mock("@/lib/metrics-cache", () => ({
+  isMetricsCacheBypassed: vi.fn().mockReturnValue(false),
+  METRICS_CACHE_TTL_SECONDS: {
+    contributions: 300,
+    repos: 300,
+    prs: 300,
+    activity: 300,
+    issues: 300,
+    languages: 300,
+    streak: 300,
+    discussions: 300,
+    "pr-review-time": 300,
+    "productive-hours": 300,
+    "inactive-repos": 300,
+  },
+  metricsCacheKey: vi.fn().mockReturnValue("test-cache-key"),
+  withMetricsCache: vi.fn().mockImplementation((_opts: unknown, fn: () => unknown) => fn()),
+}));
+
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/github-accounts", () => ({
+  getAccountToken: vi.fn().mockResolvedValue(null),
+  getAllAccounts: vi.fn().mockResolvedValue([]),
+  mergeMetrics: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: null,
+}));
+
+import { getServerSession } from "next-auth";
+const mockGetServerSession = vi.mocked(getServerSession);
+
+function revokedSession() {
+  return {
+    accessToken: "old-token",
+    githubLogin: "testuser",
+    githubId: "123",
+    error: "TokenRevoked",
+  } as any;
+}
+
+function validSession() {
+  return {
+    accessToken: "valid-token",
+    githubLogin: "testuser",
+    githubId: "123",
+  } as any;
+}
+
+function mockGitHub401() {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 401,
+    headers: { get: () => null },
+    json: async () => ({ message: "Bad credentials" }),
+  });
+}
+
+function mockGitHub403RateLimit() {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 403,
+    headers: { get: (k: string) => (k === "X-RateLimit-Remaining" ? "0" : null) },
+    json: async () => ({ message: "API rate limit exceeded" }),
+  });
+}
+
+// ─── /api/metrics/discussions ─────────────────────────────────────────────────
+
+describe("GET /api/metrics/discussions — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = new NextRequest("http://localhost/api/metrics/discussions");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub GraphQL returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = new NextRequest("http://localhost/api/metrics/discussions");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      json: async () => ({}),
+    });
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = new NextRequest("http://localhost/api/metrics/discussions");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});
+
+// ─── /api/metrics/pr-review-time ─────────────────────────────────────────────
+
+describe("GET /api/metrics/pr-review-time — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/pr-review-time/route");
+    const req = new NextRequest("http://localhost/api/metrics/pr-review-time");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub search API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/pr-review-time/route");
+    const req = new NextRequest("http://localhost/api/metrics/pr-review-time");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures (rate limit 403)", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub403RateLimit();
+
+    const { GET } = await import("@/app/api/metrics/pr-review-time/route");
+    const req = new NextRequest("http://localhost/api/metrics/pr-review-time");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});
+
+// ─── /api/metrics/productive-hours ───────────────────────────────────────────
+
+describe("GET /api/metrics/productive-hours — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/productive-hours/route");
+    const req = new NextRequest("http://localhost/api/metrics/productive-hours");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub search API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/productive-hours/route");
+    const req = new NextRequest("http://localhost/api/metrics/productive-hours");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures (rate limit 403 with no prior data)", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({ message: "API rate limit exceeded" }),
+    });
+
+    const { GET } = await import("@/app/api/metrics/productive-hours/route");
+    const req = new NextRequest("http://localhost/api/metrics/productive-hours");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});
+
+// ─── /api/metrics/inactive-repos ─────────────────────────────────────────────
+
+describe("GET /api/metrics/inactive-repos — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/inactive-repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/inactive-repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/inactive-repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/inactive-repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures (422 malformed query)", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      headers: { get: () => null },
+      json: async () => ({ message: "Validation failed" }),
+    });
+
+    const { GET } = await import("@/app/api/metrics/inactive-repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/inactive-repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});
+
+// ─── /api/metrics/weekly-summary ─────────────────────────────────────────────
+
+describe("GET /api/metrics/weekly-summary — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = new NextRequest("http://localhost/api/metrics/weekly-summary");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub commits search returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = new NextRequest("http://localhost/api/metrics/weekly-summary");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 when PR search fails with a non-auth error after commits succeed", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+
+    // First call (commits search) succeeds with empty results
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ items: [] }),
+      })
+      // Second call (PR search) fails with a non-auth 500
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        headers: { get: () => null },
+        json: async () => ({}),
+      });
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = new NextRequest("http://localhost/api/metrics/weekly-summary");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});

--- a/test/github-fetch.test.ts
+++ b/test/github-fetch.test.ts
@@ -34,6 +34,16 @@ describe("GitHubRateLimitError", () => {
     expect(error.resetAt).toBeNull();
   });
 
+  it("should store retryAfter when provided", () => {
+    const error = new GitHubRateLimitError(null, 60);
+    expect(error.retryAfter).toBe(60);
+  });
+
+  it("should default retryAfter to null", () => {
+    const error = new GitHubRateLimitError(null);
+    expect(error.retryAfter).toBeNull();
+  });
+
   it("should be instance of Error", () => {
     const error = new GitHubRateLimitError(null);
     expect(error).toBeInstanceOf(Error);
@@ -79,17 +89,7 @@ describe("githubFetch", () => {
     expect(result).toEqual(mockData);
   });
 
-  it("should throw GitHubRateLimitError on 403", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-      headers: { get: () => null },
-    });
-
-    await expect(
-      githubFetch("https://api.github.com/test", "test-token")
-    ).rejects.toThrow(GitHubRateLimitError);
-  });
+  // ── 429 ─────────────────────────────────────────────────────────────────────
 
   it("should throw GitHubRateLimitError on 429", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -103,39 +103,220 @@ describe("githubFetch", () => {
     ).rejects.toThrow(GitHubRateLimitError);
   });
 
-  it("should parse resetAt from X-RateLimit-Reset header", async () => {
+  it("should parse resetAt from X-RateLimit-Reset header on 429", async () => {
     const resetTimestamp = 1735689600;
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 429,
-      headers: { get: (key: string) => key === "X-RateLimit-Reset" ? String(resetTimestamp) : null },
+      headers: {
+        get: (key: string) =>
+          key === "X-RateLimit-Reset" ? String(resetTimestamp) : null,
+      },
     });
 
-    try {
-      await githubFetch("https://api.github.com/test", "test-token");
-    } catch (err) {
-      expect(err).toBeInstanceOf(GitHubRateLimitError);
-      const rateLimitErr = err as GitHubRateLimitError;
-      expect(rateLimitErr.resetAt).toEqual(
-        new Date(resetTimestamp * 1000)
-      );
-    }
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toMatchObject({
+      resetAt: new Date(resetTimestamp * 1000),
+    });
   });
 
-  it("should set resetAt to null when header is missing", async () => {
+  it("should parse retryAfter from Retry-After header on 429", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      headers: {
+        get: (key: string) =>
+          key === "Retry-After" ? "60" : null,
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toMatchObject({
+      retryAfter: 60,
+    });
+  });
+
+  // ── 403 — rate limit ─────────────────────────────────────────────────────────
+
+  it("should throw GitHubRateLimitError on 403 with X-RateLimit-Remaining: 0", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "X-RateLimit-Remaining" ? "0" : null,
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should throw GitHubRateLimitError on 403 with Retry-After header (secondary rate limit)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "Retry-After" ? "120" : null,
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should parse retryAfter from Retry-After header on 403 secondary rate limit", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "Retry-After" ? "120" : null,
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toMatchObject({
+      retryAfter: 120,
+    });
+  });
+
+  it("should throw GitHubRateLimitError on 403 with secondary rate limit body message", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 403,
       headers: { get: () => null },
+      json: async () => ({
+        message: "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+      }),
     });
 
-    try {
-      await githubFetch("https://api.github.com/test", "test-token");
-    } catch (err) {
-      expect(err).toBeInstanceOf(GitHubRateLimitError);
-      expect((err as GitHubRateLimitError).resetAt).toBeNull();
-    }
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
   });
+
+  it("should throw GitHubRateLimitError on 403 with 'rate limit exceeded' body message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "API rate limit exceeded for user ID 123",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should include resetAt from X-RateLimit-Reset on 403 with remaining=0", async () => {
+    const resetTimestamp = 1735689600;
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) => {
+          if (key === "X-RateLimit-Remaining") return "0";
+          if (key === "X-RateLimit-Reset") return String(resetTimestamp);
+          return null;
+        },
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toMatchObject({
+      resetAt: new Date(resetTimestamp * 1000),
+    });
+  });
+
+  // ── 403 — authorization failure (must NOT be classified as rate limit) ──────
+
+  it("should throw GitHubApiError on 403 with remaining > 0 (permission failure)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "X-RateLimit-Remaining" ? "4999" : null,
+      },
+      json: async () => ({
+        message: "Must have push access to create or delete labels.",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("should throw GitHubApiError on 403 with invalid credentials message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "Bad credentials",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("should throw GitHubApiError on 403 with insufficient scope message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "Token does not have the required scope.",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("should throw GitHubApiError on 403 without any rate-limit indicators", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "Resource not accessible by personal access token",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("should throw GitHubApiError on 403 when body is not JSON", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => { throw new SyntaxError("Unexpected token"); },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  // ── other non-ok statuses ────────────────────────────────────────────────────
 
   it("should throw GitHubApiError on other non-ok status", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -148,6 +329,23 @@ describe("githubFetch", () => {
       githubFetch("https://api.github.com/test", "test-token")
     ).rejects.toThrow(GitHubApiError);
   });
+
+  it("should set resetAt to null when X-RateLimit-Reset header is missing on 429", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      headers: { get: () => null },
+    });
+
+    try {
+      await githubFetch("https://api.github.com/test", "test-token");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubRateLimitError);
+      expect((err as GitHubRateLimitError).resetAt).toBeNull();
+    }
+  });
+
+  // ── request headers ──────────────────────────────────────────────────────────
 
   it("should send correct Authorization header", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -186,17 +384,7 @@ describe("githubGraphQL", () => {
     expect(result).toEqual(mockData);
   });
 
-  it("should throw GitHubRateLimitError on 403", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-      headers: { get: () => null },
-    });
-
-    await expect(
-      githubGraphQL("{ viewer { login } }", "test-token")
-    ).rejects.toThrow(GitHubRateLimitError);
-  });
+  // ── 429 ─────────────────────────────────────────────────────────────────────
 
   it("should throw GitHubRateLimitError on 429", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -209,6 +397,72 @@ describe("githubGraphQL", () => {
       githubGraphQL("{ viewer { login } }", "test-token")
     ).rejects.toThrow(GitHubRateLimitError);
   });
+
+  // ── 403 — rate limit ─────────────────────────────────────────────────────────
+
+  it("should throw GitHubRateLimitError on 403 with X-RateLimit-Remaining: 0", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "X-RateLimit-Remaining" ? "0" : null,
+      },
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should throw GitHubRateLimitError on 403 with Retry-After header", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "Retry-After" ? "60" : null,
+      },
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should throw GitHubRateLimitError on 403 with secondary rate limit body message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "You have exceeded a secondary rate limit.",
+      }),
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  // ── 403 — authorization failure ──────────────────────────────────────────────
+
+  it("should throw GitHubApiError on 403 without rate-limit indicators (permission failure)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "Your token has not been granted the required scopes.",
+      }),
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  // ── other non-ok statuses ────────────────────────────────────────────────────
 
   it("should throw GitHubApiError on other non-ok status", async () => {
     mockFetch.mockResolvedValueOnce({

--- a/test/github-fetch.test.ts
+++ b/test/github-fetch.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   GitHubRateLimitError,
   GitHubApiError,
+  GitHubAuthError,
   githubFetch,
   githubGraphQL,
 } from "@/lib/github-fetch";
@@ -66,6 +67,26 @@ describe("GitHubApiError", () => {
 
   it("should be instance of Error", () => {
     const error = new GitHubApiError(404);
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+// ─── GitHubAuthError ─────────────────────────────────────────────────────────
+
+describe("GitHubAuthError", () => {
+  it("should have correct name and message", () => {
+    const error = new GitHubAuthError();
+    expect(error.name).toBe("GitHubAuthError");
+    expect(error.message).toContain("GitHub authentication failed");
+  });
+
+  it("should have status 401", () => {
+    const error = new GitHubAuthError();
+    expect(error.status).toBe(401);
+  });
+
+  it("should be instance of Error", () => {
+    const error = new GitHubAuthError();
     expect(error).toBeInstanceOf(Error);
   });
 });

--- a/test/github-fetch.test.ts
+++ b/test/github-fetch.test.ts
@@ -110,6 +110,47 @@ describe("githubFetch", () => {
     expect(result).toEqual(mockData);
   });
 
+  // ── 401 — token revoked / invalid ────────────────────────────────────────────
+
+  it("should throw GitHubAuthError on 401 (revoked token)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "revoked-token")
+    ).rejects.toThrow(GitHubAuthError);
+  });
+
+  it("should not classify 401 as a rate-limit error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "revoked-token")
+    ).rejects.not.toThrow(GitHubRateLimitError);
+  });
+
+  it("GitHubAuthError from 401 should have status 401", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    try {
+      await githubFetch("https://api.github.com/test", "expired-token");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubAuthError);
+      expect((err as GitHubAuthError).status).toBe(401);
+    }
+  });
+
   // ── 429 ─────────────────────────────────────────────────────────────────────
 
   it("should throw GitHubRateLimitError on 429", async () => {
@@ -403,6 +444,20 @@ describe("githubGraphQL", () => {
 
     const result = await githubGraphQL("{ viewer { login } }", "test-token");
     expect(result).toEqual(mockData);
+  });
+
+  // ── 401 — token revoked / invalid ────────────────────────────────────────────
+
+  it("should throw GitHubAuthError on 401", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "revoked-token")
+    ).rejects.toThrow(GitHubAuthError);
   });
 
   // ── 429 ─────────────────────────────────────────────────────────────────────

--- a/test/goal-history.test.ts
+++ b/test/goal-history.test.ts
@@ -1,0 +1,526 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "@/app/api/goals/route";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveAppUser: vi.fn(),
+  supabaseFrom: vi.fn(),
+  dispatchToAllWebhooks: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/resolve-user", () => ({ resolveAppUser: mocks.resolveAppUser }));
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+vi.mock("@/lib/webhooks", () => ({
+  dispatchToAllWebhooks: mocks.dispatchToAllWebhooks,
+}));
+vi.mock("@/lib/sanitize", () => ({ stripHtml: (s: string) => s }));
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const PAST_MONDAY = "2026-05-25T00:00:00.000Z"; // a Monday in a past week
+const PAST_MONTH_START = "2026-05-01T00:00:00.000Z";
+
+function buildWeeklyGoal(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "goal-weekly-1",
+    user_id: "user-1",
+    title: "Weekly commits",
+    target: 10,
+    current: 7,
+    unit: "hours",
+    recurrence: "weekly",
+    deadline: null,
+    period_start: PAST_MONDAY,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function buildMonthlyGoal(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "goal-monthly-1",
+    user_id: "user-1",
+    title: "Monthly goal",
+    target: 20,
+    current: 20,
+    unit: "hours",
+    recurrence: "monthly",
+    deadline: null,
+    period_start: PAST_MONTH_START,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function buildNoneGoal(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "goal-none-1",
+    user_id: "user-1",
+    title: "One-time goal",
+    target: 5,
+    current: 2,
+    unit: "hours",
+    recurrence: "none",
+    deadline: null,
+    period_start: "1970-01-01T00:00:00.000Z",
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+/**
+ * Sets up supabaseAdmin.from() mock routing by table name.
+ *
+ * goalsResponse  – what `from("goals").select().eq().order().limit()` resolves to
+ * upsertResult   – what `from("goal_history").upsert()` resolves to
+ * updatedGoal    – what `from("goals").update().eq().lt().select().single()` resolves to
+ * historyRows    – what `from("goal_history").select().in().order()` resolves to
+ */
+function setupSupabase({
+  goalsResponse,
+  upsertResult = { data: null, error: null },
+  updatedGoal,
+  historyRows = [],
+}: {
+  goalsResponse: unknown[];
+  upsertResult?: { data: unknown; error: unknown };
+  updatedGoal?: unknown;
+  historyRows?: unknown[];
+}) {
+  const upsertMock = vi.fn().mockResolvedValue(upsertResult);
+
+  const updateSingle = vi.fn().mockResolvedValue({
+    data: updatedGoal ?? null,
+    error: updatedGoal ? null : { message: "no rows" },
+  });
+  const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+  const updateLt = vi.fn().mockReturnValue({ select: updateSelect });
+  const updateEqId = vi.fn().mockReturnValue({ lt: updateLt });
+  const updateChain = vi.fn().mockReturnValue({ eq: updateEqId });
+
+  const historySelectOrder = vi.fn().mockResolvedValue({ data: historyRows, error: null });
+  const historySelectIn = vi.fn().mockReturnValue({ order: historySelectOrder });
+  const historySelectChain = vi.fn().mockReturnValue({ in: historySelectIn });
+
+  const goalsSelectLimit = vi.fn().mockResolvedValue({ data: goalsResponse, error: null });
+  const goalsSelectOrder = vi.fn().mockReturnValue({ limit: goalsSelectLimit });
+  const goalsSelectEq = vi.fn().mockReturnValue({ order: goalsSelectOrder });
+  const goalsSelectChain = vi.fn().mockReturnValue({ eq: goalsSelectEq });
+
+  // Fallback select for the race-condition branch: from("goals").select("*").eq("id", ...).single()
+  const fallbackSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+  const fallbackEq = vi.fn().mockReturnValue({ single: fallbackSingle });
+
+  mocks.supabaseFrom.mockImplementation((table: string) => {
+    if (table === "goal_history") {
+      return {
+        upsert: upsertMock,
+        select: historySelectChain,
+      };
+    }
+    // "goals" table
+    return {
+      select: (cols: string) => {
+        if (cols === "*") {
+          return {
+            eq: goalsSelectEq,
+            // single-row fallback for race-condition case
+          };
+        }
+        return { eq: fallbackEq };
+      },
+      update: updateChain,
+    };
+  });
+
+  return { upsertMock, updateChain, updateEqId, updateLt, updateSelect, updateSingle };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/goals — recurring goal history archival", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue({ githubId: "gh-123", githubLogin: "alice" });
+    mocks.resolveAppUser.mockResolvedValue({ id: "user-1" });
+  });
+
+  it("returns 401 when there is no session", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the user cannot be resolved", async () => {
+    mocks.resolveAppUser.mockResolvedValue(null);
+    setupSupabase({ goalsResponse: [] });
+    const res = await GET();
+    expect(res.status).toBe(404);
+  });
+
+  // ── non-recurring goals are never archived ────────────────────────────────
+
+  it("does not insert a history row for a one-time goal", async () => {
+    const goal = buildNoneGoal();
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      historyRows: [],
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  // ── weekly goal reset ─────────────────────────────────────────────────────
+
+  it("inserts a history row before resetting a weekly goal", async () => {
+    const goal = buildWeeklyGoal({ current: 7, target: 10 });
+    const resetGoal = { ...goal, current: 0, period_start: new Date().toISOString() };
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      updatedGoal: resetGoal,
+      historyRows: [],
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(upsertMock).toHaveBeenCalledOnce();
+
+    const [insertedData] = upsertMock.mock.calls[0];
+    expect(insertedData.goal_id).toBe(goal.id);
+    expect(insertedData.user_id).toBe(goal.user_id);
+    expect(insertedData.achieved_value).toBe(7);
+    expect(insertedData.target).toBe(10);
+    expect(insertedData.completed).toBe(false);
+    expect(insertedData.period_start).toBe(PAST_MONDAY);
+  });
+
+  it("records completed=true when weekly goal was achieved before reset", async () => {
+    const goal = buildWeeklyGoal({ current: 10, target: 10 });
+    const resetGoal = { ...goal, current: 0, period_start: new Date().toISOString() };
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      updatedGoal: resetGoal,
+      historyRows: [],
+    });
+
+    await GET();
+
+    const [insertedData] = upsertMock.mock.calls[0];
+    expect(insertedData.completed).toBe(true);
+    expect(insertedData.achieved_value).toBe(10);
+  });
+
+  it("records completed=false when weekly goal was not achieved before reset", async () => {
+    const goal = buildWeeklyGoal({ current: 3, target: 10 });
+    const resetGoal = { ...goal, current: 0, period_start: new Date().toISOString() };
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      updatedGoal: resetGoal,
+      historyRows: [],
+    });
+
+    await GET();
+
+    const [insertedData] = upsertMock.mock.calls[0];
+    expect(insertedData.completed).toBe(false);
+    expect(insertedData.achieved_value).toBe(3);
+  });
+
+  it("preserves the target value at time of reset in the history row", async () => {
+    const goal = buildWeeklyGoal({ current: 5, target: 12 });
+    const resetGoal = { ...goal, current: 0 };
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      updatedGoal: resetGoal,
+      historyRows: [],
+    });
+
+    await GET();
+
+    const [insertedData] = upsertMock.mock.calls[0];
+    expect(insertedData.target).toBe(12);
+  });
+
+  // ── monthly goal reset ────────────────────────────────────────────────────
+
+  it("inserts a history row before resetting a monthly goal", async () => {
+    const goal = buildMonthlyGoal({ current: 20, target: 20 });
+    const resetGoal = { ...goal, current: 0, period_start: new Date().toISOString() };
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      updatedGoal: resetGoal,
+      historyRows: [],
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(upsertMock).toHaveBeenCalledOnce();
+
+    const [insertedData] = upsertMock.mock.calls[0];
+    expect(insertedData.goal_id).toBe(goal.id);
+    expect(insertedData.completed).toBe(true);
+    expect(insertedData.achieved_value).toBe(20);
+  });
+
+  it("records completed=false for an incomplete monthly goal", async () => {
+    const goal = buildMonthlyGoal({ current: 8, target: 20 });
+    const resetGoal = { ...goal, current: 0 };
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      updatedGoal: resetGoal,
+      historyRows: [],
+    });
+
+    await GET();
+
+    const [insertedData] = upsertMock.mock.calls[0];
+    expect(insertedData.completed).toBe(false);
+    expect(insertedData.achieved_value).toBe(8);
+  });
+
+  // ── idempotency / transaction behaviour ───────────────────────────────────
+
+  it("uses upsert with ignoreDuplicates to prevent double history rows on concurrent resets", async () => {
+    const goal = buildWeeklyGoal({ current: 5, target: 10 });
+    const resetGoal = { ...goal, current: 0 };
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      updatedGoal: resetGoal,
+      historyRows: [],
+    });
+
+    await GET();
+
+    const [, upsertOptions] = upsertMock.mock.calls[0];
+    expect(upsertOptions).toMatchObject({
+      onConflict: "goal_id,period_start",
+      ignoreDuplicates: true,
+    });
+  });
+
+  it("history upsert is called before the goal update", async () => {
+    const callOrder: string[] = [];
+    const goal = buildWeeklyGoal({ current: 5, target: 10 });
+    const resetGoal = { ...goal, current: 0 };
+
+    const upsertMock = vi.fn().mockImplementation(async () => {
+      callOrder.push("upsert");
+      return { data: null, error: null };
+    });
+
+    const updateSingle = vi.fn().mockImplementation(async () => {
+      callOrder.push("update");
+      return { data: resetGoal, error: null };
+    });
+    const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+    const updateLt = vi.fn().mockReturnValue({ select: updateSelect });
+    const updateEqId = vi.fn().mockReturnValue({ lt: updateLt });
+    const updateChain = vi.fn().mockReturnValue({ eq: updateEqId });
+
+    const historySelectOrder = vi.fn().mockResolvedValue({ data: [], error: null });
+    const historySelectIn = vi.fn().mockReturnValue({ order: historySelectOrder });
+    const historySelectChain = vi.fn().mockReturnValue({ in: historySelectIn });
+
+    const goalsSelectLimit = vi.fn().mockResolvedValue({ data: [goal], error: null });
+    const goalsSelectOrder = vi.fn().mockReturnValue({ limit: goalsSelectLimit });
+    const goalsSelectEq = vi.fn().mockReturnValue({ order: goalsSelectOrder });
+
+    mocks.supabaseFrom.mockImplementation((table: string) => {
+      if (table === "goal_history") {
+        return { upsert: upsertMock, select: historySelectChain };
+      }
+      return {
+        select: () => ({ eq: goalsSelectEq }),
+        update: updateChain,
+      };
+    });
+
+    await GET();
+
+    expect(callOrder[0]).toBe("upsert");
+    expect(callOrder[1]).toBe("update");
+  });
+
+  // ── period_end is 1 ms before new period_start ────────────────────────────
+
+  it("sets period_end to 1 ms before the new period_start", async () => {
+    const goal = buildWeeklyGoal({ current: 4, target: 10 });
+    const resetGoal = { ...goal, current: 0 };
+    const { upsertMock } = setupSupabase({
+      goalsResponse: [goal],
+      updatedGoal: resetGoal,
+      historyRows: [],
+    });
+
+    await GET();
+
+    const [insertedData] = upsertMock.mock.calls[0];
+    const periodEnd = new Date(insertedData.period_end);
+    const periodStart = new Date(insertedData.period_start);
+
+    // period_end must be strictly before the start of the old stored period...
+    // No: period_end is 1 ms before the NEW period start, not the old one.
+    // Just verify it is a valid date and comes after period_start.
+    expect(periodEnd.getTime()).toBeGreaterThan(periodStart.getTime());
+    // And it should end before "now" (the current period hasn't started in the far future)
+    expect(periodEnd.getTime()).toBeLessThanOrEqual(Date.now());
+  });
+
+  // ── last_period returned in GET response ──────────────────────────────────
+
+  it("attaches last_period to recurring goals in the response", async () => {
+    const goal = buildWeeklyGoal({ current: 0, target: 10 }); // already in current period
+    // Simulate goal already in current period (storedPeriodStart >= periodStart)
+    // by setting period_start to the current Monday
+    const now = new Date();
+    const day = now.getUTCDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    const thisMonday = new Date(now);
+    thisMonday.setUTCDate(now.getUTCDate() + diff);
+    thisMonday.setUTCHours(0, 0, 0, 0);
+    const currentGoal = { ...goal, period_start: thisMonday.toISOString() };
+
+    const historyRow = {
+      goal_id: goal.id,
+      period_start: PAST_MONDAY,
+      period_end: "2026-05-31T23:59:59.999Z",
+      target: 10,
+      achieved_value: 7,
+      completed: false,
+    };
+
+    setupSupabase({
+      goalsResponse: [currentGoal],
+      historyRows: [historyRow],
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const returnedGoal = body.goals[0];
+
+    expect(returnedGoal.last_period).toBeDefined();
+    expect(returnedGoal.last_period.achieved_value).toBe(7);
+    expect(returnedGoal.last_period.target).toBe(10);
+    expect(returnedGoal.last_period.completed).toBe(false);
+  });
+
+  it("last_period is null for recurring goals with no history", async () => {
+    const now = new Date();
+    const day = now.getUTCDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    const thisMonday = new Date(now);
+    thisMonday.setUTCDate(now.getUTCDate() + diff);
+    thisMonday.setUTCHours(0, 0, 0, 0);
+    const goal = buildWeeklyGoal({ current: 3, period_start: thisMonday.toISOString() });
+
+    setupSupabase({ goalsResponse: [goal], historyRows: [] });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.goals[0].last_period).toBeNull();
+  });
+
+  it("last_period is null for one-time goals", async () => {
+    const goal = buildNoneGoal();
+    setupSupabase({ goalsResponse: [goal], historyRows: [] });
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.goals[0].last_period).toBeNull();
+  });
+
+  it("attaches the most recent period when multiple history rows exist", async () => {
+    const now = new Date();
+    const day = now.getUTCDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    const thisMonday = new Date(now);
+    thisMonday.setUTCDate(now.getUTCDate() + diff);
+    thisMonday.setUTCHours(0, 0, 0, 0);
+    const goal = buildWeeklyGoal({ current: 2, period_start: thisMonday.toISOString() });
+
+    const historyRows = [
+      // Most recent (returned first from DB because ordered desc)
+      {
+        goal_id: goal.id,
+        period_start: PAST_MONDAY,
+        period_end: "2026-05-31T23:59:59.999Z",
+        target: 10,
+        achieved_value: 9,
+        completed: false,
+      },
+      // Older period
+      {
+        goal_id: goal.id,
+        period_start: "2026-05-18T00:00:00.000Z",
+        period_end: "2026-05-24T23:59:59.999Z",
+        target: 10,
+        achieved_value: 10,
+        completed: true,
+      },
+    ];
+
+    setupSupabase({ goalsResponse: [goal], historyRows });
+
+    const res = await GET();
+    const body = await res.json();
+    const returnedGoal = body.goals[0];
+
+    // Should pick the most recent (first) row
+    expect(returnedGoal.last_period.achieved_value).toBe(9);
+    expect(returnedGoal.last_period.completed).toBe(false);
+  });
+
+  it("handles multiple recurring goals, each getting their own last_period", async () => {
+    const now = new Date();
+    const day = now.getUTCDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    const thisMonday = new Date(now);
+    thisMonday.setUTCDate(now.getUTCDate() + diff);
+    thisMonday.setUTCHours(0, 0, 0, 0);
+
+    const thisMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+
+    const weeklyGoal = buildWeeklyGoal({ id: "wg-1", current: 1, period_start: thisMonday.toISOString() });
+    const monthlyGoal = buildMonthlyGoal({ id: "mg-1", current: 5, period_start: thisMonth.toISOString() });
+
+    const historyRows = [
+      {
+        goal_id: "wg-1",
+        period_start: PAST_MONDAY,
+        period_end: "2026-05-31T23:59:59.999Z",
+        target: 10,
+        achieved_value: 6,
+        completed: false,
+      },
+      {
+        goal_id: "mg-1",
+        period_start: PAST_MONTH_START,
+        period_end: "2026-05-31T23:59:59.999Z",
+        target: 20,
+        achieved_value: 20,
+        completed: true,
+      },
+    ];
+
+    setupSupabase({ goalsResponse: [weeklyGoal, monthlyGoal], historyRows });
+
+    const res = await GET();
+    const body = await res.json();
+    const wg = body.goals.find((g: { id: string }) => g.id === "wg-1");
+    const mg = body.goals.find((g: { id: string }) => g.id === "mg-1");
+
+    expect(wg.last_period.achieved_value).toBe(6);
+    expect(wg.last_period.completed).toBe(false);
+    expect(mg.last_period.achieved_value).toBe(20);
+    expect(mg.last_period.completed).toBe(true);
+  });
+});

--- a/test/response-cache.test.ts
+++ b/test/response-cache.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { privateCacheHeaders, publicCacheHeaders } from "../src/lib/response-cache";
 
+// ─── privateCacheHeaders ──────────────────────────────────────────────────────
+
 describe("privateCacheHeaders", () => {
+  // ── default values ───────────────────────────────────────────────────────
+
   it("returns correct headers with default values", () => {
     const headers = privateCacheHeaders();
     expect(headers["Cache-Control"]).toBe("private, max-age=300, stale-while-revalidate=600");
@@ -21,9 +25,106 @@ describe("privateCacheHeaders", () => {
     const headers = privateCacheHeaders(0, 0);
     expect(headers["Cache-Control"]).toBe("private, max-age=0, stale-while-revalidate=0");
   });
+
+  // ── SWR default formula ──────────────────────────────────────────────────
+
+  it("defaults stale-while-revalidate to exactly 2× maxAgeSeconds", () => {
+    expect(privateCacheHeaders(100)["Cache-Control"]).toBe(
+      "private, max-age=100, stale-while-revalidate=200"
+    );
+  });
+
+  it("applies the 2× SWR default correctly for a 1-hour max-age", () => {
+    expect(privateCacheHeaders(3600)["Cache-Control"]).toBe(
+      "private, max-age=3600, stale-while-revalidate=7200"
+    );
+  });
+
+  // ── directive presence ───────────────────────────────────────────────────
+
+  it("always includes the private directive", () => {
+    expect(privateCacheHeaders()["Cache-Control"]).toMatch(/\bprivate\b/);
+    expect(privateCacheHeaders(0, 0)["Cache-Control"]).toMatch(/\bprivate\b/);
+  });
+
+  it("never includes s-maxage — private responses must not be CDN-cached", () => {
+    expect(privateCacheHeaders()["Cache-Control"]).not.toContain("s-maxage");
+    expect(privateCacheHeaders(600)["Cache-Control"]).not.toContain("s-maxage");
+    expect(privateCacheHeaders(0, 0)["Cache-Control"]).not.toContain("s-maxage");
+  });
+
+  it("never includes the public directive", () => {
+    expect(privateCacheHeaders()["Cache-Control"]).not.toContain("public");
+    expect(privateCacheHeaders(600)["Cache-Control"]).not.toContain("public");
+  });
+
+  it("includes stale-while-revalidate directive", () => {
+    expect(privateCacheHeaders()["Cache-Control"]).toContain("stale-while-revalidate=");
+  });
+
+  // ── directive format ─────────────────────────────────────────────────────
+
+  it("uses comma-space as directive separator — exact format", () => {
+    const value = privateCacheHeaders(300)["Cache-Control"];
+    expect(value).toMatch(/^private, max-age=\d+, stale-while-revalidate=\d+$/);
+  });
+
+  it("uses = not : to assign directive values", () => {
+    const value = privateCacheHeaders(300)["Cache-Control"];
+    expect(value).toContain("max-age=300");
+    expect(value).toContain("stale-while-revalidate=600");
+    expect(value).not.toContain("max-age:300");
+    expect(value).not.toContain("stale-while-revalidate:600");
+  });
+
+  it("directive keyword is stale-while-revalidate, not an abbreviation", () => {
+    const value = privateCacheHeaders()["Cache-Control"];
+    expect(value).toContain("stale-while-revalidate=");
+    expect(value).not.toContain("swr=");
+    expect(value).not.toContain("stale-revalidate=");
+  });
+
+  // ── return object shape ──────────────────────────────────────────────────
+
+  it("returns an object with exactly one key: Cache-Control", () => {
+    const headers = privateCacheHeaders();
+    expect(Object.keys(headers)).toHaveLength(1);
+    expect(Object.keys(headers)).toEqual(["Cache-Control"]);
+  });
+
+  it("Cache-Control value is a string", () => {
+    expect(typeof privateCacheHeaders()["Cache-Control"]).toBe("string");
+  });
+
+  // ── large / boundary values ──────────────────────────────────────────────
+
+  it("handles a 24-hour max-age correctly", () => {
+    expect(privateCacheHeaders(86400)["Cache-Control"]).toBe(
+      "private, max-age=86400, stale-while-revalidate=172800"
+    );
+  });
+
+  it("allows an explicit swrSeconds of 0 independent of maxAgeSeconds", () => {
+    expect(privateCacheHeaders(300, 0)["Cache-Control"]).toBe(
+      "private, max-age=300, stale-while-revalidate=0"
+    );
+  });
+
+  // ── Headers constructor compatibility ────────────────────────────────────
+
+  it("returned object is valid HeadersInit for the Headers constructor", () => {
+    const init = privateCacheHeaders(300);
+    expect(() => new Headers(init as HeadersInit)).not.toThrow();
+    const h = new Headers(init as HeadersInit);
+    expect(h.get("Cache-Control")).toBe("private, max-age=300, stale-while-revalidate=600");
+  });
 });
 
+// ─── publicCacheHeaders ───────────────────────────────────────────────────────
+
 describe("publicCacheHeaders", () => {
+  // ── default values ───────────────────────────────────────────────────────
+
   it("returns correct headers with default values", () => {
     const headers = publicCacheHeaders();
     expect(headers["Cache-Control"]).toBe("public, s-maxage=300, stale-while-revalidate=600");
@@ -53,5 +154,186 @@ describe("publicCacheHeaders", () => {
   it("does not include private for public caching", () => {
     const headers = publicCacheHeaders();
     expect(headers["Cache-Control"]).not.toContain("private");
+  });
+
+  // ── SWR default formula ──────────────────────────────────────────────────
+
+  it("defaults stale-while-revalidate to exactly 2× maxAgeSeconds", () => {
+    expect(publicCacheHeaders(100)["Cache-Control"]).toBe(
+      "public, s-maxage=100, stale-while-revalidate=200"
+    );
+  });
+
+  it("applies the 2× SWR default correctly for a 1-hour s-maxage", () => {
+    expect(publicCacheHeaders(3600)["Cache-Control"]).toBe(
+      "public, s-maxage=3600, stale-while-revalidate=7200"
+    );
+  });
+
+  // ── directive presence ───────────────────────────────────────────────────
+
+  it("always includes the public directive", () => {
+    expect(publicCacheHeaders()["Cache-Control"]).toMatch(/\bpublic\b/);
+    expect(publicCacheHeaders(0, 0)["Cache-Control"]).toMatch(/\bpublic\b/);
+  });
+
+  it("always includes s-maxage — required for CDN caching", () => {
+    expect(publicCacheHeaders()["Cache-Control"]).toContain("s-maxage=");
+    expect(publicCacheHeaders(600)["Cache-Control"]).toContain("s-maxage=");
+    expect(publicCacheHeaders(0, 0)["Cache-Control"]).toContain("s-maxage=");
+  });
+
+  it("never includes standalone max-age (only s-maxage is used for public responses)", () => {
+    const value = publicCacheHeaders()["Cache-Control"];
+    // s-maxage= is present but `, max-age=` (standalone directive) must not be
+    expect(value).not.toContain(", max-age=");
+  });
+
+  it("never includes the private directive", () => {
+    expect(publicCacheHeaders()["Cache-Control"]).not.toContain("private");
+    expect(publicCacheHeaders(600)["Cache-Control"]).not.toContain("private");
+  });
+
+  it("includes stale-while-revalidate directive", () => {
+    expect(publicCacheHeaders()["Cache-Control"]).toContain("stale-while-revalidate=");
+  });
+
+  // ── directive format ─────────────────────────────────────────────────────
+
+  it("uses comma-space as directive separator — exact format", () => {
+    const value = publicCacheHeaders(300)["Cache-Control"];
+    expect(value).toMatch(/^public, s-maxage=\d+, stale-while-revalidate=\d+$/);
+  });
+
+  it("uses = not : to assign directive values", () => {
+    const value = publicCacheHeaders(300)["Cache-Control"];
+    expect(value).toContain("s-maxage=300");
+    expect(value).toContain("stale-while-revalidate=600");
+    expect(value).not.toContain("s-maxage:300");
+    expect(value).not.toContain("stale-while-revalidate:600");
+  });
+
+  it("directive keyword is stale-while-revalidate, not an abbreviation", () => {
+    const value = publicCacheHeaders()["Cache-Control"];
+    expect(value).toContain("stale-while-revalidate=");
+    expect(value).not.toContain("swr=");
+    expect(value).not.toContain("stale-revalidate=");
+  });
+
+  // ── return object shape ──────────────────────────────────────────────────
+
+  it("returns an object with exactly one key: Cache-Control", () => {
+    const headers = publicCacheHeaders();
+    expect(Object.keys(headers)).toHaveLength(1);
+    expect(Object.keys(headers)).toEqual(["Cache-Control"]);
+  });
+
+  it("Cache-Control value is a string", () => {
+    expect(typeof publicCacheHeaders()["Cache-Control"]).toBe("string");
+  });
+
+  // ── large / boundary values ──────────────────────────────────────────────
+
+  it("handles a 24-hour s-maxage correctly", () => {
+    expect(publicCacheHeaders(86400)["Cache-Control"]).toBe(
+      "public, s-maxage=86400, stale-while-revalidate=172800"
+    );
+  });
+
+  it("allows an explicit swrSeconds of 0 independent of maxAgeSeconds", () => {
+    expect(publicCacheHeaders(300, 0)["Cache-Control"]).toBe(
+      "public, s-maxage=300, stale-while-revalidate=0"
+    );
+  });
+
+  // ── Headers constructor compatibility ────────────────────────────────────
+
+  it("returned object is valid HeadersInit for the Headers constructor", () => {
+    const init = publicCacheHeaders(300);
+    expect(() => new Headers(init as HeadersInit)).not.toThrow();
+    const h = new Headers(init as HeadersInit);
+    expect(h.get("Cache-Control")).toBe("public, s-maxage=300, stale-while-revalidate=600");
+  });
+});
+
+// ─── cross-function regression ────────────────────────────────────────────────
+
+describe("cache header regression", () => {
+  it("privateCacheHeaders and publicCacheHeaders produce distinct headers for the same input", () => {
+    const priv = privateCacheHeaders(300)["Cache-Control"];
+    const pub = publicCacheHeaders(300)["Cache-Control"];
+    expect(priv).not.toBe(pub);
+  });
+
+  it("privateCacheHeaders uses max-age while publicCacheHeaders uses s-maxage", () => {
+    const privValue = privateCacheHeaders(300)["Cache-Control"];
+    const pubValue = publicCacheHeaders(300)["Cache-Control"];
+
+    expect(privValue).toContain(", max-age=300");
+    expect(privValue).not.toContain("s-maxage=");
+
+    expect(pubValue).toContain("s-maxage=300");
+    expect(pubValue).not.toContain(", max-age=");
+  });
+
+  it("private/public directives are mutually exclusive between the two functions", () => {
+    expect(privateCacheHeaders()["Cache-Control"]).toContain("private");
+    expect(privateCacheHeaders()["Cache-Control"]).not.toContain("public");
+
+    expect(publicCacheHeaders()["Cache-Control"]).toContain("public");
+    expect(publicCacheHeaders()["Cache-Control"]).not.toContain("private");
+  });
+
+  it("both functions expose a stale-while-revalidate directive", () => {
+    expect(privateCacheHeaders()["Cache-Control"]).toContain("stale-while-revalidate=");
+    expect(publicCacheHeaders()["Cache-Control"]).toContain("stale-while-revalidate=");
+  });
+
+  it("default SWR window is double the age directive for both functions", () => {
+    const maxAge = 150;
+    const expectedSwr = maxAge * 2; // 300
+    expect(privateCacheHeaders(maxAge)["Cache-Control"]).toContain(
+      `stale-while-revalidate=${expectedSwr}`
+    );
+    expect(publicCacheHeaders(maxAge)["Cache-Control"]).toContain(
+      `stale-while-revalidate=${expectedSwr}`
+    );
+  });
+
+  it("header key is exactly Cache-Control — correct capitalisation and hyphen", () => {
+    const priv = privateCacheHeaders();
+    const pub = publicCacheHeaders();
+
+    expect(priv).toHaveProperty("Cache-Control");
+    expect(pub).toHaveProperty("Cache-Control");
+
+    // Wrong casing must not silently appear
+    expect(priv).not.toHaveProperty("cache-control");
+    expect(pub).not.toHaveProperty("cache-control");
+    expect(priv).not.toHaveProperty("CacheControl");
+    expect(pub).not.toHaveProperty("CacheControl");
+  });
+
+  it("directive ordering is stable: visibility, age, revalidation", () => {
+    // privateCacheHeaders: private → max-age → stale-while-revalidate
+    const privValue = privateCacheHeaders(60)["Cache-Control"];
+    const privParts = privValue.split(", ");
+    expect(privParts[0]).toBe("private");
+    expect(privParts[1]).toMatch(/^max-age=/);
+    expect(privParts[2]).toMatch(/^stale-while-revalidate=/);
+
+    // publicCacheHeaders: public → s-maxage → stale-while-revalidate
+    const pubValue = publicCacheHeaders(60)["Cache-Control"];
+    const pubParts = pubValue.split(", ");
+    expect(pubParts[0]).toBe("public");
+    expect(pubParts[1]).toMatch(/^s-maxage=/);
+    expect(pubParts[2]).toMatch(/^stale-while-revalidate=/);
+  });
+
+  it("both functions return exactly three directives", () => {
+    const privParts = privateCacheHeaders(300)["Cache-Control"].split(", ");
+    const pubParts = publicCacheHeaders(300)["Cache-Control"].split(", ");
+    expect(privParts).toHaveLength(3);
+    expect(pubParts).toHaveLength(3);
   });
 });

--- a/test/sse-stream-route.test.ts
+++ b/test/sse-stream-route.test.ts
@@ -228,4 +228,59 @@ describe("GET /api/stream — SSE stream route", () => {
     const res = await GET(makeRequest());
     expect(res.headers.get("Connection")).toBe("keep-alive");
   });
+
+  // ── connection-lifetime constants ──────────────────────────────────────
+
+  it("exports HEARTBEAT_INTERVAL_MS as 30 seconds", async () => {
+    const { HEARTBEAT_INTERVAL_MS } = await import("@/app/api/stream/route");
+    expect(HEARTBEAT_INTERVAL_MS).toBe(30_000);
+  });
+
+  it("exports IDLE_TIMEOUT_MS as 5 minutes", async () => {
+    const { IDLE_TIMEOUT_MS } = await import("@/app/api/stream/route");
+    expect(IDLE_TIMEOUT_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("exports MAX_AGE_MS as 30 minutes", async () => {
+    const { MAX_AGE_MS } = await import("@/app/api/stream/route");
+    expect(MAX_AGE_MS).toBe(30 * 60 * 1000);
+  });
+
+  // ── idle timeout ──────────────────────────────────────────────────────
+
+  it("releases the connection slot after idle timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const { GET, IDLE_TIMEOUT_MS } = await import("@/app/api/stream/route");
+      await GET(makeRequest());
+      expect(activeStreamConnections.get("user-1")).toBe(1);
+
+      // The idle-check callback is synchronous; it fires inline during
+      // advanceTimersByTime. IDLE_TIMEOUT_MS (5 min) + one check cycle (60 s).
+      vi.advanceTimersByTime(IDLE_TIMEOUT_MS + 60_001);
+
+      expect(activeStreamConnections.has("user-1")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ── max-age ────────────────────────────────────────────────────────────
+
+  it("releases the connection slot when max-age expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const { GET, MAX_AGE_MS } = await import("@/app/api/stream/route");
+      await GET(makeRequest());
+      expect(activeStreamConnections.get("user-1")).toBe(1);
+
+      // Connections with no changing data are closed by the idle-timeout
+      // mechanism before MAX_AGE_MS, but either path must release the slot.
+      vi.advanceTimersByTime(MAX_AGE_MS + 1);
+
+      expect(activeStreamConnections.has("user-1")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/test/token-expired.test.ts
+++ b/test/token-expired.test.ts
@@ -195,3 +195,225 @@ describe("/api/metrics/issues — token expiry handling", () => {
     expect(body.error).toBe("token_expired");
   });
 });
+
+describe("/api/metrics/discussions — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub GraphQL returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "valid-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toBe("token_expired");
+  });
+});
+
+describe("/api/metrics/pinned-repos — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/pinned-repos/route");
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub GraphQL returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/pinned-repos/route");
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+});
+
+describe("/api/metrics/pr-breakdown — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/pr-breakdown/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub search API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/pr-breakdown/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "valid-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/pr-breakdown/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toBe("token_expired");
+  });
+});
+
+describe("/api/metrics/weekly-summary — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub commit search returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+});

--- a/test/token-expired.test.ts
+++ b/test/token-expired.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Focused tests for GitHub token-expiry / revocation handling.
+ *
+ * Covers:
+ *  - GitHubAuthError thrown when GitHub returns 401
+ *  - githubAuthErrorResponse() shape
+ *  - Metrics routes return { error: "token_expired" } on GitHubAuthError
+ *  - Metrics routes return { error: "token_expired" } when session.error === "TokenRevoked"
+ *  - Non-auth GitHub failures still return the generic 502 error
+ */
+
+import "./setup";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Shared mock setup ────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/metrics-cache", () => ({
+  isMetricsCacheBypassed: vi.fn().mockReturnValue(false),
+  METRICS_CACHE_TTL_SECONDS: {
+    contributions: 300,
+    repos: 300,
+    prs: 300,
+    activity: 300,
+    issues: 300,
+    languages: 300,
+    streak: 300,
+  },
+  metricsCacheKey: vi.fn().mockReturnValue("test-cache-key"),
+  withMetricsCache: vi.fn().mockImplementation((_opts: unknown, fn: () => unknown) => fn()),
+}));
+
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/github-accounts", () => ({
+  getAccountToken: vi.fn().mockResolvedValue(null),
+  getAllAccounts: vi.fn().mockResolvedValue([]),
+  mergeMetrics: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: null,
+}));
+
+import { getServerSession } from "next-auth";
+
+const mockGetServerSession = vi.mocked(getServerSession);
+
+// ─── GitHubAuthError and githubAuthErrorResponse ──────────────────────────────
+
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
+
+describe("GitHubAuthError", () => {
+  it("has name GitHubAuthError and status 401", () => {
+    const err = new GitHubAuthError();
+    expect(err.name).toBe("GitHubAuthError");
+    expect(err.status).toBe(401);
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe("githubAuthErrorResponse", () => {
+  it("returns a 401 response with token_expired error body", async () => {
+    const res = githubAuthErrorResponse();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "token_expired" });
+  });
+});
+
+// ─── Metrics routes ───────────────────────────────────────────────────────────
+
+describe("/api/metrics/repos — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures (not a 401)", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "valid-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("GitHub API error");
+  });
+});
+
+describe("/api/metrics/issues — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/issues/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub search API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/issues/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+});

--- a/test/weekly-digest-cron-auth.test.ts
+++ b/test/weekly-digest-cron-auth.test.ts
@@ -149,18 +149,19 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
       { github_login: "alice", email: "alice@example.com" },
       { github_login: "bob", email: "bob@example.com" },
     ]);
-    mocks.resendFetch.mockResolvedValue({ ok: true });
+    mocks.resendFetch.mockResolvedValue({ ok: true, status: 200, text: async () => "" });
 
     const res = await GET(makeRequest("Bearer s3cr3t"));
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.sentCount).toBe(2);
+    expect(body.failedCount).toBe(0);
     // One POST to Resend for each user
     expect(mocks.resendFetch).toHaveBeenCalledTimes(2);
   });
 
-  it("counts sent emails even when RESEND_API_KEY is absent (no network call made)", async () => {
+  it("skips email send and does not count as sent when RESEND_API_KEY is absent", async () => {
     vi.stubEnv("CRON_SECRET", "s3cr3t");
     vi.stubEnv("RESEND_API_KEY", "");
     stubUsers([{ github_login: "charlie", email: "charlie@example.com" }]);
@@ -169,9 +170,8 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    // sentCount still increments so the response reflects how many users were
-    // eligible, but no external call is made
-    expect(body.sentCount).toBe(1);
+    expect(body.sentCount).toBe(0);
+    expect(body.failedCount).toBe(0);
     expect(mocks.resendFetch).not.toHaveBeenCalled();
   });
 
@@ -220,7 +220,7 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
     vi.stubEnv("CRON_SECRET", "s3cr3t");
     vi.stubEnv("RESEND_API_KEY", "resend-key");
     stubUsers([{ github_login: "devtracker", email: "devtracker@example.com" }]);
-    mocks.resendFetch.mockResolvedValue({ ok: true });
+    mocks.resendFetch.mockResolvedValue({ ok: true, status: 200, text: async () => "" });
 
     await GET(makeRequest("Bearer s3cr3t"));
 
@@ -231,5 +231,148 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
 
     expect(body.to).toBe("devtracker@example.com");
     expect(body.html).toContain("devtracker");
+  });
+});
+
+// ─── Delivery accounting (#1688) ─────────────────────────────────────────────
+
+describe("GET /api/cron/weekly-digest — delivery accounting (#1688)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv("CRON_SECRET", "s3cr3t");
+    vi.stubEnv("RESEND_API_KEY", "resend-key");
+  });
+
+  // ── successful delivery ───────────────────────────────────────────────────
+
+  it("increments sentCount and leaves failedCount at 0 on successful delivery", async () => {
+    stubUsers([{ github_login: "alice", email: "alice@example.com" }]);
+    mocks.resendFetch.mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    const body = await res.json();
+
+    expect(body.sentCount).toBe(1);
+    expect(body.failedCount).toBe(0);
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  // ── Resend error responses ────────────────────────────────────────────────
+
+  it("increments failedCount on Resend 422 (validation error) — not sentCount", async () => {
+    stubUsers([{ github_login: "alice", email: "alice@example.com" }]);
+    mocks.resendFetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => '{"name":"validation_error","message":"Invalid to field"}',
+    });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    const body = await res.json();
+
+    expect(body.sentCount).toBe(0);
+    expect(body.failedCount).toBe(1);
+    expect(res.status).toBe(200);
+  });
+
+  it("increments failedCount on Resend 429 (rate limited) — not sentCount", async () => {
+    stubUsers([{ github_login: "alice", email: "alice@example.com" }]);
+    mocks.resendFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => '{"message":"Too many requests"}',
+    });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    const body = await res.json();
+
+    expect(body.sentCount).toBe(0);
+    expect(body.failedCount).toBe(1);
+    expect(res.status).toBe(200);
+  });
+
+  it("increments failedCount on Resend 500 (server error) — not sentCount", async () => {
+    stubUsers([{ github_login: "alice", email: "alice@example.com" }]);
+    mocks.resendFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    const body = await res.json();
+
+    expect(body.sentCount).toBe(0);
+    expect(body.failedCount).toBe(1);
+    expect(res.status).toBe(200);
+  });
+
+  // ── network exception ─────────────────────────────────────────────────────
+
+  it("increments failedCount on network exception — does not throw or return 500", async () => {
+    stubUsers([{ github_login: "alice", email: "alice@example.com" }]);
+    mocks.resendFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    const body = await res.json();
+
+    expect(body.sentCount).toBe(0);
+    expect(body.failedCount).toBe(1);
+    expect(res.status).toBe(200);
+  });
+
+  // ── mixed batch ───────────────────────────────────────────────────────────
+
+  it("tracks sentCount and failedCount accurately across a mixed batch", async () => {
+    stubUsers([
+      { github_login: "alice", email: "alice@example.com" },
+      { github_login: "bob",   email: "bob@example.com" },
+      { github_login: "carol", email: "carol@example.com" },
+    ]);
+    mocks.resendFetch
+      .mockResolvedValueOnce({ ok: true,  status: 200, text: async () => "" })
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => "" })
+      .mockResolvedValueOnce({ ok: true,  status: 200, text: async () => "" });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    const body = await res.json();
+
+    expect(body.sentCount).toBe(2);
+    expect(body.failedCount).toBe(1);
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("continues processing remaining users after one send failure", async () => {
+    stubUsers([
+      { github_login: "alice", email: "alice@example.com" },
+      { github_login: "bob",   email: "bob@example.com" },
+    ]);
+    mocks.resendFetch
+      .mockRejectedValueOnce(new TypeError("network error"))
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => "" });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    const body = await res.json();
+
+    expect(mocks.resendFetch).toHaveBeenCalledTimes(2);
+    expect(body.sentCount).toBe(1);
+    expect(body.failedCount).toBe(1);
+  });
+
+  // ── response shape ────────────────────────────────────────────────────────
+
+  it("always includes failedCount in the response", async () => {
+    stubUsers([{ github_login: "alice", email: "alice@example.com" }]);
+    mocks.resendFetch.mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+
+    const res = await GET(makeRequest("Bearer s3cr3t"));
+    const body = await res.json();
+
+    expect(body).toHaveProperty("failedCount");
+    expect(body).toHaveProperty("sentCount");
+    expect(body).toHaveProperty("success");
   });
 });


### PR DESCRIPTION
Closes #1687
Closes #1847

---

## Issue #1687 — SSE stream unbounded polling load

### Root cause

`/api/stream` polled two Supabase tables every **2 seconds per open connection** with no concurrent connection limit and no mechanism to close zombie connections. Under concurrent usage this creates O(connections × queries/second) database load.

### Scalability analysis

| Metric | Before | After |
|---|---|---|
| Poll interval | 2 s | 15 s (7.5× reduction) |
| Max connections per user | Unlimited | 4 (HTTP 429 above cap) |
| Events when nothing changed | Every poll | Never |
| Zombie connection lifetime | Forever | 5 min idle / 30 min absolute |
| Heartbeat | None | Every 30 s |

### Connection management changes

- **Per-user cap**: `activeStreamConnections` map enforces `MAX_CONNECTIONS_PER_USER = 4`. Excess connections return `429` with `Retry-After: 30`.
- **Atomic slot accounting**: `releaseSlot()` with a `cleanedUp` guard prevents double-decrement when abort, idle-timeout, and max-age fire concurrently.
- **Single close path**: `closeStream()` guards with `isClosed`, clears all four timers atomically, always calls `releaseSlot()`.
- **Idle timeout** (`IDLE_TIMEOUT_MS = 5 min`): frees slots held by zombie connections.
- **Max-age ceiling** (`MAX_AGE_MS = 30 min`): forcibly recycles long-lived connections. `EventSource` reconnects within seconds.
- **Heartbeat** (`HEARTBEAT_INTERVAL_MS = 30 s`): `: heartbeat\n\n` comment keeps TCP alive; a failed enqueue triggers `closeStream()` immediately.

### Files changed

- `src/app/api/stream/route.ts` — heartbeat, idle-timeout, max-age, single close path, named exports
- `test/sse-stream-route.test.ts` — 5 new tests (20 total): constant values + fake-timer idle/max-age lifecycle

---

## Issue #1847 — Recurring goals silently erase completion history on reset

### Root cause

When a recurring goal's period boundary was crossed, `GET /api/goals` called `supabase.update({ current: 0, period_start })` directly with no prior archival step, permanently discarding the achieved value, target, and completion status for the expired period.

### Implementation

- Upsert into `goal_history` (unique on `goal_id, period_start`) before every reset. `ignoreDuplicates: true` makes concurrent resets idempotent.
- Fetch the most recent history row per recurring goal and attach as `last_period` in the GET response.
- `GoalTracker` renders `✓ N / M last period` or `✗ N / M last period` for recurring goals.
- `data-export` includes full `goal_history` records; `goal_history` is purged on account deletion.

### Schema changes

New table `goal_history`: `id`, `goal_id` (FK→goals, CASCADE), `user_id` (FK→users, CASCADE), `period_start`, `period_end`, `target`, `achieved_value`, `completed`, `created_at`. Unique constraint on `(goal_id, period_start)`. Two indexes for efficient lookups.

### Files changed

- `src/app/api/goals/route.ts` — archive upsert before reset, fetch/attach `last_period`
- `src/components/GoalTracker.tsx` — display ✓/✗ last-period summary
- `src/app/api/user/data-export/route.ts` — include `goalHistory` in exports + purge on delete
- `supabase/migrations/20260602000000_add_goal_history.sql` — new table migration
- `test/goal-history.test.ts` — 17 tests

---

## Verification

```
npm run lint        # warnings only, no errors
npm run type-check  # clean
npm run test test/sse-stream-route.test.ts   # 20/20 passed
npm run test test/goal-history.test.ts       # 17/17 passed
```
