### PR TITLE
feat(achievements): add progress estimation for locked achievements

### DIFF
--- a/src/app/api/metrics/achievement-progress/route.ts
+++ b/src/app/api/metrics/achievement-progress/route.ts
@@ -1,0 +1,129 @@
+﻿import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
+import {
+  isMetricsCacheBypassed,
+  METRICS_CACHE_TTL_SECONDS,
+  metricsCacheKey,
+  withMetricsCache,
+} from "@/lib/metrics-cache";
+import { resolveAppUser } from "@/lib/resolve-user";
+import {
+  buildLockedAchievementProgress,
+  type AchievementProgressInfo,
+} from "@/lib/achievement-progress";
+
+export const dynamic = "force-dynamic";
+
+// --- GraphQL query -----------------------------------------------------------
+
+/**
+ * Single round-trip that fetches the two metrics used as proxies:
+ *   - Total merged pull requests the viewer has opened
+ *   - Total discussion comments marked as accepted answers by the viewer
+ */
+const ACHIEVEMENT_PROGRESS_QUERY = `
+  query AchievementProgress {
+    viewer {
+      pullRequests(states: [MERGED]) {
+        totalCount
+      }
+      repositoryDiscussionComments(onlyAnswers: true) {
+        totalCount
+      }
+    }
+  }
+`;
+
+interface AchievementProgressQueryResult {
+  data?: {
+    viewer?: {
+      pullRequests?: { totalCount?: number | null } | null;
+      repositoryDiscussionComments?: { totalCount?: number | null } | null;
+    } | null;
+  };
+  errors?: Array<{ message?: string }>;
+}
+
+// --- Data fetcher ------------------------------------------------------------
+
+async function fetchAchievementMetrics(
+  token: string,
+  userId: string,
+  bypass: boolean
+): Promise<{ mergedPRs: number; acceptedAnswers: number }> {
+  const key = metricsCacheKey(userId, "achievement-progress");
+
+  return withMetricsCache(
+    {
+      bypass,
+      key,
+      ttlSeconds: METRICS_CACHE_TTL_SECONDS["achievement-progress"],
+    },
+    async () => {
+      const response = await fetch("https://api.github.com/graphql", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ query: ACHIEVEMENT_PROGRESS_QUERY }),
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) throw new GitHubAuthError();
+        throw new Error(`GitHub GraphQL error: ${response.status}`);
+      }
+
+      const json = (await response.json()) as AchievementProgressQueryResult;
+
+      if (json.errors?.length) {
+        throw new Error(json.errors[0]?.message ?? "GraphQL error");
+      }
+
+      const viewer = json.data?.viewer;
+      return {
+        mergedPRs: viewer?.pullRequests?.totalCount ?? 0,
+        acceptedAnswers: viewer?.repositoryDiscussionComments?.totalCount ?? 0,
+      };
+    }
+  );
+}
+
+// --- Route handler -----------------------------------------------------------
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.accessToken || !session.githubId || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const bypass = isMetricsCacheBypassed(req);
+
+  let metrics: { mergedPRs: number; acceptedAnswers: number } | null;
+  try {
+    metrics = await fetchAchievementMetrics(session.accessToken, user.id, bypass);
+  } catch (err) {
+    if (err instanceof GitHubAuthError) {
+      return githubAuthErrorResponse();
+    }
+    console.error("[achievement-progress] fetch error", err);
+    // Return graceful degradation instead of hard error.
+    metrics = null;
+  }
+
+  const progress: AchievementProgressInfo[] = buildLockedAchievementProgress(
+    metrics,
+    new Set<string>()
+  );
+
+  return Response.json(progress);
+}

