### PR TITLE
fix(repo-analytics): align chart dataKeys with actual API response fields

### DIFF
--- a/src/components/repo-analytics/RepoTimelineChart.tsx
+++ b/src/components/repo-analytics/RepoTimelineChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BarChart, Bar, LineChart, Line, ResponsiveContainer, CartesianGrid, XAxis, YAxis, Tooltip, Legend } from "recharts";
+import { BarChart, Bar, LineChart, Line, ResponsiveContainer, CartesianGrid, XAxis, YAxis, Tooltip } from "recharts";
 import { TimelinePoint } from "@/lib/repoAnalytics";
 
 export default function RepoTimelineChart({ timeline }: { timeline: TimelinePoint[] }) {
@@ -29,34 +29,12 @@ export default function RepoTimelineChart({ timeline }: { timeline: TimelinePoin
                 color: "var(--card-foreground)",
               }}
             />
-            <Legend 
-              wrapperStyle={{ 
-                color: "var(--foreground)",
-                paddingTop: "10px"
-              }}
-              formatter={(value) => (
-                <span style={{ color: "var(--foreground)" }}>{value}</span>
-              )}
-            />
-            <Line 
-              type="monotone" 
-              dataKey="commits" 
-              stroke="var(--accent)" 
-              strokeWidth={2} 
-              dot={false}
-            />
-            <Line 
-              type="monotone" 
-              dataKey="prs" 
-              stroke="var(--accent-secondary)" 
-              strokeWidth={2} 
-              dot={false}
-            />
-            <Line 
-              type="monotone" 
-              dataKey="issues" 
-              stroke="var(--warning)" 
-              strokeWidth={2} 
+            <Line
+              type="monotone"
+              dataKey="events"
+              name="Commits"
+              stroke="var(--accent)"
+              strokeWidth={2}
               dot={false}
             />
           </LineChart>
@@ -86,9 +64,10 @@ export default function RepoTimelineChart({ timeline }: { timeline: TimelinePoin
                 color: "var(--card-foreground)",
               }}
             />
-            <Bar 
-              dataKey="commits" 
-              fill="var(--accent)" 
+            <Bar
+              dataKey="events"
+              name="Commits"
+              fill="var(--accent)"
               radius={[4, 4, 0, 0]}
             />
           </BarChart>


### PR DESCRIPTION
## Summary

Fixes the blank repo analytics chart caused by a mismatch between the API response shape and what the chart component tried to read.

Closes #2096

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Root Cause

`RepoTimelineChart` used `dataKey="commits"`, `dataKey="prs"`, and `dataKey="issues"` for its Recharts series. The API and the shared `TimelinePoint` type only return `{ date: string; events: number }`. Because `commits`, `prs`, and `issues` were always `undefined`, both the line chart and bar chart rendered as flat/blank.

## Changes Made

- `src/components/repo-analytics/RepoTimelineChart.tsx`
  - Changed `dataKey="commits"` → `dataKey="events"` in both `<Line>` and `<Bar>` 
  - Added `name="Commits"` so the tooltip label is human-readable
  - Removed the `<Legend>` block (unnecessary for a single-series chart) and its import

No changes to the API or type definitions were needed — the contract was already correct.

---

## How to Test

1. Open the repository analytics drawer for any repository.
2. Confirm the timeline line chart and bar chart now render non-blank data when commit activity exists.
3. Hover over a data point and confirm the tooltip shows "Commits: N".

---

## Screenshots (if UI change)

Before: all chart series rendered as flat/blank lines and empty bars.  
After: the `events` field is read correctly and the chart displays actual commit activity.

---

## Checklist

- [x] Linked issue in summary
- [x] `pnpm run lint` passes locally
- [x] No TypeScript errors (`pnpm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] No structural HTML changes; tooltip and chart labels remain accessible.

---

## Additional Notes

The `commits`, `prs`, and `issues` series were never backed by data. If separate PR/issue series are desired in the future, the API and `TimelinePoint` type would need to be extended first — this PR only removes the dead series.