### PR TITLE
docs(security): expand GSSoC API logging redaction standards

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,8 +73,135 @@ DevTrack uses Supabase with Row Level Security on all user-data tables.
 
 
 ### GSSoC API Logging Redaction Standards
-- Never log authorization tokens or passwords.
-- Redact sensitive data before production logs persist.
+
+This section is the canonical reference for **what may and may not appear in logs**
+produced by DevTrack's API and background workers. It applies to every code path that
+calls `console.*`, `logger.*`, `pino.*`, `winston.*`, or any third-party logging library.
+
+#### What Must NEVER Be Logged
+
+The following are strictly forbidden in any log line at any level (including debug):
+
+| Category | Examples |
+|----------|----------|
+| **Authentication tokens** | GitHub OAuth tokens, Supabase service-role keys, JWT bearer tokens, session cookies, refresh tokens, API keys |
+| **Secrets** | `CLIENT_SECRET`, `RESEND_API_KEY`, `DATABASE_URL` containing credentials, signing keys, webhook secrets |
+| **Passwords** | User passwords (plain or hashed), password reset tokens, MFA backup codes, TOTP seeds |
+| **Personal Identifiable Information (PII)** | Email addresses (in URLs only — see exception below), full names, phone numbers, government IDs |
+| **Request/response bodies in full** | Form payloads that may contain passwords, payment fields, medical info |
+| **Cookies and Authorization headers** | `Cookie:`, `Authorization:`, `Set-Cookie:` values |
+
+> **Exception — email addresses in URLs:** the email-as-path-segment pattern (`/api/users/foo@example.com/...`) is allowed in info-level request logs because the email is the path. Do not log the *body* of such requests, only the method and path.
+
+#### What To Log At Each Level
+
+| Level | Use for | Examples |
+|-------|---------|----------|
+| `error` | Failures requiring attention | `Failed to sync repo data`, `Rate limit hit for user ${userId}` |
+| `warn` | Recoverable issues, degraded operation | `Retrying Supabase query (attempt 2/3)`, `Cache miss for key ${nonSensitiveKey}` |
+| `info` | Lifecycle events | `User ${userId} signed in via GitHub`, `Background sync started` |
+| `debug` | Developer-only diagnostics | `Calling GitHub API: GET /user/repos` (no body) |
+
+#### Redaction Patterns
+
+**Pattern 1: Centralised logger (preferred).**
+
+Use a single `logger` module that wraps the underlying library. The wrapper redacts
+sensitive keys before they reach the transport:
+
+```ts
+// lib/logger.ts
+const REDACT_KEYS = new Set([
+  'authorization', 'cookie', 'set-cookie',
+  'password', 'token', 'secret', 'apiKey',
+  'accessToken', 'refreshToken', 'sessionId',
+]);
+
+function redact(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redact);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (REDACT_KEYS.has(k)) out[k] = '[REDACTED]';
+      else out[k] = redact(v);
+    }
+    return out;
+  }
+  return value;
+}
+```
+
+**Pattern 2: Manual redaction at the call site.**
+
+When logging raw objects, copy and strip before passing to the logger:
+
+```ts
+logger.info('user.update', {
+  userId: user.id,
+  email: '[REDACTED]',
+  preferences: user.preferences, // safe — no PII
+});
+```
+
+#### What To Log
+
+- **Correlation IDs** — every request gets a `requestId` (UUID) emitted at start and end
+- **User identifiers** — `userId` (internal) or GitHub `login` (public) is safe
+- **Resource identifiers** — `repoId`, `goalId`, `metricId` are safe
+- **Counts and durations** — `cacheHits=42 durationMs=128` are safe
+- **Public profile fields** — `login`, `avatarUrl`, `displayName` (no email) are safe
+
+#### What NOT To Log (Even at Debug)
+
+- Full request bodies (use `body` field for a sanitized summary, not the raw payload)
+- Headers (especially `Authorization`, `Cookie`, `Set-Cookie`)
+- Stack traces from production users that include secrets in the message
+- Raw SQL queries with parameter interpolation (use parameterised queries + log the
+  parameters list separately, with secrets redacted)
+
+#### Testing Redaction
+
+Unit tests for the logger should include a fixture per redaction rule. The fixture
+should assert that:
+
+1. A `console.log({ authorization: '...' })` call produces output where the
+   `authorization` key is `[REDACTED]`.
+2. Nested objects with redacted keys at depth 3+ are still redacted.
+3. Arrays of objects with redacted keys are redacted in every element.
+4. The original object passed to the logger is **not mutated** (the redaction must
+   produce a copy).
+
+Example fixture:
+
+```ts
+test('redacts authorization header at any depth', () => {
+  const input = { req: { headers: { authorization: 'Bearer xyz' } } };
+  const out = redact(input) as typeof input;
+  expect(out.req.headers.authorization).toBe('[REDACTED]');
+  expect(input.req.headers.authorization).toBe('Bearer xyz'); // original intact
+});
+```
+
+#### Reviewer Checklist
+
+When reviewing a PR that adds or modifies logging code, reviewers should confirm:
+
+- [ ] No new log call introduces a `REDACT_KEYS` member at any depth
+- [ ] If a new sensitive field is added to the data model, `REDACT_KEYS` is updated in
+  the same PR
+- [ ] Error logs include a `requestId` for traceability
+- [ ] No `console.log` / `console.error` calls were added (use the centralised `logger`)
+- [ ] No secrets or PII appear in commit messages or PR descriptions
+
+#### Out of Scope
+
+- **Client-side logging** (browser console, React component error boundaries) — the
+  above applies to server-side logs only. Client logs should never include tokens
+  because tokens should never reach the client.
+- **Aggregated metrics** sent to analytics (PostHog, etc.) — these are governed by the
+  privacy policy, not this document.
+- **Audit logs** of administrative actions — these intentionally include the actor's
+  identity and are stored separately.
 
 ---
 


### PR DESCRIPTION
## Summary
Addresses #1947 by expanding the existing 2-line "GSSoC API Logging Redaction Standards" stub at the bottom of `SECURITY.md` into a full reference manual.

## What changed
Single file: `SECURITY.md` (+129 / -2).

The original 2-line stub is preserved as the section heading. The new content adds:

- **What Must NEVER Be Logged** — explicit table with categories (auth tokens, secrets, passwords, PII, full bodies, cookies/Authorization headers) and the one exception (email addresses when they are the path segment)
- **What To Log At Each Level** — error / warn / info / debug guidance with examples
- **Redaction Patterns** — code samples for two patterns: centralised logger wrapper that recursively redacts `REDACT_KEYS`, and manual call-site redaction
- **What To Log** — correlation IDs, user/resource IDs, counts, public profile fields
- **What NOT To Log** — full request bodies, headers, stack traces carrying secrets, raw SQL with parameter interpolation
- **Testing Redaction** — 4 fixture cases including the "original object not mutated" invariant
- **Reviewer Checklist** — 5 items reviewers must check on any PR that touches logging code
- **Out of Scope** — client-side logging, analytics, audit logs (which intentionally include actor identity)

## Why
- The existing 2-line stub was too vague to be actionable
- The project's RLS section (above) is detailed; the logging section should match that level of detail
- New GSSoC contributors working on logging code need a single source of truth rather than reverse-engineering the conventions from existing code

## Testing
- 1 file changed, +129 / -2 lines
- No code changes, no new files
- Renders correctly in GitHub markdown preview
- All table columns aligned
- Code samples follow the project's existing TypeScript style

Closes #1947