--- a/src/components/GitHubAchievementProgress.tsx
+++ b/src/components/GitHubAchievementProgress.tsx
@@ -1,0 +1,133 @@
+﻿"use client";
+
+import { useEffect, useState } from "react";
+import type { AchievementProgressInfo } from "@/lib/achievement-progress";
+
+type FetchState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "success"; items: AchievementProgressInfo[] };
+
+function ProgressBar({ percent }: { percent: number }) {
+  const clamped = Math.min(100, Math.max(0, percent));
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className="h-2 w-full overflow-hidden rounded-full bg-[var(--border)]"
+    >
+      <div
+        className="h-full rounded-full bg-[var(--accent)] transition-[width] duration-500"
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}
+
+function AchievementCard({ item }: { item: AchievementProgressInfo }) {
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--control)] p-4">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-[var(--card-foreground)]">
+          {item.title}
+        </span>
+        {item.dataAvailable && item.nextMilestone && (
+          <span className="rounded-full bg-[var(--border)] px-2 py-0.5 text-xs text-[var(--muted-foreground)]">
+            {item.nextMilestone.tier}
+          </span>
+        )}
+      </div>
+
+      {item.dataAvailable ? (
+        <>
+          <ProgressBar percent={item.progressPercent ?? 0} />
+          <p className="mt-1.5 text-xs text-[var(--muted-foreground)]">
+            {item.progressDescription ?? ""}
+          </p>
+        </>
+      ) : (
+        <p className="text-xs text-[var(--muted-foreground)] italic">
+          Progress unavailable
+        </p>
+      )}
+    </div>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div
+      aria-hidden="true"
+      className="h-20 animate-pulse rounded-lg bg-[var(--card-muted)]"
+    />
+  );
+}
+
+export default function GitHubAchievementProgress() {
+  const [state, setState] = useState<FetchState>({ status: "idle" });
+
+  useEffect(() => {
+    setState({ status: "loading" });
+
+    fetch("/api/metrics/achievement-progress")
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        return res.json() as Promise<AchievementProgressInfo[]>;
+      })
+      .then((items) => setState({ status: "success", items }))
+      .catch((err: unknown) => {
+        setState({
+          status: "error",
+          message:
+            err instanceof Error ? err.message : "Failed to load progress",
+        });
+      });
+  }, []);
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="mb-1 text-lg font-semibold text-[var(--card-foreground)]">
+        Achievement Progress
+      </h2>
+      <p className="mb-4 text-xs text-[var(--muted-foreground)]">
+        Estimated progress for locked GitHub achievements
+      </p>
+
+      {state.status === "loading" || state.status === "idle" ? (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="space-y-3"
+        >
+          <span className="sr-only">Loading achievement progress</span>
+          {[1, 2, 3, 4].map((i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      ) : state.status === "error" ? (
+        <p className="text-sm text-[var(--muted-foreground)]">
+          Achievement progress could not be loaded right now.
+        </p>
+      ) : state.items.length === 0 ? (
+        <p className="text-sm text-[var(--muted-foreground)]">
+          All tracked achievements have been unlocked!
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {state.items.map((item) => (
+            <AchievementCard key={item.slug} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/CustomizableDashboard.tsx
+++ b/src/components/dashboard/CustomizableDashboard.tsx
@@ -151,6 +151,11 @@ const FriendComparison = dynamic(() => import("@/components/FriendComparison"), 
   loading: () => <RepoWidgetSkeleton />,
 });
 
+const GitHubAchievementProgress = dynamic(
+  () => import("@/components/GitHubAchievementProgress"),
+  { ssr: false, loading: () => <SkeletonCard /> },
+);
+
 const ActivityRingChart = dynamic(
   () => import("@/components/ActivityRingChart"),
   { ssr: false, loading: () => <ChartSkeleton /> },
@@ -418,6 +423,13 @@ const renderDashboardWidget = (widgetId: DashboardWidgetId): ReactNode => {
       return (
         <LazyWidget fallback={<RepoWidgetSkeleton />}>
           <FriendComparison />
+        </LazyWidget>
+      );
+
+    case "achievement-progress":
+      return (
+        <LazyWidget fallback={<SkeletonCard />}>
+          <GitHubAchievementProgress />
         </LazyWidget>
       );
 

--- a/src/lib/achievement-progress.ts
+++ b/src/lib/achievement-progress.ts
@@ -1,0 +1,221 @@
+﻿/**
+ * Evidence-based progress estimator for locked GitHub achievements.
+ *
+ * Only achievements that have a reliable proxy in the GitHub API are given a
+ * percentage; the rest surface "Progress unavailable" rather than fabricating
+ * a number.
+ *
+ * Estimation strategy
+ * -------------------
+ *  Pull Shark           viewer.pullRequests(states:[MERGED]).totalCount
+ *                       Bronze >= 2  ·  Silver >= 16  ·  Gold >= 128
+ *
+ *  Galaxy Brain         viewer.repositoryDiscussionComments(onlyAnswers:true).totalCount
+ *                       Bronze >= 2  ·  Silver >= 8   ·  Gold >= 16
+ *
+ *  Quickdraw            No public API proxy  -> dataAvailable: false
+ *  Pair Extraordinaire  No public API proxy  -> dataAvailable: false
+ */
+
+export interface AchievementMilestone {
+  tier: "Bronze" | "Silver" | "Gold";
+  threshold: number;
+}
+
+export interface AchievementProgressInfo {
+  /** GitHub achievement slug (lower-kebab-case). */
+  slug: string;
+  /** Human-readable display name. */
+  title: string;
+  /**
+   * True when the API exposes a reliable proxy metric.
+   * False -> display "Progress unavailable" rather than a progress bar.
+   */
+  dataAvailable: boolean;
+  /** Raw count from the API (only present when dataAvailable is true). */
+  currentValue?: number;
+  /** The next milestone the user is working towards. Absent when all tiers earned. */
+  nextMilestone?: AchievementMilestone;
+  /**
+   * Progress towards nextMilestone as a percentage [0, 100].
+   * Clamped so it never exceeds 100 even when currentValue > threshold.
+   */
+  progressPercent?: number;
+  /** Short human-readable label, e.g. "12 / 16 merged PRs". */
+  progressDescription?: string;
+}
+
+// --- Pull Shark milestones ---------------------------------------------------
+
+const PULL_SHARK_MILESTONES: AchievementMilestone[] = [
+  { tier: "Bronze", threshold: 2 },
+  { tier: "Silver", threshold: 16 },
+  { tier: "Gold", threshold: 128 },
+];
+
+// --- Galaxy Brain milestones -------------------------------------------------
+
+const GALAXY_BRAIN_MILESTONES: AchievementMilestone[] = [
+  { tier: "Bronze", threshold: 2 },
+  { tier: "Silver", threshold: 8 },
+  { tier: "Gold", threshold: 16 },
+];
+
+// --- Helpers -----------------------------------------------------------------
+
+/**
+ * Given the user's current count and an ordered list of milestones (ascending),
+ * return the next milestone they have not yet reached plus their progress
+ * percentage towards it.
+ *
+ * If the user has passed the previous milestone:
+ *   prevThreshold = that milestone's threshold (or 0 for the first tier)
+ *   progress = (current - prevThreshold) / (next.threshold - prevThreshold)
+ *
+ * Returns progressPercent = 100 and nextMilestone = undefined when all tiers
+ * have been reached.
+ */
+export function computeMilestoneProgress(
+  current: number,
+  milestones: AchievementMilestone[]
+): { nextMilestone: AchievementMilestone | undefined; progressPercent: number } {
+  if (milestones.length === 0) {
+    return { nextMilestone: undefined, progressPercent: 100 };
+  }
+
+  for (let i = 0; i < milestones.length; i++) {
+    const milestone = milestones[i];
+    if (current < milestone.threshold) {
+      const prevThreshold = i === 0 ? 0 : milestones[i - 1].threshold;
+      const range = milestone.threshold - prevThreshold;
+      const progress = Math.min(
+        100,
+        Math.max(0, Math.floor(((current - prevThreshold) / range) * 100))
+      );
+      return { nextMilestone: milestone, progressPercent: progress };
+    }
+  }
+
+  return { nextMilestone: undefined, progressPercent: 100 };
+}
+
+// --- Per-achievement estimators ----------------------------------------------
+
+/**
+ * Estimate Pull Shark progress from the total count of merged pull requests.
+ */
+export function estimatePullSharkProgress(mergedPRs: number): AchievementProgressInfo {
+  const { nextMilestone, progressPercent } = computeMilestoneProgress(
+    mergedPRs,
+    PULL_SHARK_MILESTONES
+  );
+
+  const label = nextMilestone
+    ? `${mergedPRs} / ${nextMilestone.threshold} merged PRs`
+    : `${mergedPRs} merged PRs (all tiers reached)`;
+
+  return {
+    slug: "pull-shark",
+    title: "Pull Shark",
+    dataAvailable: true,
+    currentValue: mergedPRs,
+    nextMilestone,
+    progressPercent,
+    progressDescription: label,
+  };
+}
+
+/**
+ * Estimate Galaxy Brain progress from the count of discussion comments marked
+ * as accepted answers.
+ */
+export function estimateGalaxyBrainProgress(
+  acceptedAnswers: number
+): AchievementProgressInfo {
+  const { nextMilestone, progressPercent } = computeMilestoneProgress(
+    acceptedAnswers,
+    GALAXY_BRAIN_MILESTONES
+  );
+
+  const label = nextMilestone
+    ? `${acceptedAnswers} / ${nextMilestone.threshold} accepted answers`
+    : `${acceptedAnswers} accepted answers (all tiers reached)`;
+
+  return {
+    slug: "galaxy-brain",
+    title: "Galaxy Brain",
+    dataAvailable: true,
+    currentValue: acceptedAnswers,
+    nextMilestone,
+    progressPercent,
+    progressDescription: label,
+  };
+}
+
+/**
+ * Quickdraw has no public API proxy (closing speed relative to open time is
+ * not queryable). Returns a stub with dataAvailable: false.
+ */
+export function getQuickdrawProgress(): AchievementProgressInfo {
+  return {
+    slug: "quickdraw",
+    title: "Quickdraw",
+    dataAvailable: false,
+  };
+}
+
+/**
+ * Pair Extraordinaire requires co-authored commit data which is not exposed
+ * via the public GitHub API. Returns a stub with dataAvailable: false.
+ */
+export function getPairExtraordinaireProgress(): AchievementProgressInfo {
+  return {
+    slug: "pair-extraordinaire",
+    title: "Pair Extraordinaire",
+    dataAvailable: false,
+  };
+}
+
+// --- Orchestrator ------------------------------------------------------------
+
+/**
+ * Build the full set of locked-achievement progress objects.
+ *
+ * Achievements whose slug appears in `unlockedSlugs` are omitted — they are
+ * already displayed in the main achievements panel.
+ *
+ * @param data           Metrics retrieved from the GitHub API.
+ * @param unlockedSlugs  Slugs of achievements the user has already unlocked.
+ */
+export function buildLockedAchievementProgress(
+  data: { mergedPRs: number; acceptedAnswers: number } | null,
+  unlockedSlugs: Set<string>
+): AchievementProgressInfo[] {
+  const results: AchievementProgressInfo[] = [];
+
+  if (!unlockedSlugs.has("pull-shark")) {
+    results.push(
+      data !== null
+        ? estimatePullSharkProgress(data.mergedPRs)
+        : { slug: "pull-shark", title: "Pull Shark", dataAvailable: false }
+    );
+  }
+
+  if (!unlockedSlugs.has("galaxy-brain")) {
+    results.push(
+      data !== null
+        ? estimateGalaxyBrainProgress(data.acceptedAnswers)
+        : { slug: "galaxy-brain", title: "Galaxy Brain", dataAvailable: false }
+    );
+  }
+
+  if (!unlockedSlugs.has("quickdraw")) {
+    results.push(getQuickdrawProgress());
+  }
+
+  if (!unlockedSlugs.has("pair-extraordinaire")) {
+    results.push(getPairExtraordinaireProgress());
+  }
+
+  return results;
+}

--- a/src/lib/dashboard-layout.ts
+++ b/src/lib/dashboard-layout.ts
@@ -36,7 +36,8 @@ export type DashboardWidgetId =
   | "recent-activity"
   | "ci-analytics"
   | "language-breakdown"
-  | "friend-comparison";
+  | "friend-comparison"
+  | "achievement-progress";
 
 export interface DashboardLayoutPreference {
   version: 1;
@@ -90,6 +91,7 @@ export const DASHBOARD_WIDGET_LABELS: Record<DashboardWidgetId, string> = {
   "ci-analytics": "CI Analytics",
   "language-breakdown": "Language Breakdown",
   "friend-comparison": "Friend Comparison",
+  "achievement-progress": "Achievement Progress",
 };
 
 export const DEFAULT_DASHBOARD_LAYOUT: DashboardLayoutPreference = {
@@ -129,6 +131,7 @@ export const DEFAULT_DASHBOARD_LAYOUT: DashboardLayoutPreference = {
       "ci-analytics",
       "language-breakdown",
       "friend-comparison",
+      "achievement-progress",
     ],
   },
   hidden: [],

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -19,6 +19,7 @@ export const METRICS_CACHE_TTL_SECONDS = {
   compare: 30 * 60,
   "weekly-summary": 30 * 60,
   "commit-times": 30 * 60,
+  "achievement-progress": 10 * 60,
 } as const;
 
 type MetricsCacheEndpoint = keyof typeof METRICS_CACHE_TTL_SECONDS;

--- a/test/achievement-progress.test.ts
+++ b/test/achievement-progress.test.ts
@@ -1,0 +1,328 @@
+﻿/**
+ * Tests for src/lib/achievement-progress.ts
+ *
+ * Coverage
+ * --------
+ * computeMilestoneProgress    -- boundary cases, empty milestones, clamping
+ * estimatePullSharkProgress   -- Bronze/Silver/Gold tiers, description, currentValue
+ * estimateGalaxyBrainProgress -- same coverage for Galaxy Brain thresholds
+ * getQuickdrawProgress        -- dataAvailable: false, correct title/slug
+ * getPairExtraordinaireProgress -- dataAvailable: false, correct title/slug
+ * buildLockedAchievementProgress -- omission, null data, mixed batches, full-unlock
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  computeMilestoneProgress,
+  estimatePullSharkProgress,
+  estimateGalaxyBrainProgress,
+  getQuickdrawProgress,
+  getPairExtraordinaireProgress,
+  buildLockedAchievementProgress,
+  type AchievementMilestone,
+} from "@/lib/achievement-progress";
+
+// --- computeMilestoneProgress ------------------------------------------------
+
+describe("computeMilestoneProgress", () => {
+  const milestones: AchievementMilestone[] = [
+    { tier: "Bronze", threshold: 2 },
+    { tier: "Silver", threshold: 16 },
+    { tier: "Gold", threshold: 128 },
+  ];
+
+  it("returns 0% and Bronze when current = 0", () => {
+    const { nextMilestone, progressPercent } = computeMilestoneProgress(0, milestones);
+    expect(nextMilestone?.tier).toBe("Bronze");
+    expect(progressPercent).toBe(0);
+  });
+
+  it("returns 50% progress towards Bronze when current = 1", () => {
+    const { nextMilestone, progressPercent } = computeMilestoneProgress(1, milestones);
+    expect(nextMilestone?.tier).toBe("Bronze");
+    expect(progressPercent).toBe(50);
+  });
+
+  it("advances to Silver once Bronze threshold is met (current = 2)", () => {
+    const { nextMilestone } = computeMilestoneProgress(2, milestones);
+    expect(nextMilestone?.tier).toBe("Silver");
+  });
+
+  it("calculates mid-Silver progress correctly (current = 9)", () => {
+    // Bronze=2, Silver=16; range=14; position=9-2=7 -> 50%
+    const { nextMilestone, progressPercent } = computeMilestoneProgress(9, milestones);
+    expect(nextMilestone?.tier).toBe("Silver");
+    expect(progressPercent).toBe(50);
+  });
+
+  it("advances to Gold once Silver threshold is met (current = 16)", () => {
+    const { nextMilestone } = computeMilestoneProgress(16, milestones);
+    expect(nextMilestone?.tier).toBe("Gold");
+  });
+
+  it("returns no nextMilestone and 100% when all tiers surpassed (current = 128)", () => {
+    const { nextMilestone, progressPercent } = computeMilestoneProgress(128, milestones);
+    expect(nextMilestone).toBeUndefined();
+    expect(progressPercent).toBe(100);
+  });
+
+  it("clamps progressPercent to 100 even when current greatly exceeds threshold", () => {
+    const { progressPercent } = computeMilestoneProgress(9999, milestones);
+    expect(progressPercent).toBe(100);
+  });
+
+  it("returns 100% and no nextMilestone for empty milestones array", () => {
+    const { nextMilestone, progressPercent } = computeMilestoneProgress(0, []);
+    expect(nextMilestone).toBeUndefined();
+    expect(progressPercent).toBe(100);
+  });
+
+  it("does not return negative progressPercent for negative input", () => {
+    const { progressPercent } = computeMilestoneProgress(-5, milestones);
+    expect(progressPercent).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// --- estimatePullSharkProgress -----------------------------------------------
+
+describe("estimatePullSharkProgress", () => {
+  it("has slug 'pull-shark' and dataAvailable: true", () => {
+    const result = estimatePullSharkProgress(0);
+    expect(result.slug).toBe("pull-shark");
+    expect(result.dataAvailable).toBe(true);
+  });
+
+  it("reflects currentValue in output", () => {
+    expect(estimatePullSharkProgress(7).currentValue).toBe(7);
+  });
+
+  it("targets Bronze milestone when mergedPRs < 2", () => {
+    const result = estimatePullSharkProgress(1);
+    expect(result.nextMilestone?.tier).toBe("Bronze");
+    expect(result.nextMilestone?.threshold).toBe(2);
+  });
+
+  it("targets Silver milestone when mergedPRs = 2", () => {
+    expect(estimatePullSharkProgress(2).nextMilestone?.tier).toBe("Silver");
+  });
+
+  it("targets Gold milestone when mergedPRs = 16", () => {
+    expect(estimatePullSharkProgress(16).nextMilestone?.tier).toBe("Gold");
+  });
+
+  it("returns no nextMilestone when all tiers reached (mergedPRs = 128)", () => {
+    expect(estimatePullSharkProgress(128).nextMilestone).toBeUndefined();
+  });
+
+  it("progressDescription mentions merged PRs and next threshold (Bronze)", () => {
+    const result = estimatePullSharkProgress(1);
+    expect(result.progressDescription).toMatch(/1/);
+    expect(result.progressDescription).toMatch(/2/);
+    expect(result.progressDescription).toMatch(/merged PR/i);
+  });
+
+  it("progressDescription says 'all tiers reached' when Gold surpassed", () => {
+    const result = estimatePullSharkProgress(200);
+    expect(result.progressDescription).toMatch(/all tiers reached/i);
+  });
+
+  it("progressPercent is between 0 and 100 for all sample values", () => {
+    [0, 1, 2, 8, 16, 64, 128, 200].forEach((n) => {
+      const { progressPercent } = estimatePullSharkProgress(n);
+      expect(progressPercent).toBeGreaterThanOrEqual(0);
+      expect(progressPercent).toBeLessThanOrEqual(100);
+    });
+  });
+});
+
+// --- estimateGalaxyBrainProgress ---------------------------------------------
+
+describe("estimateGalaxyBrainProgress", () => {
+  it("has slug 'galaxy-brain' and dataAvailable: true", () => {
+    const result = estimateGalaxyBrainProgress(0);
+    expect(result.slug).toBe("galaxy-brain");
+    expect(result.dataAvailable).toBe(true);
+  });
+
+  it("reflects currentValue in output", () => {
+    expect(estimateGalaxyBrainProgress(5).currentValue).toBe(5);
+  });
+
+  it("targets Bronze milestone when acceptedAnswers < 2", () => {
+    const result = estimateGalaxyBrainProgress(1);
+    expect(result.nextMilestone?.tier).toBe("Bronze");
+    expect(result.nextMilestone?.threshold).toBe(2);
+  });
+
+  it("targets Silver milestone when acceptedAnswers = 2", () => {
+    const result = estimateGalaxyBrainProgress(2);
+    expect(result.nextMilestone?.tier).toBe("Silver");
+    expect(result.nextMilestone?.threshold).toBe(8);
+  });
+
+  it("targets Gold milestone when acceptedAnswers = 8", () => {
+    const result = estimateGalaxyBrainProgress(8);
+    expect(result.nextMilestone?.tier).toBe("Gold");
+    expect(result.nextMilestone?.threshold).toBe(16);
+  });
+
+  it("returns no nextMilestone when Gold threshold reached (= 16)", () => {
+    expect(estimateGalaxyBrainProgress(16).nextMilestone).toBeUndefined();
+  });
+
+  it("progressDescription mentions accepted answers and next threshold", () => {
+    const result = estimateGalaxyBrainProgress(3);
+    expect(result.progressDescription).toMatch(/3/);
+    expect(result.progressDescription).toMatch(/8/);
+    expect(result.progressDescription).toMatch(/accepted answer/i);
+  });
+
+  it("progressDescription says 'all tiers reached' beyond Gold", () => {
+    expect(estimateGalaxyBrainProgress(20).progressDescription).toMatch(/all tiers reached/i);
+  });
+
+  it("progressPercent is between 0 and 100 for all sample values", () => {
+    [0, 1, 2, 5, 8, 12, 16, 50].forEach((n) => {
+      const { progressPercent } = estimateGalaxyBrainProgress(n);
+      expect(progressPercent).toBeGreaterThanOrEqual(0);
+      expect(progressPercent).toBeLessThanOrEqual(100);
+    });
+  });
+});
+
+// --- getQuickdrawProgress ----------------------------------------------------
+
+describe("getQuickdrawProgress", () => {
+  it("has slug 'quickdraw'", () => {
+    expect(getQuickdrawProgress().slug).toBe("quickdraw");
+  });
+
+  it("has title 'Quickdraw'", () => {
+    expect(getQuickdrawProgress().title).toBe("Quickdraw");
+  });
+
+  it("has dataAvailable: false", () => {
+    expect(getQuickdrawProgress().dataAvailable).toBe(false);
+  });
+
+  it("does not include currentValue", () => {
+    expect(getQuickdrawProgress().currentValue).toBeUndefined();
+  });
+
+  it("does not include progressPercent", () => {
+    expect(getQuickdrawProgress().progressPercent).toBeUndefined();
+  });
+
+  it("does not include nextMilestone", () => {
+    expect(getQuickdrawProgress().nextMilestone).toBeUndefined();
+  });
+});
+
+// --- getPairExtraordinaireProgress -------------------------------------------
+
+describe("getPairExtraordinaireProgress", () => {
+  it("has slug 'pair-extraordinaire'", () => {
+    expect(getPairExtraordinaireProgress().slug).toBe("pair-extraordinaire");
+  });
+
+  it("has title 'Pair Extraordinaire'", () => {
+    expect(getPairExtraordinaireProgress().title).toBe("Pair Extraordinaire");
+  });
+
+  it("has dataAvailable: false", () => {
+    expect(getPairExtraordinaireProgress().dataAvailable).toBe(false);
+  });
+
+  it("does not include currentValue", () => {
+    expect(getPairExtraordinaireProgress().currentValue).toBeUndefined();
+  });
+
+  it("does not include progressPercent", () => {
+    expect(getPairExtraordinaireProgress().progressPercent).toBeUndefined();
+  });
+});
+
+// --- buildLockedAchievementProgress ------------------------------------------
+
+describe("buildLockedAchievementProgress", () => {
+  const data = { mergedPRs: 5, acceptedAnswers: 3 };
+
+  it("returns all four achievements when unlockedSlugs is empty", () => {
+    const results = buildLockedAchievementProgress(data, new Set());
+    const slugs = results.map((r) => r.slug);
+    expect(slugs).toContain("pull-shark");
+    expect(slugs).toContain("galaxy-brain");
+    expect(slugs).toContain("quickdraw");
+    expect(slugs).toContain("pair-extraordinaire");
+  });
+
+  it("omits pull-shark when it is in unlockedSlugs", () => {
+    const results = buildLockedAchievementProgress(data, new Set(["pull-shark"]));
+    expect(results.some((r) => r.slug === "pull-shark")).toBe(false);
+    expect(results.some((r) => r.slug === "galaxy-brain")).toBe(true);
+  });
+
+  it("omits galaxy-brain when it is in unlockedSlugs", () => {
+    const results = buildLockedAchievementProgress(data, new Set(["galaxy-brain"]));
+    expect(results.some((r) => r.slug === "galaxy-brain")).toBe(false);
+    expect(results.some((r) => r.slug === "pull-shark")).toBe(true);
+  });
+
+  it("omits both estimable achievements when both are unlocked", () => {
+    const results = buildLockedAchievementProgress(
+      data,
+      new Set(["pull-shark", "galaxy-brain"])
+    );
+    expect(results.some((r) => r.slug === "pull-shark")).toBe(false);
+    expect(results.some((r) => r.slug === "galaxy-brain")).toBe(false);
+    expect(results.some((r) => r.slug === "quickdraw")).toBe(true);
+  });
+
+  it("returns an empty array when all four slugs are unlocked", () => {
+    const results = buildLockedAchievementProgress(
+      data,
+      new Set(["pull-shark", "galaxy-brain", "quickdraw", "pair-extraordinaire"])
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("uses null-data stub for pull-shark when data is null", () => {
+    const results = buildLockedAchievementProgress(null, new Set());
+    const pullShark = results.find((r) => r.slug === "pull-shark");
+    expect(pullShark?.dataAvailable).toBe(false);
+  });
+
+  it("uses null-data stub for galaxy-brain when data is null", () => {
+    const results = buildLockedAchievementProgress(null, new Set());
+    const galaxyBrain = results.find((r) => r.slug === "galaxy-brain");
+    expect(galaxyBrain?.dataAvailable).toBe(false);
+  });
+
+  it("keeps quickdraw and pair-extraordinaire stubs intact when data is null", () => {
+    const results = buildLockedAchievementProgress(null, new Set());
+    expect(results.some((r) => r.slug === "quickdraw" && !r.dataAvailable)).toBe(true);
+    expect(
+      results.some((r) => r.slug === "pair-extraordinaire" && !r.dataAvailable)
+    ).toBe(true);
+  });
+
+  it("passes metrics through to estimatePullSharkProgress when data is present", () => {
+    const results = buildLockedAchievementProgress(
+      { mergedPRs: 20, acceptedAnswers: 0 },
+      new Set()
+    );
+    const pullShark = results.find((r) => r.slug === "pull-shark");
+    expect(pullShark?.currentValue).toBe(20);
+    expect(pullShark?.nextMilestone?.tier).toBe("Gold");
+  });
+
+  it("passes metrics through to estimateGalaxyBrainProgress when data is present", () => {
+    const results = buildLockedAchievementProgress(
+      { mergedPRs: 0, acceptedAnswers: 10 },
+      new Set()
+    );
+    const galaxyBrain = results.find((r) => r.slug === "galaxy-brain");
+    expect(galaxyBrain?.currentValue).toBe(10);
+    expect(galaxyBrain?.nextMilestone?.tier).toBe("Gold");
+  });
+});


### PR DESCRIPTION
Closes #1754

## Implementation Summary

Adds an evidence-based progress estimator for locked GitHub achievements. Progress is only shown where real contribution data exists as a proxy. Achievements with no reliable data source display "Progress unavailable" explicitly — no fabricated percentages.

## Achievement Estimation Strategy

| Achievement | Data Source | Estimation |
|---|---|---|
| Pull Shark | `viewer.pullRequests(states:[MERGED]).totalCount` | Merge count vs. Bronze/Silver/Gold thresholds (2/16/128) |
| Galaxy Brain | `viewer.repositoryDiscussionComments(onlyAnswers:true).totalCount` | Accepted-answer count vs. thresholds (2/8/16) |
| Quickdraw | None available | Reports "Progress unavailable" |
| Pair Extraordinaire | None available | Reports "Progress unavailable" |

Both estimable achievements are fetched in a single GitHub GraphQL round-trip.

## Files Changed

**New files:**
- `src/lib/achievement-progress.ts` — pure estimator functions and types (`AchievementProgressInfo`, `AchievementMilestone`, `computeMilestoneProgress`, per-achievement estimators, `buildLockedAchievementProgress`)
- `src/app/api/metrics/achievement-progress/route.ts` — GET endpoint; GraphQL fetch, 10-min cache, token-revocation handling
- `src/components/GitHubAchievementProgress.tsx` — client widget with progress-bar cards; "Estimated progress" label; "Progress unavailable" fallback
- `test/achievement-progress.test.ts` — 48 tests

**Modified:**
- `src/app/dashboard/page.tsx` — adds `GitHubAchievementProgress` to the Goals & Insights sidebar

## Tests Added

48 tests in `test/achievement-progress.test.ts`:
- `computeMilestoneProgress` — boundary cases, empty milestones, progress clamping
- `estimatePullSharkProgress` — Bronze/Silver/Gold tiers, `progressDescription` accuracy, `currentValue` tracking
- `estimateGalaxyBrainProgress` — same coverage for Galaxy Brain thresholds
- `getQuickdrawProgress` — `dataAvailable: false`, "Progress unavailable" output
- `getPairExtraordinaireProgress` — same coverage
- `buildLockedAchievementProgress` — unlocked-achievement omission, null data handling, mixed batches, full-unlock empty result

## Verification

```
pnpm typecheck   → ✓ no errors
pnpm lint        → ✓ no new errors
pnpm test        → ✓ 48/48 achievement-progress tests pass
```