### PR TITLE
fix(security): prevent reverse tabnabbing in ContributionAnalysisPanel

### DIFF
--- a/src/components/career-intelligence/ContributionAnalysisPanel.tsx
+++ b/src/components/career-intelligence/ContributionAnalysisPanel.tsx
@@ -211,7 +211,7 @@ export default function ContributionAnalysisPanel({ analysis }: ContributionAnal
                   <a
                     href={repo.url}
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     className="flex items-center gap-1.5 text-sm font-bold text-[var(--foreground)] hover:text-[var(--accent)] transition-colors"
                   >
                     {repo.name}


### PR DESCRIPTION
### Security Improvement: Prevent Reverse Tabnabbing in ContributionAnalysisPanel

#### Description
This PR addresses a reverse tabnabbing vulnerability in `ContributionAnalysisPanel.tsx` by upgrading the external link `rel` attribute from `noreferrer` to `noopener noreferrer`. This prevents target external pages from gaining access to the original page window object via `window.opener`.

*I am contributing on behalf of GSSoc’26.*

Closes #2021