### PR TITLE
fix: correct first-interaction action input names (unblocks all PR checks)

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue on DevTrack! 🎉
 
             A maintainer will take a look shortly. In the meantime:
@@ -26,7 +26,7 @@ jobs:
             - Look for [`good first issue`](https://github.com/Priyanshu-byte-coder/devtrack/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) if you want somewhere to start
 
             If you find DevTrack useful, a ⭐ [star on the repo](https://github.com/Priyanshu-byte-coder/devtrack) is always appreciated — it helps the project reach more developers!
-          pr-message: |
+          pr_message: |
             Thanks for your first PR on DevTrack! 🎉
 
             A maintainer will review it within 48 hours. While you wait:


### PR DESCRIPTION
## Description

`actions/first-interaction@v3` expects underscore-separated input names (`repo_token`, `issue_message`, `pr_message`), but the workflow uses hyphens (`repo-token`, `issue-message`, `pr-message`). This causes the action to fail with:

> Unexpected input(s) 'repo-token', 'issue-message', 'pr-message', valid inputs are ['issue_message', 'pr_message', 'repo_token']

This blocks `mergeStateStatus: BLOCKED` on **every PR** in the repo, including all GSSoC contributions.

## Fix

Changed the three action input names from hyphens to underscores to match the v3 API:
- `repo-token` → `repo_token`
- `issue-message` → `issue_message`
- `pr-message` → `pr_message`

Closes #N/A — infrastructure fix, not linked to a specific issue.