### PR TITLE
"perf: cache package metadata lookups"

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -17,6 +17,7 @@ const FRAMEWORK_ALIASES = new Set([
   "next", "react", "react-dom",
   "server-only", "client-only",
 ]);
+const packageMetadataCache = new Map();
 
 function collectFiles(dir) {
   const out = [];
@@ -96,14 +97,22 @@ function loadInternalAliases(rootDir) {
 }
 function isValidPackageSubpath(pkgName, mod, cwd) {
   try {
-    const pkgJsonPath = require.resolve(
-      `${pkgName}/package.json`,
-      { paths: [cwd] }
-    );
+    let pkgJson;
 
-    const pkgJson = JSON.parse(
-      fs.readFileSync(pkgJsonPath, "utf8")
-    );
+    if (packageMetadataCache.has(pkgName)) {
+      pkgJson = packageMetadataCache.get(pkgName);
+    } else {
+      const pkgJsonPath = require.resolve(
+        `${pkgName}/package.json`,
+        { paths: [cwd] }
+      );
+
+      pkgJson = JSON.parse(
+        fs.readFileSync(pkgJsonPath, "utf8")
+      );
+
+      packageMetadataCache.set(pkgName, pkgJson);
+    }
 
     const exportsField = pkgJson.exports;
 


### PR DESCRIPTION
Summary

Cache package metadata during subpath validation to avoid repeated filesystem reads and JSON parsing for the same package.

Closes #1885 

---

Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / code cleanup

---

Changes Made

- Added an in-memory cache for package metadata
- Reused cached package.json data across validations
- Reduced repeated calls to "require.resolve()"
- Reduced repeated filesystem reads and JSON parsing
- Preserved existing validation behavior

---

How to Test

Steps for the reviewer to verify this works:

1. Run the dependency checker on a project containing multiple imports from the same package
2. Confirm the output matches the current implementation
3. Verify no regressions in subpath validation
4. Ensure all existing checks continue to pass

---

Screenshots (if UI change)

N/A

---

Checklist

- [x] Linked issue in summary
- [x] Self-reviewed the diff
- [x] No behavior changes introduced
- [ ] Added/updated tests if applicable

---

Additional Notes

This change is a performance optimization only. It reduces redundant package metadata lookups while maintaining the existing validation logic and output.