### PR TITLE
fix(date-utils): add dateDiff alias to resolve import error (#1879)

### DIFF
--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -27,6 +27,9 @@ export function dateDiffDays(a: string, b: string): number {
   return (new Date(b).getTime() - new Date(a).getTime()) / 86400000;
 }
 
+// Alias to fix import mismatch (issue #1879)
+export const dateDiff = dateDiffDays;
+
 export function getThisWeekRange(): { start: string; end: string } {
   const now = new Date();
   const weekStart = getUtcWeekStart(now);


### PR DESCRIPTION
## Summary
Added an alias `dateDiff` pointing to `dateDiffDays` in `src/lib/date-utils.ts` to resolve an import mismatch that caused build/TypeScript errors.

Closes #1879

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Added `export const dateDiff = dateDiffDays;` after the `dateDiffDays` function.
- This allows other files to import `dateDiff` (which was previously missing) while keeping `dateDiffDays` for backward compatibility.

---

## How to Test

1. Run `npm run type-check` – it should pass without any "missing export" errors.
2. Optionally, start the dev server (`npm run dev`) to verify no import errors at runtime.

---

## Screenshots (if UI change)

N/A

---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable (N/A for this simple alias)

---

## Accessibility Checklist

N/A – no UI changes.

---

## Additional Notes

The root cause was a mismatch between the exported function name (`dateDiffDays`) and the name imported elsewhere (`dateDiff`). This alias resolves the issue without breaking existing code.