### PR TITLE
fix(e2e): update theme.spec.js locators for combobox UI (#2001)

### DIFF
--- a/e2e/theme.spec.js
+++ b/e2e/theme.spec.js
@@ -58,7 +58,7 @@ test("theme selector switches between themes on the dashboard", async ({ page })
 
   // The DashboardHeader provides the ThemeToggle select on the dashboard
   const themeSelect = page
-    .getByRole("combobox", { name: "Select dashboard theme" })
+    .locator('select[aria-label="Select dashboard theme"]')
     .first();
   await expect(themeSelect).toBeVisible({ timeout: 10000 });
 
@@ -98,7 +98,7 @@ test("public profile page theme selector works without authentication", async ({
   // ThemeToggle select must be present in the AppNavbar and functional without login
   const themeSelect = page
     .getByRole("banner")
-    .getByRole("combobox", { name: "Select dashboard theme" });
+    .locator('select[aria-label="Select dashboard theme"]');
   await expect(themeSelect).toBeVisible({ timeout: 10000 });
 
   const initialValue = await themeSelect.inputValue();
@@ -112,5 +112,5 @@ test("public profile page theme selector works without authentication", async ({
 
   // Theme preference must be persisted to localStorage
   const stored = await page.evaluate(() => localStorage.getItem("theme"));
-  expect(stored === "dark" || stored === "light" || stored === nextTheme).toBe(true);
+  expect(stored).toBe(nextTheme);
 });


### PR DESCRIPTION
## Purpose & Rationale

Closes #2001. Both `theme.spec.js` tests silently failed because the UI was refactored from a toggle button to a `<select>` combobox (`ThemePresetPicker`). The old locators (`getByRole("button", ...)`) matched nothing, and the accessibility-tree-based fallback (`getByRole("combobox", ...)`) also missed the element because the `<select>` is rendered at `opacity: 0` and hidden from the AX tree.

## Technical Resolution Details

Changed 3 lines in `e2e/theme.spec.js`:

1. **Dashboard test** - replaced `getByRole("combobox", { name: "Select dashboard theme" })` with `locator('select[aria-label="Select dashboard theme"]')` to bypass AX-tree opacity filtering.
2. **Public-profile test** - same locator replacement, scoped under `getByRole("banner")`.
3. **localStorage assertion** - tightened `expect(stored === "dark" || stored === "light" || stored === nextTheme)` to `expect(stored).toBe(nextTheme)`, reflecting that the new system stores full theme IDs (e.g. `"modern-light-blue"`) not `"dark"`/`"light"`.

All pre-existing comments left untouched. No other files modified.

## Local Testing Execution

1. `npx playwright test e2e/theme.spec.js --workers=1` - **2/2 passed**
2. `npm run lint` - **0 new warnings** (only pre-existing warnings)
3. `npm run type-check` - **0 errors**

## Desired Review Feedback Type

Please confirm the `locator()` pattern is acceptable for the codebase's E2E conventions, and that the stricter localStorage assertion (`toBe(nextTheme)` vs the previous loose check) won't break in CI environments where a prior theme may already be stored.

## Integrity & AI Usage Disclosure

In compliance with the GSSoC 2026 AI Conduct rules, I disclose that AI tools were used solely as learning and boilerplate aids. The final logic was fully reviewed, tested, and manually adapted to match human styling and clean-code design.