### PR TITLE
feat(auth): add GitHub App installation token service layer

### DIFF
--- a/src/lib/github-app.ts
+++ b/src/lib/github-app.ts
@@ -1,0 +1,358 @@
+/**
+ * GitHub App service layer.
+ *
+ * Provides installation access tokens using GitHub App credentials so
+ * DevTrack can make authenticated GitHub API calls from server-side code
+ * (public profile pages, background digests, achievement syncs) without
+ * relying on an individual user's OAuth token.
+ *
+ * How it works
+ * â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+ * 1. Sign a short-lived JWT (RS256, 10 min TTL) using the App's private key.
+ * 2. POST the JWT to /app/installations/{id}/access_tokens to obtain a
+ *    standard bearer token (GitHub issues these with a 1-hour lifetime).
+ * 3. Cache the bearer token in memory and refresh it ~5 minutes before it
+ *    expires so callers always receive a valid token.
+ * 4. Concurrent callers share a single in-flight refresh request â€” no
+ *    duplicate token generation on bursts.
+ *
+ * Environment variables
+ * â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+ *   GITHUB_APP_ID              Numeric App ID (App settings â†’ About this App)
+ *   GITHUB_APP_PRIVATE_KEY     PEM-encoded RSA private key.  Literal \n
+ *                              escaping (as stored in Vercel / Railway env
+ *                              dashboards) is normalised automatically.
+ *   GITHUB_APP_INSTALLATION_ID Installation ID for the target account/org.
+ *                              Find it in the App's installation URL:
+ *                              /settings/installations/{id}
+ *
+ * Required permissions on the GitHub App
+ * â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+ *   contents:read    â€” read repository file trees and commit data
+ *   metadata:read    â€” read public repository metadata
+ *   pull_requests:read â€” read PR lists and review state
+ *
+ * Backwards compatibility
+ * â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+ * All three env vars must be set for the App path to activate.  When any is
+ * missing, isGitHubAppConfigured() returns false and callers fall back to
+ * process.env.GITHUB_TOKEN (a PAT) or unauthenticated requests.  Existing
+ * authenticated user routes continue to use the per-user OAuth token stored
+ * in the NextAuth session â€” those are unaffected by this module.
+ */
+
+import { createSign } from "node:crypto";
+
+const GITHUB_API_BASE = "https://api.github.com";
+
+// GitHub App JWTs may not exceed 10 minutes.
+const JWT_LIFETIME_SECONDS = 600;
+
+// Back-date iat by 60 seconds to absorb clock skew between the server and
+// GitHub's API endpoints.  Without this, a fast machine can occasionally
+// generate a token with an iat that GitHub considers to be in the future.
+const IAT_DRIFT_SECONDS = 60;
+
+// Start refreshing the installation token this many milliseconds before it
+// expires so callers always receive a token with meaningful remaining life.
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes
+
+// â”€â”€ Public types â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+export interface AppConfig {
+  appId: string;
+  privateKey: string;
+  installationId: string;
+}
+
+/** A valid installation access token together with its expiry time. */
+export interface InstallationToken {
+  token: string;
+  /** Unix timestamp in milliseconds when this token expires (~1 hour). */
+  expiresAt: number;
+}
+
+/** Diagnostics returned by getInstallationRateLimitInfo(). */
+export interface RateLimitInfo {
+  remaining: number;
+  limit: number;
+  resetAt: Date | null;
+  resource: string;
+}
+
+// â”€â”€ In-process token cache â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+let tokenCache: InstallationToken | null = null;
+
+/**
+ * Single in-flight refresh promise.  Any caller that arrives while a refresh
+ * is already running awaits the same promise rather than issuing a duplicate
+ * token-generation request.
+ */
+let refreshPromise: Promise<InstallationToken> | null = null;
+
+// â”€â”€ Config helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/**
+ * Returns true when all three GitHub App environment variables are present
+ * and non-empty.  Use this to guard App-based code paths so deployments that
+ * have not configured a GitHub App continue to work without modification.
+ */
+export function isGitHubAppConfigured(): boolean {
+  return Boolean(
+    process.env.GITHUB_APP_ID &&
+      process.env.GITHUB_APP_PRIVATE_KEY &&
+      process.env.GITHUB_APP_INSTALLATION_ID,
+  );
+}
+
+/**
+ * Read and validate the GitHub App environment variables.
+ * Normalises literal \n sequences in the private key so the PEM can be stored
+ * as a single-line string in environment dashboards.
+ *
+ * @throws {Error} When any required variable is missing.
+ */
+export function readAppConfig(): AppConfig {
+  const appId = process.env.GITHUB_APP_ID;
+  const rawKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+
+  if (!appId) throw new Error("GITHUB_APP_ID is not configured");
+  if (!rawKey) throw new Error("GITHUB_APP_PRIVATE_KEY is not configured");
+  if (!installationId)
+    throw new Error("GITHUB_APP_INSTALLATION_ID is not configured");
+
+  // Normalise keys stored with literal backslash-n (common in Vercel,
+  // Railway, and similar env dashboards that don't support multiline values).
+  const privateKey = rawKey.replace(/\\n/g, "\n");
+
+  return { appId, privateKey, installationId };
+}
+
+// â”€â”€ JWT generation â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+function toBase64Url(input: string | Buffer): string {
+  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
+  return buf.toString("base64url");
+}
+
+/**
+ * Generate a signed RS256 JWT for GitHub App authentication.
+ *
+ * The JWT is intentionally short-lived (â‰¤10 min) and is used solely to
+ * exchange for an installation access token â€” it is never exposed to users.
+ *
+ * @param appId      GitHub App numeric ID (from the App settings page).
+ * @param privateKey PEM-encoded RSA private key with proper header/footer.
+ */
+export function buildAppJwt(appId: string, privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const iat = now - IAT_DRIFT_SECONDS;
+  const exp = now + JWT_LIFETIME_SECONDS;
+
+  const header = toBase64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = toBase64Url(JSON.stringify({ iss: appId, iat, exp }));
+  const signingInput = `${header}.${payload}`;
+
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  const signature = signer.sign(privateKey, "base64url");
+
+  return `${signingInput}.${signature}`;
+}
+
+// â”€â”€ Installation token fetch â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/**
+ * Request a fresh installation access token from GitHub.
+ *
+ * Callers should prefer getInstallationToken() which wraps this function with
+ * caching and deduplication logic.
+ *
+ * @throws {Error} On network failure, non-2xx response, or malformed payload.
+ */
+export async function fetchInstallationToken(
+  config: AppConfig,
+): Promise<InstallationToken> {
+  const jwt = buildAppJwt(config.appId, config.privateKey);
+
+  const res = await fetch(
+    `${GITHUB_API_BASE}/app/installations/${config.installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "(no body)");
+    throw new Error(
+      `GitHub App token request failed: HTTP ${res.status} â€” ${body}`,
+    );
+  }
+
+  const data = (await res.json()) as {
+    token?: string;
+    expires_at?: string;
+  };
+
+  if (!data.token || !data.expires_at) {
+    throw new Error(
+      "GitHub App token response is missing required fields (token, expires_at)",
+    );
+  }
+
+  return {
+    token: data.token,
+    expiresAt: new Date(data.expires_at).getTime(),
+  };
+}
+
+// â”€â”€ Token lifecycle management â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/**
+ * Returns true when the cached token has more than TOKEN_REFRESH_BUFFER_MS
+ * of remaining lifetime so it is safe to use without an immediate refresh.
+ */
+function isCacheValid(): boolean {
+  if (!tokenCache) return false;
+  const refreshAt = tokenCache.expiresAt - TOKEN_REFRESH_BUFFER_MS;
+  return Date.now() < refreshAt;
+}
+
+/**
+ * Return a valid installation access token, refreshing it as needed.
+ *
+ * Tokens are cached for their full lifetime (~1 hour) and proactively
+ * refreshed 5 minutes before expiry.  Concurrent callers share one in-flight
+ * refresh request â€” the GitHub API is never called more than once per window.
+ *
+ * @throws {Error} When env vars are missing or the GitHub API request fails.
+ *   On failure the cache is cleared so the next call retries rather than
+ *   serving a known-bad entry.
+ */
+export async function getInstallationToken(): Promise<string> {
+  // Fast path: cached token is still fresh.
+  if (isCacheValid()) {
+    return tokenCache!.token;
+  }
+
+  // If a refresh is already in flight, piggyback on it rather than issuing a
+  // second parallel request.
+  if (refreshPromise) {
+    const result = await refreshPromise;
+    return result.token;
+  }
+
+  // Kick off a new refresh.  The finally block clears refreshPromise so the
+  // next caller after this one completes starts a clean refresh.
+  const pending = (async (): Promise<InstallationToken> => {
+    try {
+      const config = readAppConfig();
+      const fresh = await fetchInstallationToken(config);
+      tokenCache = fresh;
+      return fresh;
+    } catch (err) {
+      // Clear a potentially stale cache entry so the next call retries.
+      tokenCache = null;
+      throw err;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  refreshPromise = pending;
+  const result = await pending;
+  return result.token;
+}
+
+/**
+ * Evict the in-process token cache.
+ *
+ * Useful in error-recovery paths where a token has been rejected by GitHub
+ * (e.g. after an installation is suspended) and in tests that need a clean
+ * cache state between runs.
+ */
+export function clearTokenCache(): void {
+  tokenCache = null;
+  refreshPromise = null;
+}
+
+// â”€â”€ Server-side token resolution â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/**
+ * Resolve the best available server-side GitHub token for operations that run
+ * outside of a user request (background jobs, public-profile API, digests).
+ *
+ * Priority:
+ *  1. GitHub App installation token â€” 5 000 req/hr per installation, shared
+ *     across all server-side calls, automatically refreshed before expiry.
+ *  2. GITHUB_TOKEN environment variable â€” a classic PAT for simpler setups.
+ *  3. undefined â€” GitHub allows 60 unauthenticated req/hr per origin IP.
+ *
+ * This function never throws; App token failures are logged and the PAT
+ * fallback is used so background jobs remain operational.
+ */
+export async function resolveServerGitHubToken(): Promise<string | undefined> {
+  if (isGitHubAppConfigured()) {
+    try {
+      return await getInstallationToken();
+    } catch (err) {
+      console.warn(
+        "[github-app] Installation token unavailable, falling back to GITHUB_TOKEN:",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+  return process.env.GITHUB_TOKEN || undefined;
+}
+
+// â”€â”€ Rate limit diagnostics â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/**
+ * Return the current rate limit status for the installation token, or null
+ * when the GitHub App is not configured or the request fails.
+ *
+ * Use this to surface rate-limit headroom in diagnostics / health endpoints.
+ */
+export async function getInstallationRateLimitInfo(): Promise<RateLimitInfo | null> {
+  if (!isGitHubAppConfigured()) return null;
+
+  try {
+    const token = await getInstallationToken();
+
+    const res = await fetch(`${GITHUB_API_BASE}/rate_limit`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+      cache: "no-store",
+    });
+
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as {
+      resources: {
+        core: { remaining: number; limit: number; reset: number };
+      };
+    };
+
+    const core = data.resources?.core;
+    if (!core) return null;
+
+    return {
+      remaining: core.remaining,
+      limit: core.limit,
+      resetAt: new Date(core.reset * 1000),
+      resource: "core",
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/public-profile-data.ts
+++ b/src/lib/public-profile-data.ts
@@ -3,6 +3,7 @@ import type { GitHubAchievement } from "@/lib/github-achievements";
 import { syncGitHubAchievementsForUser } from "@/lib/github-achievements";
 import { fetchPinnedRepoDetails, type PinnedRepoDetails } from "@/lib/pinned-repos";
 import { getUserByUsername, supabaseAdmin } from "@/lib/supabase";
+import { resolveServerGitHubToken } from "@/lib/github-app";
 
 const GITHUB_API = "https://api.github.com";
 
@@ -287,7 +288,9 @@ export async function fetchPublicProfile(
   const user = await getUserByUsername(username);
   if (!user) return null;
 
-  const githubToken = process.env.GITHUB_TOKEN;
+  // Prefer a GitHub App installation token (5 000 req/hr per installation)
+  // over a plain PAT, then fall back to unauthenticated (60 req/hr per IP).
+  const githubToken = await resolveServerGitHubToken();
   const [
     publicGists,
     repos,

--- a/test/github-app.test.ts
+++ b/test/github-app.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Tests for the GitHub App service layer (issue #238).
+ *
+ * Coverage:
+ *  - isGitHubAppConfigured      â€” env-var presence checks
+ *  - readAppConfig              â€” validation and \n normalisation
+ *  - buildAppJwt                â€” JWT structure, RS256 signing, correct claims
+ *  - fetchInstallationToken     â€” HTTP request/response handling
+ *  - getInstallationToken       â€” caching, refresh, concurrent deduplication
+ *  - clearTokenCache            â€” cache eviction
+ *  - resolveServerGitHubToken   â€” priority chain (App â†’ PAT â†’ undefined)
+ *  - getInstallationRateLimitInfo â€” diagnostics
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+
+// â”€â”€ Shared RSA key for all JWT/signing tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// Generated once â€” avoids repeated keygen overhead while keeping tests realistic.
+const { privateKey: TEST_PRIVATE_KEY } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+// â”€â”€ fetch mock â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+// â”€â”€ helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+/** One-hour expiry from a given Unix-ms timestamp. */
+function expiresAt(fromMs = Date.now()): string {
+  return new Date(fromMs + 60 * 60 * 1000).toISOString();
+}
+
+/** Mock a successful installation-token GitHub response. */
+function mockSuccessfulTokenFetch(token = "ghs_test_token", fromMs?: number) {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ token, expires_at: expiresAt(fromMs) }),
+    text: async () => "",
+  });
+}
+
+/** Decode a base64url string to a plain UTF-8 string. */
+function b64urlDecode(input: string): string {
+  return Buffer.from(input, "base64url").toString("utf8");
+}
+
+// â”€â”€ env helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+function setAppEnv(overrides: Partial<Record<string, string>> = {}) {
+  const defaults: Record<string, string> = {
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_PRIVATE_KEY: TEST_PRIVATE_KEY,
+    GITHUB_APP_INSTALLATION_ID: "99",
+  };
+  for (const [k, v] of Object.entries({ ...defaults, ...overrides })) {
+    process.env[k] = v;
+  }
+}
+
+function clearAppEnv() {
+  delete process.env.GITHUB_APP_ID;
+  delete process.env.GITHUB_APP_PRIVATE_KEY;
+  delete process.env.GITHUB_APP_INSTALLATION_ID;
+}
+
+// â”€â”€ isGitHubAppConfigured â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+describe("isGitHubAppConfigured", () => {
+  afterEach(clearAppEnv);
+
+  it("returns true when all three env vars are set", async () => {
+    setAppEnv();
+    const { isGitHubAppConfigured } = await import("@/lib/github-app");
+    expect(isGitHubAppConfigured()).toBe(true);
+  });
+
+  it("returns false when GITHUB_APP_ID is missing", async () => {
+    setAppEnv({ GITHUB_APP_ID: "" });
+    const { isGitHubAppConfigured } = await import("@/lib/github-app");
+    expect(isGitHubAppConfigured()).toBe(false);
+  });
+
+  it("returns false when GITHUB_APP_PRIVATE_KEY is missing", async () => {
+    setAppEnv({ GITHUB_APP_PRIVATE_KEY: "" });
+    const { isGitHubAppConfigured } = await import("@/lib/github-app");
+    expect(isGitHubAppConfigured()).toBe(false);
+  });
+
+  it("returns false when GITHUB_APP_INSTALLATION_ID is missing", async () => {
+    setAppEnv({ GITHUB_APP_INSTALLATION_ID: "" });
+    const { isGitHubAppConfigured } = await import("@/lib/github-app");
+    expect(isGitHubAppConfigured()).toBe(false);
+  });
+
+  it("returns false when none of the env vars are set", async () => {
+    clearAppEnv();
+    const { isGitHubAppConfigured } = await import("@/lib/github-app");
+    expect(isGitHubAppConfigured()).toBe(false);
+  });
+});
+
+// â”€â”€ readAppConfig â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+describe("readAppConfig", () => {
+  afterEach(clearAppEnv);
+
+  it("returns config when all vars are present", async () => {
+    setAppEnv();
+    const { readAppConfig } = await import("@/lib/github-app");
+    const cfg = readAppConfig();
+    expect(cfg.appId).toBe("12345");
+    expect(cfg.installationId).toBe("99");
+  });
+
+  it("normalises literal \\n sequences in the private key", async () => {
+    // Store key with literal \n (as common in Vercel env dashboards)
+    const compact = TEST_PRIVATE_KEY.replace(/\n/g, "\\n");
+    setAppEnv({ GITHUB_APP_PRIVATE_KEY: compact });
+    const { readAppConfig } = await import("@/lib/github-app");
+    const cfg = readAppConfig();
+    expect(cfg.privateKey).toContain("\n");
+    expect(cfg.privateKey).not.toContain("\\n");
+  });
+
+  it("throws when GITHUB_APP_ID is absent", async () => {
+    setAppEnv({ GITHUB_APP_ID: "" });
+    const { readAppConfig } = await import("@/lib/github-app");
+    expect(() => readAppConfig()).toThrow("GITHUB_APP_ID is not configured");
+  });
+
+  it("throws when GITHUB_APP_PRIVATE_KEY is absent", async () => {
+    setAppEnv({ GITHUB_APP_PRIVATE_KEY: "" });
+    const { readAppConfig } = await import("@/lib/github-app");
+    expect(() => readAppConfig()).toThrow("GITHUB_APP_PRIVATE_KEY is not configured");
+  });
+
+  it("throws when GITHUB_APP_INSTALLATION_ID is absent", async () => {
+    setAppEnv({ GITHUB_APP_INSTALLATION_ID: "" });
+    const { readAppConfig } = await import("@/lib/github-app");
+    expect(() => readAppConfig()).toThrow("GITHUB_APP_INSTALLATION_ID is not configured");
+  });
+});
+
+// â”€â”€ buildAppJwt â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+describe("buildAppJwt", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a JWT with three dot-separated parts", async () => {
+    const { buildAppJwt } = await import("@/lib/github-app");
+    const jwt = buildAppJwt("42", TEST_PRIVATE_KEY);
+    expect(jwt.split(".")).toHaveLength(3);
+  });
+
+  it("encodes the correct RS256 / JWT header", async () => {
+    const { buildAppJwt } = await import("@/lib/github-app");
+    const jwt = buildAppJwt("42", TEST_PRIVATE_KEY);
+    const header = JSON.parse(b64urlDecode(jwt.split(".")[0]));
+    expect(header.alg).toBe("RS256");
+    expect(header.typ).toBe("JWT");
+  });
+
+  it("encodes the correct iss, iat, and exp claims in the payload", async () => {
+    const { buildAppJwt } = await import("@/lib/github-app");
+    const jwt = buildAppJwt("99999", TEST_PRIVATE_KEY);
+    const payload = JSON.parse(b64urlDecode(jwt.split(".")[1]));
+
+    const now = Math.floor(Date.now() / 1000);
+    expect(payload.iss).toBe("99999");
+    expect(payload.iat).toBe(now - 60);   // 60 s clock-skew buffer
+    expect(payload.exp).toBe(now + 600);  // 10 min lifetime
+  });
+
+  it("produces a non-empty signature in the third part", async () => {
+    const { buildAppJwt } = await import("@/lib/github-app");
+    const jwt = buildAppJwt("1", TEST_PRIVATE_KEY);
+    const sig = jwt.split(".")[2];
+    expect(sig).toBeTruthy();
+    expect(sig.length).toBeGreaterThan(10);
+  });
+
+  it("produces different JWTs for different app IDs", async () => {
+    const { buildAppJwt } = await import("@/lib/github-app");
+    const jwt1 = buildAppJwt("1", TEST_PRIVATE_KEY);
+    const jwt2 = buildAppJwt("2", TEST_PRIVATE_KEY);
+    expect(jwt1).not.toBe(jwt2);
+  });
+});
+
+// â”€â”€ fetchInstallationToken â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+describe("fetchInstallationToken", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("returns token and expiresAt on a successful response", async () => {
+    const exp = "2025-01-15T13:00:00Z";
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: "ghs_abc123", expires_at: exp }),
+      text: async () => "",
+    });
+
+    const { fetchInstallationToken } = await import("@/lib/github-app");
+    const result = await fetchInstallationToken({
+      appId: "1",
+      privateKey: TEST_PRIVATE_KEY,
+      installationId: "99",
+    });
+
+    expect(result.token).toBe("ghs_abc123");
+    expect(result.expiresAt).toBe(new Date(exp).getTime());
+  });
+
+  it("POSTs to the correct GitHub App endpoint", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: "t", expires_at: expiresAt() }),
+      text: async () => "",
+    });
+
+    const { fetchInstallationToken } = await import("@/lib/github-app");
+    await fetchInstallationToken({
+      appId: "1",
+      privateKey: TEST_PRIVATE_KEY,
+      installationId: "42",
+    });
+
+    const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+    expect(calledUrl).toContain("/app/installations/42/access_tokens");
+  });
+
+  it("sends the App JWT in the Authorization header", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: "t", expires_at: expiresAt() }),
+      text: async () => "",
+    });
+
+    const { fetchInstallationToken } = await import("@/lib/github-app");
+    await fetchInstallationToken({
+      appId: "1",
+      privateKey: TEST_PRIVATE_KEY,
+      installationId: "1",
+    });
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers?.Authorization).toMatch(/^Bearer /);
+  });
+
+  it("throws when GitHub returns a non-2xx status", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: async () => "Bad credentials",
+    });
+
+    const { fetchInstallationToken } = await import("@/lib/github-app");
+    await expect(
+      fetchInstallationToken({ appId: "1", privateKey: TEST_PRIVATE_KEY, installationId: "1" })
+    ).rejects.toThrow("HTTP 401");
+  });
+
+  it("throws when the response body is missing required fields", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "",
+    });
+
+    const { fetchInstallationToken } = await import("@/lib/github-app");
+    await expect(
+      fetchInstallationToken({ appId: "1", privateKey: TEST_PRIVATE_KEY, installationId: "1" })
+    ).rejects.toThrow("missing required fields");
+  });
+});
+
+// â”€â”€ getInstallationToken â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+describe("getInstallationToken", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(0);
+    fetchMock.mockReset();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    const mod = await import("@/lib/github-app");
+    mod.clearTokenCache();
+    clearAppEnv();
+  });
+
+  it("fetches a token on the first call", async () => {
+    setAppEnv();
+    mockSuccessfulTokenFetch("tok-1");
+    const { getInstallationToken } = await import("@/lib/github-app");
+    const token = await getInstallationToken();
+    expect(token).toBe("tok-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the cached token on the second call without a new fetch", async () => {
+    setAppEnv();
+    mockSuccessfulTokenFetch("tok-cached");
+    const { getInstallationToken } = await import("@/lib/github-app");
+    const first = await getInstallationToken();
+    const second = await getInstallationToken();
+    expect(first).toBe("tok-cached");
+    expect(second).toBe("tok-cached");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes the token after it crosses the 5-minute refresh threshold", async () => {
+    setAppEnv();
+    // T=0: token expires at T+1h; refresh threshold = T+55min
+    vi.setSystemTime(0);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        token: "tok-old",
+        expires_at: new Date(60 * 60 * 1000).toISOString(),
+      }),
+      text: async () => "",
+    });
+
+    const { getInstallationToken } = await import("@/lib/github-app");
+    await getInstallationToken();
+
+    // Advance to T+56min â€” past the 55-minute refresh threshold
+    vi.setSystemTime(56 * 60 * 1000);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        token: "tok-new",
+        expires_at: new Date(56 * 60 * 1000 + 60 * 60 * 1000).toISOString(),
+      }),
+      text: async () => "",
+    });
+
+    const refreshed = await getInstallationToken();
+    expect(refreshed).toBe("tok-new");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT refresh when the token still has >5 min remaining", async () => {
+    setAppEnv();
+    vi.setSystemTime(0);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        token: "tok-valid",
+        expires_at: new Date(60 * 60 * 1000).toISOString(),
+      }),
+      text: async () => "",
+    });
+
+    const { getInstallationToken } = await import("@/lib/github-app");
+    await getInstallationToken();
+
+    // Advance to T+50min â€” still within the safe window
+    vi.setSystemTime(50 * 60 * 1000);
+    const second = await getInstallationToken();
+    expect(second).toBe("tok-valid");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the cache and rethrows when the token request fails", async () => {
+    setAppEnv();
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: async () => "Forbidden",
+    });
+
+    const { getInstallationToken } = await import("@/lib/github-app");
+    await expect(getInstallationToken()).rejects.toThrow("HTTP 403");
+
+    // Second call must retry (cache was cleared on failure)
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: "tok-retry", expires_at: expiresAt() }),
+      text: async () => "",
+    });
+
+    const token = await getInstallationToken();
+    expect(token).toBe("tok-retry");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent refresh requests into a single HTTP call", async () => {
+    setAppEnv();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: "tok-dedup", expires_at: expiresAt() }),
+      text: async () => "",
+    });
+
+    const { getInstallationToken } = await import("@/lib/github-app");
+
+    // Three concurrent calls must share the single in-flight request.
+    const [a, b, c] = await Promise.all([
+      getInstallationToken(),
+      getInstallationToken(),
+      getInstallationToken(),
+    ]);
+
+    expect(a).toBe("tok-dedup");
+    expect(b).toBe("tok-dedup");
+    expect(c).toBe("tok-dedup");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// â”€â”€ clearTokenCache â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+describe("clearTokenCache", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(clearAppEnv);
+
+  it("forces a fresh fetch after the cache is cleared", async () => {
+    setAppEnv();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: "tok-x", expires_at: expiresAt() }),
+      text: async () => "",
+    });
+
+    const { getInstallationToken, clearTokenCache } = await import("@/lib/github-app");
+    await getInstallationToken(); // populates cache
+    clearTokenCache();
+    await getInstallationToken(); // should fetch again
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// â”€â”€ resolveServerGitHubToken â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+describe("resolveServerGitHubToken", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(async () => {
+    delete process.env.GITHUB_TOKEN;
+    clearAppEnv();
+    const mod = await import("@/lib/github-app");
+    mod.clearTokenCache();
+  });
+
+  it("returns the installation token when the App is configured", async () => {
+    setAppEnv();
+    mockSuccessfulTokenFetch("inst-tok");
+
+    const { resolveServerGitHubToken, clearTokenCache } = await import("@/lib/github-app");
+    clearTokenCache();
+    const token = await resolveServerGitHubToken();
+    expect(token).toBe("inst-tok");
+  });
+
+  it("falls back to GITHUB_TOKEN when the App is not configured", async () => {
+    clearAppEnv();
+    process.env.GITHUB_TOKEN = "pat-token";
+
+    const { resolveServerGitHubToken } = await import("@/lib/github-app");
+    const token = await resolveServerGitHubToken();
+    expect(token).toBe("pat-token");
+    // No GitHub API call should have been made
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to GITHUB_TOKEN when the App token fetch fails", async () => {
+    setAppEnv();
+    process.env.GITHUB_TOKEN = "fallback-pat";
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Server Error",
+    });
+
+    const { resolveServerGitHubToken, clearTokenCache } = await import("@/lib/github-app");
+    clearTokenCache();
+    const token = await resolveServerGitHubToken();
+    expect(token).toBe("fallback-pat");
+  });
+
+  it("returns undefined when neither App nor GITHUB_TOKEN is configured", async () => {
+    clearAppEnv();
+    delete process.env.GITHUB_TOKEN;
+
+    const { resolveServerGitHubToken } = await import("@/lib/github-app");
+    const token = await resolveServerGitHubToken();
+    expect(token).toBeUndefined();
+  });
+});
+
+// â”€â”€ getInstallationRateLimitInfo â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+describe("getInstallationRateLimitInfo", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(async () => {
+    clearAppEnv();
+    const mod = await import("@/lib/github-app");
+    mod.clearTokenCache();
+  });
+
+  it("returns null when the App is not configured", async () => {
+    clearAppEnv();
+    const { getInstallationRateLimitInfo } = await import("@/lib/github-app");
+    const info = await getInstallationRateLimitInfo();
+    expect(info).toBeNull();
+  });
+
+  it("returns rate limit details on a successful response", async () => {
+    setAppEnv();
+    mockSuccessfulTokenFetch("tok-rl");
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        resources: {
+          core: { remaining: 4800, limit: 5000, reset: 1700000000 },
+        },
+      }),
+    });
+
+    const { getInstallationRateLimitInfo, clearTokenCache } = await import("@/lib/github-app");
+    clearTokenCache();
+    const info = await getInstallationRateLimitInfo();
+
+    expect(info).not.toBeNull();
+    expect(info!.remaining).toBe(4800);
+    expect(info!.limit).toBe(5000);
+    expect(info!.resource).toBe("core");
+    expect(info!.resetAt).toBeInstanceOf(Date);
+  });
+
+  it("returns null when the rate-limit request fails (non-2xx)", async () => {
+    setAppEnv();
+    mockSuccessfulTokenFetch("tok-rl2");
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const { getInstallationRateLimitInfo, clearTokenCache } = await import("@/lib/github-app");
+    clearTokenCache();
+    const info = await getInstallationRateLimitInfo();
+    expect(info).toBeNull();
+  });
+
+  it("returns null on network error without throwing", async () => {
+    setAppEnv();
+    mockSuccessfulTokenFetch("tok-rl3");
+    fetchMock.mockRejectedValueOnce(new Error("network failure"));
+
+    const { getInstallationRateLimitInfo, clearTokenCache } = await import("@/lib/github-app");
+    clearTokenCache();
+    const info = await getInstallationRateLimitInfo();
+    expect(info).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces `src/lib/github-app.ts` — a dedicated GitHub App service that generates RS256 JWTs, exchanges them for installation access tokens, and maintains an in-process cache with proactive refresh ~5 minutes before expiry.
- Concurrent callers share a single in-flight refresh request; token failures evict the cache so the next call retries cleanly.
- `src/lib/public-profile-data.ts` updated to call `resolveServerGitHubToken()` so public profile pages prefer the installation token (5 000 req/hr per installation) over the legacy `GITHUB_TOKEN` PAT.
- All three new env vars are fully optional — existing deployments are unaffected.

## Architecture

### Current state (before this PR)
- All GitHub API calls use the signed-in user's OAuth token from the NextAuth session.
- Server-side background code (`public-profile-data.ts`, weekly digest) falls back to `GITHUB_TOKEN` (a PAT) or unauthenticated requests.
- No GitHub App support existed.

### After this PR
- A GitHub App installation token can be configured via three env vars.
- When configured, it is preferred for server-side, non-user-scoped calls (public profiles, future background jobs).
- User-facing metric routes still use the per-user OAuth token — no change to the authenticated experience.
- Fallback chain: **App installation token → `GITHUB_TOKEN` PAT → unauthenticated**.

## Key exports (`src/lib/github-app.ts`)

| Export | Purpose |
|---|---|
| `isGitHubAppConfigured()` | Guard for optional App code paths |
| `readAppConfig()` | Validated env-var reader; normalises literal `\n` in PEM keys |
| `buildAppJwt(appId, privateKey)` | Signs an RS256 JWT for App-level auth |
| `fetchInstallationToken(config)` | `POST /app/installations/{id}/access_tokens` |
| `getInstallationToken()` | Cached, auto-refreshing token accessor |
| `resolveServerGitHubToken()` | Priority chain: App → PAT → `undefined` |
| `clearTokenCache()` | Cache eviction for error recovery and tests |
| `getInstallationRateLimitInfo()` | Rate-limit diagnostics for health endpoints |

## Token lifecycle

1. On first call to `getInstallationToken()`, a 10-minute RS256 JWT is signed with the App's private key.
2. The JWT is exchanged for a bearer token (GitHub issues these with a 1-hour TTL).
3. The token is stored in memory with its expiry timestamp.
4. Subsequent calls return the cached token until 5 minutes before expiry.
5. Near-expiry triggers a single refresh; concurrent callers await the same in-flight promise.
6. On network or HTTP failure the cache is cleared so the next call retries.

## Environment variables

All three must be set to enable the App path; any missing var leaves `isGitHubAppConfigured()` returning `false` and callers fall back to existing behaviour.

| Variable | Description |
|---|---|
| `GITHUB_APP_ID` | Numeric App ID (App settings → *About this App*) |
| `GITHUB_APP_PRIVATE_KEY` | PEM-encoded RSA private key. Literal `\n` escaping is normalised so the key can be stored as a single line in Vercel / Railway dashboards. |
| `GITHUB_APP_INSTALLATION_ID` | Installation ID — appears in the URL when viewing the App's installation page: `/settings/installations/{id}` |

## Required GitHub App permissions

- `contents:read`
- `metadata:read`
- `pull_requests:read`

## Files modified

| File | Change |
|---|---|
| `src/lib/github-app.ts` | **New** — complete service layer |
| `src/lib/public-profile-data.ts` | Use `resolveServerGitHubToken()` instead of `process.env.GITHUB_TOKEN` |
| `test/github-app.test.ts` | **New** — 35 tests |

## Security

- Private key is read from env vars and never logged; the JWT and installation tokens are also never written to logs.
- `buildAppJwt` back-dates `iat` by 60 seconds to absorb server clock skew.
- JWT lifetime is capped at 10 minutes (GitHub's maximum).
- Installation tokens expire in ~1 hour and are rotated automatically.

## Test results

```
✓ test/github-app.test.ts (35 tests) — 35 passed
✓ test/public-profile-data.test.ts (9 tests) — 9 passed
✓ test/public-profile-uuid-exposure.test.ts (8 tests) — 8 passed
```

Closes #238