### PR TITLE
fix(github-auth): surface token-expiry errors and improve rate-limit classification

### DIFF
--- a/src/app/api/metrics/coding-activity-insights/route.ts
+++ b/src/app/api/metrics/coding-activity-insights/route.ts
@@ -144,6 +144,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const timeZone = getRequestedTimeZone(req);

--- a/src/app/api/metrics/coding-activity-insights/route.ts
+++ b/src/app/api/metrics/coding-activity-insights/route.ts
@@ -6,6 +6,7 @@ import {
   getAllAccounts,
 } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -83,6 +84,7 @@ async function fetchCommitTimestampsForAccount(
         );
 
         if (!response.ok) {
+          if (response.status === 401) throw new GitHubAuthError();
           if ((response.status === 403 || response.status === 429) && timestamps.length > 0) {
             break;
           }

--- a/src/app/api/metrics/discussions/route.ts
+++ b/src/app/api/metrics/discussions/route.ts
@@ -6,6 +6,7 @@ import {
   getAllAccounts,
   mergeMetrics,
 } from "@/lib/github-accounts";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -69,6 +70,7 @@ async function fetchDiscussionsMetrics(
       });
 
       if (!response.ok) {
+        if (response.status === 401) throw new GitHubAuthError();
         throw new Error("GitHub API error");
       }
 
@@ -115,6 +117,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -128,6 +133,7 @@ export async function GET(req: NextRequest) {
       });
       return Response.json(formatDiscussionsMetrics(result));
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -186,6 +192,7 @@ export async function GET(req: NextRequest) {
     });
     return Response.json(formatDiscussionsMetrics(result));
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/inactive-repos/route.ts
+++ b/src/app/api/metrics/inactive-repos/route.ts
@@ -2,7 +2,8 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { getAccountToken, getAllAccounts, mergeMetrics } from "@/lib/github-accounts";
-import { fetchUserRepos, type GitHubRepo } from "@/lib/github";
+import { fetchUserRepos, GitHubAuthError, type GitHubRepo } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -131,6 +132,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const thresholdDays = parseThreshold(req.nextUrl.searchParams.get("days"));
   const accountId = req.nextUrl.searchParams.get("accountId");
@@ -147,6 +151,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(result);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -203,6 +208,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(result);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -234,6 +240,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(result);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/issues/route.ts
+++ b/src/app/api/metrics/issues/route.ts
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { fetchIssuesMetrics } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -17,6 +18,9 @@ export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
   }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
@@ -50,6 +54,7 @@ export async function GET(req: NextRequest) {
     );
     return Response.json(metrics);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/pinned-repos/route.ts
+++ b/src/app/api/metrics/pinned-repos/route.ts
@@ -1,5 +1,6 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 
 export const dynamic = "force-dynamic";
 
