### PR TITLE
fix: hide StreakAtRiskBanner when streak freeze is active

### DIFF
--- a/src/components/StreakAtRiskBanner.tsx
+++ b/src/components/StreakAtRiskBanner.tsx
@@ -86,7 +86,10 @@ export default function StreakAtRiskBanner({
     setIsAtRisk(true);
   }, [lastCommitDate, currentStreak, hasStreakFreezeState, dismissed]);
 
-  if (!isAtRisk || dismissed) return null;
+  // Guard: hide banner when streak freeze is confirmed active (true) or
+  // still loading (undefined). Only render when we know for sure the user
+  // has no freeze (hasStreakFreezeState === false) and the streak is at risk.
+  if (!isAtRisk || dismissed || hasStreakFreezeState !== false) return null;
 
   return (
     <div


### PR DESCRIPTION
## 🐛 Bug Fix: StreakAtRiskBanner shows despite active streak freeze

Fixes #1900

### Problem
The `StreakAtRiskBanner` component was incorrectly rendering even when a user had an active streak freeze applied. Users would see the "your streak is at risk" warning despite having purchased and activated a streak freeze, causing confusion.

### Root Cause
The bug was caused by a **race condition** between two API calls:
1. The streak data (`/api/metrics/streak`) loaded first and set `currentStreak` + `lastCommitDate`
2. The freeze status (`/api/streak/freeze`) loaded asynchronously, leaving `hasStreakFreezeState` as `undefined` initially
3. Since `undefined` is falsy, the existing guard `if (hasStreakFreezeState)` in the `useEffect` did not prevent `isAtRisk` from being set to `true`
4. The banner rendered before freeze data arrived
5. If the freeze API call failed silently (`.catch(() => {})`), `hasStreakFreezeState` remained `undefined` permanently, and the banner would **persist indefinitely**

### Solution
Added a render-level guard on the `return null` condition:

```diff
- if (!isAtRisk || dismissed) return null;
+ if (!isAtRisk || dismissed || hasStreakFreezeState !== false) return null;
```

This ensures the banner is hidden when:
- `hasStreakFreezeState === true` → freeze is active, banner should not show
- `hasStreakFreezeState === undefined` → freeze status still loading (or fetch failed), do not flash the banner
- `hasStreakFreezeState === false` → confirmed no freeze, banner renders normally if streak is at risk

### Files Changed
- `src/components/StreakAtRiskBanner.tsx` — Added render-level freeze guard

### Testing
- [x] ESLint passes with no warnings or errors
- [x] `next build` compiles successfully
- [x] Banner is hidden when `hasStreakFreezeState = true` (freeze active)
- [x] Banner is hidden when `hasStreakFreezeState = undefined` (loading/error)
- [x] Banner shows normally when `hasStreakFreezeState = false` and streak is at risk

### Acceptance Criteria (from #1900)
- [x] Banner hidden when streak freeze is active
- [x] Banner shows normally when no freeze is active and streak is at risk