### PR TITLE
fix(webhooks): harden github webhook signature verification

### DIFF
--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -1,8 +1,8 @@
-import { createHmac } from "crypto";
+
 import { revalidatePath } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
-import { safeCompare } from "./safe-compare";
+import { verifyGitHubSignature } from "@/lib/crypto";
 import { logError } from "@/lib/error-handler";
 import { sendSSEEvent } from "@/lib/sse";
 import { invalidateUserMetricsCache } from "@/lib/metrics-cache";
@@ -11,6 +11,10 @@ export const dynamic = "force-dynamic";
 
 const SIGNATURE_HEADER = "x-hub-signature-256";
 const GITHUB_EVENT_HEADER = "x-github-event";
+const DELIVERY_HEADER = "x-github-delivery";
+const REPLAY_WINDOW_MS = 5 * 60 * 1000;
+
+const recentDeliveries = new Map<string, number>();
 
 interface GitHubPushPayload {
   after?: string;
@@ -26,20 +30,25 @@ interface GitHubPushPayload {
   };
 }
 
-function getExpectedSignature(secret: string, body: string): string {
-  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
-}
-
-function verifyGitHubSignature(
-  body: string,
-  signature: string | null,
-  secret: string
-): boolean {
-  if (!signature?.startsWith("sha256=")) {
-    return false;
+function isReplayRequest(deliveryId: string | null): boolean {
+  if (!deliveryId) {
+    return true;
   }
 
-  return safeCompare(signature, getExpectedSignature(secret, body));
+  const now = Date.now();
+
+  for (const [id, timestamp] of recentDeliveries) {
+    if (now - timestamp > REPLAY_WINDOW_MS) {
+      recentDeliveries.delete(id);
+    }
+  }
+
+  if (recentDeliveries.has(deliveryId)) {
+    return true;
+  }
+
+  recentDeliveries.set(deliveryId, now);
+  return false;
 }
 
 function getPushActor(payload: GitHubPushPayload): string | null {
@@ -94,6 +103,14 @@ export async function POST(req: NextRequest) {
 
   const body = await req.text();
   const signature = req.headers.get(SIGNATURE_HEADER);
+  const deliveryId = req.headers.get(DELIVERY_HEADER);
+
+  if (isReplayRequest(deliveryId)) {
+    return NextResponse.json(
+      { error: "Replay request detected" },
+      { status: 401 }
+    );
+  }
 
   if (!verifyGitHubSignature(body, signature, secret)) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 401 });


### PR DESCRIPTION
## Summary

Improves GitHub webhook security by hardening signature verification and adding replay attack protection.

Closes #1610

---

## Type of Change

* [x] Security Fix
* [x] Bug Fix
* [ ] New Feature
* [ ] Documentation Update

---

## Changes Made

* Replaced local webhook signature verification with the centralized implementation from `src/lib/crypto.ts`
* Ensured constant-time signature comparison using Node.js `crypto.timingSafeEqual()`
* Reused the shared `verifyGitHubSignature()` utility to avoid duplicate security logic
* Added replay attack protection using the `X-GitHub-Delivery` header
* Added validation to reject duplicate webhook deliveries within a defined time window
* Improved maintainability by centralizing webhook verification behavior

---

## Security Improvements

* Prevents timing attacks during HMAC signature verification
* Enforces constant-time comparison for webhook signatures
* Rejects replayed webhook requests
* Reduces risk of unauthorized webhook execution and cache invalidation

---

## How to Test

1. Start the application locally
2. Send a webhook request with a valid GitHub signature
3. Verify the request is accepted
4. Send the same webhook again with the same delivery ID
5. Verify the request is rejected as a replay
6. Send a webhook with an invalid signature
7. Verify a `401 Unauthorized` response is returned

---

## Checklist

* [x] Linked issue in summary
* [x] Self-reviewed the changes
* [x] Security-related logic verified
* [x] No unnecessary files modified
* [x] Existing webhook functionality preserved


