### PR TITLE
fix(rooms): sanitize message content before persistence

### DIFF
--- a/src/app/api/rooms/[roomId]/messages/route.ts
+++ b/src/app/api/rooms/[roomId]/messages/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { getRoomById, getRoomMessages, sendRoomMessage } from '@/lib/supabase';
+import { validateTextInput } from '@/lib/sanitize';
 import { NextResponse } from 'next/server';
 
 export async function GET(
@@ -27,16 +28,15 @@ export async function POST(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const room = await getRoomById(params.roomId, session.user.name);
   if (!room) return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  const { content } = await req.json();
-  if (!content?.trim())
-    return NextResponse.json({ error: 'Content required' }, { status: 400 });
-  if (content.length > 4000)
-    return NextResponse.json({ error: 'Message too long' }, { status: 400 });
+  const body = await req.json();
+  const validation = validateTextInput(body?.content, 'content', 4000);
+  if (!validation.ok)
+    return NextResponse.json({ error: validation.error }, { status: 400 });
   const message = await sendRoomMessage(
     params.roomId,
     session.user.name,
     session.user.image ?? null,
-    content.trim()
+    validation.value
   );
   return NextResponse.json(message, { status: 201 });
 }

--- a/test/rooms-messages.test.ts
+++ b/test/rooms-messages.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Regression tests for issue #1917 — room messages must be sanitized before
+ * persistence.
+ *
+ * The POST handler now passes content through validateTextInput() before
+ * calling sendRoomMessage().  This ensures:
+ *   - HTML tags are stripped
+ *   - Content that is empty after stripping is rejected
+ *   - The 4 000-character limit is applied to the stripped value
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── hoisted mocks ──────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  getRoomById: vi.fn(),
+  getRoomMessages: vi.fn(),
+  sendRoomMessage: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/supabase", () => ({
+  getRoomById: mocks.getRoomById,
+  getRoomMessages: mocks.getRoomMessages,
+  sendRoomMessage: mocks.sendRoomMessage,
+}));
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const SESSION = { user: { name: "alice", image: "https://example.com/a.png" } };
+const ROOM = { id: "room-1", name: "Dev chat" };
+const BASE_URL = "http://localhost/api/rooms/room-1/messages";
+
+function makePost(content: unknown): NextRequest {
+  return new NextRequest(BASE_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content }),
+  });
+}
+
+// ─── POST /api/rooms/[roomId]/messages ───────────────────────────────────────
+
+describe("POST /api/rooms/[roomId]/messages — message sanitization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue(SESSION);
+    mocks.getRoomById.mockResolvedValue(ROOM);
+    mocks.sendRoomMessage.mockResolvedValue({
+      id: "msg-1",
+      room_id: "room-1",
+      sender_username: "alice",
+      sender_avatar: SESSION.user.image,
+      content: "Hello",
+      created_at: new Date().toISOString(),
+    });
+  });
+
+  // ── authentication & room access ─────────────────────────────────────────
+
+  it("returns 401 when unauthenticated", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost("Hello"), {
+      params: { roomId: "room-1" },
+    });
+    expect(res.status).toBe(401);
+    expect(mocks.sendRoomMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the room does not exist", async () => {
+    mocks.getRoomById.mockResolvedValue(null);
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost("Hello"), {
+      params: { roomId: "nonexistent" },
+    });
+    expect(res.status).toBe(404);
+    expect(mocks.sendRoomMessage).not.toHaveBeenCalled();
+  });
+
+  // ── plain text ────────────────────────────────────────────────────────────
+
+  it("stores a plain-text message and returns 201", async () => {
+    mocks.sendRoomMessage.mockResolvedValue({
+      id: "msg-1",
+      room_id: "room-1",
+      sender_username: "alice",
+      sender_avatar: SESSION.user.image,
+      content: "Hello world",
+      created_at: new Date().toISOString(),
+    });
+
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost("Hello world"), {
+      params: { roomId: "room-1" },
+    });
+
+    expect(res.status).toBe(201);
+    expect(mocks.sendRoomMessage).toHaveBeenCalledWith(
+      "room-1",
+      "alice",
+      SESSION.user.image,
+      "Hello world"
+    );
+  });
+
+  // ── HTML stripping — regression for #1917 ────────────────────────────────
+
+  it("strips HTML tags before storing — regression for #1917", async () => {
+    mocks.sendRoomMessage.mockResolvedValue({
+      id: "msg-2",
+      room_id: "room-1",
+      sender_username: "alice",
+      sender_avatar: null,
+      content: "Hello",
+      created_at: new Date().toISOString(),
+    });
+
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost("<b>Hello</b>"), {
+      params: { roomId: "room-1" },
+    });
+
+    expect(res.status).toBe(201);
+    // sendRoomMessage must receive the stripped value, not the raw HTML
+    expect(mocks.sendRoomMessage).toHaveBeenCalledWith(
+      "room-1",
+      "alice",
+      SESSION.user.image,
+      "Hello"
+    );
+  });
+
+  it("strips <script> tags before storing — regression for #1917", async () => {
+    // stripHtml removes tags but preserves inner text.
+    // <script>alert(1)</script> → "alert(1)" (tag removed, text kept).
+    // The dangerous element (the script tag itself) is never stored.
+    mocks.sendRoomMessage.mockResolvedValue({
+      id: "msg-6",
+      room_id: "room-1",
+      sender_username: "alice",
+      sender_avatar: null,
+      content: "alert(1)",
+      created_at: new Date().toISOString(),
+    });
+
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost("<script>alert(1)</script>"), {
+      params: { roomId: "room-1" },
+    });
+
+    expect(res.status).toBe(201);
+    expect(mocks.sendRoomMessage).toHaveBeenCalledWith(
+      "room-1",
+      "alice",
+      SESSION.user.image,
+      "alert(1)"
+    );
+  });
+
+  it("strips mixed HTML and text — stores only the text portion", async () => {
+    mocks.sendRoomMessage.mockResolvedValue({
+      id: "msg-3",
+      room_id: "room-1",
+      sender_username: "alice",
+      sender_avatar: null,
+      content: "click here",
+      created_at: new Date().toISOString(),
+    });
+
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(
+      makePost('<a href="javascript:void(0)">click here</a>'),
+      { params: { roomId: "room-1" } }
+    );
+
+    expect(res.status).toBe(201);
+    expect(mocks.sendRoomMessage).toHaveBeenCalledWith(
+      "room-1",
+      "alice",
+      SESSION.user.image,
+      "click here"
+    );
+  });
+
+  // ── empty / whitespace rejection ─────────────────────────────────────────
+
+  it("returns 400 when content is missing", async () => {
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(
+      new NextRequest(BASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+      { params: { roomId: "room-1" } }
+    );
+    expect(res.status).toBe(400);
+    expect(mocks.sendRoomMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when content is empty string", async () => {
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost(""), { params: { roomId: "room-1" } });
+    expect(res.status).toBe(400);
+    expect(mocks.sendRoomMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when content is whitespace only", async () => {
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost("   \t\n  "), {
+      params: { roomId: "room-1" },
+    });
+    expect(res.status).toBe(400);
+    expect(mocks.sendRoomMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when content becomes empty after HTML stripping — regression for #1917", async () => {
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    // Tags only, no visible text
+    const res = await POST(makePost("<div><span></span></div>"), {
+      params: { roomId: "room-1" },
+    });
+    expect(res.status).toBe(400);
+    expect(mocks.sendRoomMessage).not.toHaveBeenCalled();
+  });
+
+  // ── length validation ─────────────────────────────────────────────────────
+
+  it("returns 400 when content exceeds 4000 characters", async () => {
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost("x".repeat(4001)), {
+      params: { roomId: "room-1" },
+    });
+    expect(res.status).toBe(400);
+    expect(mocks.sendRoomMessage).not.toHaveBeenCalled();
+  });
+
+  it("accepts content exactly at 4000 characters", async () => {
+    const longContent = "x".repeat(4000);
+    mocks.sendRoomMessage.mockResolvedValue({
+      id: "msg-4",
+      room_id: "room-1",
+      sender_username: "alice",
+      sender_avatar: null,
+      content: longContent,
+      created_at: new Date().toISOString(),
+    });
+
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost(longContent), {
+      params: { roomId: "room-1" },
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("length check is applied to stripped content, not raw input", async () => {
+    // Wrap 100 chars in a tag — raw length is >100 but stripped is 100
+    const text = "a".repeat(100);
+    const raw = `<b>${text}</b>`; // raw length = 103, stripped = 100
+    mocks.sendRoomMessage.mockResolvedValue({
+      id: "msg-5",
+      room_id: "room-1",
+      sender_username: "alice",
+      sender_avatar: null,
+      content: text,
+      created_at: new Date().toISOString(),
+    });
+
+    const { POST } = await import(
+      "@/app/api/rooms/[roomId]/messages/route"
+    );
+    const res = await POST(makePost(raw), { params: { roomId: "room-1" } });
+    expect(res.status).toBe(201);
+    expect(mocks.sendRoomMessage).toHaveBeenCalledWith(
+      "room-1",
+      "alice",
+      SESSION.user.image,
+      text
+    );
+  });
+});


### PR DESCRIPTION
Closes #1917

## Root cause

`POST /api/rooms/[roomId]/messages` stored the raw `content` value from the request body after only a `.trim()` and a character-count check. HTML tags were never stripped before the value was persisted in `room_messages` or broadcast to subscribers via Supabase Realtime.

## Security impact

A user could submit content containing HTML markup (`<script>`, `<img onerror=...>`, anchor `href`s, etc.) and those tags would be stored verbatim in the database. While React's JSX escaping prevents direct script execution in `MessageFeed`, the unsanitized content is exposed in:

- the stored database record
- the JSON response from the GET endpoint
- Supabase Realtime broadcast payloads consumed by all connected clients
- any future non-React consumer (REST clients, data exports, rich-text renderers)

## Sanitization changes

**`src/app/api/rooms/[roomId]/messages/route.ts`**

Replaced the manual `content.trim()` + length check with a call to `validateTextInput()` from `@/lib/sanitize` — the same utility already used by the `daily-focus` and `goals` routes:

```ts
// Before
const { content } = await req.json();
if (!content?.trim()) return ...400...;
if (content.length > 4000) return ...400...;
const message = await sendRoomMessage(..., content.trim());

// After
const body = await req.json();
const validation = validateTextInput(body?.content, 'content', 4000);
if (!validation.ok) return NextResponse.json({ error: validation.error }, { status: 400 });
const message = await sendRoomMessage(..., validation.value);
```

`validateTextInput` strips all HTML tags via `stripHtml()`, then checks that the result is non-empty and within the length limit. `validation.value` is the sanitized, trimmed string that is persisted.

## Tests added

`test/rooms-messages.test.ts` — 13 regression tests:

| Test | Expected |
|------|----------|
| Unauthenticated request | 401 |
| Room not found | 404 |
| Plain-text message | 201, stored verbatim |
| `<b>Hello</b>` | 201, stored as `"Hello"` |
| `<script>alert(1)</script>` | 201, stored as `"alert(1)"` (tag stripped) |
| Mixed HTML + text | 201, only text stored |
| Missing content | 400 |
| Empty string | 400 |
| Whitespace-only | 400 |
| Tags-only after strip | 400 |
| Content > 4 000 chars | 400 |
| Content exactly 4 000 chars | 201 |
| Length checked after stripping | 201 (raw > stripped length) |

## Verification

```
next lint     # warnings only (pre-existing), no errors
tsc --noEmit  # clean
vitest run test/rooms-messages.test.ts  # 13/13 passed
```
