### PR TITLE
feat: repository comparison analytics with charts

### DIFF
--- a/e2e/dashboard-widgets.spec.js
+++ b/e2e/dashboard-widgets.spec.js
@@ -182,7 +182,9 @@ test.beforeEach(async ({ page }) => {
 });
 test("dashboard widgets render with mocked metrics", async ({ page }) => {
   await page.goto("/dashboard", { waitUntil: "load" });
-  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible({ timeout: 30000 });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30000 });
   await expect(page.getByRole("heading", { name: "Your Commits" })).toBeVisible({ timeout: 10000 });
   await expect(page.getByRole("heading", { name: "PR Analytics" })).toBeVisible({ timeout: 10000 });
   await expect(page.getByRole("heading", { name: "Goals", exact: true })).toBeVisible({ timeout: 10000 });
@@ -198,7 +200,9 @@ test("contribution graph range buttons request a new range", async ({ page }) =>
   });
 
   await page.goto("/dashboard", { waitUntil: "load" });
-  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible({ timeout: 30000 });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30000 });
   await page.getByRole("button", { name: "Show 90-day range" }).first().click();
   await page
     .locator("#contribution-activity")
@@ -217,7 +221,9 @@ test("goal form posts a new goal", async ({ page }) => {
   });
 
   await page.goto("/dashboard", { waitUntil: "load" });
-  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible({ timeout: 30000 });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30000 });
   await page.getByLabel("Goal title").fill("Ship one PR");
   await page.getByLabel("Target").fill("1");
   await page.getByLabel("Unit").selectOption("prs");

--- a/e2e/notifications.spec.js
+++ b/e2e/notifications.spec.js
@@ -184,7 +184,9 @@ test("notification bell opens and closes drawer", async ({ page }) => {
   await page.goto("/dashboard", { waitUntil: "load" });
 
   // Wait for the dashboard to fully render
-  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible({ timeout: 30000 });
+  await expect(
+  page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30000 });
 
   // Find and click the notification bell
   const bellButton = page.getByRole("button", { name: /Notifications/ });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "dompurify": "^3.1.6",
+        "fflate": "^0.8.3",
         "html-to-image": "^1.11.13",
         "idb-keyval": "^6.2.4",
         "jspdf": "^4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^10.1.0",
-        "recharts": "^2.12.7",
+        "recharts": "^2.15.4",
         "rehype-sanitize": "^6.0.0",
         "server-only": "^0.0.1",
         "sharp": "^0.34.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4691,6 +4691,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11794,9 +11810,9 @@
       "license": "ISC"
     },
     "node_modules/idb-keyval": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.4.tgz",
-      "integrity": "sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.5.tgz",
+      "integrity": "sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==",
       "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
@@ -15500,22 +15516,6 @@
         "next": ">=9.0.0"
       }
     },
-    "node_modules/next/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
-      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -19033,22 +19033,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.0.tgz",
+      "integrity": "sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.2"
+        "tldts-core": "^7.4.0"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.1.tgz",
+      "integrity": "sha512-sc2nGvGbixlJRHwTh/qQdPXTxJU1UDJboGPQm4d/01YUJ9r/u6aeIulQvEaxUlvKDN7hb1qCLjax+jhVAPLa/g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "dompurify": "^3.1.6",
+    "fflate": "^0.8.3",
     "html-to-image": "^1.11.13",
     "idb-keyval": "^6.2.4",
     "jspdf": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^10.1.0",
-    "recharts": "^2.12.7",
+    "recharts": "^2.15.4",
     "rehype-sanitize": "^6.0.0",
     "server-only": "^0.0.1",
     "sharp": "^0.34.5",

--- a/src/app/dashboard/repo-comparison/error.tsx
+++ b/src/app/dashboard/repo-comparison/error.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Something went wrong</h2>
+      <p>{error.message}</p>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/src/app/dashboard/repo-comparison/loading.tsx
+++ b/src/app/dashboard/repo-comparison/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div style={{ padding: 20 }}>Loading repo comparison...</div>;
+}

