### PR TITLE
feat(github): add organization contribution support

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -6,6 +6,7 @@ import {
   getAllAccounts,
   mergeMetrics,
 } from "@/lib/github-accounts";
+import { orgSearchSegment } from "@/lib/github-orgs";
 import { GITHUB_API, GitHubCommitSearchItem, CommitItem } from "@/lib/github";
 import {
   isMetricsCacheBypassed,
@@ -103,16 +104,18 @@ async function fetchContributionsForAccount(
   cacheContext: { bypass: boolean; userId: string },
   timezone: string,
   fromDate?: string,
-  repo?: string | null
-
+  repo?: string | null,
+  orgLogin?: string | null,
 ): Promise<ContributionResponse> {
   const repoFilter = repo ? ` repo:${repo}` : "";
+  const orgFilter = orgSearchSegment(orgLogin);
 
   const key = metricsCacheKey(cacheContext.userId, "contributions", {
     days,
     githubLogin,
     from: fromDate ?? undefined,
     repo,
+    org: orgLogin ?? undefined,
   });
 
   return withMetricsCache(
@@ -138,7 +141,7 @@ async function fetchContributionsForAccount(
         const searchUrl = new URL(`${GITHUB_API}/search/commits`);
         searchUrl.searchParams.set(
           "q",
-          `author:${githubLogin} author-date:>=${sinceStr}${repoFilter}`
+          `author:${githubLogin} author-date:>=${sinceStr}${repoFilter}${orgFilter}`
         );
         searchUrl.searchParams.set("per_page", "100");
         searchUrl.searchParams.set("page", String(page));
@@ -427,6 +430,30 @@ export async function GET(req: NextRequest) {
 
   if (!userRow) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // org: prefix — filter contributions to a specific GitHub organization.
+  // Uses the primary account's token; no additional account lookup is needed.
+  if (accountId?.startsWith("org:")) {
+    const orgLogin = accountId.slice(4).trim();
+    if (!orgLogin) {
+      return Response.json({ error: "Invalid org identifier" }, { status: 400 });
+    }
+    try {
+      const result = await fetchContributionsForAccount(
+        session.accessToken,
+        session.githubLogin,
+        days,
+        { bypass, userId: session.githubId ?? session.githubLogin },
+        timezone,
+        fromDate,
+        repoParam,
+        orgLogin,
+      );
+      return Response.json(result);
+    } catch {
+      return Response.json({ error: "GitHub API error" }, { status: 502 });
+    }
   }
 
   if (accountId === "combined") {

--- a/src/app/api/user/github-orgs/route.ts
+++ b/src/app/api/user/github-orgs/route.ts
@@ -1,0 +1,166 @@
+/**
+ * GET  /api/user/github-orgs
+ *   Returns the authenticated user's GitHub organizations merged with their
+ *   stored metric-inclusion preferences.  On first call the org list is
+ *   fetched live from the GitHub API and upserted into user_github_orgs;
+ *   subsequent calls return the stored record (refreshed when the GitHub
+ *   list is fetched).
+ *
+ * PATCH /api/user/github-orgs
+ *   Updates the include_in_metrics preference for a single organization.
+ *   Body: { orgId: string; includeInMetrics: boolean }
+ *
+ * Requires the read:org OAuth scope for full private-membership visibility.
+ * Without it the GitHub API returns only public memberships (no error), so
+ * the endpoint degrades gracefully rather than failing.
+ */
+
+import { getServerSession } from "next-auth";
+import { type NextRequest, NextResponse } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
+import { fetchUserOrgs } from "@/lib/github-orgs";
+
+export const dynamic = "force-dynamic";
+
+interface OrgRow {
+  org_id: string;
+  org_login: string;
+  avatar_url: string | null;
+  include_in_metrics: boolean;
+}
+
+export interface OrgRecord {
+  orgId: string;
+  orgLogin: string;
+  avatarUrl: string | null;
+  includeInMetrics: boolean;
+}
+
+// ── GET ──────────────────────────────────────────────────────────────────────
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.githubId || !session.accessToken) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  // Fetch live org list from GitHub (graceful on missing read:org scope).
+  const githubOrgs = await fetchUserOrgs(session.accessToken);
+
+  // Upsert discovered orgs into the preference table so users can control
+  // per-org inclusion.  Existing rows keep their include_in_metrics value.
+  if (githubOrgs.length > 0) {
+    const now = new Date().toISOString();
+    const upsertRows = githubOrgs.map((org) => ({
+      user_id: user.id,
+      org_id: String(org.id),
+      org_login: org.login,
+      avatar_url: org.avatar_url ?? null,
+      updated_at: now,
+    }));
+
+    await supabaseAdmin
+      .from("user_github_orgs")
+      .upsert(upsertRows, {
+        onConflict: "user_id,org_id",
+        ignoreDuplicates: false,
+      })
+      .select("id");
+    // Errors are swallowed intentionally — a failed upsert does not prevent
+    // returning the live GitHub data to the client.
+  }
+
+  // Fetch stored preferences (may include previously discovered orgs no
+  // longer returned by GitHub, e.g. if the user left an org).
+  const { data: stored, error: fetchErr } = await supabaseAdmin
+    .from("user_github_orgs")
+    .select("org_id, org_login, avatar_url, include_in_metrics")
+    .eq("user_id", user.id)
+    .order("org_login", { ascending: true });
+
+  if (fetchErr) {
+    return NextResponse.json(
+      { error: "Failed to load org preferences" },
+      { status: 500 }
+    );
+  }
+
+  const orgs: OrgRecord[] = (stored ?? []).map((row: OrgRow) => ({
+    orgId: row.org_id,
+    orgLogin: row.org_login,
+    avatarUrl: row.avatar_url,
+    includeInMetrics: row.include_in_metrics,
+  }));
+
+  // Indicate when the GitHub API returned no results so the client can
+  // differentiate "user has no orgs" from "scope not granted yet".
+  const hasReadOrgScope = githubOrgs.length > 0 || orgs.length === 0;
+
+  return NextResponse.json({ orgs, hasReadOrgScope });
+}
+
+// ── PATCH ─────────────────────────────────────────────────────────────────────
+
+export async function PATCH(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.githubId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { orgId, includeInMetrics } = body as Record<string, unknown>;
+
+  if (typeof orgId !== "string" || orgId.trim().length === 0) {
+    return NextResponse.json(
+      { error: "orgId must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+
+  if (typeof includeInMetrics !== "boolean") {
+    return NextResponse.json(
+      { error: "includeInMetrics must be a boolean" },
+      { status: 400 }
+    );
+  }
+
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const { error } = await supabaseAdmin
+    .from("user_github_orgs")
+    .update({
+      include_in_metrics: includeInMetrics,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("user_id", user.id)
+    .eq("org_id", orgId.trim());
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to update org preference" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/AccountToggle.tsx
+++ b/src/components/AccountToggle.tsx
@@ -9,6 +9,13 @@ interface LinkedAccount {
   githubLogin: string;
 }
 
+interface OrgRecord {
+  orgId: string;
+  orgLogin: string;
+  avatarUrl: string | null;
+  includeInMetrics: boolean;
+}
+
 interface AccountsResponse {
   accounts: Array<{
     githubId: string;
@@ -16,12 +23,20 @@ interface AccountsResponse {
   }>;
 }
 
+interface OrgsResponse {
+  orgs: OrgRecord[];
+  hasReadOrgScope: boolean;
+}
+
 export default function AccountToggle() {
   const { selectedAccount, setSelectedAccount } = useAccount();
   const { data: session } = useSession();
   const [linkedAccounts, setLinkedAccounts] = useState<LinkedAccount[]>([]);
+  const [orgs, setOrgs] = useState<OrgRecord[]>([]);
 
   useEffect(() => {
+    if (!session?.githubLogin) return;
+
     async function loadAccounts() {
       try {
         const response = await fetch("/api/user/github-accounts");
@@ -29,62 +44,104 @@ export default function AccountToggle() {
           setLinkedAccounts([]);
           return;
         }
-
         const data = (await response.json()) as AccountsResponse;
         setLinkedAccounts(
-          (data.accounts ?? []).map((account) => ({
-            githubId: account.githubId,
-            githubLogin: account.githubLogin,
+          (data.accounts ?? []).map((a) => ({
+            githubId: a.githubId,
+            githubLogin: a.githubLogin,
           }))
         );
-      } catch (e) {
+      } catch {
         setLinkedAccounts([]);
       }
     }
 
-    if (session?.githubLogin) {
-      loadAccounts();
+    async function loadOrgs() {
+      try {
+        const response = await fetch("/api/user/github-orgs");
+        if (!response.ok) {
+          setOrgs([]);
+          return;
+        }
+        const data = (await response.json()) as OrgsResponse;
+        // Only show orgs the user has chosen to include in metrics.
+        setOrgs(
+          (data.orgs ?? []).filter((o) => o.includeInMetrics)
+        );
+      } catch {
+        setOrgs([]);
+      }
     }
+
+    loadAccounts();
+    loadOrgs();
   }, [session?.githubLogin]);
 
-  if (!session?.githubLogin || linkedAccounts.length === 0) {
-    return null;
-  }
+  if (!session?.githubLogin) return null;
 
-  const options: Array<{ label: string; value: string | null }> = [
+  const hasLinkedAccounts = linkedAccounts.length > 0;
+  const hasOrgs = orgs.length > 0;
+
+  // Render nothing if the user has neither linked accounts nor orgs
+  if (!hasLinkedAccounts && !hasOrgs) return null;
+
+  const accountOptions: Array<{ label: string; value: string | null }> = [
     { label: session.githubLogin, value: null },
-    ...linkedAccounts.map((account) => ({
-      label: account.githubLogin,
-      value: account.githubId,
-    })),
-    { label: "Combined", value: "combined" },
+    ...linkedAccounts.map((a) => ({ label: a.githubLogin, value: a.githubId })),
+    ...(hasLinkedAccounts ? [{ label: "Combined", value: "combined" }] : []),
   ];
 
-  return (
-    <div
-      className="mt-4 flex flex-wrap gap-2"
-      role="group"
-      aria-label="Select GitHub account"
-    >
-      {options.map((option) => {
-        const isActive = selectedAccount === option.value;
+  const orgOptions: Array<{ label: string; value: string }> = orgs.map(
+    (o) => ({ label: o.orgLogin, value: `org:${o.orgLogin}` })
+  );
 
-        return (
-          <button
-            key={`${option.label}-${option.value ?? "primary"}`}
-            type="button"
-            aria-pressed={isActive}
-            onClick={() => setSelectedAccount(option.value)}
-            className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
-              isActive
-                ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-foreground)]"
-                : "border-[var(--card-muted)] bg-[var(--card-muted)] text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
-            }`}
-          >
-            {option.label}
-          </button>
-        );
-      })}
+  const renderButton = (
+    label: string,
+    value: string | null,
+    prefix?: string
+  ) => {
+    const isActive = selectedAccount === value;
+    return (
+      <button
+        key={`${prefix ?? ""}${label}-${value ?? "primary"}`}
+        type="button"
+        aria-pressed={isActive}
+        onClick={() => setSelectedAccount(value)}
+        className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+          isActive
+            ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-foreground)]"
+            : "border-[var(--card-muted)] bg-[var(--card-muted)] text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+        }`}
+      >
+        {label}
+      </button>
+    );
+  };
+
+  return (
+    <div className="mt-4 space-y-2">
+      {hasLinkedAccounts && (
+        <div
+          className="flex flex-wrap gap-2"
+          role="group"
+          aria-label="Select GitHub account"
+        >
+          {accountOptions.map((o) => renderButton(o.label, o.value, "acct-"))}
+        </div>
+      )}
+
+      {hasOrgs && (
+        <div
+          className="flex flex-wrap gap-2"
+          role="group"
+          aria-label="Filter by organization"
+        >
+          <span className="self-center text-xs text-[var(--muted-foreground)] mr-1">
+            Orgs:
+          </span>
+          {orgOptions.map((o) => renderButton(o.label, o.value, "org-"))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -24,7 +24,7 @@ export const authOptions: NextAuthOptions = {
       clientId: process.env.GITHUB_ID ?? "",
       clientSecret: process.env.GITHUB_SECRET ?? "",
       authorization: {
-        params: { scope: "read:user user:email repo read:discussion" },
+        params: { scope: "read:user user:email repo read:discussion read:org" },
       },
     }),
   ],

--- a/src/lib/github-orgs.ts
+++ b/src/lib/github-orgs.ts
@@ -1,0 +1,57 @@
+/**
+ * GitHub Organization utilities.
+ *
+ * Fetches the organizations the authenticated user belongs to via the
+ * GitHub REST API.  Requires the `read:org` OAuth scope for private
+ * membership visibility; without it the endpoint silently returns only
+ * public memberships (no error), so callers always get a best-effort list.
+ */
+
+import { GITHUB_API } from "@/lib/github";
+
+export interface GitHubOrg {
+  id: number;
+  login: string;
+  avatar_url: string;
+  description: string | null;
+}
+
+/**
+ * Fetch the authenticated user's organization memberships.
+ *
+ * Returns an empty array rather than throwing on network or permission
+ * failures so callers can degrade gracefully when the `read:org` scope
+ * has not been granted.
+ */
+export async function fetchUserOrgs(token: string): Promise<GitHubOrg[]> {
+  try {
+    const res = await fetch(`${GITHUB_API}/user/orgs?per_page=100`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      cache: "no-store",
+    });
+
+    if (!res.ok) {
+      // 403 / 404 typically means missing read:org scope or the token is
+      // revoked.  Return an empty list rather than propagating the error.
+      return [];
+    }
+
+    return (await res.json()) as GitHubOrg[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Build the org-filter segment for a GitHub commit search query.
+ *
+ * Returns an empty string when orgLogin is falsy so callers can safely
+ * concatenate it without a conditional:
+ *   `author:${login}${orgSearchSegment(orgLogin)} author-date:>=...`
+ */
+export function orgSearchSegment(orgLogin: string | null | undefined): string {
+  return orgLogin ? ` org:${orgLogin}` : "";
+}

--- a/supabase/migrations/20260604000000_add_user_github_orgs.sql
+++ b/supabase/migrations/20260604000000_add_user_github_orgs.sql
@@ -1,0 +1,39 @@
+-- Migration: Add user_github_orgs for GitHub Organization contribution support
+-- Stores which organizations a user has discovered and their per-org metric
+-- inclusion preference.  The primary token (read:org scope) is reused to
+-- fetch org membership; no additional token storage is required.
+
+create table if not exists user_github_orgs (
+  id                 text        primary key default gen_random_uuid()::text,
+  user_id            text        not null references users(id) on delete cascade,
+  org_login          text        not null,
+  org_id             text        not null,
+  avatar_url         text,
+  include_in_metrics boolean     not null default true,
+  created_at         timestamptz not null default now(),
+  updated_at         timestamptz not null default now(),
+
+  unique (user_id, org_id)
+);
+
+create index if not exists user_github_orgs_user_id
+  on user_github_orgs (user_id);
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+alter table user_github_orgs enable row level security;
+
+create policy "user_github_orgs_select_own"
+  on user_github_orgs for select
+  using (user_id = auth.uid()::text);
+
+create policy "user_github_orgs_insert_own"
+  on user_github_orgs for insert
+  with check (user_id = auth.uid()::text);
+
+create policy "user_github_orgs_update_own"
+  on user_github_orgs for update
+  using (user_id = auth.uid()::text);
+
+create policy "user_github_orgs_delete_own"
+  on user_github_orgs for delete
+  using (user_id = auth.uid()::text);

--- a/test/github-orgs.test.ts
+++ b/test/github-orgs.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Tests for GitHub Organization support (issue #1039).
+ *
+ * Coverage:
+ *  - github-orgs.ts utility functions
+ *  - GET /api/user/github-orgs
+ *  - PATCH /api/user/github-orgs
+ *  - Contributions route org: prefix handling
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── hoisted mocks ────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  resolveAppUser: vi.fn(),
+  supabaseFrom: vi.fn(),
+  fetchFn: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: mocks.getServerSession }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: mocks.resolveAppUser,
+}));
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+// Intercept global fetch for GitHub API calls
+vi.stubGlobal("fetch", mocks.fetchFn);
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const SESSION = {
+  githubId: "gh-100",
+  githubLogin: "alice",
+  accessToken: "tok-alice",
+};
+const USER = { id: "user-uuid-100" };
+
+function makeRequest(
+  method: string,
+  url: string,
+  body?: unknown
+): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : {},
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+const SAMPLE_ORG = {
+  id: 12345,
+  login: "my-company",
+  avatar_url: "https://avatars.githubusercontent.com/o/12345",
+  description: "My Company",
+};
+
+// ─── github-orgs.ts utilities ─────────────────────────────────────────────────
+
+describe("fetchUserOrgs", () => {
+  it("returns orgs on a successful GitHub API response", async () => {
+    mocks.fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [SAMPLE_ORG],
+    });
+
+    const { fetchUserOrgs } = await import("../src/lib/github-orgs");
+    const result = await fetchUserOrgs("tok");
+    expect(result).toHaveLength(1);
+    expect(result[0].login).toBe("my-company");
+  });
+
+  it("returns [] when GitHub returns 403 (missing read:org scope)", async () => {
+    mocks.fetchFn.mockResolvedValueOnce({ ok: false, status: 403 });
+    const { fetchUserOrgs } = await import("../src/lib/github-orgs");
+    const result = await fetchUserOrgs("tok");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when the GitHub request throws a network error", async () => {
+    mocks.fetchFn.mockRejectedValueOnce(new Error("network failure"));
+    const { fetchUserOrgs } = await import("../src/lib/github-orgs");
+    const result = await fetchUserOrgs("tok");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when GitHub returns an empty array (no orgs)", async () => {
+    mocks.fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+    const { fetchUserOrgs } = await import("../src/lib/github-orgs");
+    const result = await fetchUserOrgs("tok");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("orgSearchSegment", () => {
+  it("returns ' org:{login}' when orgLogin is provided", async () => {
+    const { orgSearchSegment } = await import("../src/lib/github-orgs");
+    expect(orgSearchSegment("acme")).toBe(" org:acme");
+  });
+
+  it("returns '' for null orgLogin", async () => {
+    const { orgSearchSegment } = await import("../src/lib/github-orgs");
+    expect(orgSearchSegment(null)).toBe("");
+  });
+
+  it("returns '' for undefined orgLogin", async () => {
+    const { orgSearchSegment } = await import("../src/lib/github-orgs");
+    expect(orgSearchSegment(undefined)).toBe("");
+  });
+
+  it("returns '' for empty string orgLogin", async () => {
+    const { orgSearchSegment } = await import("../src/lib/github-orgs");
+    expect(orgSearchSegment("")).toBe("");
+  });
+});
+
+// ─── GET /api/user/github-orgs ─────────────────────────────────────────────────
+
+describe("GET /api/user/github-orgs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue(SESSION);
+    mocks.resolveAppUser.mockResolvedValue(USER);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/user/github-orgs/route");
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns orgs merged with stored preferences", async () => {
+    // GitHub API returns one org
+    mocks.fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [SAMPLE_ORG],
+    });
+
+    // Supabase upsert
+    const upsertMock = vi.fn().mockReturnValue({
+      select: vi.fn().mockResolvedValue({ data: [], error: null }),
+    });
+    // Supabase select (stored prefs)
+    const orderMock = vi.fn().mockResolvedValue({
+      data: [
+        {
+          org_id: "12345",
+          org_login: "my-company",
+          avatar_url: "https://avatars.githubusercontent.com/o/12345",
+          include_in_metrics: true,
+        },
+      ],
+      error: null,
+    });
+    const eqMock = vi.fn().mockReturnValue({ order: orderMock });
+
+    let callCount = 0;
+    mocks.supabaseFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // upsert call
+        return { upsert: upsertMock };
+      }
+      // select call
+      return { select: vi.fn().mockReturnValue({ eq: eqMock }) };
+    });
+
+    const { GET } = await import("@/app/api/user/github-orgs/route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json() as { orgs: unknown[]; hasReadOrgScope: boolean };
+    expect(body.orgs).toHaveLength(1);
+    expect(body.hasReadOrgScope).toBe(true);
+  });
+
+  it("returns empty orgs when user has no organizations", async () => {
+    mocks.fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+    const orderMock = vi.fn().mockResolvedValue({ data: [], error: null });
+    const eqMock = vi.fn().mockReturnValue({ order: orderMock });
+    mocks.supabaseFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({ eq: eqMock }),
+    });
+
+    const { GET } = await import("@/app/api/user/github-orgs/route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json() as { orgs: unknown[] };
+    expect(body.orgs).toHaveLength(0);
+  });
+
+  it("returns 500 when the Supabase select fails", async () => {
+    mocks.fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+    const orderMock = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: "db error" },
+    });
+    const eqMock = vi.fn().mockReturnValue({ order: orderMock });
+    mocks.supabaseFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({ eq: eqMock }),
+    });
+
+    const { GET } = await import("@/app/api/user/github-orgs/route");
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── PATCH /api/user/github-orgs ──────────────────────────────────────────────
+
+describe("PATCH /api/user/github-orgs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue(SESSION);
+    mocks.resolveAppUser.mockResolvedValue(USER);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mocks.getServerSession.mockResolvedValue(null);
+    const { PATCH } = await import("@/app/api/user/github-orgs/route");
+    const res = await PATCH(
+      makeRequest("PATCH", "http://localhost/api/user/github-orgs", {
+        orgId: "12345",
+        includeInMetrics: false,
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("updates include_in_metrics and returns ok:true", async () => {
+    const eqOrgMock = vi.fn().mockResolvedValue({ error: null });
+    const eqUserMock = vi.fn().mockReturnValue({ eq: eqOrgMock });
+    const updateMock = vi.fn().mockReturnValue({ eq: eqUserMock });
+    mocks.supabaseFrom.mockReturnValue({ update: updateMock });
+
+    const { PATCH } = await import("@/app/api/user/github-orgs/route");
+    const res = await PATCH(
+      makeRequest("PATCH", "http://localhost/api/user/github-orgs", {
+        orgId: "12345",
+        includeInMetrics: false,
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it("returns 400 when orgId is missing", async () => {
+    const { PATCH } = await import("@/app/api/user/github-orgs/route");
+    const res = await PATCH(
+      makeRequest("PATCH", "http://localhost/api/user/github-orgs", {
+        includeInMetrics: true,
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when includeInMetrics is not a boolean", async () => {
+    const { PATCH } = await import("@/app/api/user/github-orgs/route");
+    const res = await PATCH(
+      makeRequest("PATCH", "http://localhost/api/user/github-orgs", {
+        orgId: "12345",
+        includeInMetrics: "yes",
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const { PATCH } = await import("@/app/api/user/github-orgs/route");
+    const req = new NextRequest("http://localhost/api/user/github-orgs", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when the Supabase update fails", async () => {
+    const eqOrgMock = vi.fn().mockResolvedValue({
+      error: { message: "db error" },
+    });
+    const eqUserMock = vi.fn().mockReturnValue({ eq: eqOrgMock });
+    const updateMock = vi.fn().mockReturnValue({ eq: eqUserMock });
+    mocks.supabaseFrom.mockReturnValue({ update: updateMock });
+
+    const { PATCH } = await import("@/app/api/user/github-orgs/route");
+    const res = await PATCH(
+      makeRequest("PATCH", "http://localhost/api/user/github-orgs", {
+        orgId: "12345",
+        includeInMetrics: true,
+      })
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Contributions route — org: prefix ────────────────────────────────────────
+
+describe("GET /api/metrics/contributions — org: accountId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getServerSession.mockResolvedValue(SESSION);
+    mocks.resolveAppUser.mockResolvedValue(USER);
+  });
+
+  it("passes org filter in search query for org: accountId", async () => {
+    // Stub the commit search request — first call is the GitHub Search API
+    mocks.fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ total_count: 0, items: [] }),
+    });
+
+    // Stub metrics cache (supabase) — needs select chain
+    const cacheSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+    const cacheEq = vi.fn().mockReturnValue({ single: cacheSingle });
+    const cacheSelect = vi.fn().mockReturnValue({ eq: cacheEq });
+    mocks.supabaseFrom.mockReturnValue({ select: cacheSelect });
+
+    const { GET } = await import("@/app/api/metrics/contributions/route");
+    const req = makeRequest(
+      "GET",
+      "http://localhost/api/metrics/contributions?days=30&accountId=org:acme-corp"
+    );
+    await GET(req);
+
+    // The GitHub Search API must have been called with org:acme-corp in the query
+    const calledUrl = (mocks.fetchFn.mock.calls[0]?.[0] as string) ?? "";
+    expect(calledUrl).toContain("org%3Aacme-corp");
+  });
+
+  it("returns 400 for empty org login (org: with no name)", async () => {
+    // Stub session / user
+    const { GET } = await import("@/app/api/metrics/contributions/route");
+    const req = makeRequest(
+      "GET",
+      "http://localhost/api/metrics/contributions?days=30&accountId=org:"
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("does NOT include org filter when accountId is null (personal view)", async () => {
+    mocks.fetchFn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ total_count: 0, items: [] }),
+    });
+    const cacheSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+    const cacheEq = vi.fn().mockReturnValue({ single: cacheSingle });
+    const cacheSelect = vi.fn().mockReturnValue({ eq: cacheEq });
+    mocks.supabaseFrom.mockReturnValue({ select: cacheSelect });
+
+    const { GET } = await import("@/app/api/metrics/contributions/route");
+    const req = makeRequest(
+      "GET",
+      "http://localhost/api/metrics/contributions?days=30"
+    );
+    await GET(req);
+
+    const calledUrl = (mocks.fetchFn.mock.calls[0]?.[0] as string) ?? "";
+    expect(calledUrl).not.toContain("org%3A");
+  });
+});


### PR DESCRIPTION
Closes #1039

## Architecture discovered

DevTrack uses GitHub OAuth with scopes `read:user user:email repo read:discussion` — no `read:org` was previously requested. The contributions metrics route already uses `author:{login}` in GitHub Search queries, which inherently includes commits in org repositories. Organization contributions were already being counted, but there was no way to discover organizations, filter by them, or persist per-org preferences.

## OAuth scope changes

Added `read:org` to the GitHub provider scope in `src/lib/auth.ts`. Without this scope `/user/orgs` returns only public memberships; with it all memberships are visible. **Existing sessions continue working** — they show public org memberships only until the user reauthorizes naturally (next sign-in).

## Organization sync strategy

`GET /api/user/github-orgs` fetches the live org list from the GitHub REST API (`/user/orgs`), upserts discovered orgs into `user_github_orgs` (preserving existing `include_in_metrics` preferences), then returns the merged list. The primary access token is reused — no extra token storage is required. The endpoint degrades gracefully when `read:org` is not yet granted: it returns whatever GitHub provides (public orgs only) rather than failing.

## Org filtering in contributions

The contributions route now handles `accountId` values prefixed with `org:` (e.g. `accountId=org:acme-corp`). When this pattern is detected:
- The primary user's token is used (no linked-account lookup)
- `org:acme-corp` is appended to the GitHub commit search query
- Results are scoped to that organization only

Existing personal-view and combined-account paths are completely unchanged — no double-counting risk.

## Privacy controls

`PATCH /api/user/github-orgs` lets users toggle `include_in_metrics` per org. `AccountToggle` renders only orgs where `include_in_metrics = true`, so users can exclude specific orgs from dashboard filtering without removing the discovery record.

## Dashboard / AccountToggle integration

`AccountToggle` now renders an **Organizations** section below the existing account buttons. Clicking an org button sets `selectedAccount = org:{orgLogin}`. `ContributionGraph` and all other components that already forward `selectedAccount` as `accountId` to metric routes automatically pass the org filter — no changes to `AccountContext` or any metric widget were required.

## Migration

`supabase/migrations/20260604000000_add_user_github_orgs.sql`
- Table: `user_github_orgs` — `id`, `user_id` (FK + ON DELETE CASCADE), `org_login`, `org_id`, `avatar_url`, `include_in_metrics` (default `true`), `created_at`, `updated_at`
- `unique(user_id, org_id)` constraint
- Index on `user_id`
- RLS policies matching project conventions

## Files changed

| File | Change |
|------|--------|
| `src/lib/auth.ts` | Add `read:org` scope |
| `src/lib/github-orgs.ts` | `fetchUserOrgs()`, `orgSearchSegment()` |
| `src/app/api/user/github-orgs/route.ts` | GET + PATCH handlers |
| `src/app/api/metrics/contributions/route.ts` | `org:` prefix support |
| `src/components/AccountToggle.tsx` | Organizations section |
| `supabase/migrations/20260604000000_add_user_github_orgs.sql` | DB migration |

## Tests added

`test/github-orgs.test.ts` — **21 tests**:
- `fetchUserOrgs` — success, 403 (missing scope), network error, empty list
- `orgSearchSegment` — with org login, null, undefined, empty string
- `GET /api/user/github-orgs` — 401, merged prefs, no orgs, db error
- `PATCH /api/user/github-orgs` — 401, success, missing orgId, non-bool `includeInMetrics`, invalid JSON, db error
- Contributions `org:` prefix — query includes `org:` filter, 400 for empty org name, no filter for personal view

## Verification

```
tsc --noEmit    clean (no errors)
next lint       warnings only (all pre-existing)
vitest run      21/21 tests passed
```
