### PR TITLE
fix: resolve E2E 500 error from incomplete weekly-summary mock (#1972)

### DIFF
--- a/e2e/dashboard-widgets.spec.js
+++ b/e2e/dashboard-widgets.spec.js
@@ -1,32 +1,34 @@
 import { expect, test } from "@playwright/test";
 import { encode } from "next-auth/jwt";
 
-test.beforeEach(async ({ page }) => {
-  const authSecret =
-    process.env.NEXTAUTH_SECRET ||
-    "test-nextauth-secret-for-playwright-tests";
+const authSecret =
+  process.env.NEXTAUTH_SECRET ||
+  "test-nextauth-secret-for-playwright-tests";
 
-  const token = await encode({
+test.beforeEach(async ({ page }) => {
+  const sessionToken = await encode({
     secret: authSecret,
     token: {
       name: "Playwright User",
       email: "playwright@example.com",
+      sub: "12345",
       githubLogin: "playwright-user",
       githubId: "12345",
       accessToken: "test-token",
-      expires: "2099-01-01T00:00:00.000Z",
     },
+    maxAge: 60 * 60,
   });
 
   await page.context().addCookies([
     {
       name: "next-auth.session-token",
-      value: String(token ?? ""),
+      value: sessionToken,
       domain: "127.0.0.1",
       path: "/",
       httpOnly: true,
       sameSite: "Lax",
       secure: false,
+      expires: Math.floor(Date.now() / 1000) + 60 * 60,
     },
   ]);
 
@@ -265,6 +267,8 @@ function mockMetricResponse(url) {
         thisWeek: { opened: 3, merged: 2 },
         lastWeek: { opened: 1, merged: 1 },
       },
+      issues: { thisWeek: 4, lastWeek: 3 },
+      productivityScore: { current: 85, previous: 78 },
       activeDays: {
         thisWeek: 5,
         lastWeek: 4,

--- a/e2e/notifications.spec.js
+++ b/e2e/notifications.spec.js
@@ -22,6 +22,8 @@ function mockMetricResponse(url) {
     return {
       commits: { current: 10, previous: 7, delta: 3, trend: "up" },
       prs: { thisWeek: { opened: 3, merged: 2 }, lastWeek: { opened: 1, merged: 1 } },
+      issues: { thisWeek: 4, lastWeek: 3 },
+      productivityScore: { current: 85, previous: 78 },
       activeDays: { thisWeek: 5, lastWeek: 4 },
       streak: 3,
       topRepo: "demo/repo",
@@ -54,27 +56,29 @@ function mockMetricResponse(url) {
 }
 
 test.beforeEach(async ({ page }) => {
-  const token = await encode({
-    secret: process.env.NEXTAUTH_SECRET || authSecret,
+  const sessionToken = await encode({
+    secret: authSecret,
     token: {
       name: "Playwright User",
       email: "playwright@example.com",
+      sub: "12345",
       githubLogin: "playwright-user",
       githubId: "12345",
       accessToken: "test-token",
-      expires: "2099-01-01T00:00:00.000Z",
     },
+    maxAge: 60 * 60,
   });
 
   await page.context().addCookies([
     {
       name: "next-auth.session-token",
-      value: String(token ?? ""),
+      value: sessionToken,
       domain: "127.0.0.1",
       path: "/",
       httpOnly: true,
       sameSite: "Lax",
       secure: false,
+      expires: Math.floor(Date.now() / 1000) + 60 * 60,
     },
   ]);
 

--- a/e2e/theme.spec.js
+++ b/e2e/theme.spec.js
@@ -6,22 +6,23 @@ const authSecret =
   "test-nextauth-secret-for-playwright-tests";
 
 test.beforeEach(async ({ page }) => {
-  const token = await encode({
+  const sessionToken = await encode({
     secret: authSecret,
     token: {
       name: "Playwright User",
       email: "playwright@example.com",
+      sub: "12345",
       githubLogin: "playwright-user",
       githubId: "12345",
       accessToken: "test-token",
-      expires: "2099-01-01T00:00:00.000Z",
     },
+    maxAge: 60 * 60,
   });
 
   await page.context().addCookies([
     {
       name: "next-auth.session-token",
-      value: String(token ?? ""),
+      value: sessionToken,
       domain: "127.0.0.1",
       path: "/",
       httpOnly: true,

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -258,7 +258,7 @@ Productivity Score  : ${summary.productivityScore.current} (${scoreSign}${scoreD
               </div>
             </div>
 
-            {/* Issues Resolved */}
+            {summary.issues && (
             <div className="rounded-lg bg-[var(--control)] p-4">
               <div className="mb-3 flex items-center justify-between">
                 <span className="text-sm text-[var(--muted-foreground)]">Issues Resolved</span>
@@ -291,6 +291,7 @@ Productivity Score  : ${summary.productivityScore.current} (${scoreSign}${scoreD
                 </div>
               </div>
             </div>
+            )}
 
             {/* Active Days Comparison */}
             <div className="rounded-lg bg-[var(--control)] p-4">


### PR DESCRIPTION
Closes #1972 | Labels: bug; Level: critical; priority: High (was blocking CI pipeline)

## Purpose & Rationale

The Playwright E2E smoke tests (`dashboard-widgets`, `notifications`) crashed with a 500 error page immediately on navigation, blocking all dashboard coverage. The root cause was a client-side `TypeError` in `WeeklySummaryCard` triggered when the mocked `/api/metrics/weekly-summary` response omitted the `issues` field that the component unconditionally accesses.

## Technical Resolution Details

Two fixes in `src/components/WeeklySummaryCard.tsx`: added `issues` and `productivityScore` fields to the mock response in `e2e/dashboard-widgets.spec.js` and `e2e/notifications.spec.js` so the mock matches the `WeeklySummaryData` interface; wrapped the Issues Resolved render section with a defensive `{summary.issues && (...)}` guard matching the pre-existing `productivityScore` pattern. Additionally aligned auth cookie setup (`sub`, `maxAge`, `expires`) across all four E2E spec files for consistency with `settings.spec.js`.

## Local Testing Execution

1. `npx playwright test e2e/dashboard-widgets.spec.js --workers=1` - 3/3 pass
2. `npx playwright test e2e/theme.spec.js e2e/settings.spec.js e2e/notifications.spec.js --workers=1` — 4/4 pass  
3. `npm run type-check` - zero errors
4. `npm run lint` - zero new warnings (pre-existing only)

## Desired Review Feedback Type

Edge-case correctness: confirm the `issues` guard doesn't hide data the real API always provides, and that the auth pattern changes are idiomatic for Playwright + NextAuth.

## Integrity & AI Usage Disclosure

In compliance with the GSSoC 2026 AI Conduct rules, I disclose that AI tools were used solely as learning and boilerplate aids. The final logic was fully reviewed, tested, and manually adapted to match human styling and clean-code design.