### PR TITLE
fix(ai-insights): check cache before incrementing rate-limit counter

### DIFF
--- a/src/app/api/ai-insights/route.ts
+++ b/src/app/api/ai-insights/route.ts
@@ -75,6 +75,36 @@ export async function GET(request: Request) {
   const WINDOW_MS = 60 * 60 * 1000;
   const MAX_REQUESTS = 5;
 
+  const { searchParams } = new URL(request.url);
+  const rawType = searchParams.get("type") ?? "weekly_summary";
+
+  // Validate against the DB CHECK constraint allowlist so that an unrecognised
+  // type fails with a clear 400 instead of a Supabase constraint-violation 500.
+  if (!VALID_INSIGHT_TYPES.has(rawType as InsightType)) {
+    return NextResponse.json(
+      { error: `Invalid insight type. Must be one of: ${[...VALID_INSIGHT_TYPES].join(", ")}` },
+      { status: 400 }
+    );
+  }
+  const type = rawType as InsightType;
+
+  // Check the cache before touching the rate-limit counter so that repeated
+  // reads of already-generated insights never consume quota.
+  const { data: cached } = await supabaseAdmin
+    .from("ai_insights")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("insight_type", type)
+    .gte("expires_at", new Date().toISOString())
+    .order("generated_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (cached) {
+    return NextResponse.json({ data: cached.content, cached: true });
+  }
+
+  // No valid cache — enforce the rate limit only when a fresh generation is needed.
   let existing = aiInsightsRateLimit.get(userId);
   if (!existing || currentTime > existing.resetTime) {
     existing = { count: 0, resetTime: currentTime + WINDOW_MS };
@@ -95,33 +125,6 @@ export async function GET(request: Request) {
     );
   }
   existing.count += 1;
-
-  const { searchParams } = new URL(request.url);
-  const rawType = searchParams.get("type") ?? "weekly_summary";
-
-  // Validate against the DB CHECK constraint allowlist so that an unrecognised
-  // type fails with a clear 400 instead of a Supabase constraint-violation 500.
-  if (!VALID_INSIGHT_TYPES.has(rawType as InsightType)) {
-    return NextResponse.json(
-      { error: `Invalid insight type. Must be one of: ${[...VALID_INSIGHT_TYPES].join(", ")}` },
-      { status: 400 }
-    );
-  }
-  const type = rawType as InsightType;
-
-  const { data: cached } = await supabaseAdmin
-    .from("ai_insights")
-    .select("*")
-    .eq("user_id", userId)
-    .eq("insight_type", type)
-    .gte("expires_at", new Date().toISOString())
-    .order("generated_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  if (cached) {
-    return NextResponse.json({ data: cached.content, cached: true });
-  }
 
   const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
   const cookie = request.headers.get("cookie") ?? "";


### PR DESCRIPTION
## Summary

Fixes a rate-limit fairness bug where every request to the AI insights endpoint consumed quota — even when a valid cached insight was returned without any AI generation.

Closes #2097

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Root Cause

The original execution order was:

1. Check + increment rate-limit counter
2. Look up Supabase cache
3. Return cache hit (quota already spent)

This meant dashboard refreshes that hit the cache still burned one of the user's 5 hourly generations, causing spurious `429 Rate limit exceeded` responses.

## Changes Made

- `src/app/api/ai-insights/route.ts`
  - Moved the Supabase `ai_insights` cache lookup to run **before** the rate-limit check.
  - The rate-limit counter is now read and incremented only when no valid cache entry exists and a fresh AI generation is needed.
  - The `Retry-After` response for genuine rate-limit exhaustion is unchanged.

---

## How to Test

1. Trigger a fresh AI insight generation to populate the cache.
2. Reload the dashboard (or call the endpoint) multiple times within the same hour — confirm quota is not consumed on cache hits.
3. Clear the cache and make 6 requests in under an hour — confirm the 6th returns `429` with a `Retry-After` header.

---

## Screenshots (if UI change)

N/A — server-side logic only.

---

## Checklist

- [x] Linked issue in summary
- [x] `pnpm run lint` passes locally
- [x] No TypeScript errors (`pnpm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] No UI changes; not applicable.

---

## Additional Notes

The in-memory `aiInsightsRateLimit` map is process-scoped and resets on server restart, which is a separate concern. This PR only fixes the ordering bug described in #2097.