### PR TITLE
[Test] : Base schema.sql is out of sync with recent migrations

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -370,9 +370,18 @@ You hit the 30 requests/minute search API limit. Wait 1 minute. In production th
 
 ---
 
+## Schema synchronization (important)
+
+When you add a new Supabase migration under `supabase/migrations/`, you must also update `supabase/schema.sql` so that fresh local setups work without manually running every migration.
+
+A simple rule: append the new migration SQL into `supabase/schema.sql` (including any new columns, tables, indexes, functions, and RLS policies).
+
+---
+
 ## Questions?
 
 Open a [GitHub Discussion](https://github.com/Priyanshu-byte-coder/devtrack/discussions) — not an issue.
+
 
 
 ### Husky Hooks Troubleshooting Guide

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -16,6 +16,11 @@ create table if not exists users (
   timezone text default 'UTC',
   last_discord_notification_at timestamptz
 );
+
+CREATE INDEX IF NOT EXISTS users_leaderboard_opt_in_idx
+  ON users(leaderboard_opt_in)
+  WHERE leaderboard_opt_in = true;
+
 create table if not exists goals (
   id           text primary key default gen_random_uuid()::text,
   user_id      text not null references users(id) on delete cascade,


### PR DESCRIPTION
Fixed local Supabase base schema sync issues.

Updated supabase/schema.sql to include the missing leaderboard visibility index:
CREATE INDEX IF NOT EXISTS users_leaderboard_opt_in_idx ON users(leaderboard_opt_in) WHERE leaderboard_opt_in = true;
Updated DEVELOPMENT.md with a guideline reminding contributors to keep supabase/schema.sql in sync with new migration files so fresh local setups don’t break.


closes #599