### PR TITLE
docs(coc): add GSSoC contributor procedures section

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -29,3 +29,79 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+
+---
+
+## GSSoC Contributor Procedures
+
+This section supplements the Contributor Covenant above with procedures specific to
+**GirlScript Summer of Code (GSSoC) 2026** contributors. Both the Contributor Covenant
+and these GSSoC procedures apply; in case of conflict, the Contributor Covenant prevails
+for non-GSSoC contributions.
+
+### Scope
+
+These procedures apply to:
+
+- All participants registered for GSSoC 2026 (mentors, contributors, maintainers)
+- All DevTrack contribution channels: GitHub Issues, Pull Requests, Discussions, and the
+  project Discord (if applicable) during the GSSoC program window
+- All GSSoC-related work, including issue selection, claims, reviews, and evaluations
+
+### Reporting Procedure
+
+If you experience or witness behavior that violates the Contributor Covenant during
+GSSoC participation:
+
+1. **Open a private GitHub Security Advisory** at
+   <https://github.com/Priyanshu-byte-coder/devtrack/security/advisories/new> with the
+   `gsoc-coc` label in the title. This keeps the report visible only to the maintainer.
+2. **If the advisory form is unavailable**, email **doshipriyanshu3@gmail.com** with
+   subject line `GSSoC CoC Report`.
+3. Include the following:
+   - Your GitHub handle and GSSoC participant ID (if registered)
+   - The GitHub handle of the person whose behavior is being reported
+   - A factual description of the incident(s) with dates and links to public evidence
+     (issues, PRs, comments) when possible
+   - The specific section of the Contributor Covenant that you believe was violated
+
+### Response Timeline
+
+- **Acknowledgement:** within **48 hours** of receiving a report
+- **Initial review outcome:** within **5 business days**
+- **Resolution and any corrective action:** communicated privately to the reporter
+  and, where appropriate, to the GSSoC program admins
+
+### Confidentiality and Anonymity
+
+- Reports are kept confidential. Details are shared only with maintainers who need to
+  know to investigate or take action.
+- Reporter identity is not disclosed publicly or to the reported person beyond what is
+  necessary to convey the report.
+- If the reporter wishes to remain anonymous to the reported person, the maintainer will
+  honor that request to the extent possible.
+
+### Appeals
+
+If you disagree with a CoC enforcement decision made under these procedures, you may
+appeal by replying to the original advisory thread within **14 days** of the decision.
+An uninvolved maintainer (or, if none is available, a GSSoC program admin) will review
+the appeal and respond within **7 business days**.
+
+### After a Report
+
+Once a report is filed:
+
+1. The maintainer acknowledges receipt within 48 hours.
+2. The maintainer investigates by reviewing the linked evidence and may request
+   additional context from the reporter.
+3. The maintainer decides on a resolution (no action, warning, temporary restriction,
+   or permanent ban) and communicates it privately.
+4. The reporter is informed of the resolution and, if applicable, the appeal window.
+
+### Out of Scope
+
+- Disputes over technical decisions (architecture, code style, merge timing) are
+  handled through normal PR review and Discussion channels, not CoC procedures.
+- Issues with the GSSoC platform itself (points, leaderboard, certificate eligibility)
+  should be directed to the GSSoC program admins, not the project maintainer.


### PR DESCRIPTION
## Summary
Addresses #1945 by adding a clearly-labelled "GSSoC Contributor Procedures" section to `CODE_OF_CONDUCT.md`.

## What changed
Adds a single new section after the existing Contributor Covenant attribution. The Covenant content is preserved verbatim; this adds supplementary procedures specific to GSSoC 2026 contributors.

The new section covers:

- **Scope** — who the procedures apply to (GSSoC participants, all DevTrack contribution channels, all GSSoC work)
- **Reporting procedure** — private GitHub Security Advisory with `gsoc-coc` label, email fallback to `doshipriyanshu3@gmail.com`, required info (handles, evidence, violated section)
- **Response timeline** — 48h acknowledgement, 5 business day initial review, resolution communicated privately
- **Confidentiality and anonymity** — reports kept confidential, identity not disclosed, anonymity honored when possible
- **Appeals** — 14-day appeal window via original advisory thread, reviewed by uninvolved maintainer within 7 business days
- **After a report** — acknowledge → investigate → decide → communicate, with possible outcomes (no action, warning, temp/perm restriction)
- **Out of scope** — technical disputes (use PR review), GSSoC platform issues (contact program admins)

## Why
- The existing CoC references GitHub Discussions or "contact the project maintainer" but does not give GSSoC contributors a clear, structured path to report issues
- The project's `SECURITY.md` already uses private security advisories for vulnerabilities; this aligns CoC reporting with that existing pattern
- Provides specific timelines and appeal rights that GSSoC contributors can rely on

## Testing
- 1 file changed, +76 lines, 0 deletions
- No other content modified
- Renders correctly in GitHub markdown preview
- All section headings follow the existing H2/H3 hierarchy

Closes #1945