### PR TITLE
fix: guard contribution graph zero commits

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -58,6 +58,29 @@ const charts: { key: ViewMode; label: string }[] = [
   { key: "area", label: "Area" },
 ];
 
+function normalizeCommitCount(count: unknown): number {
+  const numericCount = Number(count ?? 0);
+
+  if (!Number.isFinite(numericCount) || numericCount <= 0) {
+    return 0;
+  }
+
+  return numericCount;
+}
+
+function normalizeContributionData(data: Record<string, number>): DayData[] {
+  return Object.entries(data)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([day, commits]) => ({
+      day,
+      commits: normalizeCommitCount(commits),
+    }));
+}
+
+function getTotalCommits(data: DayData[]): number {
+  return data.reduce((total, day) => total + normalizeCommitCount(day.commits), 0);
+}
+
 function mergeContributionData(
   myData: DayData[],
   friendData: DayData[]
@@ -67,7 +90,7 @@ function mergeContributionData(
   myData.forEach(d => {
     map.set(d.day, {
       date: d.day,
-      you: d.commits,
+      you: normalizeCommitCount(d.commits),
       friend: 0,
     });
   });
@@ -77,10 +100,10 @@ function mergeContributionData(
       map.set(d.day, {
         date: d.day,
         you: 0,
-        friend: d.commits,
+        friend: normalizeCommitCount(d.commits),
       });
     } else {
-      map.get(d.day)!.friend = d.commits;
+      map.get(d.day)!.friend = normalizeCommitCount(d.commits);
     }
   });
 
@@ -100,7 +123,7 @@ function mergeContributionSources(
   const merged = { ...github };
 
   for (const [day, commits] of Object.entries(gitlab)) {
-    merged[day] = (merged[day] ?? 0) + commits;
+    merged[day] = normalizeCommitCount(merged[day]) + normalizeCommitCount(commits);
   }
 
   return merged;
@@ -249,9 +272,7 @@ export default function ContributionGraph() {
           res.sources,
           res.data ?? {}
         );
-        const sorted = Object.entries(merged)
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([day, commits]) => ({ day, commits }));
+        const sorted = normalizeContributionData(merged);
 
         setData(sorted);
         setCommits(res.commits ?? []);
@@ -316,9 +337,7 @@ export default function ContributionGraph() {
         return r.json();
       })
       .then((res: { data: Record<string, number> }) => {
-        const sorted = Object.entries(res.data ?? {})
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([day, commits]) => ({ day, commits }));
+        const sorted = normalizeContributionData(res.data ?? {});
         setFriendData(sorted);
       })
       .catch(() => {
@@ -447,6 +466,9 @@ export default function ContributionGraph() {
   const displayData = compareMode ? mergedData : data;
   const hasFriendData = compareMode && friendData.length > 0 && !compareError;
   const tooltipTrigger = usesTouchTooltip ? "click" : "hover";
+  const totalCommits = compareMode
+    ? getTotalCommits(data)
+    : getTotalCommits(displayData as DayData[]);
 
   return (
     <div
@@ -463,6 +485,11 @@ export default function ContributionGraph() {
           )}
           {compareMode && compareLoading && (
             <p className="text-xs text-[var(--muted-foreground)] mt-1">Loading friend data...</p>
+          )}
+          {!compareMode && !loading && !error && (
+            <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+              {totalCommits} commit{totalCommits === 1 ? "" : "s"}
+            </p>
           )}
         </div>
 

--- a/test/ContributionGraph.test.ts
+++ b/test/ContributionGraph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import ContributionGraph from '@/components/ContributionGraph';
 import { get, set } from 'idb-keyval';
@@ -86,6 +86,43 @@ describe('ContributionGraph - IndexedDB Caching and Background Sync', () => {
         })
       );
     });
+  });
+
+  it('renders zero commits instead of NaN for empty contribution ranges', async () => {
+    vi.mocked(get).mockResolvedValue(undefined);
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('/api/metrics/contributions')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            data: {
+              '2026-05-30': undefined,
+            },
+            commits: [],
+            sources: {
+              github: {
+                '2026-05-30': undefined,
+              },
+            },
+          }),
+        } as Response);
+      }
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ repos: [] }),
+      } as Response);
+    }));
+
+    render(React.createElement(ContributionGraph));
+
+    await waitFor(() => {
+      expect(screen.getByText('0 commits')).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/NaN commits/i)).toBeNull();
   });
 
   it('hydrates locally and bypasses network fetch when cache is fresh (< 1 hour)', async () => {


### PR DESCRIPTION
Closes #1889

## Summary
- Normalize contribution counts before chart/compare rendering so undefined, non-finite, or negative values become 0.
- Show a finite total count in the ContributionGraph header for zero-commit ranges.
- Add a regression test that verifies empty/undefined contribution ranges render `0 commits` instead of `NaN commits`.

## Validation
- `npx vitest run test/ContributionGraph.test.ts`
- `npm run type-check`
- `npm run lint`
- `git diff --check`

Note: `npm run lint` passes with existing warnings in unrelated files:
- `src/app/api/og/user/route.tsx`
- `src/components/DailyNoteWidget.tsx`
