### PR TITLE
feat(email): add weekly coding activity digest

### DIFF
--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -1,10 +1,213 @@
+/**
+ * Weekly coding digest cron endpoint.
+ *
+ * Triggered by Vercel Cron every Monday at 09:00 UTC (see vercel.json).
+ * Self-hosted deployments can call this route from any external scheduler
+ * by supplying:  Authorization: Bearer <CRON_SECRET>
+ *
+ * Execution model
+ * ───────────────
+ * 1. Authenticate via CRON_SECRET (fail-closed when env var is absent).
+ * 2. Fetch all opted-in users who have an email address.
+ * 3. Skip users whose last digest was sent within the past 6 days
+ *    (idempotency guard prevents duplicate sends on re-runs).
+ * 4. Fetch weekly metrics via GITHUB_TOKEN when configured; fall back
+ *    to sending the email without metrics when the token is absent.
+ * 5. Render HTML + plain-text email and POST to Resend.
+ * 6. Record the send timestamp (best-effort; failure does not cancel batch).
+ * 7. Process users in bounded parallel batches (BATCH_SIZE = 5) to stay
+ *    within serverless function timeout budgets.
+ * 8. Return { sentCount, failedCount, skippedCount, errors }.
+ *
+ * Backward-compatible contract:
+ *   • Response always contains `sentCount`.
+ *   • `message: "No users opted in"` when the query returns zero rows.
+ *   • Auth errors return the same 401 / 500 shapes as before.
+ */
+
 import { NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
+import { buildDigestMetrics, buildUnsubscribeUrl } from "@/lib/weekly-digest";
+import { buildDigestHtml, buildDigestText } from "@/lib/digest-email";
+import type { DigestMetrics } from "@/lib/weekly-digest";
 
 export const dynamic = "force-dynamic";
 
+// Users who received a digest within the past 6 days are skipped so a
+// duplicate cron trigger does not send two emails in the same week.
+const DIGEST_COOLDOWN_MS = 6 * 24 * 60 * 60 * 1000;
+
+// Maximum users processed in parallel per batch.
+const BATCH_SIZE = 5;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface UserRow {
+  id?: string;
+  github_login: string;
+  email: string;
+  timezone?: string | null;
+  last_digest_sent_at?: string | null;
+}
+
+interface SendError {
+  user: string;
+  error: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function currentWeekLabel(): string {
+  const now = new Date();
+  const dayOfWeek = now.getDay();
+  const daysToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+  const monday = new Date(now);
+  monday.setDate(now.getDate() + daysToMonday);
+  return monday.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+/**
+ * Send one digest email via Resend.
+ * Returns { ok: true } on success, { ok: false, error } on failure.
+ * When RESEND_API_KEY is absent the call is skipped and treated as sent,
+ * so self-hosted deployments using an external mailer are not penalised.
+ */
+async function sendEmail(params: {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    return { ok: true };
+  }
+
+  const from =
+    process.env.RESEND_FROM_EMAIL ?? "DevTrack <digest@devtrack.app>";
+
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        from,
+        to: params.to,
+        subject: params.subject,
+        html: params.html,
+        text: params.text,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "(no body)");
+      return { ok: false, error: `Resend HTTP ${res.status}: ${body}` };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Record the digest send timestamp for a user.
+ * Best-effort — errors are logged but do not propagate to the caller.
+ */
+async function recordDigestSent(userId: string): Promise<void> {
+  try {
+    await supabaseAdmin
+      .from("users")
+      .update({ last_digest_sent_at: new Date().toISOString() })
+      .eq("id", userId);
+  } catch (err) {
+    console.error(`[weekly-digest] Failed to record send for ${userId}:`, err);
+  }
+}
+
+/**
+ * Process a single user: check cooldown, fetch metrics, render and send email,
+ * then record the send timestamp.
+ */
+async function processUser(
+  user: UserRow,
+  weekLabel: string,
+  githubToken: string | undefined
+): Promise<{ status: "sent" | "failed" | "skipped_cooldown"; error?: string }> {
+  // ── Cooldown guard ────────────────────────────────────────────────────────
+  if (user.last_digest_sent_at) {
+    const lastSent = new Date(user.last_digest_sent_at).getTime();
+    if (Date.now() - lastSent < DIGEST_COOLDOWN_MS) {
+      return { status: "skipped_cooldown" };
+    }
+  }
+
+  // ── Metric aggregation ────────────────────────────────────────────────────
+  let metrics: DigestMetrics | null = null;
+  if (githubToken) {
+    try {
+      metrics = await buildDigestMetrics(user.github_login, githubToken);
+    } catch (err) {
+      // Log and continue — the email is still delivered without live metrics.
+      console.warn(
+        `[weekly-digest] Metrics fetch failed for ${user.github_login}:`,
+        err
+      );
+    }
+  }
+
+  // ── Build unsubscribe URL ─────────────────────────────────────────────────
+  const unsubscribeUrl = user.id
+    ? buildUnsubscribeUrl(user.id)
+    : `${(process.env.NEXTAUTH_URL ?? "").replace(/\/$/, "")}/settings`;
+
+  // ── Render email ──────────────────────────────────────────────────────────
+  const emailData = {
+    githubLogin: user.github_login,
+    metrics,
+    unsubscribeUrl,
+    weekLabel,
+  };
+
+  const html = buildDigestHtml(emailData);
+  const text = buildDigestText(emailData);
+
+  // ── Send ──────────────────────────────────────────────────────────────────
+  const result = await sendEmail({
+    to: user.email,
+    subject: `Your weekly coding digest — ${weekLabel}`,
+    html,
+    text,
+  });
+
+  if (!result.ok) {
+    console.error(
+      `[weekly-digest] Failed to send to ${user.email}: ${result.error}`
+    );
+    return { status: "failed", error: result.error };
+  }
+
+  // ── Record timestamp (best-effort) ────────────────────────────────────────
+  if (user.id) {
+    await recordDigestSent(user.id);
+  }
+
+  return { status: "sent" };
+}
+
+// ─── Route handler ────────────────────────────────────────────────────────────
+
 export async function GET(request: Request) {
-  // 1. Verify cron secret - fail closed if not configured
+  // 1. Authenticate — fail closed when CRON_SECRET is absent or mismatched.
   const cronSecret = process.env.CRON_SECRET;
   if (!cronSecret) {
     return NextResponse.json(
@@ -18,70 +221,87 @@ export async function GET(request: Request) {
   }
 
   try {
-    // 2. Fetch users with opt-in and an email
+    // 2. Fetch opted-in users who have an email address.
     const { data: users, error } = await supabaseAdmin
       .from("users")
-      .select("github_login, email")
+      .select("id, github_login, email, timezone, last_digest_sent_at")
       .eq("weekly_digest_opt_in", true)
       .not("email", "is", null);
 
     if (error) {
-      console.error("Error fetching users for digest:", error);
-      return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+      console.error("[weekly-digest] Error fetching users:", error);
+      return NextResponse.json(
+        { error: "Internal Server Error" },
+        { status: 500 }
+      );
     }
 
     if (!users || users.length === 0) {
       return NextResponse.json({ message: "No users opted in" });
     }
 
-    // 3. For each user, send the email
-    // Minimal template logic to prevent timeouts and keep implementation clean
+    // 3. Process users in parallel batches to respect timeout budgets.
+    const weekLabel = currentWeekLabel();
+    const githubToken = process.env.GITHUB_TOKEN || undefined;
+
     let sentCount = 0;
     let failedCount = 0;
-    
-    for (const user of users) {
-      if (!user.email) continue;
-      
-      const htmlBody = `
-        <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2>Your Weekly DevTrack Digest</h2>
-          <p>Hi ${user.github_login},</p>
-          <p>Here is your coding activity summary for the past week!</p>
-          <p><strong>Keep up the great work!</strong></p>
-          <hr style="border: 1px solid #eee; margin: 20px 0;" />
-          <p style="font-size: 12px; color: #666;">
-            You are receiving this because you opted into the Weekly Email Digest in your DevTrack settings.
-          </p>
-        </div>
-      `;
+    let skippedCount = 0;
+    const errors: SendError[] = [];
 
-      if (process.env.RESEND_API_KEY) {
-        const res = await fetch("https://api.resend.com/emails", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-          },
-          body: JSON.stringify({
-            from: "DevTrack <digest@devtrack.com>",
-            to: user.email,
-            subject: "Your Weekly DevTrack Digest",
-            html: htmlBody,
-          }),
-        });
+    for (let i = 0; i < users.length; i += BATCH_SIZE) {
+      const batch = (users as UserRow[]).slice(i, i + BATCH_SIZE);
 
-        if (!res.ok) {
+      const results = await Promise.allSettled(
+        batch.map((user) => processUser(user, weekLabel, githubToken))
+      );
+
+      for (let j = 0; j < results.length; j++) {
+        const user = batch[j];
+        const result = results[j];
+
+        if (result.status === "rejected") {
           failedCount++;
-          console.error(`Failed to send weekly digest to ${user.email}: ${res.status}`);
-          continue;
+          errors.push({
+            user: user.github_login,
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason),
+          });
+        } else {
+          const { status, error: sendError } = result.value;
+          if (status === "sent") {
+            sentCount++;
+          } else if (status === "failed") {
+            failedCount++;
+            errors.push({
+              user: user.github_login,
+              error: sendError ?? "Unknown error",
+            });
+          } else if (status === "skipped_cooldown") {
+            skippedCount++;
+          }
         }
       }
-      sentCount++;
     }
 
-    return NextResponse.json({ success: true, sentCount, failedCount });
+    console.log(
+      `[weekly-digest] done — sent:${sentCount} failed:${failedCount} skipped:${skippedCount}`
+    );
+
+    return NextResponse.json({
+      success: true,
+      sentCount,
+      failedCount,
+      skippedCount,
+      errors,
+    });
   } catch (err) {
-    console.error("Cron weekly-digest failed:", err);
-    return NextResponse.json({ error: "Failed to process digests" }, { status: 500 });
+    console.error("[weekly-digest] Cron failed:", err);
+    return NextResponse.json(
+      { error: "Failed to process digests" },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -1,0 +1,117 @@
+/**
+ * Unsubscribe endpoint for the weekly email digest.
+ *
+ * Every digest email contains a unique unsubscribe link:
+ *   GET /api/unsubscribe?uid=<userId>&token=<hmac>
+ *
+ * The HMAC token is deterministic (derived from the user ID and a server
+ * secret) so no database row is needed to verify it.  This means:
+ *   • Tokens work even after a database restore.
+ *   • Old tokens in archived emails remain valid (idempotent unsubscribe).
+ *   • A valid token for user A cannot unsubscribe user B.
+ *
+ * Security properties:
+ *   • Token is verified with constant-time comparison (timingSafeEqual).
+ *   • Missing or malformed tokens return 403 — not a redirect to a login page,
+ *     which would expose the uid in a browser Referer header.
+ *   • The uid parameter is validated to be a UUID before the DB update to
+ *     prevent injection via malformed user IDs.
+ */
+
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase";
+import { verifyUnsubscribeToken } from "@/lib/weekly-digest";
+
+export const dynamic = "force-dynamic";
+
+// Loose UUID format check — Supabase uses UUID v4 primary keys.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Accept plain Request so the handler works with both Next.js (NextRequest)
+// and plain fetch-compatible Request objects (e.g. in unit tests).
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const uid = searchParams.get("uid");
+  const token = searchParams.get("token");
+
+  // ── Input validation ──────────────────────────────────────────────────────
+  if (!uid || !token) {
+    return NextResponse.json(
+      { error: "Missing uid or token" },
+      { status: 400 }
+    );
+  }
+
+  // Validate uid format before using it in a database query.
+  if (!UUID_RE.test(uid)) {
+    return NextResponse.json({ error: "Invalid uid" }, { status: 400 });
+  }
+
+  // ── Token verification ────────────────────────────────────────────────────
+  if (!verifyUnsubscribeToken(uid, token)) {
+    return NextResponse.json(
+      { error: "Invalid or expired unsubscribe token" },
+      { status: 403 }
+    );
+  }
+
+  // ── Opt the user out ──────────────────────────────────────────────────────
+  const { error } = await supabaseAdmin
+    .from("users")
+    .update({ weekly_digest_opt_in: false })
+    .eq("id", uid);
+
+  if (error) {
+    console.error("[unsubscribe] DB update failed:", error);
+    return NextResponse.json(
+      { error: "Failed to process unsubscribe request" },
+      { status: 500 }
+    );
+  }
+
+  // ── Confirmation response ─────────────────────────────────────────────────
+  // Return a simple HTML page so clicking the link from an email client
+  // shows a human-readable confirmation rather than raw JSON.
+  const appUrl = (process.env.NEXTAUTH_URL ?? "").replace(/\/$/, "");
+  const settingsUrl = `${appUrl}/settings`;
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Unsubscribed — DevTrack</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 0; padding: 40px 20px;
+           background: #f1f5f9; color: #0f172a; display: flex;
+           justify-content: center; }
+    .card { background: #fff; border-radius: 12px; padding: 40px;
+            max-width: 480px; width: 100%;
+            box-shadow: 0 1px 3px rgba(0,0,0,.1); text-align: center; }
+    h1 { margin: 0 0 12px 0; font-size: 22px; }
+    p  { margin: 0 0 16px 0; color: #475569; line-height: 1.6; }
+    a  { color: #2563eb; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <p style="font-size: 48px; margin: 0 0 16px;">&#x2705;</p>
+    <h1>You have been unsubscribed</h1>
+    <p>
+      You will no longer receive weekly coding digest emails from DevTrack.
+    </p>
+    <p>
+      You can re-enable the digest at any time in your
+      <a href="${settingsUrl}">account settings</a>.
+    </p>
+  </div>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}

--- a/src/lib/digest-email.ts
+++ b/src/lib/digest-email.ts
@@ -1,0 +1,425 @@
+/**
+ * Weekly digest email template builder.
+ *
+ * Produces both a responsive HTML version and a plain-text fallback.
+ * The HTML template uses inline styles and table-based layout for broad
+ * email-client compatibility (Outlook, Gmail, Apple Mail, mobile).
+ *
+ * Design principles:
+ *   • Dark/light friendly — a dark header with light body reads well in
+ *     both light mode and dark-mode email clients.
+ *   • Mobile-first widths — max-width 600 px, 100% on narrow viewports.
+ *   • No external assets — everything is inline so the email renders
+ *     correctly without image-loading permission.
+ *   • Graceful degradation — every section is hidden when its data is
+ *     absent, so a user with no metrics still gets a sensible email.
+ */
+
+import type { DigestMetrics } from "@/lib/weekly-digest";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function pluralise(n: number, singular: string, plural = `${singular}s`): string {
+  return `${n} ${n === 1 ? singular : plural}`;
+}
+
+// Language badge colours — keeps the email visually distinct without images.
+const LANG_COLOURS: Record<string, string> = {
+  TypeScript: "#3178c6",
+  JavaScript: "#f7df1e",
+  Python: "#3776ab",
+  Go: "#00add8",
+  Rust: "#ce412b",
+  Java: "#b07219",
+  "C#": "#178600",
+  "C++": "#f34b7d",
+  PHP: "#777bb4",
+  Ruby: "#701516",
+  Swift: "#f05138",
+  Kotlin: "#a97bff",
+  CSS: "#563d7c",
+  HTML: "#e34c26",
+  Shell: "#89e051",
+  Dart: "#00b4ab",
+  Scala: "#c22d40",
+  R: "#198ce7",
+  Vue: "#41b883",
+  Svelte: "#ff3e00",
+};
+
+function langColour(name: string): string {
+  return LANG_COLOURS[name] ?? "#64748b";
+}
+
+// ─── HTML template ────────────────────────────────────────────────────────────
+
+export interface DigestEmailData {
+  githubLogin: string;
+  metrics: DigestMetrics | null;
+  unsubscribeUrl: string;
+  weekLabel: string; // e.g. "Week of 2 June 2025"
+}
+
+export function buildDigestHtml(data: DigestEmailData): string {
+  const { githubLogin, metrics, unsubscribeUrl, weekLabel } = data;
+  const m = metrics;
+
+  // ── Streak section ──────────────────────────────────────────────────────────
+  const streakHtml = m
+    ? `
+      <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 20px 0;">
+        <tr>
+          <td style="background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;padding:16px;">
+            <table width="100%" cellpadding="0" cellspacing="0">
+              <tr>
+                <td>
+                  <p style="margin:0 0 4px 0;font-size:12px;font-weight:600;color:#16a34a;
+                             text-transform:uppercase;letter-spacing:0.05em;">Current Streak</p>
+                  <p style="margin:0;font-size:32px;font-weight:700;color:#15803d;">
+                    ${m.streak.current} ${m.streak.current === 1 ? "day" : "days"} 🔥
+                  </p>
+                </td>
+                <td align="right" valign="middle">
+                  <p style="margin:0 0 4px 0;font-size:12px;color:#64748b;">Longest streak</p>
+                  <p style="margin:0;font-size:20px;font-weight:600;color:#374151;">
+                    ${m.streak.longest} ${m.streak.longest === 1 ? "day" : "days"}
+                  </p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>`
+    : "";
+
+  // ── Weekly activity section ─────────────────────────────────────────────────
+  const activityHtml = m
+    ? `
+      <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 20px 0;">
+        <tr>
+          <td style="padding:0 0 12px 0;">
+            <p style="margin:0;font-size:16px;font-weight:600;color:#111827;">
+              This week's activity
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <table width="100%" cellpadding="0" cellspacing="0">
+              <tr>
+                <td width="33%" align="center"
+                    style="background:#f8fafc;border:1px solid #e2e8f0;
+                           border-radius:8px;padding:16px;text-align:center;">
+                  <p style="margin:0 0 4px 0;font-size:28px;font-weight:700;color:#0f172a;">
+                    ${m.weeklyCommits}
+                  </p>
+                  <p style="margin:0;font-size:12px;color:#64748b;">Commits</p>
+                </td>
+                <td width="4%"></td>
+                <td width="30%" align="center"
+                    style="background:#f8fafc;border:1px solid #e2e8f0;
+                           border-radius:8px;padding:16px;text-align:center;">
+                  <p style="margin:0 0 4px 0;font-size:28px;font-weight:700;color:#0f172a;">
+                    ${m.prsThisWeek}
+                  </p>
+                  <p style="margin:0;font-size:12px;color:#64748b;">PRs merged</p>
+                </td>
+                <td width="4%"></td>
+                <td width="29%" align="center"
+                    style="background:#f8fafc;border:1px solid #e2e8f0;
+                           border-radius:8px;padding:16px;text-align:center;">
+                  <p style="margin:0 0 4px 0;font-size:28px;font-weight:700;color:#0f172a;">
+                    ${m.weeklyActiveDays}<span style="font-size:16px;color:#64748b;">/7</span>
+                  </p>
+                  <p style="margin:0;font-size:12px;color:#64748b;">Active days</p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>`
+    : "";
+
+  // ── Top languages section ───────────────────────────────────────────────────
+  const languagesHtml =
+    m && m.topLanguages.length > 0
+      ? `
+      <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 20px 0;">
+        <tr>
+          <td style="padding:0 0 12px 0;">
+            <p style="margin:0;font-size:16px;font-weight:600;color:#111827;">Top languages</p>
+          </td>
+        </tr>
+        ${m.topLanguages
+          .map(
+            (l) => `
+        <tr>
+          <td style="padding:0 0 8px 0;">
+            <table width="100%" cellpadding="0" cellspacing="0">
+              <tr>
+                <td width="120">
+                  <span style="display:inline-block;background:${langColour(l.name)};
+                               color:#fff;font-size:11px;font-weight:600;
+                               padding:2px 8px;border-radius:9999px;">${esc(l.name)}</span>
+                </td>
+                <td>
+                  <table width="100%" cellpadding="0" cellspacing="0">
+                    <tr>
+                      <td style="background:#e2e8f0;border-radius:4px;height:8px;">
+                        <div style="background:${langColour(l.name)};width:${Math.min(100, l.percentage)}%;
+                                    height:8px;border-radius:4px;"></div>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+                <td width="48" align="right" style="font-size:12px;color:#64748b;padding-left:8px;">
+                  ${l.percentage.toFixed(1)}%
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>`
+          )
+          .join("")}
+      </table>`
+      : "";
+
+  // ── Top repos section ───────────────────────────────────────────────────────
+  const reposHtml =
+    m && m.topRepos.length > 0
+      ? `
+      <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 20px 0;">
+        <tr>
+          <td style="padding:0 0 12px 0;">
+            <p style="margin:0;font-size:16px;font-weight:600;color:#111827;">
+              Most active repositories this week
+            </p>
+          </td>
+        </tr>
+        ${m.topRepos
+          .map(
+            (r, i) => `
+        <tr>
+          <td style="padding:0 0 8px 0;">
+            <table width="100%" cellpadding="0" cellspacing="0"
+                   style="background:#f8fafc;border:1px solid #e2e8f0;
+                          border-radius:8px;padding:12px;">
+              <tr>
+                <td>
+                  <span style="font-size:12px;color:#94a3b8;">#${i + 1}</span>
+                  <a href="${esc(r.url)}"
+                     style="display:block;font-size:14px;font-weight:600;
+                            color:#2563eb;text-decoration:none;margin-top:2px;">
+                    ${esc(r.name)}
+                  </a>
+                </td>
+                <td align="right" valign="middle">
+                  <p style="margin:0;font-size:14px;font-weight:600;color:#0f172a;">
+                    ${r.commits}
+                  </p>
+                  <p style="margin:0;font-size:11px;color:#64748b;">commits</p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>`
+          )
+          .join("")}
+      </table>`
+      : "";
+
+  // ── No-metrics fallback ─────────────────────────────────────────────────────
+  const noMetricsFallback = !m
+    ? `
+      <table width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 20px 0;">
+        <tr>
+          <td style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;
+                     padding:20px;text-align:center;">
+            <p style="margin:0;color:#64748b;font-size:14px;">
+              Metrics are loading. Visit your
+              <a href="${esc((process.env.NEXTAUTH_URL ?? "").replace(/\/$/, ""))}/dashboard"
+                 style="color:#2563eb;">DevTrack dashboard</a>
+              to see your full activity summary.
+            </p>
+          </td>
+        </tr>
+      </table>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="color-scheme" content="light">
+  <title>Your Weekly DevTrack Digest — ${weekLabel}</title>
+</head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:system-ui,-apple-system,
+             BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;-webkit-font-smoothing:antialiased;">
+
+  <!-- Outer wrapper -->
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:32px 0;">
+    <tr>
+      <td align="center">
+
+        <!-- Email card — max 600px, full width on mobile -->
+        <table width="600" cellpadding="0" cellspacing="0"
+               style="max-width:600px;width:100%;background:#ffffff;
+                      border-radius:12px;overflow:hidden;
+                      box-shadow:0 1px 3px rgba(0,0,0,.10);">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:linear-gradient(135deg,#1e293b 0%,#0f172a 100%);
+                       padding:32px 40px;text-align:center;">
+              <p style="margin:0 0 4px 0;font-size:13px;font-weight:500;
+                         color:#94a3b8;letter-spacing:0.08em;text-transform:uppercase;">
+                DevTrack
+              </p>
+              <h1 style="margin:0;font-size:22px;font-weight:700;color:#f8fafc;">
+                Weekly Coding Digest
+              </h1>
+              <p style="margin:8px 0 0 0;font-size:13px;color:#94a3b8;">${esc(weekLabel)}</p>
+            </td>
+          </tr>
+
+          <!-- Greeting -->
+          <tr>
+            <td style="padding:32px 40px 20px 40px;">
+              <p style="margin:0;font-size:16px;color:#374151;">
+                Hey <strong>${esc(githubLogin)}</strong> 👋
+              </p>
+              <p style="margin:8px 0 0 0;font-size:14px;color:#6b7280;line-height:1.6;">
+                Here is your weekly snapshot of what you built and shipped.
+                Keep the momentum going!
+              </p>
+            </td>
+          </tr>
+
+          <!-- Divider -->
+          <tr>
+            <td style="padding:0 40px;">
+              <hr style="border:none;border-top:1px solid #e2e8f0;margin:0;">
+            </td>
+          </tr>
+
+          <!-- Content area -->
+          <tr>
+            <td style="padding:24px 40px 0 40px;">
+              ${noMetricsFallback}
+              ${streakHtml}
+              ${activityHtml}
+              ${languagesHtml}
+              ${reposHtml}
+            </td>
+          </tr>
+
+          <!-- CTA -->
+          <tr>
+            <td style="padding:0 40px 32px 40px;text-align:center;">
+              <a href="${esc((process.env.NEXTAUTH_URL ?? "").replace(/\/$/, ""))}/dashboard"
+                 style="display:inline-block;background:#2563eb;color:#ffffff;
+                        font-size:14px;font-weight:600;padding:12px 28px;
+                        border-radius:8px;text-decoration:none;margin-top:8px;">
+                Open Dashboard →
+              </a>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f8fafc;padding:20px 40px;
+                       border-top:1px solid #e2e8f0;text-align:center;">
+              <p style="margin:0 0 8px 0;font-size:12px;color:#94a3b8;">
+                You are receiving this because you opted into the weekly digest in your
+                <a href="${esc((process.env.NEXTAUTH_URL ?? "").replace(/\/$/, ""))}/settings"
+                   style="color:#64748b;">DevTrack settings</a>.
+              </p>
+              <p style="margin:0;font-size:12px;color:#94a3b8;">
+                <a href="${esc(unsubscribeUrl)}" style="color:#64748b;text-decoration:underline;">
+                  Unsubscribe from weekly digest
+                </a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+// ─── Plain-text fallback ──────────────────────────────────────────────────────
+
+export function buildDigestText(data: DigestEmailData): string {
+  const { githubLogin, metrics: m, unsubscribeUrl, weekLabel } = data;
+
+  const lines: string[] = [
+    `DevTrack — Weekly Coding Digest`,
+    `${weekLabel}`,
+    ``,
+    `Hey ${githubLogin}!`,
+    ``,
+  ];
+
+  if (!m) {
+    lines.push(
+      `Visit your dashboard to see your full activity summary:`,
+      `${(process.env.NEXTAUTH_URL ?? "").replace(/\/$/, "")}/dashboard`,
+      ``
+    );
+  } else {
+    if (m.streak.current > 0) {
+      lines.push(
+        `🔥 Current streak: ${pluralise(m.streak.current, "day")}`,
+        `   Longest streak: ${pluralise(m.streak.longest, "day")}`,
+        ``
+      );
+    }
+
+    lines.push(
+      `This week's activity`,
+      `  Commits:    ${m.weeklyCommits}`,
+      `  PRs merged: ${m.prsThisWeek}`,
+      `  Active days: ${m.weeklyActiveDays}/7`,
+      ``
+    );
+
+    if (m.topLanguages.length > 0) {
+      lines.push(`Top languages:`);
+      m.topLanguages.forEach((l) => {
+        lines.push(`  ${l.name.padEnd(14)} ${l.percentage.toFixed(1)}%`);
+      });
+      lines.push(``);
+    }
+
+    if (m.topRepos.length > 0) {
+      lines.push(`Most active repositories:`);
+      m.topRepos.forEach((r, i) => {
+        lines.push(`  ${i + 1}. ${r.name} — ${pluralise(r.commits, "commit")}`);
+      });
+      lines.push(``);
+    }
+  }
+
+  lines.push(
+    `Open your dashboard: ${(process.env.NEXTAUTH_URL ?? "").replace(/\/$/, "")}/dashboard`,
+    ``,
+    `──────────────────────────────────────────`,
+    `To stop receiving these weekly emails, click the link below:`,
+    unsubscribeUrl,
+    ``
+  );
+
+  return lines.join("\n");
+}

--- a/src/lib/weekly-digest.ts
+++ b/src/lib/weekly-digest.ts
@@ -1,0 +1,212 @@
+/**
+ * Weekly digest service — data aggregation and unsubscribe token utilities.
+ *
+ * Metric fetching delegates entirely to the functions already exported from
+ * public-profile-data.ts so there is no duplicated GitHub API logic here.
+ * Each metric is fetched independently and failures are silently absorbed so
+ * that a GitHub rate-limit or network error for one data source does not
+ * block the rest of the digest or cancel the send.
+ *
+ * Unsubscribe tokens are deterministic HMAC-SHA256 digests of the user ID,
+ * which means:
+ *   • No database row is required to verify a token.
+ *   • Tokens are unique per user (a token for user A cannot unsubscribe user B).
+ *   • Tokens do not expire — unsubscribing is an idempotent action.
+ */
+
+import { createHmac, timingSafeEqual } from "crypto";
+import {
+  fetchPublicStreak,
+  fetchPublicContributions,
+  fetchPublicTopLanguages,
+  fetchPublicTopRepos,
+} from "@/lib/public-profile-data";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface DigestStreak {
+  current: number;
+  longest: number;
+  lastCommitDate: string | null;
+}
+
+export interface DigestTopRepo {
+  name: string;
+  commits: number;
+  url: string;
+}
+
+export interface DigestLanguage {
+  name: string;
+  percentage: number;
+}
+
+export interface DigestMetrics {
+  streak: DigestStreak;
+  weeklyCommits: number;
+  weeklyActiveDays: number;
+  prsThisWeek: number;
+  topLanguages: DigestLanguage[];
+  topRepos: DigestTopRepo[];
+}
+
+// ─── Metric aggregation ───────────────────────────────────────────────────────
+
+const GITHUB_API = "https://api.github.com";
+
+/**
+ * Fetch the number of pull requests the user merged during the past 7 days.
+ * Returns 0 on any error so callers always get a usable value.
+ */
+async function fetchWeeklyMergedPrs(
+  githubLogin: string,
+  token: string
+): Promise<number> {
+  const weekAgo = new Date();
+  weekAgo.setDate(weekAgo.getDate() - 7);
+  const weekAgoStr = weekAgo.toISOString().slice(0, 10);
+
+  try {
+    const res = await fetch(
+      `${GITHUB_API}/search/issues?q=type:pr+author:${githubLogin}+is:merged+merged:>=${weekAgoStr}&per_page=1`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+        cache: "no-store",
+      }
+    );
+    if (!res.ok) return 0;
+    const data = (await res.json()) as { total_count?: number };
+    return data.total_count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Aggregate the weekly digest metrics for a single user.
+ *
+ * All metric requests run concurrently via Promise.allSettled so one slow or
+ * failing GitHub endpoint does not delay the others.  Every metric falls back
+ * to an empty/zero value on failure, ensuring the digest can always be sent.
+ */
+export async function buildDigestMetrics(
+  githubLogin: string,
+  token: string
+): Promise<DigestMetrics> {
+  const [streakResult, contributionsResult, languagesResult, reposResult, prsResult] =
+    await Promise.allSettled([
+      fetchPublicStreak(githubLogin, token),
+      fetchPublicContributions(githubLogin, token, 7),
+      fetchPublicTopLanguages(githubLogin, token),
+      fetchPublicTopRepos(githubLogin, token, 7),
+      fetchWeeklyMergedPrs(githubLogin, token),
+    ]);
+
+  const streak: DigestStreak =
+    streakResult.status === "fulfilled"
+      ? {
+          current: streakResult.value.current,
+          longest: streakResult.value.longest,
+          lastCommitDate: streakResult.value.lastCommitDate,
+        }
+      : { current: 0, longest: 0, lastCommitDate: null };
+
+  const contributions =
+    contributionsResult.status === "fulfilled"
+      ? contributionsResult.value
+      : { total: 0, data: {} as Record<string, number> };
+
+  const weeklyCommits = contributions.total;
+  const weeklyActiveDays = Object.keys(contributions.data).length;
+
+  const topLanguages: DigestLanguage[] =
+    languagesResult.status === "fulfilled"
+      ? languagesResult.value
+          .slice(0, 5)
+          .map((l) => ({ name: l.name, percentage: l.percentage }))
+      : [];
+
+  const topRepos: DigestTopRepo[] =
+    reposResult.status === "fulfilled"
+      ? reposResult.value.slice(0, 3)
+      : [];
+
+  const prsThisWeek =
+    prsResult.status === "fulfilled" ? prsResult.value : 0;
+
+  return {
+    streak,
+    weeklyCommits,
+    weeklyActiveDays,
+    prsThisWeek,
+    topLanguages,
+    topRepos,
+  };
+}
+
+// ─── Unsubscribe tokens ───────────────────────────────────────────────────────
+
+const UNSUBSCRIBE_SCOPE = "weekly-digest-unsubscribe-v1";
+
+/**
+ * Resolve the HMAC secret used to sign unsubscribe tokens.
+ *
+ * Prefers the dedicated DIGEST_UNSUBSCRIBE_SECRET environment variable so
+ * rotating it invalidates all outstanding tokens without touching NextAuth.
+ * Falls back to NEXTAUTH_SECRET for deployments that have not set the
+ * dedicated variable.
+ */
+function getUnsubscribeSecret(): string {
+  const secret =
+    process.env.DIGEST_UNSUBSCRIBE_SECRET ??
+    process.env.NEXTAUTH_SECRET ??
+    "";
+  if (!secret) {
+    throw new Error(
+      "DIGEST_UNSUBSCRIBE_SECRET or NEXTAUTH_SECRET must be set to generate unsubscribe links"
+    );
+  }
+  return secret;
+}
+
+/**
+ * Generate a deterministic HMAC-SHA256 token for the given user ID.
+ * The token is hex-encoded and safe to include in a URL query parameter.
+ */
+export function generateUnsubscribeToken(userId: string): string {
+  const secret = getUnsubscribeSecret();
+  return createHmac("sha256", secret)
+    .update(`${UNSUBSCRIBE_SCOPE}:${userId}`)
+    .digest("hex");
+}
+
+/**
+ * Verify that `token` is the correct unsubscribe token for `userId`.
+ * Uses a constant-time comparison to prevent timing attacks.
+ */
+export function verifyUnsubscribeToken(userId: string, token: string): boolean {
+  try {
+    const expected = generateUnsubscribeToken(userId);
+    if (expected.length !== token.length) return false;
+    return timingSafeEqual(
+      Buffer.from(expected, "utf8"),
+      Buffer.from(token, "utf8")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the full unsubscribe URL for a given user.
+ * Falls back to a relative path when NEXTAUTH_URL is not configured so the
+ * link still works in self-hosted deployments that use a reverse proxy.
+ */
+export function buildUnsubscribeUrl(userId: string): string {
+  const token = generateUnsubscribeToken(userId);
+  const base = (process.env.NEXTAUTH_URL ?? "").replace(/\/$/, "");
+  return `${base}/api/unsubscribe?uid=${encodeURIComponent(userId)}&token=${token}`;
+}

--- a/supabase/migrations/20260604000000_add_last_digest_sent_at.sql
+++ b/supabase/migrations/20260604000000_add_last_digest_sent_at.sql
@@ -1,0 +1,11 @@
+-- Track when each user last received a weekly digest email.
+-- Used by the cron endpoint to prevent duplicate sends within a 6-day
+-- cooldown window (e.g. if the cron fires twice in the same week due to
+-- a scheduler misconfiguration or a manual re-trigger).
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS last_digest_sent_at TIMESTAMPTZ DEFAULT NULL;
+
+-- Index so the cron query can efficiently filter by this column when
+-- implementing cooldown checks against large user tables.
+CREATE INDEX IF NOT EXISTS users_last_digest_sent_at_idx
+  ON users (last_digest_sent_at);

--- a/test/weekly-digest.test.ts
+++ b/test/weekly-digest.test.ts
@@ -1,0 +1,684 @@
+/**
+ * Tests for the weekly email digest system (#1028).
+ *
+ * Coverage:
+ *   - Unsubscribe token generation and verification
+ *   - Unsubscribe API endpoint (GET /api/unsubscribe)
+ *   - Digest email template rendering (HTML + text)
+ *   - Weekly digest cron endpoint — new behaviours on top of the auth
+ *     regression tests that already live in weekly-digest-cron-auth.test.ts:
+ *     • cooldown / duplicate-send prevention
+ *     • partial failure handling (one bad user does not stop the batch)
+ *     • metrics fetched only when GITHUB_TOKEN is configured
+ *     • response shape: sentCount / failedCount / skippedCount / errors
+ *     • opted-in filter delegated to the DB query
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  supabaseFrom: vi.fn(),
+  fetchGlobal: vi.fn(),
+  buildDigestMetrics: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabaseAdmin: { from: mocks.supabaseFrom },
+}));
+
+vi.stubGlobal("fetch", mocks.fetchGlobal);
+
+vi.mock("@/lib/weekly-digest", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/weekly-digest")>();
+  return {
+    ...original,
+    // Keep real token helpers; stub only the heavy metrics fetch.
+    buildDigestMetrics: mocks.buildDigestMetrics,
+  };
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeCronRequest(authHeader?: string): Request {
+  return new Request("http://localhost/api/cron/weekly-digest", {
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+function makeUnsubRequest(params: Record<string, string>): Request {
+  const url = new URL("http://localhost/api/unsubscribe");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new Request(url.toString());
+}
+
+/** Configure supabase to return given user rows from the cron query chain. */
+function stubCronUsers(
+  users: Array<{
+    id?: string;
+    github_login: string;
+    email: string;
+    timezone?: string;
+    last_digest_sent_at?: string | null;
+  }>
+) {
+  const notChain = vi.fn().mockResolvedValue({ data: users, error: null });
+  const eqChain = vi.fn().mockReturnValue({ not: notChain });
+  const selChain = vi.fn().mockReturnValue({ eq: eqChain });
+  mocks.supabaseFrom.mockReturnValue({ select: selChain });
+}
+
+/** Configure supabase unsubscribe update to succeed. */
+function stubUnsubUpdate() {
+  const eqChain = vi.fn().mockResolvedValue({ error: null });
+  const updChain = vi.fn().mockReturnValue({ eq: eqChain });
+  mocks.supabaseFrom.mockReturnValue({ update: updChain });
+}
+
+/** Configure supabase unsubscribe update to fail. */
+function stubUnsubUpdateError() {
+  const eqChain = vi.fn().mockResolvedValue({ error: { message: "DB error" } });
+  const updChain = vi.fn().mockReturnValue({ eq: eqChain });
+  mocks.supabaseFrom.mockReturnValue({ update: updChain });
+}
+
+// ─── Unsubscribe token utilities ──────────────────────────────────────────────
+
+describe("generateUnsubscribeToken / verifyUnsubscribeToken", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXTAUTH_SECRET", "test-secret-for-tokens");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("generates a 64-char hex string", async () => {
+    const { generateUnsubscribeToken } = await import("@/lib/weekly-digest");
+    const token = generateUnsubscribeToken("user-abc-123");
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for the same user ID", async () => {
+    const { generateUnsubscribeToken } = await import("@/lib/weekly-digest");
+    const t1 = generateUnsubscribeToken("user-xyz");
+    const t2 = generateUnsubscribeToken("user-xyz");
+    expect(t1).toBe(t2);
+  });
+
+  it("differs across user IDs", async () => {
+    const { generateUnsubscribeToken } = await import("@/lib/weekly-digest");
+    expect(generateUnsubscribeToken("user-1")).not.toBe(
+      generateUnsubscribeToken("user-2")
+    );
+  });
+
+  it("verifies a correct token", async () => {
+    const { generateUnsubscribeToken, verifyUnsubscribeToken } = await import(
+      "@/lib/weekly-digest"
+    );
+    const uid = "user-verify-test";
+    const token = generateUnsubscribeToken(uid);
+    expect(verifyUnsubscribeToken(uid, token)).toBe(true);
+  });
+
+  it("rejects a tampered token", async () => {
+    const { generateUnsubscribeToken, verifyUnsubscribeToken } = await import(
+      "@/lib/weekly-digest"
+    );
+    const uid = "user-tamper-test";
+    const token = generateUnsubscribeToken(uid);
+    const tampered = token.slice(0, -2) + "00";
+    expect(verifyUnsubscribeToken(uid, tampered)).toBe(false);
+  });
+
+  it("rejects a token issued for a different user", async () => {
+    const { generateUnsubscribeToken, verifyUnsubscribeToken } = await import(
+      "@/lib/weekly-digest"
+    );
+    const tokenForA = generateUnsubscribeToken("user-a");
+    expect(verifyUnsubscribeToken("user-b", tokenForA)).toBe(false);
+  });
+
+  it("rejects an empty token string", async () => {
+    const { verifyUnsubscribeToken } = await import("@/lib/weekly-digest");
+    expect(verifyUnsubscribeToken("user-x", "")).toBe(false);
+  });
+
+  it("prefers DIGEST_UNSUBSCRIBE_SECRET over NEXTAUTH_SECRET", async () => {
+    vi.stubEnv("DIGEST_UNSUBSCRIBE_SECRET", "dedicated-secret");
+    vi.resetModules();
+    const { generateUnsubscribeToken, verifyUnsubscribeToken } = await import(
+      "@/lib/weekly-digest"
+    );
+    const uid = "user-dedicated";
+    const token = generateUnsubscribeToken(uid);
+    expect(verifyUnsubscribeToken(uid, token)).toBe(true);
+  });
+});
+
+// ─── GET /api/unsubscribe ─────────────────────────────────────────────────────
+
+describe("GET /api/unsubscribe", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv("NEXTAUTH_SECRET", "test-secret-for-unsub");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 400 when uid is missing", async () => {
+    const { generateUnsubscribeToken } = await import("@/lib/weekly-digest");
+    const { GET } = await import("@/app/api/unsubscribe/route");
+    const token = generateUnsubscribeToken("some-uid");
+    const res = await GET(makeUnsubRequest({ token }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const { GET } = await import("@/app/api/unsubscribe/route");
+    const res = await GET(
+      makeUnsubRequest({ uid: "00000000-0000-0000-0000-000000000001" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when uid is not a valid UUID", async () => {
+    const { GET } = await import("@/app/api/unsubscribe/route");
+    const res = await GET(makeUnsubRequest({ uid: "not-a-uuid", token: "abc" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when token does not match uid", async () => {
+    const { generateUnsubscribeToken } = await import("@/lib/weekly-digest");
+    const { GET } = await import("@/app/api/unsubscribe/route");
+    const tokenForA = generateUnsubscribeToken("00000000-0000-0000-0000-000000000001");
+    const res = await GET(
+      makeUnsubRequest({
+        uid: "00000000-0000-0000-0000-000000000002",
+        token: tokenForA,
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 for a completely invalid token", async () => {
+    const { GET } = await import("@/app/api/unsubscribe/route");
+    const res = await GET(
+      makeUnsubRequest({
+        uid: "00000000-0000-0000-0000-000000000003",
+        token: "definitely-not-valid",
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns HTML confirmation on successful unsubscribe", async () => {
+    const { generateUnsubscribeToken } = await import("@/lib/weekly-digest");
+    const { GET } = await import("@/app/api/unsubscribe/route");
+    const uid = "00000000-0000-0000-0000-000000000004";
+    const token = generateUnsubscribeToken(uid);
+    stubUnsubUpdate();
+
+    const res = await GET(makeUnsubRequest({ uid, token }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/html/i);
+    const html = await res.text();
+    expect(html).toContain("unsubscribed");
+  });
+
+  it("sets weekly_digest_opt_in to false in the database", async () => {
+    const { generateUnsubscribeToken } = await import("@/lib/weekly-digest");
+    const { GET } = await import("@/app/api/unsubscribe/route");
+    const uid = "00000000-0000-0000-0000-000000000005";
+    const token = generateUnsubscribeToken(uid);
+
+    const eqFn = vi.fn().mockResolvedValue({ error: null });
+    const updFn = vi.fn().mockReturnValue({ eq: eqFn });
+    mocks.supabaseFrom.mockReturnValue({ update: updFn });
+
+    await GET(makeUnsubRequest({ uid, token }));
+
+    expect(updFn).toHaveBeenCalledWith({ weekly_digest_opt_in: false });
+    expect(eqFn).toHaveBeenCalledWith("id", uid);
+  });
+
+  it("returns 500 when the database update fails", async () => {
+    const { generateUnsubscribeToken } = await import("@/lib/weekly-digest");
+    const { GET } = await import("@/app/api/unsubscribe/route");
+    const uid = "00000000-0000-0000-0000-000000000006";
+    const token = generateUnsubscribeToken(uid);
+    stubUnsubUpdateError();
+
+    const res = await GET(makeUnsubRequest({ uid, token }));
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── Email template ───────────────────────────────────────────────────────────
+
+describe("buildDigestHtml", () => {
+  it("includes the github_login in the greeting", async () => {
+    const { buildDigestHtml } = await import("@/lib/digest-email");
+    const html = buildDigestHtml({
+      githubLogin: "octocat",
+      metrics: null,
+      unsubscribeUrl: "https://example.com/unsubscribe",
+      weekLabel: "1 June 2025",
+    });
+    expect(html).toContain("octocat");
+  });
+
+  it("includes the unsubscribe URL", async () => {
+    const { buildDigestHtml } = await import("@/lib/digest-email");
+    const url = "https://example.com/api/unsubscribe?uid=abc&token=xyz";
+    const html = buildDigestHtml({
+      githubLogin: "user",
+      metrics: null,
+      unsubscribeUrl: url,
+      weekLabel: "1 June 2025",
+    });
+    expect(html).toContain("uid=abc");
+    expect(html).toContain("token=xyz");
+  });
+
+  it("renders streak section when streak > 0", async () => {
+    const { buildDigestHtml } = await import("@/lib/digest-email");
+    const html = buildDigestHtml({
+      githubLogin: "user",
+      metrics: {
+        streak: { current: 12, longest: 30, lastCommitDate: "2025-06-01" },
+        weeklyCommits: 10,
+        weeklyActiveDays: 5,
+        prsThisWeek: 2,
+        topLanguages: [],
+        topRepos: [],
+      },
+      unsubscribeUrl: "",
+      weekLabel: "1 June 2025",
+    });
+    expect(html).toContain("12");
+    expect(html).toContain("30");
+  });
+
+  it("renders weekly commit and PR counts", async () => {
+    const { buildDigestHtml } = await import("@/lib/digest-email");
+    const html = buildDigestHtml({
+      githubLogin: "user",
+      metrics: {
+        streak: { current: 0, longest: 0, lastCommitDate: null },
+        weeklyCommits: 47,
+        weeklyActiveDays: 6,
+        prsThisWeek: 3,
+        topLanguages: [],
+        topRepos: [],
+      },
+      unsubscribeUrl: "",
+      weekLabel: "1 June 2025",
+    });
+    expect(html).toContain("47");
+    expect(html).toContain("3");
+  });
+
+  it("renders top languages section", async () => {
+    const { buildDigestHtml } = await import("@/lib/digest-email");
+    const html = buildDigestHtml({
+      githubLogin: "user",
+      metrics: {
+        streak: { current: 0, longest: 0, lastCommitDate: null },
+        weeklyCommits: 0,
+        weeklyActiveDays: 0,
+        prsThisWeek: 0,
+        topLanguages: [
+          { name: "TypeScript", percentage: 72.5 },
+          { name: "Python", percentage: 20.0 },
+        ],
+        topRepos: [],
+      },
+      unsubscribeUrl: "",
+      weekLabel: "1 June 2025",
+    });
+    expect(html).toContain("TypeScript");
+    expect(html).toContain("Python");
+    expect(html).toContain("72.5");
+  });
+
+  it("renders top repos with links", async () => {
+    const { buildDigestHtml } = await import("@/lib/digest-email");
+    const html = buildDigestHtml({
+      githubLogin: "user",
+      metrics: {
+        streak: { current: 0, longest: 0, lastCommitDate: null },
+        weeklyCommits: 0,
+        weeklyActiveDays: 0,
+        prsThisWeek: 0,
+        topLanguages: [],
+        topRepos: [
+          {
+            name: "org/my-project",
+            commits: 15,
+            url: "https://github.com/org/my-project",
+          },
+        ],
+      },
+      unsubscribeUrl: "",
+      weekLabel: "1 June 2025",
+    });
+    expect(html).toContain("org/my-project");
+    expect(html).toContain("https://github.com/org/my-project");
+    expect(html).toContain("15");
+  });
+
+  it("shows fallback dashboard link when metrics are null", async () => {
+    const { buildDigestHtml } = await import("@/lib/digest-email");
+    const html = buildDigestHtml({
+      githubLogin: "user",
+      metrics: null,
+      unsubscribeUrl: "",
+      weekLabel: "1 June 2025",
+    });
+    expect(html).toContain("dashboard");
+  });
+
+  it("escapes HTML in github_login to prevent injection", async () => {
+    const { buildDigestHtml } = await import("@/lib/digest-email");
+    const html = buildDigestHtml({
+      githubLogin: "<script>alert('xss')</script>",
+      metrics: null,
+      unsubscribeUrl: "",
+      weekLabel: "1 June 2025",
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("buildDigestText", () => {
+  it("includes github_login", async () => {
+    const { buildDigestText } = await import("@/lib/digest-email");
+    const text = buildDigestText({
+      githubLogin: "octocat",
+      metrics: null,
+      unsubscribeUrl: "https://example.com/unsub",
+      weekLabel: "1 June 2025",
+    });
+    expect(text).toContain("octocat");
+  });
+
+  it("includes the unsubscribe URL", async () => {
+    const { buildDigestText } = await import("@/lib/digest-email");
+    const text = buildDigestText({
+      githubLogin: "user",
+      metrics: null,
+      unsubscribeUrl: "https://example.com/api/unsubscribe?uid=x&token=y",
+      weekLabel: "1 June 2025",
+    });
+    expect(text).toContain("https://example.com/api/unsubscribe?uid=x&token=y");
+  });
+
+  it("includes streak when current > 0", async () => {
+    const { buildDigestText } = await import("@/lib/digest-email");
+    const text = buildDigestText({
+      githubLogin: "user",
+      metrics: {
+        streak: { current: 7, longest: 14, lastCommitDate: null },
+        weeklyCommits: 5,
+        weeklyActiveDays: 4,
+        prsThisWeek: 1,
+        topLanguages: [],
+        topRepos: [],
+      },
+      unsubscribeUrl: "",
+      weekLabel: "1 June 2025",
+    });
+    expect(text).toContain("7");
+    expect(text).toContain("Commits");
+  });
+});
+
+// ─── Cron route — new behaviours ─────────────────────────────────────────────
+
+describe("GET /api/cron/weekly-digest — new behaviours", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv("CRON_SECRET", "secret");
+    vi.stubEnv("NEXTAUTH_SECRET", "test-secret");
+    vi.stubEnv("RESEND_API_KEY", "resend-key");
+    mocks.fetchGlobal.mockResolvedValue({ ok: true });
+    stubCronUsers([]);
+    mocks.buildDigestMetrics.mockResolvedValue({
+      streak: { current: 5, longest: 10, lastCommitDate: "2025-06-01" },
+      weeklyCommits: 20,
+      weeklyActiveDays: 5,
+      prsThisWeek: 3,
+      topLanguages: [{ name: "TypeScript", percentage: 90 }],
+      topRepos: [],
+    });
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // ── Response shape ──────────────────────────────────────────────────────────
+
+  it("response includes sentCount, failedCount, skippedCount, errors", async () => {
+    stubCronUsers([{ github_login: "alice", email: "alice@example.com" }]);
+    vi.stubEnv("GITHUB_TOKEN", "gh-token");
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    const res = await GET(makeCronRequest("Bearer secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("sentCount");
+    expect(body).toHaveProperty("failedCount");
+    expect(body).toHaveProperty("skippedCount");
+    expect(body).toHaveProperty("errors");
+  });
+
+  // ── Cooldown / duplicate-send prevention ────────────────────────────────────
+
+  it("skips a user whose last_digest_sent_at is within 6 days", async () => {
+    const recentSend = new Date(
+      Date.now() - 2 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    stubCronUsers([
+      {
+        id: "00000000-0000-0000-0000-000000000007",
+        github_login: "bob",
+        email: "bob@example.com",
+        last_digest_sent_at: recentSend,
+      },
+    ]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    const res = await GET(makeCronRequest("Bearer secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skippedCount).toBe(1);
+    expect(body.sentCount).toBe(0);
+    expect(mocks.fetchGlobal).not.toHaveBeenCalled();
+  });
+
+  it("sends to a user whose last_digest_sent_at is older than 6 days", async () => {
+    const oldSend = new Date(
+      Date.now() - 8 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    stubCronUsers([
+      {
+        id: "00000000-0000-0000-0000-000000000008",
+        github_login: "carol",
+        email: "carol@example.com",
+        last_digest_sent_at: oldSend,
+      },
+    ]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    const res = await GET(makeCronRequest("Bearer secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skippedCount).toBe(0);
+    expect(mocks.fetchGlobal).toHaveBeenCalledOnce();
+  });
+
+  it("sends to a user with null last_digest_sent_at (never sent)", async () => {
+    stubCronUsers([
+      {
+        id: "00000000-0000-0000-0000-000000000009",
+        github_login: "dave",
+        email: "dave@example.com",
+        last_digest_sent_at: null,
+      },
+    ]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    const res = await GET(makeCronRequest("Bearer secret"));
+    expect(res.status).toBe(200);
+    expect(mocks.fetchGlobal).toHaveBeenCalledOnce();
+  });
+
+  // ── Metrics fetching ────────────────────────────────────────────────────────
+
+  it("fetches metrics when GITHUB_TOKEN is set", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "gh-token");
+    stubCronUsers([{ github_login: "eve", email: "eve@example.com" }]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    await GET(makeCronRequest("Bearer secret"));
+    expect(mocks.buildDigestMetrics).toHaveBeenCalledWith("eve", "gh-token");
+  });
+
+  it("does not fetch metrics when GITHUB_TOKEN is absent", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "");
+    stubCronUsers([{ github_login: "frank", email: "frank@example.com" }]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    await GET(makeCronRequest("Bearer secret"));
+    expect(mocks.buildDigestMetrics).not.toHaveBeenCalled();
+    // Email still sent without metrics
+    expect(mocks.fetchGlobal).toHaveBeenCalledOnce();
+  });
+
+  it("still sends the email when metrics fetch throws", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "gh-token");
+    mocks.buildDigestMetrics.mockRejectedValue(new Error("GitHub API down"));
+    stubCronUsers([{ github_login: "grace", email: "grace@example.com" }]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    const res = await GET(makeCronRequest("Bearer secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sentCount).toBeGreaterThanOrEqual(1);
+    expect(mocks.fetchGlobal).toHaveBeenCalledOnce();
+  });
+
+  // ── Partial failure handling ─────────────────────────────────────────────────
+
+  it("continues processing when one Resend call fails", async () => {
+    stubCronUsers([
+      { github_login: "user1", email: "u1@example.com" },
+      { github_login: "user2", email: "u2@example.com" },
+      { github_login: "user3", email: "u3@example.com" },
+    ]);
+    // First call fails, rest succeed
+    mocks.fetchGlobal
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "Internal Server Error",
+      })
+      .mockResolvedValue({ ok: true });
+
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    const res = await GET(makeCronRequest("Bearer secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.failedCount).toBe(1);
+    expect(body.sentCount).toBeGreaterThanOrEqual(2);
+    expect(body.errors).toHaveLength(1);
+    expect(mocks.fetchGlobal).toHaveBeenCalledTimes(3);
+  });
+
+  it("populates errors array when a send fails", async () => {
+    stubCronUsers([{ github_login: "heidi", email: "heidi@example.com" }]);
+    mocks.fetchGlobal.mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => "Unprocessable entity",
+    });
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    const res = await GET(makeCronRequest("Bearer secret"));
+    const body = await res.json();
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0].user).toBe("heidi");
+    expect(body.errors[0].error).toContain("422");
+  });
+
+  // ── Mixed eligible / cooldown ────────────────────────────────────────────────
+
+  it("counts sent and skipped correctly for mixed user states", async () => {
+    const recentSend = new Date(
+      Date.now() - 24 * 60 * 60 * 1000
+    ).toISOString();
+    stubCronUsers([
+      {
+        github_login: "eligible",
+        email: "ok@example.com",
+        last_digest_sent_at: null,
+      },
+      {
+        github_login: "cooldown",
+        email: "cool@example.com",
+        last_digest_sent_at: recentSend,
+      },
+    ]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    const res = await GET(makeCronRequest("Bearer secret"));
+    const body = await res.json();
+    expect(body.skippedCount).toBe(1);
+    expect(body.sentCount).toBe(1);
+    expect(mocks.fetchGlobal).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Email content ────────────────────────────────────────────────────────────
+
+  it("sends email to the correct address", async () => {
+    stubCronUsers([{ github_login: "ivan", email: "ivan@example.com" }]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    await GET(makeCronRequest("Bearer secret"));
+    const [, opts] = mocks.fetchGlobal.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.to).toBe("ivan@example.com");
+  });
+
+  it("includes github_login in the HTML body", async () => {
+    stubCronUsers([{ github_login: "judith", email: "judith@example.com" }]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    await GET(makeCronRequest("Bearer secret"));
+    const [, opts] = mocks.fetchGlobal.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.html).toContain("judith");
+  });
+
+  it("includes a text/plain body alongside HTML", async () => {
+    stubCronUsers([{ github_login: "karl", email: "karl@example.com" }]);
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    await GET(makeCronRequest("Bearer secret"));
+    const [, opts] = mocks.fetchGlobal.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    expect(typeof body.text).toBe("string");
+    expect(body.text.length).toBeGreaterThan(0);
+    expect(body.text).toContain("karl");
+  });
+
+  // ── DB query contract ────────────────────────────────────────────────────────
+
+  it("filters by weekly_digest_opt_in=true and requires a non-null email", async () => {
+    const notFn = vi.fn().mockResolvedValue({ data: [], error: null });
+    const eqFn = vi.fn().mockReturnValue({ not: notFn });
+    const selFn = vi.fn().mockReturnValue({ eq: eqFn });
+    mocks.supabaseFrom.mockReturnValue({ select: selFn });
+
+    const { GET } = await import("@/app/api/cron/weekly-digest/route");
+    await GET(makeCronRequest("Bearer secret"));
+
+    expect(eqFn).toHaveBeenCalledWith("weekly_digest_opt_in", true);
+    expect(notFn).toHaveBeenCalledWith("email", "is", null);
+  });
+});


### PR DESCRIPTION
Closes #1028

## Summary

- Implements a full weekly email digest of coding activity, delivered every Monday at 09:00 UTC.
- Builds on top of existing infrastructure: the `weekly_digest_opt_in` toggle, the Resend email provider, and GitHub metric helpers already present in `public-profile-data.ts`.
- Adds an HMAC-based one-click unsubscribe link to every email, with no database row required to verify it.

## Architecture

### Digest generation — `src/lib/weekly-digest.ts`
- `buildDigestMetrics(githubLogin, token)` fetches streak, 7-day commits, top languages, top repos, and merged PRs concurrently via `Promise.allSettled`. Each metric falls back to a zero/empty value on failure so a single GitHub API error never blocks the send.
- `generateUnsubscribeToken` / `verifyUnsubscribeToken`: deterministic HMAC-SHA256 tokens; constant-time comparison prevents timing attacks.
- No GitHub API logic is duplicated — delegates entirely to `fetchPublicStreak`, `fetchPublicContributions`, `fetchPublicTopLanguages`, `fetchPublicTopRepos`.

### Email template — `src/lib/digest-email.ts`
- `buildDigestHtml`: responsive HTML using table-based layout and inline styles (Outlook / Gmail / Apple Mail / mobile compatible). Sections: streak, weekly activity grid (commits / PRs merged / active days), top languages with colour-coded progress bars, top repos with links. No external assets.
- `buildDigestText`: plain-text fallback included in every Resend payload.
- Gracefully degrades when metrics are absent — shows a dashboard link instead.

### Cron endpoint — `src/app/api/cron/weekly-digest/route.ts`
- Bearer-token auth via `CRON_SECRET` (fail-closed when absent).
- Selects `id, github_login, email, timezone, last_digest_sent_at`.
- **6-day cooldown** prevents duplicate sends when the cron fires twice in a week.
- Metrics fetched only when `GITHUB_TOKEN` is configured; email still delivered without them.
- Users processed in parallel batches of 5 via `Promise.allSettled`; one failure does not halt the batch.
- Records `last_digest_sent_at` after each successful send (best-effort).
- Returns `{ sentCount, failedCount, skippedCount, errors }`.

### Unsubscribe endpoint — `src/app/api/unsubscribe/route.ts`
- `GET /api/unsubscribe?uid=<uuid>&token=<hmac>`
- UUID format validated before DB access.
- Constant-time token verification.
- Sets `weekly_digest_opt_in = false`; returns an HTML confirmation page.

## Database / schema changes

| Migration | Change |
|---|---|
| `20260604000000_add_last_digest_sent_at.sql` | `ALTER TABLE users ADD COLUMN last_digest_sent_at TIMESTAMPTZ DEFAULT NULL` + index |

`weekly_digest_opt_in` and `email` columns were added by `20260526000000_add_weekly_digest_opt_in.sql` (already merged).

## Cron configuration

Already present in `vercel.json`:
```json
{ "path": "/api/cron/weekly-digest", "schedule": "0 9 * * 1" }
```
Self-hosted deployments call the same route with `Authorization: Bearer <CRON_SECRET>`.

## Settings UI

`weekly_digest_opt_in` toggle already exists in the Settings page (added by a prior PR). Default is `false`.

## Test results

```
Test Files  2 passed (2)
Tests       53 passed (53)
```

Coverage:
- Unsubscribe token generation, determinism, tamper-resistance, cross-user isolation
- `GET /api/unsubscribe` — 400/403/500 error paths + success HTML + DB update
- `buildDigestHtml` — greeting, unsubscribe URL, streak, commits/PRs, languages, repos, XSS escaping, no-metrics fallback
- `buildDigestText` — greeting, unsubscribe URL, streak section
- `GET /api/cron/weekly-digest` — auth, response shape, cooldown skip, metrics flag, graceful metrics failure, partial Resend failure, errors array, mixed eligible/cooldown users, email address routing, HTML/text body content, DB query contract