### PR TITLE
fix(ci): remove duplicate permissions block from PR Labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,9 +8,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Summary

Removed the duplicate "permissions" block from the PR Labeler workflow to eliminate YAML ambiguity and ensure the intended permissions are applied consistently.

Closes #2090 

---

Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

Changes Made

- Removed the duplicate "permissions" declaration from the "label" job
- Consolidated workflow permissions into a single block
- Preserved the required "contents", "pull-requests", and "issues" permissions
- Improved workflow configuration clarity and maintainability

---

How to Test

Steps for the reviewer to verify this works:

1. Review the workflow file for duplicate "permissions" keys
2. Confirm only one "permissions" block exists in the "label" job
3. Verify the workflow syntax remains valid
4. Ensure the PR Labeler workflow functions as expected on a pull request

---

Screenshots (if UI change)

N/A

---

Checklist

- [x] Linked issue in summary
- [x] Self-reviewed the diff
- [x] No unrelated changes included
- [x] Workflow configuration remains valid
- [ ] Added/updated tests if applicable

---

Additional Notes

This change removes a duplicate YAML key that could lead to permission configuration ambiguity. Consolidating permissions into a single block improves readability and helps ensure the workflow uses the intended permission set.