--- a/src/app/dashboard/repo-comparison/page.tsx
+++ b/src/app/dashboard/repo-comparison/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+export default function RepoComparisonPage() {
+  const [input, setInput] = useState("");
+  const [repos, setRepos] = useState<string[]>([]);
+  const [repoData, setRepoData] = useState<any[]>([]);
+  const chartData = repoData?.length
+  ? repoData.map((repo) => ({
+      name: repo.name.split("/")[1],
+      stars: repo.stars,
+      forks: repo.forks,
+      watchers: repo.watchers,
+    }))
+  : [];
+  const [loading, setLoading] = useState(false);
+
+  const addRepo = async () => {
+    const trimmed = input.trim();
+    const parts = trimmed.split("/");
+
+    if (parts.length !== 2) {
+      alert("Invalid format! Use owner/repo (e.g. facebook/react)");
+      return;
+    }
+
+    const [owner, repo] = parts;
+
+    if (!owner || !repo) {
+      alert("Invalid repository");
+      return;
+    }
+
+    if (trimmed.includes(" ")) {
+      alert("No spaces allowed in repository name");
+      return;
+    }
+
+    if (repos.includes(trimmed)) return;
+
+    if (repos.length >= 5) {
+      alert("You can compare max 5 repositories only");
+      return;
+    }
+
+    try {
+      const res = await fetch(
+        `https://api.github.com/repos/${owner}/${repo}`
+      );
+
+      if (!res.ok) {
+        alert("Repository does not exist on GitHub");
+        return;
+      }
+
+      const data = await res.json();
+
+      setRepos([...repos, data.full_name]);
+      setInput("");
+    } catch {
+      alert("Error validating repository");
+    }
+  };
+
+  const removeRepo = (repo: string) => {
+    setRepos(repos.filter((r) => r !== repo));
+  };
+
+  const fetchRepoData = async () => {
+    if (repos.length < 2) {
+      alert("Add at least 2 repositories to compare");
+      return;
+    }
+
+    setLoading(true);
+    setRepoData([]);
+
+    try {
+      const results = await Promise.all(
+        repos.map(async (fullName) => {
+          const res = await fetch(
+            `https://api.github.com/repos/${fullName}`
+          );
+
+          if (!res.ok) return null;
+
+          const data = await res.json();
+
+          return {
+            name: data.full_name,
+            stars: data.stargazers_count,
+            forks: data.forks_count,
+            watchers: data.watchers_count,
+            issues: data.open_issues_count,
+          };
+        })
+      );
+
+      setRepoData(results.filter((r): r is NonNullable<typeof r> => r !== null));
+    } catch {
+      alert("Failed to fetch repo data");
+    }
+
+    setLoading(false);
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">
+        Repository Comparison Analytics
+      </h1>
+
+      {/* INPUT */}
+      <div className="flex gap-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="owner/repo (e.g. facebook/react)"
+          className="border p-2 rounded w-80"
+        />
+
+        <button
+          onClick={addRepo}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Add Repo
+        </button>
+      </div>
+
+      {/* REPO TAGS */}
+      <div className="flex gap-2 flex-wrap">
+        {repos.map((repo) => (
+          <div
+            key={repo}
+            className="bg-gray-200 px-3 py-1 rounded flex gap-2 items-center"
+          >
+            <span>{repo}</span>
+            <button onClick={() => removeRepo(repo)}>❌</button>
+          </div>
+        ))}
+      </div>
+
+      {/* COMPARE BUTTON */}
+      <button
+        onClick={fetchRepoData}
+        className="bg-green-600 text-white px-4 py-2 rounded"
+        disabled={loading}
+      >
+        {loading ? "Comparing..." : "Compare Repositories"}
+      </button>
+
+      {/* EMPTY STATE */}
+      {repos.length === 0 && (
+        <div className="text-gray-500">
+          Add 2–5 repositories to compare
+        </div>
+      )}
+
+      {/* RESULTS */}
+      {repoData.length > 0 && (
+        <div className="border rounded p-4">
+          <h2 className="font-bold mb-3">Comparison Results</h2>
+
+          {repoData.map((repo) => (
+            <div key={repo.name} className="mb-3 p-2 border rounded">
+              <p className="font-semibold">{repo.name}</p>
+              <p>⭐ Stars: {repo.stars}</p>
+              <p>🍴 Forks: {repo.forks}</p>
+              <p>👀 Watchers: {repo.watchers}</p>
+              <p>🐛 Issues: {repo.issues}</p>
+            </div>
+          ))}
+        </div>
+      )}
+      {/* CHART */}
+      {repoData.length > 0 && (
+        <div className="w-full h-96 border rounded p-4 mt-6">
+          <h2 className="font-bold mb-3">📊 Comparison Chart</h2>
+
+          <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData}>
+          <XAxis
+            dataKey="name"
+            tick={{ fill: "#7698fe", fontSize: 12 }}
+          />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="stars" fill="#3b82f6" />
+          <Bar dataKey="forks" fill="#10b981" />
+          <Bar dataKey="watchers" fill="#f59e0b" />
+          </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implemented Repository-to-Repository Comparison Analytics feature that allows users to select 2–5 GitHub repositories and visually compare their key metrics using interactive charts.

Closes #1703

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Built repository comparison dashboard UI
- Added GitHub repository input with validation (owner/repo format)
- Integrated GitHub API to fetch repository statistics
- Implemented multi-repository selection (max 5 repos)
- Added comparison metrics:
  - Stars
  - Forks
  - Watchers
  - Open Issues
- Integrated Recharts for visual comparison
- Added bar chart visualization for selected repositories
- Added loading state and error handling

---

## How to Test

Steps for the reviewer to verify this feature:

1. Go to Repository Comparison Analytics page
2. Enter a valid GitHub repo (e.g. `facebook/react`)
3. Add 2–5 repositories
4. Click "Compare Repositories"
5. Verify:
   - Repository stats load correctly
   - Comparison cards render properly
   - Charts display stars, forks, and watchers
6. Try invalid inputs (should show validation errors)
7. Try adding more than 5 repos (should be blocked)

---

## Screenshots (if UI change)

N/A (UI available in PR preview)

---

## Checklist

- [x] Linked issue in summary
- [x] GitHub API integration tested
- [x] Recharts visualization working
- [x] Input validation implemented
- [x] Loading and error states handled
- [x] Self-reviewed the diff
- [x] No TypeScript errors locally

---

## Additional Notes

This feature enhances DevTrack by enabling cross-repository comparison, helping developers analyze project growth, popularity, and activity side-by-side in a visual format.