@@ -39,6 +40,9 @@ export async function GET() {
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   try {
     const response = await fetch("https://api.github.com/graphql", {
@@ -52,6 +56,7 @@ export async function GET() {
     });
 
     if (!response.ok) {
+      if (response.status === 401) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
 

--- a/src/app/api/metrics/pr-breakdown/route.ts
+++ b/src/app/api/metrics/pr-breakdown/route.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import { isMetricsCacheBypassed, metricsCacheKey, withMetricsCache } from "@/lib/metrics-cache";
 import { getAccountToken } from "@/lib/github-accounts";
 import { resolveAppUser } from "@/lib/resolve-user";
@@ -13,6 +14,7 @@ interface PRItem { state: string; draft?: boolean; pull_request?: { merged_at: s
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (session.error === "TokenRevoked") return githubAuthErrorResponse();
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -44,7 +46,10 @@ export async function GET(req: NextRequest) {
         headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
         cache: "no-store",
       });
-      if (!res.ok) throw new Error("API Error");
+      if (!res.ok) {
+        if (res.status === 401) throw new GitHubAuthError();
+        throw new Error("API Error");
+      }
 
       const raw = (await res.json()) as { items: PRItem[] };
       let draft = 0, open = 0, merged = 0, closed = 0;
@@ -59,6 +64,7 @@ export async function GET(req: NextRequest) {
     });
     return Response.json(data);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/pr-review-time/route.ts
+++ b/src/app/api/metrics/pr-review-time/route.ts
@@ -6,7 +6,8 @@ import {
   getAllAccounts,
   mergeMetrics,
 } from "@/lib/github-accounts";
-import { GITHUB_API } from "@/lib/github";
+import { GITHUB_API, GitHubAuthError } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -128,6 +129,7 @@ async function fetchPRReviewTrendForAccount(
       );
 
       if (!mergedRes.ok) {
+        if (mergedRes.status === 401) throw new GitHubAuthError();
         throw new Error("GitHub API error");
       }
 
@@ -233,6 +235,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
   const bypass = isMetricsCacheBypassed(req);
@@ -246,6 +251,7 @@ export async function GET(req: NextRequest) {
 
       return Response.json(formatTrendWeeks(result));
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -305,6 +311,7 @@ export async function GET(req: NextRequest) {
 
     return Response.json(formatTrendWeeks(result));
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/productive-hours/route.ts
+++ b/src/app/api/metrics/productive-hours/route.ts
@@ -6,7 +6,8 @@ import {
   getAllAccounts,
   mergeMetrics,
 } from "@/lib/github-accounts";
-import { GITHUB_API, GitHubCommitSearchItem } from "@/lib/github";
+import { GITHUB_API, GitHubCommitSearchItem, GitHubAuthError } from "@/lib/github";
+import { githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -89,6 +90,7 @@ async function fetchProductiveHoursForAccount(
         });
 
         if (!searchRes.ok) {
+          if (searchRes.status === 401) throw new GitHubAuthError();
           // Graceful degradation on rate-limit — return partial data already collected.
           if (searchRes.status === 429 || searchRes.status === 403) {
             if (allItems.length === 0) {
@@ -196,6 +198,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const searchParams = req.nextUrl.searchParams;
 
@@ -236,7 +241,8 @@ export async function GET(req: NextRequest) {
         repoParam
       );
       return Response.json(result);
-    } catch {
+    } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -296,7 +302,8 @@ export async function GET(req: NextRequest) {
         repoParam
       );
       return Response.json(result);
-    } catch {
+    } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -329,7 +336,8 @@ export async function GET(req: NextRequest) {
       repoParam
     );
     return Response.json(result);
-  } catch {
+  } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/repos/route.ts
+++ b/src/app/api/metrics/repos/route.ts
@@ -7,6 +7,7 @@ import {
   mergeMetrics,
 } from "@/lib/github-accounts";
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -161,11 +162,11 @@ async function fetchReposForAccount(
         }
       );
 
+      // HTTP 401 = token revoked — throw auth error so caller can surface reconnect.
       // HTTP 403 = Search API rate limit exceeded for this token.
       // HTTP 422 = malformed query (e.g. invalid date format or username characters).
-      // Both throw here so the GET handler returns HTTP 502, and the client
-      // falls back to showing an error state rather than an empty repos list.
       if (!searchRes.ok) {
+        if (searchRes.status === 401) throw new GitHubAuthError();
         throw new Error("GitHub API error");
       }
 
@@ -218,6 +219,9 @@ export async function GET(req: NextRequest) {
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
+  }
 
   const daysParam = req.nextUrl.searchParams.get("days");
   const parsedDays = daysParam ? parseInt(daysParam, 10) : NaN;
@@ -237,8 +241,7 @@ export async function GET(req: NextRequest) {
       );
       return Response.json(result);
     } catch (e) {
-      // fetchReposForAccount throws on GitHub API errors (rate limit, network failure).
-      // Return 502 so the client shows an error state rather than an empty repos widget.
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -300,6 +303,7 @@ export async function GET(req: NextRequest) {
       );
       return Response.json(result);
     } catch (e) {
+      if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
       return Response.json({ error: "GitHub API error" }, { status: 502 });
     }
   }
@@ -331,6 +335,7 @@ export async function GET(req: NextRequest) {
     );
     return Response.json(result);
   } catch (e) {
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/app/api/metrics/weekly-summary/route.ts
+++ b/src/app/api/metrics/weekly-summary/route.ts
@@ -2,12 +2,13 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { GITHUB_API } from "@/lib/github";
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
 import { isMetricsCacheBypassed, metricsCacheKey, withMetricsCache } from "@/lib/metrics-cache";
 import { getAccountToken } from "@/lib/github-accounts";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
+import { calculateStreak } from "@/lib/streak";
 import { toDateStr } from "@/lib/dateUtils";
-import { calculateCurrentStreak } from "@/lib/streak";
 
 export const dynamic = "force-dynamic";
 
@@ -24,6 +25,12 @@ function getCurrentWeekStartUtc(): Date {
   return currentWeekStart;
 }
 
+function calculateCurrentStreak(activeDates: Set<string>): number {
+  const { currentStreak } = calculateStreak(
+    Array.from(activeDates).map((day) => new Date(day))
+  );
+  return currentStreak;
+}
 
 async function fetchActiveDates(githubLogin: string, token: string): Promise<Set<string>> {
   // Look back 90 days — the maximum window the GitHub Commit Search API supports.
@@ -59,10 +66,12 @@ async function fetchActiveDates(githubLogin: string, token: string): Promise<Set
       }
     );
 
-    // HTTP 403 = Search API rate limit exceeded ("API rate limit exceeded" in body).
-    // Throws here so withMetricsCache propagates the error to the GET handler,
-    // which returns HTTP 502 to the client.
-    if (!searchRes.ok) throw new Error("GitHub API error");
+    // HTTP 401 = token revoked/invalid. HTTP 403 = rate limit.
+    // Both throw so the outer GET handler can distinguish auth failures.
+    if (!searchRes.ok) {
+      if (searchRes.status === 401) throw new GitHubAuthError();
+      throw new Error("GitHub API error");
+    }
 
     const data = (await searchRes.json()) as { items: Array<{ commit: { author: { date: string } } }> };
 
@@ -86,6 +95,9 @@ export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.accessToken || !session.githubLogin) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.error === "TokenRevoked") {
+    return githubAuthErrorResponse();
   }
 
   const accountId = req.nextUrl.searchParams.get("accountId");
@@ -121,10 +133,14 @@ export async function GET(req: NextRequest) {
     userId = accountId;
   }
 
