### PR TITLE
feat: add Open in GitHub link to pinned repo cards

### DIFF
--- a/src/components/PinnedReposWidget.tsx
+++ b/src/components/PinnedReposWidget.tsx
@@ -124,13 +124,13 @@ export default function PinnedReposWidget({
         {repos.map((repo) => {
           const shortName = repo.name.split("/")[1] ?? repo.name;
           const owner = repo.name.split("/")[0] ?? "";
-          
+
           // Generate Area Sparkline points
           const sparkline = repo.sparkline || Array(30).fill(0);
           const width = 140;
           const height = 34;
           const maxVal = Math.max(...sparkline, 1);
-          
+
           const points = sparkline.map((val, idx) => {
             const x = (idx / (sparkline.length - 1)) * width;
             const y = height - 2 - ((val / maxVal) * (height - 4));
@@ -166,6 +166,17 @@ export default function PinnedReposWidget({
               <p className="text-xs text-[var(--muted-foreground)] line-clamp-2 min-h-[32px] leading-relaxed">
                 {repo.description ?? "No description provided."}
               </p>
+
+              <a
+                href={repo.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open in GitHub"
+                className="inline-flex items-center gap-1 text-xs font-medium text-[var(--accent)] hover:underline"
+              >
+                <ExternalLink size={12} />
+                Open in GitHub
+              </a>
 
               {/* Sparkline Graph */}
               <div className="flex items-center justify-between border-t border-[var(--border)]/60 pt-3 mt-1">


### PR DESCRIPTION
## Summary

Added an **"Open in GitHub"** link to each repository card in `PinnedReposWidget` so users can directly open the repository from the Repository Spotlight section.

Closes #1904

---

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor / code cleanup

---

## Changes Made

* Added an **Open in GitHub** link to each pinned repository card
* Configured the link to open the repository in a new tab
* Added `rel="noopener noreferrer"` for security
* Added `aria-label="Open in GitHub"` for accessibility

---

## How to Test

1. Open the application and navigate to the Repository Spotlight section
2. Verify that each repository card displays an **Open in GitHub** link
3. Click the link and confirm the repository opens in a new browser tab
4. Verify no layout or styling issues are introduced

---

## Screenshots (if UI change)

N/A

---

## Checklist

* [x] Linked issue in summary
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [x] Self-reviewed the diff
* [ ] Added/updated tests if applicable

---

## Accessibility Checklist

* [x] Accessibility label added (`aria-label`)
* [x] Link remains keyboard accessible
* [x] Opens safely using `rel="noopener noreferrer"`

---

## Additional Notes

`npm test` reports existing webhook-related test failures unrelated to this change. `npm run lint` and `npm run type-check` pass successfully.
