### PR TITLE
feat(public-profile): add public_since audit column and weekly goal progress (#1742)

### DIFF
--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -12,7 +12,7 @@ async function fetchUserSettings(userId: string) {
   // Tier 1: All columns
   const res1 = await supabaseAdmin
     .from("users")
-    .select("id, github_login, bio, is_public, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, weekly_digest_opt_in, discord_webhook_url, timezone, webhook_url, discord_muted_until")
+    .select("id, github_login, bio, is_public, public_since, show_weekly_goals, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, weekly_digest_opt_in, discord_webhook_url, timezone, webhook_url, discord_muted_until")
     .eq("id", userId)
     .single();
 
@@ -67,7 +67,7 @@ async function fetchUserSettings(userId: string) {
   // Tier 2: Without bio, for deployments that have not run the latest migration.
   const res2 = await supabaseAdmin
     .from("users")
-    .select("id, github_login, is_public, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, webhook_url")
+      .select("id, github_login, is_public, public_since, show_weekly_goals, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, webhook_url")
     .eq("id", userId)
     .single();
 
@@ -122,7 +122,7 @@ async function fetchUserSettings(userId: string) {
   // Tier 3: Minimal (without pinned_repos and leaderboard_opt_in)
   const res3 = await supabaseAdmin
     .from("users")
-    .select("id, github_login, is_public")
+      .select("id, github_login, is_public, public_since, show_weekly_goals")
     .eq("id", userId)
     .single();
 
@@ -196,6 +196,8 @@ export async function GET(req: NextRequest) {
     github_login: (result.data as any).github_login,
     bio: (result.data as any).bio ?? "",
     is_public: (result.data as any).is_public,
+    public_since: (result.data as any).public_since ?? null,
+    show_weekly_goals: (result.data as any).show_weekly_goals ?? false,
     leaderboard_opt_in: result.leaderboard_opt_in,
     weekly_digest_opt_in: result.weekly_digest_opt_in,
     pinned_repos: result.pinned_repos,
@@ -224,14 +226,14 @@ export async function PATCH(req: NextRequest) {
     );
   }
 
-  let body: { is_public?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key?: string; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null; discord_muted_until?: string | null };
+  let body: { is_public?: boolean; show_weekly_goals?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key?: string; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null; discord_muted_until?: string | null };
   try {
     body = await req.json();
   } catch (e) {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const { is_public, leaderboard_opt_in, weekly_digest_opt_in, pinned_repos, wakatime_api_key, discord_webhook_url, timezone, bio, webhook_url, discord_muted_until } = body;
+  const { is_public, show_weekly_goals, leaderboard_opt_in, weekly_digest_opt_in, pinned_repos, wakatime_api_key, discord_webhook_url, timezone, bio, webhook_url, discord_muted_until } = body;
 
   // Retrieve supported columns first
   const settingsResult = await fetchUserSettings(user.id);
@@ -241,10 +243,15 @@ export async function PATCH(req: NextRequest) {
   }
 
   const { hasLeaderboardOptIn, hasPinnedRepos, hasWakatimeKey, hasWeeklyDigestOptIn, hasDiscordSettings, hasBio, hasWebhookUrl, hasDiscordMutedUntil } = settingsResult;
-  const updates: { is_public?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key_encrypted?: string | null; wakatime_api_key_iv?: string | null; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null; discord_muted_until?: string | null } = {};
+  const updates: { is_public?: boolean; public_since?: string | null; show_weekly_goals?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key_encrypted?: string | null; wakatime_api_key_iv?: string | null; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null; discord_muted_until?: string | null } = {};
 
   if (is_public !== undefined && is_public !== null && typeof is_public === "boolean") {
     updates.is_public = is_public;
+    if (is_public) {
+      updates.public_since = new Date().toISOString();
+    } else {
+      updates.public_since = null;
+    }
   }
 
   if (
@@ -258,6 +265,10 @@ export async function PATCH(req: NextRequest) {
       updates.is_public = true;
     }
   }
+  if (show_weekly_goals !== undefined && show_weekly_goals !== null && typeof show_weekly_goals === "boolean") {
+    updates.show_weekly_goals = show_weekly_goals;
+  }
+
   if (hasWebhookUrl && (typeof webhook_url === "string" || webhook_url === null)) {
     updates.webhook_url = webhook_url;
   }
@@ -365,7 +376,7 @@ export async function PATCH(req: NextRequest) {
   }
 
   // Query only supported columns in the returning select statement
-  const selectCols = ["id", "github_login", "is_public"];
+  const selectCols = ["id", "github_login", "is_public", "public_since", "show_weekly_goals"];
   if (hasBio) selectCols.push("bio");
   if (hasLeaderboardOptIn) selectCols.push("leaderboard_opt_in");
   if (hasWeeklyDigestOptIn) selectCols.push("weekly_digest_opt_in");
@@ -411,6 +422,8 @@ export async function PATCH(req: NextRequest) {
     github_login: (updated as any).github_login,
     bio: (updated as any).bio ?? "",
     is_public: (updated as any).is_public,
+    public_since: (updated as any).public_since ?? null,
+    show_weekly_goals: (updated as any).show_weekly_goals ?? false,
     leaderboard_opt_in: (updated as any).leaderboard_opt_in ?? false,
     weekly_digest_opt_in: (updated as any).weekly_digest_opt_in ?? false,
     pinned_repos: (updated as any).pinned_repos || [],

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -22,6 +22,8 @@ interface UserSettings {
   github_login: string;
   bio: string;
   is_public: boolean;
+  public_since?: string | null;
+  show_weekly_goals?: boolean;
   leaderboard_opt_in: boolean;
   weekly_digest_opt_in: boolean;
   has_wakatime_key?: boolean;
@@ -769,6 +771,67 @@ function SettingsPageContent() {
                 >
                   {copied ? "Copied!" : "Copy"}
                 </button>
+              </div>
+              {settings.public_since && (
+                <p className="mt-3 text-xs text-[var(--muted-foreground)]">
+                  Public since {new Date(settings.public_since).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Weekly Goals on Profile toggle */}
+          {settings.is_public && (
+            <div className="mt-6 pt-6 border-t border-[var(--border)]">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-sm font-semibold text-[var(--card-foreground)]">
+                    Weekly Goal Progress
+                  </h3>
+                  <p className="text-sm text-[var(--muted-foreground)] mt-1">
+                    Show your weekly goal completion rate on your public profile.
+                  </p>
+                </div>
+                <label className="flex items-center cursor-pointer select-none"><span className="sr-only">Toggle weekly goal visibility</span>
+                  <div className="relative">
+                    <input
+                      type="checkbox"
+                      checked={settings.show_weekly_goals ?? false}
+                      aria-label="Toggle weekly goal progress on profile"
+                      onChange={async (e) => {
+                        const value = e.target.checked;
+                        setSaving(true);
+                        try {
+                          const res = await fetch("/api/user/settings", {
+                            method: "PATCH",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ show_weekly_goals: value }),
+                          });
+                          if (res.ok) {
+                            const updated = await res.json();
+                            setSettings(updated);
+                          }
+                        } catch (error) {
+                          console.error("Failed to update weekly goals setting:", error);
+                        } finally {
+                          setSaving(false);
+                        }
+                      }}
+                      disabled={saving}
+                      className="sr-only"
+                    />
+                    <div
+                      className={`block w-10 h-6 rounded-full transition-colors ${settings.show_weekly_goals
+                        ? "bg-[var(--accent)]"
+                        : "bg-[var(--control)]"
+                        }`}
+                    />
+                    <div
+                      className={`absolute left-1 top-1 h-4 w-4 rounded-full bg-[var(--card)] transition-transform ${settings.show_weekly_goals ? "translate-x-4" : ""
+                        }`}
+                    />
+                  </div>
+                </label>
               </div>
             </div>
           )}

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -318,6 +318,13 @@ export default async function PublicProfilePage({
         </div>
       ) : null}
 
+      {/* Weekly Goal Progress */}
+      {profile.weeklyGoalProgress && (
+        <div className="mt-6">
+          <PublicWeeklyGoalProgress progress={profile.weeklyGoalProgress} />
+        </div>
+      )}
+
       {/* Row 2: Top repos */}
       <div className="mt-6">
         <PublicTopRepos repos={profile.repos} />
@@ -463,6 +470,40 @@ function PublicStreakTracker({ streak }: { streak: any }) {
             )}
           </div>
         ))}
+      </div>
+    </div>
+  );
+}
+
+function PublicWeeklyGoalProgress({
+  progress,
+}: {
+  progress: { completed: number; total: number; percentage: number };
+}) {
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-[var(--shadow-soft)]">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
+        Weekly Goal Progress
+      </h2>
+      <div className="flex items-center gap-4">
+        <div className="relative h-20 w-20">
+          <svg className="h-20 w-20 -rotate-90" viewBox="0 0 72 72">
+            <circle cx="36" cy="36" r="30" fill="none" stroke="var(--control)" strokeWidth="6" />
+            <circle
+              cx="36" cy="36" r="30"
+              fill="none" stroke="var(--accent)" strokeWidth="6"
+              strokeDasharray={2 * Math.PI * 30}
+              strokeDashoffset={2 * Math.PI * 30 * (1 - progress.percentage / 100)}
+              strokeLinecap="round"
+            />
+          </svg>
+          <span className="absolute inset-0 flex items-center justify-center text-sm font-bold text-[var(--card-foreground)]">
+            {progress.percentage}%
+          </span>
+        </div>
+        <div className="text-sm text-[var(--muted-foreground)]">
+          {progress.completed} of {progress.total} weekly goals completed
+        </div>
       </div>
     </div>
   );

--- a/src/lib/public-profile-data.ts
+++ b/src/lib/public-profile-data.ts
@@ -2,7 +2,7 @@ import { calculateStreakFromDates } from "@/lib/streak";
 import type { GitHubAchievement } from "@/lib/github-achievements";
 import { syncGitHubAchievementsForUser } from "@/lib/github-achievements";
 import { fetchPinnedRepoDetails, type PinnedRepoDetails } from "@/lib/pinned-repos";
-import { getUserByUsername } from "@/lib/supabase";
+import { getUserByUsername, supabaseAdmin } from "@/lib/supabase";
 
 const GITHUB_API = "https://api.github.com";
 
@@ -31,6 +31,12 @@ export interface StreakData {
   totalActiveDays: number;
 }
 
+export interface WeeklyGoalProgress {
+  completed: number;
+  total: number;
+  percentage: number;
+}
+
 export interface PublicProfileData {
   username: string;
   bio: string | null;
@@ -44,6 +50,7 @@ export interface PublicProfileData {
   achievements: GitHubAchievement[];
   achievementsError?: string | null;
   spotlightRepos?: PinnedRepoDetails[];
+  weeklyGoalProgress: WeeklyGoalProgress | null;
 }
 
 async function ghFetch(url: string, token?: string): Promise<Response> {
@@ -246,6 +253,33 @@ export async function fetchPublicPullRequests(
   return data.total_count ?? 0;
 }
 
+async function fetchPublicWeeklyGoalProgress(
+  userId: string,
+  showOnProfile: boolean
+): Promise<WeeklyGoalProgress | null> {
+  if (!showOnProfile) return null;
+
+  try {
+    const { data: goals, error } = await supabaseAdmin
+      .from("goals")
+      .select("current, target")
+      .eq("user_id", userId)
+      .eq("recurrence", "weekly");
+
+    if (error || !goals) return null;
+
+    const total = goals.length;
+    if (total === 0) return null;
+
+    const completed = goals.filter((g) => g.current >= g.target).length;
+    const percentage = Math.round((completed / total) * 100);
+
+    return { completed, total, percentage };
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchPublicProfile(
   username: string,
   options: { includeAchievements?: boolean } = {}
@@ -263,6 +297,7 @@ export async function fetchPublicProfile(
     pullRequests,
     achievementsCache,
     spotlight,
+    weeklyGoalProgress,
   ] = await Promise.all([
     fetchPublicGists(user.github_login, githubToken),
     fetchPublicTopRepos(user.github_login, githubToken, 30),
@@ -282,6 +317,7 @@ export async function fetchPublicProfile(
       user.pinned_repos || [],
       githubToken || ""
     ),
+    fetchPublicWeeklyGoalProgress(user.id, user.show_weekly_goals ?? false),
   ]);
 
   return {
@@ -297,5 +333,6 @@ export async function fetchPublicProfile(
     achievements: achievementsCache.achievements,
     achievementsError: achievementsCache.error,
     spotlightRepos: spotlight,
+    weeklyGoalProgress,
   };
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -42,6 +42,8 @@ interface User {
   github_login: string;
   bio: string | null;
   is_public: boolean;
+  public_since: string | null;
+  show_weekly_goals: boolean;
   pinned_repos?: string[];
   created_at: string;
   updated_at: string;
@@ -61,7 +63,7 @@ export async function getUserByUsername(
   try {
     const { data, error } = await supabaseAdmin
       .from("users")
-      .select("id,github_id,github_login,bio,is_public,pinned_repos,created_at,updated_at,is_sponsor")
+      .select("id,github_id,github_login,bio,is_public,public_since,show_weekly_goals,pinned_repos,created_at,updated_at,is_sponsor")
       .ilike("github_login", username)
       .eq("is_public", true)
       .single();
@@ -74,7 +76,7 @@ export async function getUserByUsername(
       if (error.code === "42703") {
         const { data: minimal, error: minError } = await supabaseAdmin
           .from("users")
-          .select("id,github_id,github_login,is_public,created_at,updated_at")
+          .select("id,github_id,github_login,is_public,public_since,show_weekly_goals,created_at,updated_at")
           .ilike("github_login", username)
           .eq("is_public", true)
           .single();
@@ -110,7 +112,7 @@ export async function getUserByGithubId(
   try {
     const { data, error } = await supabaseAdmin
       .from("users")
-      .select("id,github_id,github_login,is_public,created_at,updated_at")
+      .select("id,github_id,github_login,is_public,public_since,show_weekly_goals,created_at,updated_at")
       .eq("github_id", githubId)
       .single();
 
@@ -138,7 +140,7 @@ export async function updateUserPublicFlag(
       .from("users")
       .update({ is_public: isPublic })
       .eq("id", userId)
-      .select("id,github_id,github_login,bio,is_public,created_at,updated_at")
+      .select("id,github_id,github_login,bio,is_public,public_since,show_weekly_goals,created_at,updated_at")
       .single();
 
     if (error) {

--- a/supabase/migrations/20260604000001_add_public_since.sql
+++ b/supabase/migrations/20260604000001_add_public_since.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS public_since timestamptz;
+
+CREATE INDEX IF NOT EXISTS users_public_since_idx ON users(public_since);

--- a/supabase/migrations/20260604000002_add_show_weekly_goals.sql
+++ b/supabase/migrations/20260604000002_add_show_weekly_goals.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS show_weekly_goals boolean NOT NULL DEFAULT false;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -5,6 +5,8 @@ create table if not exists users (
   webhook_url  text,
   bio          text default '' check (char_length(bio) <= 500),
   is_public    boolean default false,
+  public_since timestamptz,
+  show_weekly_goals boolean default false,
   leaderboard_opt_in boolean default false,
   pinned_repos text[] default '{}',
   created_at   timestamptz default now(),


### PR DESCRIPTION
Closes #1742

Changes made: added public_since audit column + weekly goal progress opt-in for public profile page

Testing done: npm run type-check (zero errors), npm run lint (zero new warnings), npx playwright test e2e/public-profile.spec.js e2e/theme.spec.js (4/4 passed)

════════════════════════════════════════

## Purpose & Rationale

The public profile feature was missing an audit timestamp tracking when users enabled public visibility, and the profile page omitted weekly goal progress — a key metric for showcasing productivity. These gaps limited the profile's value as a portfolio tool. This PR adds both: a `public_since` column for transparency, and an opt-in weekly goal progress ring on the profile page.

## Technical Resolution Details

Added `public_since timestamptz` and `show_weekly_goals boolean` columns to the users table with migrations. The settings PATCH handler sets `public_since = now()` when enabling public and clears it when disabling. Settings GET/PATCH responses now include both fields, and the settings page shows "Public since [date]" below the share link along with a Weekly Goal Progress toggle.

Extended `PublicProfileData` with a `weeklyGoalProgress` field populated by `fetchPublicWeeklyGoalProgress()`, which queries the Supabase goals table for weekly goals and returns aggregate completion data (`completed`, `total`, `percentage`). The query is skipped unless the user has opted in. The `/u/[username]` page renders a circular progress ring with "X of Y weekly goals completed" text when data is available. No goal titles or details are exposed.

## Local Testing Execution

1. `npm run type-check` — zero errors
2. `npm run lint` — zero new warnings
3. `npx playwright test e2e/public-profile.spec.js e2e/theme.spec.js --workers=1` - 4/4 passed
4. `npx playwright test --workers=1` - 19 pass, 4 pre-existing failures on `upstream/main` (auth pattern from unmerged #1972), zero regressions from this change

## Desired Review Feedback Type

Review of the `public_since` timestamp logic in the settings PATCH handler - specifically whether setting/clearing on every toggle is the correct behavior, and whether the migration order (public_since before show_weekly_goals) is compatible with existing deployments.

## Integrity & AI Usage Disclosure
In compliance with the GSSoC 2026 AI Conduct rules, I disclose that AI tools were used solely as learning and boilerplate aids. The final logic was fully reviewed, tested, and manually adapted to match human styling and clean-code design.