### PR TITLE
fix: add re-authentication banner when GitHub token is revoked

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSession, signOut } from "next-auth/react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { ReactNode } from "react";
@@ -18,14 +18,41 @@ async function hasActiveSession(fetcher: typeof window.fetch) {
   }
 }
 
+function TokenRevokedBanner({ onReauthenticate }: { onReauthenticate: () => void }) {
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between gap-4 bg-red-600 px-6 py-3 text-white shadow-lg">
+      <div className="flex items-center gap-3">
+        <span className="text-xl">⚠️</span>
+        <p className="text-sm font-medium">
+          Your GitHub session has expired. Please sign out and sign back in to refresh your data.
+        </p>
+      </div>
+      <button
+        onClick={onReauthenticate}
+        className="rounded-lg bg-white px-4 py-2 text-sm font-semibold text-red-600 hover:bg-red-50 transition-colors"
+      >
+        Re-authenticate
+      </button>
+    </div>
+  );
+}
+
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   const router = useRouter();
-  const { status } = useSession({
+  const { data: session, status } = useSession({
     required: true,
     onUnauthenticated() {
       router.push("/");
     },
   });
+
+  const [showTokenBanner, setShowTokenBanner] = useState(false);
+
+  useEffect(() => {
+    if (session?.error === "TokenRevoked") {
+      setShowTokenBanner(true);
+    }
+  }, [session?.error]);
 
   useEffect(() => {
     const originalFetch = window.fetch;
@@ -83,7 +110,18 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
     };
   }, [router]);
 
+  const handleReauthenticate = async () => {
+    setShowTokenBanner(false);
+    await signOut({ redirect: false });
+    router.push("/auth/signin");
+  };
+
   if (status === "loading") return null;
 
-  return <>{children}</>;
+  return (
+    <>
+      {showTokenBanner && <TokenRevokedBanner onReauthenticate={handleReauthenticate} />}
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
Closes #1741

Adds a visible re-authentication banner to the dashboard layout when the GitHub OAuth token has been revoked (detected by the existing 24h token validation in auth.ts).

Changes:
- Added TokenRevokedBanner component that displays a red banner at the top of the dashboard
- Banner shows 'Your GitHub session has expired. Please sign out and sign back in to refresh your data.'
- Includes a 'Re-authenticate' button that triggers sign-out and redirects to auth
- Banner appears when session.error === 'TokenRevoked'

The backend logic already existed in auth.ts (24h validation interval, TokenRevoked flag, session.error propagation). This PR adds the missing frontend piece.