### PR TITLE
fix(repo-analytics): derive timeline labels from GitHub week timestamp

### DIFF
--- a/src/app/api/metrics/repo-analytics/route.ts
+++ b/src/app/api/metrics/repo-analytics/route.ts
@@ -90,18 +90,25 @@ export async function GET(req: NextRequest) {
       });
 
       let timeline: { date: string; events: number }[] = [];
-      if (activityRes.ok && activityRes.status === 200) {
+      let statsBuilding = false;
+
+      if (activityRes.status === 202) {
+        // GitHub is computing stats asynchronously; surface this to the caller
+        statsBuilding = true;
+      } else if (activityRes.ok) {
         const activityData = await activityRes.json();
         if (Array.isArray(activityData) && activityData.length > 0) {
           const lastWeek = activityData[activityData.length - 1];
-          const days = lastWeek.days || [];
-          const today = new Date();
+          const days: number[] = lastWeek.days || [];
+          // `lastWeek.week` is a Unix timestamp (seconds) for the Sunday that starts the bucket.
+          // Derive labels from it so they always match the actual calendar days GitHub recorded.
+          const weekStart = new Date((lastWeek.week as number) * 1000);
           for (let i = 0; i < 7; i++) {
-            const d = new Date(today);
-            d.setDate(d.getDate() - (6 - i));
+            const d = new Date(weekStart);
+            d.setUTCDate(d.getUTCDate() + i);
             timeline.push({
-              date: d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-              events: days[i] || 0
+              date: d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' }),
+              events: days[i] ?? 0,
             });
           }
         }
@@ -145,7 +152,8 @@ export async function GET(req: NextRequest) {
         timeline,
         health,
         primaryStack,
-        languageBreakdown
+        languageBreakdown,
+        ...(statsBuilding ? { statsBuilding: true } : {}),
       };
 
       return result;

--- a/src/lib/repoAnalytics.ts
+++ b/src/lib/repoAnalytics.ts
@@ -55,4 +55,6 @@ export interface RepoAnalyticsResponse {
   health: RepoHealth;
   primaryStack: string[];
   languageBreakdown: LanguageSlice[];
+  /** true when GitHub responded 202 — stats are still being computed */
+  statsBuilding?: boolean;
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in the repository analytics timeline reported in #2095:

1. **Mislabeled dates** — The previous code generated day labels from `new Date()` (today), so the 7 labels never matched the actual Sunday–Saturday week bucket GitHub returned. Labels are now derived from `lastWeek.week` (the Unix timestamp GitHub provides for each bucket).
2. **202 Accepted treated as zero activity** — When GitHub returns `202 Accepted` (stats are still being computed), the old code fell through to the all-zero fallback timeline. The fix detects `202` explicitly and sets a `statsBuilding: true` flag in the response so callers can show a loading/pending state instead.

Closes #2095

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- `src/app/api/metrics/repo-analytics/route.ts`
  - Build timeline entries using `new Date(lastWeek.week * 1000)` + UTC day offset
  - Added explicit `activityRes.status === 202` branch that sets `statsBuilding = true`
- `src/lib/repoAnalytics.ts`
  - Added optional `statsBuilding?: boolean` to `RepoAnalyticsResponse`

---

## How to Test

1. Open the repo analytics drawer for any recently-created or low-activity repository and confirm timeline date labels match the actual calendar days (Sun–Sat), not the last 7 days ending today.
2. To test `202` handling: call the endpoint for a repo whose stats haven't been cached by GitHub yet; confirm the response contains `"statsBuilding": true` rather than an all-zero timeline.

---

## Screenshots (if UI change)

N/A — server-side logic change only. A follow-up UI change can consume `statsBuilding` to show a "stats loading" notice in the chart.

---

## Checklist

- [x] Linked issue in summary
- [x] `pnpm run lint` passes locally
- [x] No TypeScript errors (`pnpm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] No UI changes; not applicable.

---

## Additional Notes

`statsBuilding` is currently only surfaced in the API response. A follow-up issue could wire it into the analytics drawer UI to show a "GitHub is computing stats, try again in a moment" message instead of a blank chart.