### PR TITLE
docs: Add GSSoC semantic versioning reference manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,5 +55,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ### GSSoC Semantic Versioning Policy
-- Bumps follow minor or patch levels strictly.
-- Major updates require prior architecture approval.
+
+#### Version Numbering
+- **MAJOR** (x.0.0): Breaking changes to public API, database schema, or authentication flow. Requires prior architecture approval.
+- **MINOR** (0.x.0): New features, new API endpoints, new components. Backward-compatible.
+- **PATCH** (0.0.x): Bug fixes, documentation updates, refactoring, performance improvements. Backward-compatible.
+
+#### GSSoC Contribution Guidelines
+- All contributions must follow semantic versioning when updating package.json or CHANGELOG.md
+- Feature additions → MINOR bump
+- Bug fixes → PATCH bump
+- Breaking changes → MAJOR bump (requires architecture review)
+
+#### Changelog Entry Format
+When adding your changes to CHANGELOG.md, use the following format:
+```markdown
+### Added
+- Feature description (#issue-number)
+
+### Fixed
+- Bug fix description (#issue-number)
+
+### Changed
+- Refactoring or behavioral changes (#issue-number)
+```
+
+#### Examples
+- New dashboard widget: `0.3.0 → 0.4.0` (MINOR)
+- Fix rate limiting bug: `0.3.0 → 0.3.1` (PATCH)
+- Database migration with breaking schema change: `0.3.0 → 1.0.0` (MAJOR)
+
+Bumps follow minor or patch levels strictly for GSSoC contributions.
+Major updates require prior architecture approval from maintainers.


### PR DESCRIPTION
Closes #1951

Adds a comprehensive GSSoC Semantic Versioning Policy to CHANGELOG.md covering:
- MAJOR/MINOR/PATCH definitions
- GSSoC contribution versioning guidelines
- Changelog entry format with examples