### PR TITLE
fix: prevent LanguageBreakdown legend overflow on mobile

### DIFF
--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -133,14 +133,17 @@ export default function LanguageBreakdown() {
           </div>
 
           {/* Legend */}
-          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
+          <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2">
             {displayLanguages.map((lang) => (
-              <div key={lang.name} className="flex items-center gap-2 text-sm">
+              <div
+                key={lang.name}
+                className="flex min-w-0 max-w-full basis-full items-center gap-2 text-sm sm:basis-[calc(50%-0.5rem)]"
+              >
                 <LanguageDot 
                   color={lang.name === "Other" ? "var(--control)" : getColor(lang.name)}
                   label={`${lang.name}: ${lang.percentage}%`}
                 />
-                <span className="truncate text-[var(--card-foreground)]">
+                <span className="min-w-0 flex-1 truncate text-[var(--card-foreground)]">
                   {lang.name}
                 </span>
                 <span className="ml-auto shrink-0 text-[var(--muted-foreground)]">


### PR DESCRIPTION
## Summary

Fixed the `LanguageBreakdown` chart legend overflowing on mobile viewports by allowing legend items to wrap and truncating long language names within the card.

Closes #1905

## Type of Change

* [x] Bug fix

## Changes Made

* Updated the language legend layout to use wrapping flex behavior
* Added width constraints so legend items stay inside the card
* Added `min-w-0` and truncation for long language names
* Preserved the two-column legend layout on larger screens

## How to Test

1. Open the DevTrack dashboard.
2. Set the browser viewport width to `375px` or narrower.
3. Scroll to the `LanguageBreakdown` widget.
4. Confirm the legend stays inside the card without horizontal page scroll.
5. Confirm long language names truncate with ellipsis.

## Screenshots

N/A

## Checklist

* [x] Linked issue in summary
* [x] Self-reviewed the changes
* [ ] Added/updated tests if applicable
* [x] Verified lint/type-check locally

## Additional Notes

Local verification completed with `npm run lint` and `npm run type-check`. The dev server visual check was blocked locally by a Next SWC binary loading issue.