### PR TITLE
fix(security): disable X-Powered-By header

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -130,6 +130,7 @@ const withPWA = withPWAInit({
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  poweredByHeader: false,
   output: "standalone",
   images: {
     remotePatterns: [


### PR DESCRIPTION
### Security Improvement: Disable X-Powered-By Header

#### Description
This PR disables the default `X-Powered-By` header in Next.js by setting `poweredByHeader: false` in `next.config.mjs`. This prevents information disclosure regarding the underlying framework (Next.js) being used by the server, adhering to security-through-obscurity best practices.

*I am contributing on behalf of GSSoc’26.*

Closes #2017