### PR TITLE
"fix: support aliases from extended tsconfig files"

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -63,6 +63,40 @@ function extractImports(src) {
 
   return imports;
 }
+function loadConfigWithExtends(configPath) {
+  const config = JSON.parse(
+    fs.readFileSync(configPath, "utf8")
+  );
+
+  if (!config.extends) {
+    return config;
+  }
+
+  const parentPath = path.resolve(
+    path.dirname(configPath),
+    config.extends
+  );
+
+  if (!fs.existsSync(parentPath)) {
+    return config;
+  }
+
+  const parentConfig =
+    loadConfigWithExtends(parentPath);
+
+  return {
+    ...parentConfig,
+    ...config,
+    compilerOptions: {
+      ...(parentConfig.compilerOptions || {}),
+      ...(config.compilerOptions || {}),
+      paths: {
+        ...(parentConfig.compilerOptions?.paths || {}),
+        ...(config.compilerOptions?.paths || {}),
+      },
+    },
+  };
+}
 function loadInternalAliases(rootDir) {
   const aliases = ["@/", "~/", "src/"];
 
@@ -74,9 +108,8 @@ function loadInternalAliases(rootDir) {
     if (!fs.existsSync(configPath)) continue;
 
     try {
-      const config = JSON.parse(
-        fs.readFileSync(configPath, "utf8")
-      );
+      const config =
+        loadConfigWithExtends(configPath);
 
       const paths = config.compilerOptions?.paths || {};
 


### PR DESCRIPTION
Summary

Adds support for path aliases defined in extended TypeScript and JavaScript configuration files.

Closes #1887 

---

Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

Changes Made

- Added support for resolving configuration files referenced through "extends"
- Merged path aliases from parent configurations
- Preserved local configuration precedence
- Improved alias detection for projects using shared base configs

---

How to Test

1. Create a "tsconfig.base.json" containing path aliases
2. Create a "tsconfig.json" that extends the base config
3. Import a module using one of the inherited aliases
4. Run the dependency checker
5. Verify the alias is not incorrectly reported as a missing dependency

---

Screenshots (if UI change)

N/A

---

Checklist

- [x] Linked issue in summary
- [x] Self-reviewed the diff
- [x] No TypeScript errors introduced
- [ ] Added/updated tests if applicable

---

Additional Notes

This fixes alias detection for projects that centralize configuration through shared TypeScript or JavaScript base configs.