### PR TITLE
fix: persist daily focus goals in database

### DIFF
--- a/src/app/api/daily-focus/route.ts
+++ b/src/app/api/daily-focus/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse, NextRequest } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase";
+import { getToken } from "next-auth/jwt";
+
+export async function GET(req: NextRequest) {
+  try {
+    const token = await getToken({
+      req,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+
+    const userId = token?.githubId;
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    let date = searchParams.get("date");
+
+    if (!date) {
+      date = new Date().toISOString().split("T")[0];
+    }
+
+    const { data } = await supabaseAdmin
+      .from("daily_focus")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("date", date)
+      .single();
+
+    return NextResponse.json({
+      goal: data?.goal_text || "",
+    });
+  } catch (error) {
+    return NextResponse.json({ error: "Something went wrong" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const token = await getToken({
+      req,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+
+    const userId = token?.githubId;
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const { goal_text, date } = body;
+
+    if (!goal_text || !goal_text.trim()) {
+      return NextResponse.json({ error: "Goal cannot be empty" }, { status: 400 });
+    }
+
+    const targetDate = date || new Date().toISOString().split("T")[0];
+
+    const { data, error } = await supabaseAdmin
+      .from("daily_focus")
+      .upsert(
+        { user_id: userId, date: targetDate, goal_text: goal_text.trim() },
+        { onConflict: "user_id,date" }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: "Failed to save goal" }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: "Something went wrong" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const token = await getToken({
+      req,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
+
+    const userId = token?.githubId;
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const date = searchParams.get("date");
+
+    if (!date) {
+      return NextResponse.json({ error: "Date is required" }, { status: 400 });
+    }
+
+    const { error } = await supabaseAdmin
+      .from("daily_focus")
+      .delete()
+      .eq("user_id", userId)
+      .eq("date", date);
+
+    if (error) {
+      return NextResponse.json({ error: "Failed to clear goal" }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json({ error: "Something went wrong" }, { status: 500 });
+  }
+}

--- a/src/app/api/daily-focus/route.ts
+++ b/src/app/api/daily-focus/route.ts
@@ -1,19 +1,18 @@
 import { NextResponse, NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
-import { getToken } from "next-auth/jwt";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { resolveAppUser } from "@/lib/resolve-user";
 
 export async function GET(req: NextRequest) {
   try {
-    const token = await getToken({
-      req,
-      secret: process.env.NEXTAUTH_SECRET,
-    });
-
-    const userId = token?.githubId;
-
-    if (!userId) {
+    const session = await getServerSession(authOptions);
+    if (!session?.githubId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    const user = await resolveAppUser(session.githubId, session.githubLogin);
+    if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
 
     const { searchParams } = new URL(req.url);
     let date = searchParams.get("date");
@@ -25,7 +24,7 @@ export async function GET(req: NextRequest) {
     const { data } = await supabaseAdmin
       .from("daily_focus")
       .select("*")
-      .eq("user_id", userId)
+      .eq("user_id", user.id)
       .eq("date", date)
       .single();
 
@@ -39,16 +38,13 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const token = await getToken({
-      req,
-      secret: process.env.NEXTAUTH_SECRET,
-    });
-
-    const userId = token?.githubId;
-
-    if (!userId) {
+    const session = await getServerSession(authOptions);
+    if (!session?.githubId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    const user = await resolveAppUser(session.githubId, session.githubLogin);
+    if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
 
     const body = await req.json();
     const { goal_text, date } = body;
@@ -62,7 +58,7 @@ export async function POST(req: NextRequest) {
     const { data, error } = await supabaseAdmin
       .from("daily_focus")
       .upsert(
-        { user_id: userId, date: targetDate, goal_text: goal_text.trim() },
+        { user_id: user.id, date: targetDate, goal_text: goal_text.trim() },
         { onConflict: "user_id,date" }
       )
       .select()
@@ -80,16 +76,13 @@ export async function POST(req: NextRequest) {
 
 export async function DELETE(req: NextRequest) {
   try {
-    const token = await getToken({
-      req,
-      secret: process.env.NEXTAUTH_SECRET,
-    });
-
-    const userId = token?.githubId;
-
-    if (!userId) {
+    const session = await getServerSession(authOptions);
+    if (!session?.githubId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    const user = await resolveAppUser(session.githubId, session.githubLogin);
+    if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
 
     const { searchParams } = new URL(req.url);
     const date = searchParams.get("date");
@@ -101,7 +94,7 @@ export async function DELETE(req: NextRequest) {
     const { error } = await supabaseAdmin
       .from("daily_focus")
       .delete()
-      .eq("user_id", userId)
+      .eq("user_id", user.id)
       .eq("date", date);
 
     if (error) {

--- a/src/components/TodayFocusHero.tsx
+++ b/src/components/TodayFocusHero.tsx
@@ -60,11 +60,12 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
     setGreeting(getGreeting(now.getHours()));
     setPrompt(getDailyPrompt(now));
 
+    let localGoal = "";
     try {
-      const storedGoal = window.localStorage.getItem(nextKey)?.trim() ?? "";
-      setGoal(storedGoal);
-      setInputValue(storedGoal);
-      setIsEditing(storedGoal.length === 0);
+      localGoal = window.localStorage.getItem(nextKey)?.trim() ?? "";
+      setGoal(localGoal);
+      setInputValue(localGoal);
+      setIsEditing(localGoal.length === 0);
     } catch (e) {
       setGoal("");
       setInputValue("");
@@ -72,9 +73,35 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
     }
 
     setIsMounted(true);
+
+    async function fetchGoal() {
+      try {
+        const year = now.getFullYear();
+        const month = String(now.getMonth() + 1).padStart(2, "0");
+        const day = String(now.getDate()).padStart(2, "0");
+        const todayStr = `${year}-${month}-${day}`;
+
+        const res = await fetch(`/api/daily-focus?date=${todayStr}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.goal) {
+            setGoal(data.goal);
+            setInputValue(data.goal);
+            setIsEditing(false);
+            try {
+              window.localStorage.setItem(nextKey, data.goal);
+            } catch (e) {}
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch daily focus", err);
+      }
+    }
+    
+    fetchGoal();
   }, []);
 
-  function handleSave() {
+  async function handleSave() {
     const trimmedGoal = inputValue.trim();
     if (!trimmedGoal || !todayKey) return;
 
@@ -85,9 +112,20 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
     setGoal(trimmedGoal);
     setInputValue(trimmedGoal);
     setIsEditing(false);
+
+    try {
+      const todayStr = todayKey.replace(STORAGE_PREFIX, "");
+      await fetch("/api/daily-focus", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ goal_text: trimmedGoal, date: todayStr }),
+      });
+    } catch (err) {
+      console.error("Failed to save daily focus", err);
+    }
   }
 
-  function handleClear() {
+  async function handleClear() {
     if (!todayKey) return;
 
     try {
@@ -97,6 +135,15 @@ export default function TodayFocusHero({ userName }: TodayFocusHeroProps) {
     setGoal("");
     setInputValue("");
     setIsEditing(true);
+
+    try {
+      const todayStr = todayKey.replace(STORAGE_PREFIX, "");
+      await fetch(`/api/daily-focus?date=${todayStr}`, {
+        method: "DELETE",
+      });
+    } catch (err) {
+      console.error("Failed to clear daily focus", err);
+    }
   }
 
   function handleEdit() {

--- a/supabase/migrations/20260603000001_add_daily_focus.sql
+++ b/supabase/migrations/20260603000001_add_daily_focus.sql
@@ -1,0 +1,36 @@
+-- Create the daily_focus table
+CREATE TABLE daily_focus (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  date TEXT NOT NULL,
+  goal_text TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Create a unique constraint for upserting
+ALTER TABLE daily_focus ADD CONSTRAINT daily_focus_user_id_date_key UNIQUE (user_id, date);
+
+-- Set up Row Level Security
+ALTER TABLE daily_focus ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to read their own focus goals
+CREATE POLICY "Users can read own daily_focus"
+  ON daily_focus FOR SELECT
+  USING (auth.uid()::text = user_id);
+
+-- Allow users to insert their own focus goals
+CREATE POLICY "Users can insert own daily_focus"
+  ON daily_focus FOR INSERT
+  WITH CHECK (auth.uid()::text = user_id);
+
+-- Allow users to update their own focus goals
+CREATE POLICY "Users can update own daily_focus"
+  ON daily_focus FOR UPDATE
+  USING (auth.uid()::text = user_id)
+  WITH CHECK (auth.uid()::text = user_id);
+
+-- Allow users to delete their own focus goals
+CREATE POLICY "Users can delete own daily_focus"
+  ON daily_focus FOR DELETE
+  USING (auth.uid()::text = user_id);


### PR DESCRIPTION
Fixes #1848 

## Description

This PR resolves the issue where the "Today's Focus" goal on the dashboard was only stored in localStorage, causing users to lose their goals when switching devices, using incognito mode, or clearing browser data.

To fix this, the daily focus goals are now persisted in the Supabase database.

## Changes Made

- Database Migration: Added a new daily_focus table (with user_id, date, and goal_text columns) and Row Level Security (RLS) policies to ensure users can only access their own goals.
- Backend Sync API: Created a new set of API endpoints (/api/daily-focus) to handle GET, POST (upsert), and DELETE requests for the daily goals.
- Frontend Refactoring: Refactored TodayFocusHero.tsx to communicate with the new backend API. It still utilizes localStorage as a fallback to maintain the instant, optimistic UI feedback, but now safely syncs state with the server in the background.
