### PR TITLE
fix(security): override serialize-javascript to mitigate RCE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4803,15 +4803,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-terser/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
@@ -17543,9 +17534,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "packageManager": "pnpm@9.0.0"
+  "packageManager": "pnpm@9.0.0",
+  "overrides": {
+    "serialize-javascript": "^6.0.2"
+  }
 }


### PR DESCRIPTION
### Security Improvement: Override serialize-javascript Dependency

#### Description
This PR addresses a known security vulnerability in the deep dependency tree of the project. We override the transitive dependency `serialize-javascript` to a secure patched version (`^6.0.2`) to mitigate a potential Remote Code Execution (RCE) vulnerability.

*I am contributing on behalf of GSSoc’26.*

Closes #2018