### PR TITLE
fix: persist recurring goal history on reset

### DIFF
--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -20,6 +20,15 @@ interface Goal {
   created_at: string;
 }
 
+interface GoalHistory {
+  goal_id: string;
+  period_start: string;
+  period_end: string;
+  target: number;
+  achieved: number;
+  completed: boolean;
+}
+
 type Recurrence = "none" | "weekly" | "monthly";
 
 const VALID_RECURRENCES = ["none", "weekly", "monthly"] as const;
@@ -45,6 +54,10 @@ function getPeriodStart(recurrence: Recurrence): string {
     return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
   }
   return new Date(0).toISOString(); // 'none' never resets
+}
+
+function getPreviousPeriodEnd(periodStart: Date): string {
+  return new Date(periodStart.getTime() - 1).toISOString();
 }
 
 export async function GET() {
@@ -76,11 +89,28 @@ export async function GET() {
         : new Date(0);
 
       if (storedPeriodStart < periodStart) {
+        const { error: historyError } = await supabaseAdmin
+          .from("goal_history")
+          .insert({
+            goal_id: goal.id,
+            user_id: goal.user_id,
+            period_start: storedPeriodStart.toISOString(),
+            period_end: getPreviousPeriodEnd(periodStart),
+            target: goal.target,
+            achieved: goal.current,
+            completed: goal.current >= goal.target,
+          });
+
+        if (historyError && historyError.code !== "23505") {
+          console.error("Failed to persist goal history before reset:", historyError);
+          return goal;
+        }
+
         const { data: updated } = await supabaseAdmin
           .from("goals")
           .update({ current: 0, period_start: periodStart.toISOString() })
           .eq("id", goal.id)
-          .lt("period_start", periodStart.toISOString())
+          .or(`period_start.lt.${periodStart.toISOString()},period_start.is.null`)
           .select()
           .single();
 
@@ -98,7 +128,33 @@ export async function GET() {
     })
   );
 
-  return Response.json({ goals: processedGoals });
+  const goalIds = processedGoals
+    .map((goal) => goal?.id)
+    .filter((id): id is string => Boolean(id));
+
+  let latestHistoryByGoal = new Map<string, GoalHistory>();
+  if (goalIds.length > 0) {
+    const { data: histories } = await supabaseAdmin
+      .from("goal_history")
+      .select("goal_id, period_start, period_end, target, achieved, completed")
+      .eq("user_id", user.id)
+      .in("goal_id", goalIds)
+      .order("period_end", { ascending: false });
+
+    latestHistoryByGoal = new Map<string, GoalHistory>();
+    for (const history of (histories ?? []) as GoalHistory[]) {
+      if (!latestHistoryByGoal.has(history.goal_id)) {
+        latestHistoryByGoal.set(history.goal_id, history);
+      }
+    }
+  }
+
+  const goalsWithHistory = processedGoals.map((goal) => ({
+    ...goal,
+    last_period: latestHistoryByGoal.get(goal.id) ?? null,
+  }));
+
+  return Response.json({ goals: goalsWithHistory });
 }
 
 export async function POST(req: Request) {

--- a/src/app/api/user/data-export/route.ts
+++ b/src/app/api/user/data-export/route.ts
@@ -201,6 +201,13 @@ export async function GET(req: NextRequest) {
     .eq("user_id", user.id);
   sections.goals = goals || [];
 
+  const { data: goalHistory } = await supabaseAdmin
+    .from("goal_history")
+    .select("id, goal_id, user_id, period_start, period_end, target, achieved, completed, created_at")
+    .eq("user_id", user.id)
+    .order("period_end", { ascending: false });
+  sections.goalHistory = goalHistory || [];
+
   const { data: snapshots } = await supabaseAdmin
     .from("metric_snapshots")
     .select(
@@ -334,6 +341,7 @@ export async function DELETE(req: NextRequest) {
     "jira_credentials",
     "webhook_configs",
     "user_github_accounts",
+    "goal_history",
     "goals",
     "metric_snapshots",
   ];

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -16,6 +16,13 @@ interface Goal {
   deadline: string | null;
   period_start: string;
   last_synced_at: string | null;
+  last_period: {
+    period_start: string;
+    period_end: string;
+    target: number;
+    achieved: number;
+    completed: boolean;
+  } | null;
 }
 
 const RECURRENCE_LABELS: Record<Recurrence, string> = {
@@ -446,6 +453,17 @@ export default function GoalTracker() {
                         {completionLabel}
                       </span>
                     ) : null}
+                    {goal.last_period && (
+                      <span
+                        className={`text-xs font-medium ${
+                          goal.last_period.completed ? "text-emerald-500" : "text-[var(--muted-foreground)]"
+                        }`}
+                        title={`Previous period ended ${new Date(goal.last_period.period_end).toLocaleDateString()}`}
+                      >
+                        Last period: {goal.last_period.completed ? "✓" : "○"}{" "}
+                        {goal.last_period.achieved}/{goal.last_period.target} {goal.unit}
+                      </span>
+                    )}
                   </div>
 
                   <div className="flex items-center gap-2">

--- a/supabase/migrations/20260603000001_add_goal_history.sql
+++ b/supabase/migrations/20260603000001_add_goal_history.sql
@@ -1,0 +1,33 @@
+-- Persist completed recurring goal periods before progress resets.
+create table if not exists goal_history (
+  id           text primary key default gen_random_uuid()::text,
+  goal_id      text not null references goals(id) on delete cascade,
+  user_id      text not null references users(id) on delete cascade,
+  period_start timestamptz not null,
+  period_end   timestamptz not null,
+  target       integer not null,
+  achieved     integer not null default 0,
+  completed    boolean not null default false,
+  created_at   timestamptz not null default now(),
+  unique(goal_id, period_start)
+);
+
+create index if not exists goal_history_user_period
+  on goal_history(user_id, period_end desc);
+
+create index if not exists goal_history_goal_period
+  on goal_history(goal_id, period_end desc);
+
+alter table goal_history enable row level security;
+
+create policy "goal_history_select_own"
+  on goal_history for select
+  using (user_id = auth.uid()::text);
+
+create policy "goal_history_insert_own"
+  on goal_history for insert
+  with check (user_id = auth.uid()::text);
+
+create policy "goal_history_delete_own"
+  on goal_history for delete
+  using (user_id = auth.uid()::text);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -31,6 +31,32 @@ create table if not exists goals (
   updated_at   timestamptz default now()
 );
 create index if not exists goals_user_period on goals(user_id, period_start);
+create table if not exists goal_history (
+  id           text primary key default gen_random_uuid()::text,
+  goal_id      text not null references goals(id) on delete cascade,
+  user_id      text not null references users(id) on delete cascade,
+  period_start timestamptz not null,
+  period_end   timestamptz not null,
+  target       integer not null,
+  achieved     integer not null default 0,
+  completed    boolean not null default false,
+  created_at   timestamptz not null default now(),
+  unique(goal_id, period_start)
+);
+create index if not exists goal_history_user_period
+  on goal_history(user_id, period_end desc);
+create index if not exists goal_history_goal_period
+  on goal_history(goal_id, period_end desc);
+alter table goal_history enable row level security;
+create policy "goal_history_select_own"
+  on goal_history for select
+  using (user_id = auth.uid()::text);
+create policy "goal_history_insert_own"
+  on goal_history for insert
+  with check (user_id = auth.uid()::text);
+create policy "goal_history_delete_own"
+  on goal_history for delete
+  using (user_id = auth.uid()::text);
 create table if not exists metric_snapshots (
   id            text primary key default gen_random_uuid()::text,
   user_id       text not null references users(id) on delete cascade,

--- a/test/GoalTracker.test.ts
+++ b/test/GoalTracker.test.ts
@@ -13,6 +13,7 @@ const mockGoals = [
     deadline: null,
     period_start: '2026-05-30T00:00:00.000Z',
     last_synced_at: null,
+    last_period: null,
   },
   {
     id: '2',
@@ -24,6 +25,7 @@ const mockGoals = [
     deadline: null,
     period_start: '2026-05-30T00:00:00.000Z',
     last_synced_at: '2026-05-30T00:00:00.000Z',
+    last_period: null,
   }
 ];
 
@@ -264,6 +266,7 @@ describe('GoalTracker - useGoalTracker Hook', () => {
           deadline: null,
           period_start: '2026-05-30T00:00:00.000Z',
           last_synced_at: null,
+          last_period: null,
         }
       ]);
     });


### PR DESCRIPTION
## Summary
Fixes recurring goal resets so previous weekly/monthly period results are persisted before progress is reset.

## Changes
- Added a `goal_history` table with period result fields.
- Records the previous period result before resetting recurring goals in `GET /api/goals`.
- Returns the latest previous period as `last_period` with each goal.
- Displays a small “Last period” result on recurring goal cards.
- Includes goal history in JSON data exports.
- Cleans up `goal_history` during account deletion.
- Updated GoalTracker tests for the new response shape.

## Verification
- `npm run type-check`
- `npm run build`
- `npx vitest run --config ./vitest.config.ts test/GoalTracker.test.ts`

Closes #1847
