### PR TITLE
fix(metrics): track repository failures in language metrics endpoint

### DIFF
--- a/src/app/api/metrics/languages/route.ts
+++ b/src/app/api/metrics/languages/route.ts
@@ -68,6 +68,7 @@ export async function GET(req: NextRequest) {
       const repoNames = Array.from(new Set<string>(raw.items.map((i: any) => i.repository.full_name)));
       const topRepoNames = repoNames.slice(0, 20);
       const langTotals: Record<string, number> = {};
+      const failedRepos: Array<{ name: string; statusCode?: number; error: string }> = [];
 
       await Promise.all(
         topRepoNames.map(async (repoName) => {
@@ -90,7 +91,14 @@ export async function GET(req: NextRequest) {
                     { headers, cache: "no-store" },
                   );
 
-                  if (!res.ok) return {};
+                  if (!res.ok) {
+                    failedRepos.push({
+                      name: repoName,
+                      statusCode: res.status,
+                      error: `GitHub API returned ${res.status}`,
+                    });
+                    return {};
+                  }
 
                   return await res.json();
                 },
@@ -98,7 +106,17 @@ export async function GET(req: NextRequest) {
             for (const [lang, bytes] of Object.entries(langs)) {
               langTotals[lang] = (langTotals[lang] ?? 0) + (bytes as number);
             }
-          } catch (e) { }
+          } catch (e) {
+            const errorMessage = e instanceof Error ? e.message : "Unknown error";
+            failedRepos.push({
+              name: repoName,
+              error: errorMessage,
+            });
+            console.warn(
+              `[METRICS] Failed to fetch languages for ${repoName}: ${errorMessage}`,
+              { userId, githubLogin }
+            );
+          }
         })
       );
 
@@ -108,10 +126,22 @@ export async function GET(req: NextRequest) {
         .sort((a, b) => b.percentage - a.percentage)
         .slice(0, 6);
 
-      return { languages };
+      const isComplete = failedRepos.length === 0;
+      
+      return {
+        languages,
+        isComplete,
+        failedRepositoriesCount: failedRepos.length,
+        ...(process.env.NODE_ENV === "development" && { failedRepositories: failedRepos }),
+      };
     });
     return Response.json(data);
   } catch (e) {
-    return Response.json({ error: "GitHub API error" }, { status: 502 });
+    const errorMessage = e instanceof Error ? e.message : "Unknown error";
+    console.error("[METRICS] Language metrics endpoint error", {
+      userId: session.githubId ?? session.githubLogin,
+      error: errorMessage,
+    });
+    return Response.json({ error: "GitHub API error", isComplete: false }, { status: 502 });
   }
 }

