### PR TITLE
feat: add tooltip to TopRepos showing full name, description and language

### DIFF
--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -58,7 +58,7 @@ const RepoItem = memo(({
             type="button"
             onClick={() => onSelectActivity(repo.name)}
             className="truncate text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)] text-left font-medium"
-            title={repo.description || `View activity for ${repo.name}`}
+            title={[repo.name,repo.description ?? "No description",repo.languages?.[0] ? `Language: ${repo.languages[0].name}` : null,].filter(Boolean).join("\n")}
           >
             <span className="mr-1 text-[var(--muted-foreground)] font-normal">#{idx + 1}</span>
             {shortName}


### PR DESCRIPTION


## Summary

Added a tooltip to each repo card in the TopRepos widget showing the full repository name, description, and primary language on hover.

Closes #1911 

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Added `title` attribute to the repo name button in `RepoItem` component
- Tooltip shows full repository name, description (or "No description" if empty), and primary language

---

## How to Test

Steps for the reviewer to verify this works:

1. Go to the dashboard
2. Hover over any repo name in the Top Repositories widget
3. Tooltip should show full repo name, description, and primary language
4. Verify "No description" shows for repos without a description

## Screenshots (if UI change)

Tooltip is a native HTML `title` attribute — appears on hover, not easily captured in a static screenshot.

---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] Proper keyboard navigation tested
- [x] Responsive UI verified
- [x] Accessibility labels added where needed

---

## Additional Notes