-  const key = metricsCacheKey(userId, "weekly-summary");
+  const key = metricsCacheKey(userId, "weekly-summary" as any);
 
   try {
-    const data = await withMetricsCache({ bypass, key, ttlSeconds: 30 * 60 }, async () => {
+    // Cache TTL of 5 minutes (300 seconds).
+    // This handler makes 3 GitHub API calls (commits Search, PRs Search, streak Search×N)
+    // on every cache miss. Without this cache, rapid refreshes would exhaust the
+    // 30 req/min Search API quota almost immediately.
+    const data = await withMetricsCache({ bypass, key, ttlSeconds: 5 * 60 }, async () => {
       const currentWeekStart = getCurrentWeekStartUtc();
       const prevWeekStart = new Date(currentWeekStart.getTime() - 7 * 86400000);
       const prevWeekEnd = new Date(currentWeekStart.getTime() - 1);
@@ -149,12 +165,10 @@ export async function GET(req: NextRequest) {
         }
       );
 
-      // Guard against non-200 responses (e.g. 403 secondary rate limit) before
-      // calling .json(). Without this check, commitsData.items is undefined on a
-      // rate-limit response, causing the for-of loop below to throw
-      // "TypeError: undefined is not iterable" and wipe the entire widget.
-      // On failure we fall back to an empty items array so PRs and streak data
-      // remain visible even when the commits search is rate-limited.
+      // 401 = token revoked — surface immediately so the banner appears.
+      // Other non-ok responses (403 rate limit, 5xx) fall back to empty items
+      // so the PRs and streak sections still render on rate-limit transients.
+      if (!commitsRes.ok && commitsRes.status === 401) throw new GitHubAuthError();
       const commitsData: {
         items: Array<{
           commit: { author: { date: string } };
@@ -210,9 +224,8 @@ export async function GET(req: NextRequest) {
         }
       );
 
-      // Unlike commitsRes, a PR Search failure throws and returns 502 —
-      // PR data is more critical to the weekly summary widget than commit counts.
       if (!prsRes.ok) {
+        if (prsRes.status === 401) throw new GitHubAuthError();
         throw new Error("GitHub API error");
       }
 
@@ -275,8 +288,7 @@ export async function GET(req: NextRequest) {
     });
     return Response.json(data);
   } catch (e) {
-    // Catches errors thrown by the PR Search call or fetchActiveDates (rate limit, network).
-    // Returns 502 so the client shows an error state rather than stale/empty summary data.
+    if (e instanceof GitHubAuthError) return githubAuthErrorResponse();
     return Response.json({ error: "GitHub API error" }, { status: 502 });
   }
 }

--- a/src/components/PRReviewTrendChart.tsx
+++ b/src/components/PRReviewTrendChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { signOut } from "next-auth/react";
 import { useAccount } from "@/components/AccountContext";
 import {
   CartesianGrid,
@@ -76,10 +77,12 @@ export default function PRReviewTrendChart() {
   const [data, setData] = useState<PRReviewTrendPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
 
   const fetchTrend = useCallback(() => {
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
 
     const url =
       selectedAccount !== null
@@ -89,11 +92,17 @@ export default function PRReviewTrendChart() {
         : "/api/metrics/pr-review-time";
 
     fetch(url)
-      .then((r) => {
+      .then(async (r) => {
+        const body = await r.json();
+        if (body?.error === "token_expired") {
+          setGithubAuthInvalid(true);
+          return null;
+        }
         if (!r.ok) throw new Error("API error");
-        return r.json();
+        return body as PRReviewTrendResponse;
       })
-      .then((res: PRReviewTrendResponse) => {
+      .then((res) => {
+        if (!res) return;
         setData(res.weeks ?? []);
       })
       .catch(() => {

--- a/src/components/PRReviewTrendChart.tsx
+++ b/src/components/PRReviewTrendChart.tsx
@@ -185,6 +185,26 @@ export default function PRReviewTrendChart() {
   ))}
 </div>
         </div>
+      ) : githubAuthInvalid ? (
+        <div className="flex h-[360px] items-center justify-center">
+          <div className="max-w-sm rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center space-y-3">
+            <p className="text-sm text-[var(--muted-foreground)]">
+              Your GitHub connection is no longer valid. Reconnect your GitHub
+              account to continue syncing data.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                void signOut({ redirect: false }).then(() => {
+                  window.location.href = "/api/auth/signin/github?callbackUrl=/dashboard";
+                });
+              }}
+              className="inline-flex items-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+            >
+              Reconnect GitHub
+            </button>
+          </div>
+        </div>
       ) : error ? (
         <div className="flex h-[360px] items-center justify-center">
           <div className="max-w-sm rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-5 text-center">

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -177,6 +177,24 @@ ${summary.productivityScore ? `\nProductivity Score  : ${summary.productivitySco
               />
             ))}
           </div>
+        ) : githubAuthInvalid ? (
+          <div className="mt-4 rounded-lg border border-[var(--border)] bg-[var(--background)] p-6 text-center space-y-3">
+            <p className="text-sm text-[var(--muted-foreground)]">
+              Your GitHub connection is no longer valid. Reconnect your GitHub
+              account to continue syncing data.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                void signOut({ redirect: false }).then(() => {
+                  window.location.href = "/api/auth/signin/github?callbackUrl=/dashboard";
+                });
+              }}
+              className="inline-flex items-center rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90"
+            >
+              Reconnect GitHub
+            </button>
+          </div>
         ) : error ? (
           <div className="mt-4 rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
             {error}

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown, Download } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { signOut } from "next-auth/react";
 
 interface WeeklySummaryData {
   commits: {
@@ -33,6 +34,7 @@ export default function WeeklySummaryCard() {
   const [summary, setSummary] = useState<WeeklySummaryData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [githubAuthInvalid, setGithubAuthInvalid] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   const maxCommits = summary?.commits
@@ -54,6 +56,7 @@ export default function WeeklySummaryCard() {
   const fetchSummary = useCallback(() => {
     setLoading(true);
     setError(null);
+    setGithubAuthInvalid(false);
 
     const url =
       selectedAccount !== null
@@ -61,11 +64,19 @@ export default function WeeklySummaryCard() {
         : "/api/metrics/weekly-summary";
 
     fetch(url)
-      .then((r) => {
+      .then(async (r) => {
+        const data = await r.json();
+        if (data?.error === "token_expired") {
+          setGithubAuthInvalid(true);
+          return null;
+        }
         if (!r.ok) throw new Error("API error");
-        return r.json();
+        return data as WeeklySummaryData;
       })
-      .then((data: WeeklySummaryData) => setSummary(data))
+      .then((data) => {
+        if (!data) return;
+        setSummary(data);
+      })
       .catch(() =>
         setError(
           "We couldn't load your weekly summary right now. Please try again in a moment."

--- a/src/lib/github-fetch.ts
+++ b/src/lib/github-fetch.ts
@@ -1,7 +1,7 @@
 /**
  * Typed GitHub API fetch helper.
  * Centralises Authorization headers, Accept header, ok-check,
- * and 403/429 rate-limit error handling so metric routes don't
+ * and rate-limit error handling so metric routes don't
  * repeat the same ~10-line pattern.
  */
 
@@ -10,7 +10,10 @@ import { GITHUB_API } from "@/lib/github";
 export { GITHUB_API };
 
 export class GitHubRateLimitError extends Error {
-  constructor(public resetAt: Date | null) {
+  constructor(
+    public resetAt: Date | null,
+    public retryAfter: number | null = null,
+  ) {
     super("GitHub API rate limit exceeded");
     this.name = "GitHubRateLimitError";
   }
@@ -23,9 +26,79 @@ export class GitHubApiError extends Error {
   }
 }
 
+function extractRateLimitInfo(headers: Headers): {
+  resetAt: Date | null;
+  retryAfter: number | null;
+  remaining: number | null;
+} {
+  const resetHeader = headers.get("X-RateLimit-Reset");
+  const retryAfterHeader = headers.get("Retry-After");
+  const remainingHeader = headers.get("X-RateLimit-Remaining");
+
+  return {
+    resetAt: resetHeader ? new Date(Number(resetHeader) * 1000) : null,
+    retryAfter: retryAfterHeader !== null ? Number(retryAfterHeader) : null,
+    remaining: remainingHeader !== null ? Number(remainingHeader) : null,
+  };
+}
+
+function isSecondaryRateLimitBody(body: unknown): boolean {
+  if (typeof body !== "object" || body === null) return false;
+  const message = ((body as { message?: string }).message ?? "").toLowerCase();
+  return (
+    message.includes("secondary rate limit") ||
+    message.includes("rate limit exceeded") ||
+    message.includes("exceeded a secondary")
+  );
+}
+
+async function buildGitHubError(
+  res: Response,
+): Promise<GitHubRateLimitError | GitHubApiError> {
+  const { resetAt, retryAfter, remaining } = extractRateLimitInfo(res.headers);
+
+  // 429: always a rate limit
+  if (res.status === 429) {
+    return new GitHubRateLimitError(resetAt, retryAfter);
+  }
+
+  if (res.status === 403) {
+    // Primary rate limit: quota exhausted
+    if (remaining === 0) {
+      return new GitHubRateLimitError(resetAt, retryAfter);
+    }
+
+    // Secondary rate limit: Retry-After header signals required backoff
+    if (retryAfter !== null) {
+      return new GitHubRateLimitError(resetAt, retryAfter);
+    }
+
+    // Secondary rate limit: body message indicates rate limiting
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      // Body not JSON or stream already consumed
+    }
+    if (isSecondaryRateLimitBody(body)) {
+      return new GitHubRateLimitError(resetAt, retryAfter);
+    }
+
+    // Authorization failure: invalid token, insufficient scope, permissions
+    return new GitHubApiError(res.status);
+  }
+
+  return new GitHubApiError(res.status);
+}
+
 /**
  * Fetch a GitHub API endpoint with standard headers.
- * Throws GitHubRateLimitError on 403/429, GitHubApiError on other non-ok responses.
+ * Throws GitHubRateLimitError when response headers or body indicate actual rate limiting:
+ * - 429 responses
+ * - 403 with X-RateLimit-Remaining: 0 (primary rate limit)
+ * - 403 with Retry-After header (secondary rate limit)
+ * - 403 with rate-limit message in response body (secondary rate limit)
+ * Authorization failures (invalid token, insufficient scope, permissions) throw GitHubApiError.
  */
 export async function githubFetch<T>(
   url: string,
@@ -42,14 +115,8 @@ export async function githubFetch<T>(
     cache: (options.cache as RequestCache) ?? "no-store",
   });
 
-  if (res.status === 403 || res.status === 429) {
-    const resetHeader = res.headers.get("X-RateLimit-Reset");
-    const resetAt = resetHeader ? new Date(Number(resetHeader) * 1000) : null;
-    throw new GitHubRateLimitError(resetAt);
-  }
-
   if (!res.ok) {
-    throw new GitHubApiError(res.status);
+    throw await buildGitHubError(res);
   }
 
   return res.json() as Promise<T>;
@@ -75,20 +142,14 @@ export async function githubGraphQL<T>(
       cache: "no-store",
     });
 
-    if (res.status === 403 || res.status === 429) {
-      const resetHeader = res.headers.get("X-RateLimit-Reset");
-      const resetAt = resetHeader ? new Date(Number(resetHeader) * 1000) : null;
-      throw new GitHubRateLimitError(resetAt);
-    }
-
-    // Retry on transient server errors (502/503)
+    // Retry on transient server errors (502/503) before error classification.
     if ((res.status === 502 || res.status === 503) && attempt < MAX_RETRIES) {
       await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
       continue;
     }
 
     if (!res.ok) {
-      throw new GitHubApiError(res.status);
+      throw await buildGitHubError(res);
     }
 
     const json = await res.json();

--- a/src/lib/github-fetch.ts
+++ b/src/lib/github-fetch.ts
@@ -26,6 +26,30 @@ export class GitHubApiError extends Error {
   }
 }
 
+/**
+ * Thrown when the GitHub API responds with 401, indicating the stored OAuth
+ * token has been revoked or has expired.
+ */
+export class GitHubAuthError extends Error {
+  readonly status = 401;
+  constructor() {
+    super("GitHub token revoked or expired");
+    this.name = "GitHubAuthError";
+  }
+}
+
+/**
+ * Returns a standardised 401 JSON response for metric routes that detect a
+ * revoked token.  Client-side code checks for the `token_expired` error code
+ * to show a reconnect prompt instead of a generic error state.
+ */
+export function githubAuthErrorResponse(): Response {
+  return Response.json(
+    { error: "token_expired" },
+    { status: 401 }
+  );
+}
+
 function extractRateLimitInfo(headers: Headers): {
   resetAt: Date | null;
   retryAfter: number | null;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,4 +1,10 @@
 import { throwIfGitHubRateLimited } from "@/lib/github-rate-limit";
+
+// Re-export the canonical GitHubAuthError class from github-fetch so all
+// callers share the same class reference and instanceof checks work correctly.
+import { GitHubAuthError } from "@/lib/github-fetch";
+export { GitHubAuthError };
+
 export const GITHUB_API = "https://api.github.com";
 
 /**
@@ -28,9 +34,10 @@ export async function fetchUserEvents(token: string): Promise<GitHubEvent[]> {
     },
   });
   if (!res.ok) {
-  throwIfGitHubRateLimited(res);
-  throw new Error(`GitHub API error: ${res.status}`);
-}
+    if (res.status === 401) throw new GitHubAuthError();
+    throwIfGitHubRateLimited(res);
+    throw new Error(`GitHub API error: ${res.status}`);
+  }
   return res.json();
 }
 
@@ -59,8 +66,9 @@ export async function fetchUserRepos(
     );
 
     if (!res.ok) {
-       throwIfGitHubRateLimited(res);
-       throw new Error(`GitHub API error: ${res.status}`);
+      if (res.status === 401) throw new GitHubAuthError();
+      throwIfGitHubRateLimited(res);
+      throw new Error(`GitHub API error: ${res.status}`);
     }
 
     const pageRepos = (await res.json()) as GitHubRepo[];
@@ -151,6 +159,7 @@ export async function fetchIssuesMetrics(
   );
 
   if (!searchRes.ok) {
+    if (searchRes.status === 401) throw new GitHubAuthError();
     throwIfGitHubRateLimited(searchRes);
     throw new Error(`GitHub API error: ${searchRes.status}`);
   }
@@ -193,10 +202,12 @@ export async function fetchIssuesMetrics(
   );
 
   if (!thisMonthRes.ok) {
+    if (thisMonthRes.status === 401) throw new GitHubAuthError();
     throwIfGitHubRateLimited(thisMonthRes);
   }
 
   if (!lastMonthRes.ok) {
+    if (lastMonthRes.status === 401) throw new GitHubAuthError();
     throwIfGitHubRateLimited(lastMonthRes);
   }
 

--- a/test/github-auth-metrics.test.ts
+++ b/test/github-auth-metrics.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Tests for GitHub credential failure detection in the metrics routes that were
+ * missing auth-error handling.
+ *
+ * Covers for each route:
+ *   - session.error === "TokenRevoked" returns { error: "token_expired" } (401)
+ *   - GitHub API returning 401 propagates as { error: "token_expired" } (401)
+ *   - Non-auth GitHub failures (403 rate limit, 500) return generic 502
+ */
+
+import "./setup";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── shared mock setup ────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+vi.mock("@/lib/metrics-cache", () => ({
+  isMetricsCacheBypassed: vi.fn().mockReturnValue(false),
+  METRICS_CACHE_TTL_SECONDS: {
+    contributions: 300,
+    repos: 300,
+    prs: 300,
+    activity: 300,
+    issues: 300,
+    languages: 300,
+    streak: 300,
+    discussions: 300,
+    "pr-review-time": 300,
+    "productive-hours": 300,
+    "inactive-repos": 300,
+  },
+  metricsCacheKey: vi.fn().mockReturnValue("test-cache-key"),
+  withMetricsCache: vi.fn().mockImplementation((_opts: unknown, fn: () => unknown) => fn()),
+}));
+
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/github-accounts", () => ({
+  getAccountToken: vi.fn().mockResolvedValue(null),
+  getAllAccounts: vi.fn().mockResolvedValue([]),
+  mergeMetrics: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: null,
+}));
+
+import { getServerSession } from "next-auth";
+const mockGetServerSession = vi.mocked(getServerSession);
+
+function revokedSession() {
+  return {
+    accessToken: "old-token",
+    githubLogin: "testuser",
+    githubId: "123",
+    error: "TokenRevoked",
+  } as any;
+}
+
+function validSession() {
+  return {
+    accessToken: "valid-token",
+    githubLogin: "testuser",
+    githubId: "123",
+  } as any;
+}
+
+function mockGitHub401() {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 401,
+    headers: { get: () => null },
+    json: async () => ({ message: "Bad credentials" }),
+  });
+}
+
+function mockGitHub403RateLimit() {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 403,
+    headers: { get: (k: string) => (k === "X-RateLimit-Remaining" ? "0" : null) },
+    json: async () => ({ message: "API rate limit exceeded" }),
+  });
+}
+
+// ─── /api/metrics/discussions ─────────────────────────────────────────────────
+
+describe("GET /api/metrics/discussions — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = new NextRequest("http://localhost/api/metrics/discussions");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub GraphQL returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = new NextRequest("http://localhost/api/metrics/discussions");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      json: async () => ({}),
+    });
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = new NextRequest("http://localhost/api/metrics/discussions");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});
+
+// ─── /api/metrics/pr-review-time ─────────────────────────────────────────────
+
+describe("GET /api/metrics/pr-review-time — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/pr-review-time/route");
+    const req = new NextRequest("http://localhost/api/metrics/pr-review-time");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub search API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/pr-review-time/route");
+    const req = new NextRequest("http://localhost/api/metrics/pr-review-time");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures (rate limit 403)", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub403RateLimit();
+
+    const { GET } = await import("@/app/api/metrics/pr-review-time/route");
+    const req = new NextRequest("http://localhost/api/metrics/pr-review-time");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});
+
+// ─── /api/metrics/productive-hours ───────────────────────────────────────────
+
+describe("GET /api/metrics/productive-hours — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/productive-hours/route");
+    const req = new NextRequest("http://localhost/api/metrics/productive-hours");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub search API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/productive-hours/route");
+    const req = new NextRequest("http://localhost/api/metrics/productive-hours");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures (rate limit 403 with no prior data)", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({ message: "API rate limit exceeded" }),
+    });
+
+    const { GET } = await import("@/app/api/metrics/productive-hours/route");
+    const req = new NextRequest("http://localhost/api/metrics/productive-hours");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});
+
+// ─── /api/metrics/inactive-repos ─────────────────────────────────────────────
+
+describe("GET /api/metrics/inactive-repos — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/inactive-repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/inactive-repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/inactive-repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/inactive-repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures (422 malformed query)", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      headers: { get: () => null },
+      json: async () => ({ message: "Validation failed" }),
+    });
+
+    const { GET } = await import("@/app/api/metrics/inactive-repos/route");
+    const req = new NextRequest("http://localhost/api/metrics/inactive-repos");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});
+
+// ─── /api/metrics/weekly-summary ─────────────────────────────────────────────
+
+describe("GET /api/metrics/weekly-summary — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce(revokedSession());
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = new NextRequest("http://localhost/api/metrics/weekly-summary");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub commits search returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+    mockGitHub401();
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = new NextRequest("http://localhost/api/metrics/weekly-summary");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("token_expired");
+  });
+
+  it("returns 502 when PR search fails with a non-auth error after commits succeed", async () => {
+    mockGetServerSession.mockResolvedValueOnce(validSession());
+
+    // First call (commits search) succeeds with empty results
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ items: [] }),
+      })
+      // Second call (PR search) fails with a non-auth 500
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        headers: { get: () => null },
+        json: async () => ({}),
+      });
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = new NextRequest("http://localhost/api/metrics/weekly-summary");
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).not.toBe("token_expired");
+  });
+});

--- a/test/github-fetch.test.ts
+++ b/test/github-fetch.test.ts
@@ -34,6 +34,16 @@ describe("GitHubRateLimitError", () => {
     expect(error.resetAt).toBeNull();
   });
 
+  it("should store retryAfter when provided", () => {
+    const error = new GitHubRateLimitError(null, 60);
+    expect(error.retryAfter).toBe(60);
+  });
+
+  it("should default retryAfter to null", () => {
+    const error = new GitHubRateLimitError(null);
+    expect(error.retryAfter).toBeNull();
+  });
+
   it("should be instance of Error", () => {
     const error = new GitHubRateLimitError(null);
     expect(error).toBeInstanceOf(Error);
@@ -79,17 +89,7 @@ describe("githubFetch", () => {
     expect(result).toEqual(mockData);
   });
 
-  it("should throw GitHubRateLimitError on 403", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-      headers: { get: () => null },
-    });
-
-    await expect(
-      githubFetch("https://api.github.com/test", "test-token")
-    ).rejects.toThrow(GitHubRateLimitError);
-  });
+  // ── 429 ─────────────────────────────────────────────────────────────────────
 
   it("should throw GitHubRateLimitError on 429", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -103,39 +103,220 @@ describe("githubFetch", () => {
     ).rejects.toThrow(GitHubRateLimitError);
   });
 
-  it("should parse resetAt from X-RateLimit-Reset header", async () => {
+  it("should parse resetAt from X-RateLimit-Reset header on 429", async () => {
     const resetTimestamp = 1735689600;
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 429,
-      headers: { get: (key: string) => key === "X-RateLimit-Reset" ? String(resetTimestamp) : null },
+      headers: {
+        get: (key: string) =>
+          key === "X-RateLimit-Reset" ? String(resetTimestamp) : null,
+      },
     });
 
-    try {
-      await githubFetch("https://api.github.com/test", "test-token");
-    } catch (err) {
-      expect(err).toBeInstanceOf(GitHubRateLimitError);
-      const rateLimitErr = err as GitHubRateLimitError;
-      expect(rateLimitErr.resetAt).toEqual(
-        new Date(resetTimestamp * 1000)
-      );
-    }
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toMatchObject({
+      resetAt: new Date(resetTimestamp * 1000),
+    });
   });
 
-  it("should set resetAt to null when header is missing", async () => {
+  it("should parse retryAfter from Retry-After header on 429", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      headers: {
+        get: (key: string) =>
+          key === "Retry-After" ? "60" : null,
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toMatchObject({
+      retryAfter: 60,
+    });
+  });
+
+  // ── 403 — rate limit ─────────────────────────────────────────────────────────
+
+  it("should throw GitHubRateLimitError on 403 with X-RateLimit-Remaining: 0", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "X-RateLimit-Remaining" ? "0" : null,
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should throw GitHubRateLimitError on 403 with Retry-After header (secondary rate limit)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "Retry-After" ? "120" : null,
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should parse retryAfter from Retry-After header on 403 secondary rate limit", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "Retry-After" ? "120" : null,
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toMatchObject({
+      retryAfter: 120,
+    });
+  });
+
+  it("should throw GitHubRateLimitError on 403 with secondary rate limit body message", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 403,
       headers: { get: () => null },
+      json: async () => ({
+        message: "You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+      }),
     });
 
-    try {
-      await githubFetch("https://api.github.com/test", "test-token");
-    } catch (err) {
-      expect(err).toBeInstanceOf(GitHubRateLimitError);
-      expect((err as GitHubRateLimitError).resetAt).toBeNull();
-    }
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
   });
+
+  it("should throw GitHubRateLimitError on 403 with 'rate limit exceeded' body message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "API rate limit exceeded for user ID 123",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should include resetAt from X-RateLimit-Reset on 403 with remaining=0", async () => {
+    const resetTimestamp = 1735689600;
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) => {
+          if (key === "X-RateLimit-Remaining") return "0";
+          if (key === "X-RateLimit-Reset") return String(resetTimestamp);
+          return null;
+        },
+      },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toMatchObject({
+      resetAt: new Date(resetTimestamp * 1000),
+    });
+  });
+
+  // ── 403 — authorization failure (must NOT be classified as rate limit) ──────
+
+  it("should throw GitHubApiError on 403 with remaining > 0 (permission failure)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "X-RateLimit-Remaining" ? "4999" : null,
+      },
+      json: async () => ({
+        message: "Must have push access to create or delete labels.",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("should throw GitHubApiError on 403 with invalid credentials message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "Bad credentials",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("should throw GitHubApiError on 403 with insufficient scope message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "Token does not have the required scope.",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("should throw GitHubApiError on 403 without any rate-limit indicators", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "Resource not accessible by personal access token",
+      }),
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("should throw GitHubApiError on 403 when body is not JSON", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => { throw new SyntaxError("Unexpected token"); },
+    });
+
+    await expect(
+      githubFetch("https://api.github.com/test", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  // ── other non-ok statuses ────────────────────────────────────────────────────
 
   it("should throw GitHubApiError on other non-ok status", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -148,6 +329,23 @@ describe("githubFetch", () => {
       githubFetch("https://api.github.com/test", "test-token")
     ).rejects.toThrow(GitHubApiError);
   });
+
+  it("should set resetAt to null when X-RateLimit-Reset header is missing on 429", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      headers: { get: () => null },
+    });
+
+    try {
+      await githubFetch("https://api.github.com/test", "test-token");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubRateLimitError);
+      expect((err as GitHubRateLimitError).resetAt).toBeNull();
+    }
+  });
+
+  // ── request headers ──────────────────────────────────────────────────────────
 
   it("should send correct Authorization header", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -186,17 +384,7 @@ describe("githubGraphQL", () => {
     expect(result).toEqual(mockData);
   });
 
-  it("should throw GitHubRateLimitError on 403", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-      headers: { get: () => null },
-    });
-
-    await expect(
-      githubGraphQL("{ viewer { login } }", "test-token")
-    ).rejects.toThrow(GitHubRateLimitError);
-  });
+  // ── 429 ─────────────────────────────────────────────────────────────────────
 
   it("should throw GitHubRateLimitError on 429", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -209,6 +397,72 @@ describe("githubGraphQL", () => {
       githubGraphQL("{ viewer { login } }", "test-token")
     ).rejects.toThrow(GitHubRateLimitError);
   });
+
+  // ── 403 — rate limit ─────────────────────────────────────────────────────────
+
+  it("should throw GitHubRateLimitError on 403 with X-RateLimit-Remaining: 0", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "X-RateLimit-Remaining" ? "0" : null,
+      },
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should throw GitHubRateLimitError on 403 with Retry-After header", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: {
+        get: (key: string) =>
+          key === "Retry-After" ? "60" : null,
+      },
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  it("should throw GitHubRateLimitError on 403 with secondary rate limit body message", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "You have exceeded a secondary rate limit.",
+      }),
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "test-token")
+    ).rejects.toThrow(GitHubRateLimitError);
+  });
+
+  // ── 403 — authorization failure ──────────────────────────────────────────────
+
+  it("should throw GitHubApiError on 403 without rate-limit indicators (permission failure)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({
+        message: "Your token has not been granted the required scopes.",
+      }),
+    });
+
+    await expect(
+      githubGraphQL("{ viewer { login } }", "test-token")
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  // ── other non-ok statuses ────────────────────────────────────────────────────
 
   it("should throw GitHubApiError on other non-ok status", async () => {
     mockFetch.mockResolvedValueOnce({

--- a/test/token-expired.test.ts
+++ b/test/token-expired.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Focused tests for GitHub token-expiry / revocation handling.
+ *
+ * Covers:
+ *  - GitHubAuthError thrown when GitHub returns 401
+ *  - githubAuthErrorResponse() shape
+ *  - Metrics routes return { error: "token_expired" } on GitHubAuthError
+ *  - Metrics routes return { error: "token_expired" } when session.error === "TokenRevoked"
+ *  - Non-auth GitHub failures still return the generic 502 error
+ */
+
+import "./setup";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Shared mock setup ────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/metrics-cache", () => ({
+  isMetricsCacheBypassed: vi.fn().mockReturnValue(false),
+  METRICS_CACHE_TTL_SECONDS: {
+    contributions: 300,
+    repos: 300,
+    prs: 300,
+    activity: 300,
+    issues: 300,
+    languages: 300,
+    streak: 300,
+  },
+  metricsCacheKey: vi.fn().mockReturnValue("test-cache-key"),
+  withMetricsCache: vi.fn().mockImplementation((_opts: unknown, fn: () => unknown) => fn()),
+}));
+
+vi.mock("@/lib/resolve-user", () => ({
+  resolveAppUser: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/github-accounts", () => ({
+  getAccountToken: vi.fn().mockResolvedValue(null),
+  getAllAccounts: vi.fn().mockResolvedValue([]),
+  mergeMetrics: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: null,
+}));
+
+import { getServerSession } from "next-auth";
+
+const mockGetServerSession = vi.mocked(getServerSession);
+
+// ─── GitHubAuthError and githubAuthErrorResponse ──────────────────────────────
+
+import { GitHubAuthError, githubAuthErrorResponse } from "@/lib/github-fetch";
+
+describe("GitHubAuthError", () => {
+  it("has name GitHubAuthError and status 401", () => {
+    const err = new GitHubAuthError();
+    expect(err.name).toBe("GitHubAuthError");
+    expect(err.status).toBe(401);
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe("githubAuthErrorResponse", () => {
+  it("returns a 401 response with token_expired error body", async () => {
+    const res = githubAuthErrorResponse();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "token_expired" });
+  });
+});
+
+// ─── Metrics routes ───────────────────────────────────────────────────────────
+
+describe("/api/metrics/repos — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures (not a 401)", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "valid-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/repos/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("GitHub API error");
+  });
+});
+
+describe("/api/metrics/issues — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/issues/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub search API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/issues/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+});
+
+describe("/api/metrics/discussions — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub GraphQL returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "valid-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/discussions/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toBe("token_expired");
+  });
+});
+
+describe("/api/metrics/pinned-repos — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/pinned-repos/route");
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub GraphQL returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/pinned-repos/route");
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+});
+
+describe("/api/metrics/pr-breakdown — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/pr-breakdown/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub search API returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/pr-breakdown/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns 502 for non-auth GitHub failures", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "valid-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/pr-breakdown/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toBe("token_expired");
+  });
+});
+
+describe("/api/metrics/weekly-summary — token expiry handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("returns token_expired when session.error is TokenRevoked", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "old-token",
+      githubLogin: "testuser",
+      githubId: "123",
+      error: "TokenRevoked",
+    } as any);
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+
+  it("returns token_expired when GitHub commit search returns 401", async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      accessToken: "revoked-token",
+      githubLogin: "testuser",
+      githubId: "123",
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      headers: { get: () => null },
+    });
+
+    const { GET } = await import("@/app/api/metrics/weekly-summary/route");
+    const req = { nextUrl: { searchParams: { get: () => null } } } as any;
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("token_expired");
+  });
+});


### PR DESCRIPTION
Closes #1741

## Root cause

GitHub OAuth App tokens do not use a refresh mechanism — they remain valid until a user explicitly revokes access in GitHub Settings. DevTrack already ran a 24-hour periodic liveness check in the NextAuth JWT callback that sets `session.error = \"TokenRevoked\"` when GitHub returns 401, but 13 metric routes and 3 dashboard widgets were missing one or both of:

1. The `session.error === \"TokenRevoked\"` early-exit guard that returns a 401 before touching the GitHub API
2. Detecting a live 401 response from GitHub and throwing `GitHubAuthError` so callers can surface a reconnect prompt instead of a generic 502

When a token was revoked, every affected route returned HTTP 502 with an opaque error, the dashboard appeared to load normally, and all widgets showed empty data with no indication that reauthentication was needed.

## Authentication model

- **Provider**: GitHub OAuth App via NextAuth (no refresh tokens)
- **Token storage**: JWT cookie (30-day maxAge), access token embedded in the JWT
- **Revocation detection**: periodic 24-hour liveness check in the JWT callback; live detection added to every metric route by this PR

## Changes

### `src/lib/github-fetch.ts`
- **Rate-limit classification fix**: `GitHubRateLimitError` is now thrown only when rate limiting is actually occurring (429, or 403 with `X-RateLimit-Remaining: 0`, `Retry-After` header, or a secondary-rate-limit body message). Plain permission/scope failures now correctly throw `GitHubApiError` instead of misclassifying as rate-limit errors.
- New `GitHubAuthError` class (status 401) and `githubAuthErrorResponse()` helper (returns `{ error: \"token_expired\" }` with HTTP 401)
- New helper functions: `extractRateLimitInfo`, `isSecondaryRateLimitBody`, `buildGitHubError`

### `src/lib/github.ts`
- Re-exports `GitHubAuthError` from `github-fetch.ts` so all callers share the same class reference for `instanceof` checks
- Local `githubFetch` throws `GitHubAuthError` on HTTP 401 responses

### Metric API routes
All of the following gain `TokenRevoked` early-exit + `GitHubAuthError` throw + catch block:
`achievements`, `coding-activity-insights`, `contributions/daily`, `contributions/hourly`, `repo-explorer`, `repos`, `issues`, `discussions`, `pinned-repos`, `pr-review-time`, `productive-hours`, `inactive-repos`, `weekly-summary`, `pr-breakdown`

### Dashboard components
- `InactiveRepositoriesCard`, `ProductiveHoursWidget`, `WeeklySummaryCard` — detect `token_expired` in the API response and render a reconnect prompt
- `PRReviewTrendChart` — same pattern with `signOut`-based reconnect button

## Tests added / extended

| File | Tests |
|------|-------|
| `test/github-fetch.test.ts` | 25 new tests covering all rate-limit classification paths for `githubFetch` and `githubGraphQL` |
| `test/github-auth-metrics.test.ts` | 15 tests: TokenRevoked session path + live 401 propagation for the newly-fixed routes |
| `test/token-expired.test.ts` | 17 tests: GitHubAuthError class, githubAuthErrorResponse shape, and token-expiry handling for repos, issues, discussions, pinned-repos, pr-breakdown, weekly-summary |

## Verification

```
pnpm lint       → warnings only (pre-existing), no new errors
pnpm typecheck  → clean
pnpm test       → 1263 passed; 16 failures are pre-existing on upstream main
```