### PR TITLE
feat(notifications): add mute notifications toggle for Discord webhook

### DIFF
--- a/src/app/api/notifications/discord-sync/route.ts
+++ b/src/app/api/notifications/discord-sync/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: Request) {
 
   const { data: users, error } = await supabaseAdmin
     .from("users")
-    .select("id, github_login, discord_webhook_url, timezone, last_discord_notification_at")
+    .select("id, github_login, discord_webhook_url, timezone, last_discord_notification_at, discord_muted_until")
     .not("discord_webhook_url", "is", null);
 
   if (error || !users) {
@@ -63,6 +63,13 @@ export async function GET(req: Request) {
     if (user.last_discord_notification_at) {
       const lastNotified = new Date(user.last_discord_notification_at);
       if (now.getTime() - lastNotified.getTime() < 20 * 60 * 60 * 1000) {
+        continue;
+      }
+    }
+
+    if (user.discord_muted_until) {
+      const mutedUntil = new Date(user.discord_muted_until);
+      if (mutedUntil.getTime() > now.getTime()) {
         continue;
       }
     }

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -12,7 +12,7 @@ async function fetchUserSettings(userId: string) {
   // Tier 1: All columns
   const res1 = await supabaseAdmin
     .from("users")
-    .select("id, github_login, bio, is_public, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, weekly_digest_opt_in, discord_webhook_url, timezone, webhook_url")
+    .select("id, github_login, bio, is_public, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, weekly_digest_opt_in, discord_webhook_url, timezone, webhook_url, discord_muted_until")
     .eq("id", userId)
     .single();
 
@@ -27,6 +27,7 @@ async function fetchUserSettings(userId: string) {
       hasDiscordSettings: true,
       hasBio: true,
       hasWebhookUrl: true,
+      hasDiscordMutedUntil: true,
       leaderboard_opt_in: (res1.data as any).leaderboard_opt_in ?? false,
       weekly_digest_opt_in: (res1.data as any).weekly_digest_opt_in ?? false,
       pinned_repos: (res1.data as any).pinned_repos || [],
@@ -35,6 +36,7 @@ async function fetchUserSettings(userId: string) {
       discord_webhook_url: (res1.data as any).discord_webhook_url || null,
       timezone: (res1.data as any).timezone || "UTC",
       webhook_url: (res1.data as any).webhook_url || null,
+      discord_muted_until: (res1.data as any).discord_muted_until || null,
     };
   }
 
@@ -49,6 +51,7 @@ async function fetchUserSettings(userId: string) {
       hasDiscordSettings: false,
       hasBio: false,
       hasWebhookUrl: false,
+      hasDiscordMutedUntil: false,
       leaderboard_opt_in: false,
       weekly_digest_opt_in: false,
       pinned_repos: [] as string[],
@@ -57,6 +60,7 @@ async function fetchUserSettings(userId: string) {
       discord_webhook_url: null,
       timezone: "UTC",
       webhook_url: null,
+      discord_muted_until: null,
     };
   }
 
@@ -78,6 +82,7 @@ async function fetchUserSettings(userId: string) {
       hasDiscordSettings: false,
       hasBio: false,
       hasWebhookUrl: true,
+      hasDiscordMutedUntil: false,
       leaderboard_opt_in: (res2.data as any).leaderboard_opt_in ?? false,
       weekly_digest_opt_in: false,
       pinned_repos: (res2.data as any).pinned_repos || [],
@@ -86,6 +91,7 @@ async function fetchUserSettings(userId: string) {
       discord_webhook_url: null,
       timezone: "UTC",
       webhook_url: (res2.data as any).webhook_url || null,
+      discord_muted_until: null,
     };
   }
 
@@ -100,6 +106,7 @@ async function fetchUserSettings(userId: string) {
       hasDiscordSettings: false,
       hasBio: false,
       hasWebhookUrl: false,
+      hasDiscordMutedUntil: false,
       leaderboard_opt_in: false,
       weekly_digest_opt_in: false,
       pinned_repos: [] as string[],
@@ -108,6 +115,7 @@ async function fetchUserSettings(userId: string) {
       discord_webhook_url: null,
       timezone: "UTC",
       webhook_url: null,
+      discord_muted_until: null,
     };
   }
 
@@ -128,6 +136,7 @@ async function fetchUserSettings(userId: string) {
       hasWeeklyDigestOptIn: false,
       hasDiscordSettings: false,
       hasBio: false,
+      hasDiscordMutedUntil: false,
       leaderboard_opt_in: false,
       weekly_digest_opt_in: false,
       pinned_repos: [] as string[],
@@ -135,6 +144,7 @@ async function fetchUserSettings(userId: string) {
       wakatime_api_key_iv: null,
       discord_webhook_url: null,
       timezone: "UTC",
+      discord_muted_until: null,
     };
   }
 
@@ -147,6 +157,7 @@ async function fetchUserSettings(userId: string) {
     hasWeeklyDigestOptIn: false,
     hasDiscordSettings: false,
     hasBio: false,
+    hasDiscordMutedUntil: false,
     leaderboard_opt_in: false,
     weekly_digest_opt_in: false,
     pinned_repos: [] as string[],
@@ -154,6 +165,7 @@ async function fetchUserSettings(userId: string) {
     wakatime_api_key_iv: null,
     discord_webhook_url: null,
     timezone: "UTC",
+    discord_muted_until: null,
   };
 }
 
@@ -191,6 +203,7 @@ export async function GET(req: NextRequest) {
     discord_webhook_url: result.discord_webhook_url,
     timezone: result.timezone,
     webhook_url: result.webhook_url ?? null,
+    discord_muted_until: result.discord_muted_until ?? null,
   });
 }
 
@@ -211,14 +224,14 @@ export async function PATCH(req: NextRequest) {
     );
   }
 
-  let body: { is_public?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key?: string; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null };
+  let body: { is_public?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key?: string; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null; discord_muted_until?: string | null };
   try {
     body = await req.json();
   } catch (e) {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const { is_public, leaderboard_opt_in, weekly_digest_opt_in, pinned_repos, wakatime_api_key, discord_webhook_url, timezone, bio, webhook_url } = body;
+  const { is_public, leaderboard_opt_in, weekly_digest_opt_in, pinned_repos, wakatime_api_key, discord_webhook_url, timezone, bio, webhook_url, discord_muted_until } = body;
 
   // Retrieve supported columns first
   const settingsResult = await fetchUserSettings(user.id);
@@ -227,8 +240,8 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Failed to update settings" }, { status: 500 });
   }
 
-  const { hasLeaderboardOptIn, hasPinnedRepos, hasWakatimeKey, hasWeeklyDigestOptIn, hasDiscordSettings, hasBio, hasWebhookUrl } = settingsResult;
-  const updates: { is_public?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key_encrypted?: string | null; wakatime_api_key_iv?: string | null; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null } = {};
+  const { hasLeaderboardOptIn, hasPinnedRepos, hasWakatimeKey, hasWeeklyDigestOptIn, hasDiscordSettings, hasBio, hasWebhookUrl, hasDiscordMutedUntil } = settingsResult;
+  const updates: { is_public?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key_encrypted?: string | null; wakatime_api_key_iv?: string | null; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null; discord_muted_until?: string | null } = {};
 
   if (is_public !== undefined && is_public !== null && typeof is_public === "boolean") {
     updates.is_public = is_public;
@@ -327,6 +340,12 @@ export async function PATCH(req: NextRequest) {
     }
   }
 
+  if (hasDiscordMutedUntil && discord_muted_until !== undefined) {
+    if (discord_muted_until === null || typeof discord_muted_until === "string") {
+      updates.discord_muted_until = discord_muted_until;
+    }
+  }
+
   // If there are no updates (or none that are supported by the schema)
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({
@@ -341,6 +360,7 @@ export async function PATCH(req: NextRequest) {
       discord_webhook_url: settingsResult.discord_webhook_url,
       timezone: settingsResult.timezone,
       webhook_url: settingsResult.webhook_url ?? null,
+      discord_muted_until: settingsResult.discord_muted_until ?? null,
     });
   }
 
@@ -355,6 +375,7 @@ export async function PATCH(req: NextRequest) {
     selectCols.push("wakatime_api_key_iv");
   }
   if (hasDiscordSettings) selectCols.push("discord_webhook_url", "timezone");
+  if (hasDiscordMutedUntil) selectCols.push("discord_muted_until");
   if (hasWebhookUrl) selectCols.push("webhook_url");
 
   const { data: updated, error: updateError } = await supabaseAdmin
@@ -397,5 +418,6 @@ export async function PATCH(req: NextRequest) {
     discord_webhook_url: (updated as any).discord_webhook_url,
     timezone: (updated as any).timezone || "UTC",
     webhook_url: (updated as any).webhook_url ?? null,
+    discord_muted_until: (updated as any).discord_muted_until ?? null,
   });
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -28,6 +28,7 @@ interface UserSettings {
   discord_webhook_url?: string;
   timezone?: string;
   pinned_repos?: string[];
+  discord_muted_until?: string | null;
 }
 
 interface LinkedAccount {
@@ -145,6 +146,8 @@ function SettingsPageContent() {
   const [timezone, setTimezone] = useState("");
   const [savingDiscord, setSavingDiscord] = useState(false);
   const [testingDiscord, setTestingDiscord] = useState(false);
+  const [discordMutedUntil, setDiscordMutedUntil] = useState<string | null>(null);
+  const [muteDuration, setMuteDuration] = useState<number>(1);
   const [isDirty, setIsDirty] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [pendingPath, setPendingPath] = useState<string | null>(null);
@@ -251,6 +254,7 @@ function SettingsPageContent() {
           setBioDraft(data.bio ?? "");
           setDiscordWebhook(data.discord_webhook_url || "");
           setTimezone(data.timezone || "UTC");
+          setDiscordMutedUntil(data.discord_muted_until ?? null);
           setWebhookUrl(data.webhook_url ?? null);
         }
       } catch (error) {
@@ -499,7 +503,7 @@ function SettingsPageContent() {
       const res = await fetch("/api/user/settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ discord_webhook_url: discordWebhook, timezone }),
+        body: JSON.stringify({ discord_webhook_url: discordWebhook, timezone, discord_muted_until: discordMutedUntil }),
       });
       if (res.ok) {
         const updated = await res.json();
@@ -541,6 +545,62 @@ function SettingsPageContent() {
       toast.error("Failed to send test notification");
     } finally {
       setTestingDiscord(false);
+    }
+  };
+
+  const handleMuteDiscord = async () => {
+    if (!settings) return;
+    const dayLabel = muteDuration === 1 ? "day" : "days";
+    const mutedUntil = new Date();
+    mutedUntil.setDate(mutedUntil.getDate() + muteDuration);
+    setSavingDiscord(true);
+    try {
+      const res = await fetch("/api/user/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ discord_muted_until: mutedUntil.toISOString() }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        setSettings(updated);
+        setDiscordMutedUntil(updated.discord_muted_until);
+        setIsDirty(false);
+        toast.success("Discord notifications muted for " + muteDuration + " " + dayLabel);
+      } else {
+        const err = await res.json();
+        toast.error(err.error || "Failed to mute notifications");
+      }
+    } catch (_err) {
+      console.error("mute error", _err);
+      toast.error("Failed to mute notifications");
+    } finally {
+      setSavingDiscord(false);
+    }
+  };
+
+  const handleUnmuteDiscord = async () => {
+    if (!settings) return;
+    setSavingDiscord(true);
+    try {
+      const res = await fetch("/api/user/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ discord_muted_until: null }),
+      });
+      const updated = await res.json();
+      if (!res.ok) {
+        toast.error(updated.error || "Failed to unmute notifications");
+        return;
+      }
+      setSettings(updated);
+      setDiscordMutedUntil(null);
+      setIsDirty(false);
+      toast.success("Discord notifications unmuted");
+    } catch (_err) {
+      console.error("unmute error", _err);
+      toast.error("Failed to unmute notifications");
+    } finally {
+      setSavingDiscord(false);
     }
   };
 
@@ -1398,6 +1458,55 @@ function SettingsPageContent() {
             <p className="mt-2 text-xs text-[var(--muted-foreground)]">
               Leave Webhook URL blank and click Save to unlink Discord.
             </p>
+
+            {discordWebhook && (
+              <div className="border-t border-[var(--border)]/60 pt-4 mt-4">
+                <h3 className="text-sm font-semibold text-[var(--card-foreground)] mb-3">
+                  Mute Notifications
+                </h3>
+                {discordMutedUntil && new Date(discordMutedUntil).getTime() > Date.now() ? (
+                  <div className="rounded-lg border border-[var(--border)] bg-[var(--control)] p-4">
+                    <p className="text-sm text-[var(--card-foreground)] mb-3">
+                      Muted until{" "}
+                      <span className="font-semibold">
+                        {new Intl.DateTimeFormat("en-US", {
+                          dateStyle: "long",
+                          timeStyle: "short",
+                        }).format(new Date(discordMutedUntil))}
+                      </span>
+                    </p>
+                    <button
+                      type="button"
+                      onClick={handleUnmuteDiscord}
+                      disabled={savingDiscord}
+                      className="px-4 py-2 rounded-lg border border-[var(--destructive-muted-border)] text-[var(--destructive)] text-sm font-medium hover:bg-[var(--destructive-muted)] transition-colors disabled:opacity-60"
+                    >
+                      {savingDiscord ? "Unmuting..." : "Unmute Now"}
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+                    <select
+                      value={muteDuration}
+                      onChange={(e) => setMuteDuration(Number(e.target.value))}
+                      className="rounded-lg border border-[var(--border)] bg-[var(--control)] px-4 py-2 text-sm text-[var(--card-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                    >
+                      <option value={1}>1 day</option>
+                      <option value={3}>3 days</option>
+                      <option value={7}>7 days</option>
+                    </select>
+                    <button
+                      type="button"
+                      onClick={handleMuteDiscord}
+                      disabled={savingDiscord}
+                      className="px-4 py-2 rounded-lg bg-[var(--accent)] text-[var(--accent-foreground)] text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-60"
+                    >
+                      {savingDiscord ? "Muting..." : "Mute Notifications"}
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
 

--- a/supabase/migrations/20260603000000_add_discord_muted_until.sql
+++ b/supabase/migrations/20260603000000_add_discord_muted_until.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS discord_muted_until TIMESTAMPTZ;

--- a/test/user-settings-api.test.ts
+++ b/test/user-settings-api.test.ts
@@ -147,6 +147,7 @@ describe("User Settings API Endpoints", () => {
         webhook_url: null,
         timezone: "UTC",
         bio: "",
+        discord_muted_until: null,
       });
     });
   });
@@ -233,6 +234,7 @@ describe("User Settings API Endpoints", () => {
         webhook_url: null,
         timezone: "UTC",
         bio: "",
+        discord_muted_until: null,
       });
       
       // Verify that no database updates were triggered (mockUpdate not called because updates is empty)
@@ -261,6 +263,7 @@ describe("User Settings API Endpoints", () => {
         webhook_url: null,
         timezone: "UTC",
         bio: "",
+        discord_muted_until: null,
       });
       
       // Verify update database query was called with the updates object


### PR DESCRIPTION
## Purpose & Rationale

Users on holiday or taking a break with streak freezes enabled still receive Discord streak reminders at 8 PM daily, creating unnecessary noise. This change introduces a configurable mute toggle that silences all Discord notifications for a user-chosen duration (1, 3, or 7 days) with automatic expiry, so the existing cron-based notification system requires no additional scheduling or cleanup logic.

## Technical Resolution Details

A nullable `discord_muted_until TIMESTAMPTZ` column was added to the `users` table via a new Supabase migration. The settings API (`src/app/api/user/settings/route.ts`) reads and writes this field using the same tiered column-detection pattern used for other schema additions, ensuring backward compatibility with older deployments. The Discord sync cron (`src/app/api/notifications/discord-sync/route.ts`) checks `discord_muted_until > now()` at line 70–75 before sending any notification — if the timestamp is in the future, the user is skipped entirely. The settings UI (`src/app/dashboard/settings/page.tsx`) renders a duration dropdown (1/3/7 days) and "Mute Notifications" button when no mute is active, or a "Muted until {date}" indicator with an "Unmute Now" button when a mute is in effect. Closes #1906.

## Local Testing Execution

1. `npm run lint` - passed (3 pre-existing warnings, 0 errors)  
2. `npm run type-check` - passed (0 errors)  
3. `npx vitest run test/user-settings-api.test.ts` - 11/11 tests passed  
4. `npx vitest run` - 76/81 test files passed (5 pre-existing failures in dateUtils, discord, github-accounts-api, goals-patch-integrity, and local-coding-stats - all unrelated)

## Desired Review Feedback Type

Logic correctness of the mute check placement in the cron loop and edge cases around timestamp parsing (timezone handling, boundary conditions when `discord_muted_until` exactly equals `now()`).

## Integrity & AI Usage Disclosure

In compliance with the GSSoC 2026 AI Conduct rules, I disclose that AI tools were used solely as learning and boilerplate aids. The final logic was fully reviewed, tested, and manually adapted to match human styling and clean-code design.