### PR TITLE
feat(leaderboard): async cache refresh via cron endpoint

### DIFF
--- a/src/app/api/leaderboard/refresh/route.ts
+++ b/src/app/api/leaderboard/refresh/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { refreshLeaderboardCache } from "@/lib/leaderboard";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const authHeader = req.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret) {
+    return NextResponse.json({ error: "CRON_SECRET is not configured" }, { status: 500 });
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}` && process.env.NODE_ENV !== "development") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const payload = await refreshLeaderboardCache();
+    return NextResponse.json({ success: true, generatedAt: payload.generatedAt });
+  } catch (err) {
+    return NextResponse.json({ error: "Failed to refresh leaderboard cache" }, { status: 500 });
+  }
+}

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -326,12 +326,17 @@ export async function buildLeaderboard(
   };
 }
 
-/**
- * Returns cached leaderboard data or builds fresh data.
- * Used by both the server component (direct call) and the API route (thin wrapper).
- * Does NOT include thundering-herd protection — that belongs in the API route
- * where multiple serverless instances may race.
- */
+export async function refreshLeaderboardCache(
+  filters: LeaderboardFilters = {}
+): Promise<LeaderboardPayload> {
+  const payload = await buildLeaderboard(filters);
+  const period = filters.period ?? DEFAULT_PERIOD;
+  const cacheKey = getLeaderboardCacheKey(period);
+  await cacheSet(cacheKey, payload, CACHE_STALE_SECONDS);
+  setMemoryCachedLeaderboard(payload, period);
+  return payload;
+}
+
 export async function getLeaderboardData(
   bypass = false,
   filters: LeaderboardFilters = {}
@@ -356,7 +361,6 @@ export async function getLeaderboardData(
     return payload;
   } catch (err) {
     console.error("[Leaderboard] Build failed:", err);
-    // Return stale data rather than null when the fresh build fails.
     const stale = await cacheGet<LeaderboardPayload>(getLeaderboardCacheKey(period));
     return stale ?? null;
   }


### PR DESCRIPTION
## Purpose & Rationale

The leaderboard GET endpoint rebuilt the full leaderboard on every cache miss, creating a thundering-herd risk across serverless instances and forcing users to wait for a slow synchronous build. A separate cron endpoint allows async cache refreshes independent of user-facing requests.

## Technical Resolution Details

Added `refreshLeaderboardCache()` to `src/lib/leaderboard.ts` that builds the leaderboard and writes to both in-memory and Upstash caches. Created `src/app/api/leaderboard/refresh/route.ts` - a cron endpoint with `CRON_SECRET` Bearer auth matching the existing discord-sync pattern. Rewrote the GET handler in `src/app/api/leaderboard/route.ts` to a pure cache lookup chain (memory → fresh Upstash → stale with stale-until header → 503), removing the on-demand `buildLeaderboard()` call and the distributed lock. Closes #1799.

## Local Testing Execution

1. `npm run type-check` - 0 errors
2. `npm run lint` - 0 new warnings
3. `npx vitest run test/leaderboard-*` - 39/39 leaderboard tests pass
4. `npm test` - full suite: 1081/1092 pass (same 11 pre-existing failures, 0 new regressions)

## Desired Review Feedback Type

Correctness of the cache-only GET flow, especially the stale-until header calculation and error-path behaviour when both caches are empty.

## Integrity & AI Usage Disclosure

In compliance with the GSSoC 2026 AI Conduct rules, I disclose that AI tools were used solely as learning and boilerplate aids. The final logic was fully reviewed, tested, and manually adapted to match human styling and clean-code design.