--- a/test/metrics-languages.test.ts
+++ b/test/metrics-languages.test.ts
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '@/app/api/metrics/languages/route';
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { resolveAppUser } from '@/lib/resolve-user';
+import { getAccountToken } from '@/lib/github-accounts';
+
+// Mock next-auth
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}));
+
+// Mock resolve-user
+vi.mock('@/lib/resolve-user', () => ({
+  resolveAppUser: vi.fn(),
+}));
+
+// Mock github-accounts
+vi.mock('@/lib/github-accounts', () => ({
+  getAccountToken: vi.fn(),
+}));
+
+// Mock Supabase
+const mockEq = vi.fn();
+const mockSelect = vi.fn();
+const mockFrom = vi.fn().mockImplementation((table: string) => {
+  return {
+    select: mockSelect,
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  supabaseAdmin: {
+    from: (table: string) => mockFrom(table),
+  },
+}));
+
+// Mock metrics cache
+vi.mock('@/lib/metrics-cache', () => ({
+  isMetricsCacheBypassed: vi.fn(() => false),
+  metricsCacheKey: vi.fn((userId: string, endpoint: string, params: any) => {
+    const paramStr = params ? Object.entries(params)
+      .sort()
+      .map(([k, v]) => `${k}=${v}`)
+      .join('&') : '';
+    return `metrics:${userId}:${endpoint}${paramStr ? ':' + paramStr : ''}`;
+  }),
+  withMetricsCache: vi.fn(async (_config, callback) => callback()),
+  METRICS_CACHE_TTL_SECONDS: {
+    languages: 3600,
+  },
+}));
+
+// Global fetch mock
+const originalFetch = global.fetch;
+let fetchMock: any;
+
+describe('Language Metrics Endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+
+    // Default successful session
+    (getServerSession as any).mockResolvedValue({
+      accessToken: 'test-token',
+      githubLogin: 'test-user',
+      githubId: 'user-123',
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns 401 when no session', async () => {
+    (getServerSession as any).mockResolvedValue(null);
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when no accessToken', async () => {
+    (getServerSession as any).mockResolvedValue({
+      githubLogin: 'test-user',
+    });
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data.error).toBe('Unauthorized');
+  });
+
+  it('returns complete language data when all repositories succeed', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              repository: {
+                full_name: 'user/repo1',
+              },
+            },
+            {
+              repository: {
+                full_name: 'user/repo2',
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          TypeScript: 50000,
+          JavaScript: 30000,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          Python: 40000,
+          TypeScript: 20000,
+        }),
+      });
+
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.isComplete).toBe(true);
+    expect(data.failedRepositoriesCount).toBe(0);
+    expect(data.languages).toBeDefined();
+    expect(Array.isArray(data.languages)).toBe(true);
+    expect(data.languages.length).toBeGreaterThan(0);
+  });
+
+  it('tracks failed repository with 403 status', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              repository: {
+                full_name: 'user/repo1',
+              },
+            },
+            {
+              repository: {
+                full_name: 'user/repo2',
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          TypeScript: 50000,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      });
+
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.isComplete).toBe(false);
+    expect(data.failedRepositoriesCount).toBe(1);
+    expect(data.languages).toBeDefined();
+  });
+
+  it('tracks failed repository with 404 status', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              repository: {
+                full_name: 'user/repo1',
+              },
+            },
+            {
+              repository: {
+                full_name: 'user/repo-deleted',
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          TypeScript: 50000,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.isComplete).toBe(false);
+    expect(data.failedRepositoriesCount).toBe(1);
+  });
+
+  it('tracks multiple failed repositories', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            { repository: { full_name: 'user/repo1' } },
+            { repository: { full_name: 'user/repo2' } },
+            { repository: { full_name: 'user/repo3' } },
+            { repository: { full_name: 'user/repo4' } },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ TypeScript: 50000 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ Python: 30000 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.isComplete).toBe(false);
+    expect(data.failedRepositoriesCount).toBe(2);
+    expect(data.languages).toBeDefined();
+  });
+
+  it('handles fetch exception for repository language request', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            { repository: { full_name: 'user/repo1' } },
+            { repository: { full_name: 'user/repo2' } },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ TypeScript: 50000 }),
+      })
+      .mockRejectedValueOnce(new Error('Network timeout'));
+
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.isComplete).toBe(false);
+    expect(data.failedRepositoriesCount).toBe(1);
+  });
+
+  it('returns 502 when search API fails', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+    });
+
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(data.error).toBe('GitHub API error');
+    expect(data.isComplete).toBe(false);
+  });
+
+  it('includes failed repositories in development mode', async () => {
+
+    const originalEnv = process.env.NODE_ENV;
+    (process.env as Record<string, string>).NODE_ENV = 'development';
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            { repository: { full_name: 'user/repo1' } },
+            { repository: { full_name: 'user/repo-broken' } },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ TypeScript: 50000 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      });
+
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(data.failedRepositories).toBeDefined();
+    expect(Array.isArray(data.failedRepositories)).toBe(true);
+    expect(data.failedRepositories.length).toBe(1);
+    expect(data.failedRepositories[0]).toHaveProperty('name', 'user/repo-broken');
+    expect(data.failedRepositories[0]).toHaveProperty('statusCode', 403);
+    expect(data.failedRepositories[0]).toHaveProperty('error');
+
+    (process.env as Record<string, string>).NODE_ENV = originalEnv ?? '';
+  });
+
+  it('does not include failed repositories in production mode', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    (process.env as Record<string, string>).NODE_ENV = 'production';   
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            { repository: { full_name: 'user/repo1' } },
+            { repository: { full_name: 'user/repo-broken' } },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ TypeScript: 50000 }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      });
+
+    const req = new NextRequest('http://localhost/api/metrics/languages');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(data.failedRepositories).toBeUndefined();
+    expect(data.failedRepositoriesCount).toBe(1);
+
+    (process.env as Record<string, string>).NODE_ENV = originalEnv ?? '';
+  });
+
+  it('handles linked account request', async () => {
+    (resolveAppUser as any).mockResolvedValue({ id: 'app-user-123' });
+    (getAccountToken as any).mockResolvedValue('linked-token');
+    mockSelect.mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { github_login: 'linked-user' },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{ repository: { full_name: 'linked-user/repo1' } }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ TypeScript: 50000 }),
+      });
+
+    const req = new NextRequest('http://localhost/api/metrics/languages?accountId=linked-user-456');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.isComplete).toBe(true);
+  });
+
+  it('returns 404 when linked account not found', async () => {
+    (resolveAppUser as any).mockResolvedValue({ id: 'app-user-123' });
+    (getAccountToken as any).mockResolvedValue(null);
+
+    const req = new NextRequest('http://localhost/api/metrics/languages?accountId=non-existent');
+    const res = await GET(req);
+    const data = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(data.error).toBe('Account not found');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes issue #2086 by preventing the language metrics endpoint from silently reporting partial data when repository language requests fail.

Previously, failed repository requests were ignored and users received incomplete language statistics without any indication that data was missing. This change introduces explicit failure tracking while preserving graceful degradation.

## Changes Made

### API Improvements

* Added failed repository tracking
* Added `isComplete` response flag
* Added `failedRepositoriesCount` response field
* Added development-only `failedRepositories` diagnostics
* Improved error handling and logging
* Added contextual warning logs with `[METRICS]` prefix

### Testing

* Added comprehensive test suite covering:

  * Authentication failures
  * Successful language aggregation
  * Repository 403 failures
  * Repository 404 failures
  * Multiple repository failures
  * Network exceptions
  * Search API failures
  * Development vs production behavior
  * Linked account requests
  * Missing linked account handling

## Response Example

Before:

```json
{
  "languages": [...]
}
```

After:

```json
{
  "languages": [...],
  "isComplete": false,
  "failedRepositoriesCount": 1
}
```

Development mode additionally exposes detailed failure information for debugging.

## Verification

* [x] Language metrics tests pass (12/12)
* [x] Manual endpoint verification completed
* [x] Partial failure handling verified
* [x] Development diagnostics verified
* [x] Backward compatibility preserved

## Impact

* Improves transparency of language metrics data
* Enables dashboards to warn users about incomplete metrics
* Preserves graceful degradation when repository requests fail
* Does not introduce breaking API changes

Closes #2086
