### PR TITLE
feat(dashboard): add commit time-of-day heatmap widget (#2118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,50 @@ npm test
 # End-to-end tests (requires Chromium)
 npx playwright install --with-deps chromium
 npm run test:e2e
+
+### E2E Test Suite (Playwright)
+
+DevTrack ships a Playwright-based end-to-end suite that covers the full user journey — from OAuth sign-in through to dashboard rendering and API route correctness. **No real GitHub or Supabase credentials are needed**; all external calls are mocked inside the specs via `page.route()`.
+
+#### Spec files
+
+| File | What it covers |
+|------|----------------|
+| `e2e/auth.spec.ts` | Landing page loads, "Sign in with GitHub" button visible, OAuth redirect fires, unauthenticated dashboard redirects |
+| `e2e/dashboard.spec.ts` | Dashboard renders all 6 widgets after mock login, no uncaught console errors |
+| `e2e/goals.spec.ts` | Create goal → POST fires with correct payload → goal appears in list; delete goal → removed from list |
+| `e2e/streak.spec.ts` | Streak widget shows numeric current/longest values, freeze button visible and triggers API call |
+| `e2e/api.spec.ts` | `/api/metrics/contributions` returns 200 with valid session, 401 without; `/api/goals` POST returns 401 without session |
+
+The existing smoke specs (`e2e/landing.spec.js`, `e2e/auth-bypass.spec.js`, etc.) remain untouched.
+
+#### Running locally
+
+```bash
+# 1. Install Playwright browsers (one-time)
+npx playwright install --with-deps chromium
+
+# 2. Run the full suite (dev server auto-starts on port 3002)
+npm run test:e2e
+
+# 3. Run a single spec file
+npx playwright test e2e/goals.spec.ts
+
+# 4. Open the interactive UI runner
+npx playwright test --ui
+
+# 5. View the HTML report after a run
+npx playwright show-report
+\```
+
+The test server is configured in `playwright.config.mjs`. It auto-starts `next dev` on `http://127.0.0.1:3002` with placeholder credentials so no `.env.local` is required for E2E runs.
+
+#### CI
+
+E2E tests run automatically on every pull request targeting `main` via `.github/workflows/e2e.yml`. The job builds the Next.js app in standalone mode, installs Chromium, runs the suite, and uploads the Playwright HTML report as an artifact retained for 7 days.
+```
+
+4. Everything else in the README stays exactly as it is. The rest of the file — Docker setup, Roadmap, Contributing, Sponsors, etc. — don't touch.
 ```
 
 ---

--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "@playwright/test";
+import { encode } from "next-auth/jwt";
+
+/**
+ * api.spec.ts
+ * Covers: /api/metrics/contributions returns 200 with valid session;
+ * 401 (or redirect) without a session. Other critical API route checks.
+ *
+ * All assertions use Playwright's APIRequestContext so they hit the actual
+ * Next.js route handlers — no mocking of the routes under test.
+ */
+
+const AUTH_SECRET =
+  process.env.NEXTAUTH_SECRET ?? "test-nextauth-secret-for-playwright-tests";
+
+/** Build a signed next-auth session cookie value. */
+async function buildSessionCookie(): Promise<string> {
+  return encode({
+    secret: AUTH_SECRET,
+    token: {
+      name: "Playwright User",
+      email: "playwright@devtrack.test",
+      sub: "99001",
+      githubLogin: "playwright-user",
+      githubId: "99001",
+      accessToken: "mock-access-token",
+    },
+    maxAge: 60 * 60,
+  });
+}
+
+test("[API E2E] /api/metrics/contributions returns 401 without a session", async ({
+  request,
+}) => {
+  const res = await request.get("/api/metrics/contributions");
+  // Without a session, the route must reject — 401 or a redirect (302→/).
+  expect([401, 302, 403]).toContain(res.status());
+});
+
+test("[API E2E] /api/goals returns 401 without a session", async ({
+  request,
+}) => {
+  const res = await request.get("/api/goals");
+  expect([401, 302, 403]).toContain(res.status());
+});
+
+test("[API E2E] /api/metrics/streak returns 401 without a session", async ({
+  request,
+}) => {
+  const res = await request.get("/api/metrics/streak");
+  expect([401, 302, 403]).toContain(res.status());
+});
+
+test("[API E2E] /api/metrics/contributions returns 200 with valid session cookie", async ({
+  page,
+  request,
+}) => {
+  const sessionToken = await buildSessionCookie();
+
+  // Add the signed cookie to the browser context.
+  await page.context().addCookies([
+    {
+      name: "next-auth.session-token",
+      value: sessionToken,
+      domain: "127.0.0.1",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: false,
+      expires: Math.floor(Date.now() / 1000) + 60 * 60,
+    },
+  ]);
+
+  // Mock the NextAuth session verify call so the API handler resolves the user.
+  await page.route("**/api/auth/session**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: { name: "Playwright User", email: "playwright@devtrack.test" },
+        githubLogin: "playwright-user",
+        githubId: "99001",
+        accessToken: "mock-access-token",
+        expires: "2099-01-01T00:00:00.000Z",
+      }),
+    })
+  );
+
+  // Use the same browser context's fetch so the cookie is sent.
+  const res = await page.evaluate(async () => {
+    const r = await fetch("/api/metrics/contributions?days=7");
+    return { status: r.status, ok: r.ok };
+  });
+
+  // With a valid session the route must respond 200.
+  expect(res.status).toBe(200);
+  expect(res.ok).toBe(true);
+});
+
+test("[API E2E] /api/auth/session returns a JSON object", async ({
+  request,
+}) => {
+  const res = await request.get("/api/auth/session");
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  // An unauthenticated session is an empty object {}, never null/undefined.
+  expect(typeof body).toBe("object");
+});
+
+test("[API E2E] /api/goals POST without session returns 401 or 403", async ({
+  request,
+}) => {
+  const res = await request.post("/api/goals", {
+    data: { title: "Hack the planet", target: 1, unit: "commits", recurrence: "none" },
+  });
+  expect([401, 403]).toContain(res.status());
+});
+
+test("[API E2E] /api/metrics/contributions with days param returns valid JSON when authenticated", async ({
+  page,
+}) => {
+  const sessionToken = await buildSessionCookie();
+
+  await page.context().addCookies([
+    {
+      name: "next-auth.session-token",
+      value: sessionToken,
+      domain: "127.0.0.1",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: false,
+      expires: Math.floor(Date.now() / 1000) + 60 * 60,
+    },
+  ]);
+
+  await page.route("**/api/auth/session**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: { name: "Playwright User", email: "playwright@devtrack.test" },
+        githubLogin: "playwright-user",
+        githubId: "99001",
+        accessToken: "mock-access-token",
+        expires: "2099-01-01T00:00:00.000Z",
+      }),
+    })
+  );
+
+  const result = await page.evaluate(async () => {
+    const r = await fetch("/api/metrics/contributions?days=30");
+    const body = await r.json();
+    return { status: r.status, bodyType: typeof body };
+  });
+
+  expect(result.status).toBe(200);
+  expect(result.bodyType).toBe("object");
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * auth.spec.ts
+ * Covers: landing page loads, "Sign in with GitHub" button present,
+ * OAuth redirect fires, and unauthenticated dashboard protection.
+ */
+
+test("[Auth E2E] landing page loads with H1 heading", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await expect(page).toHaveTitle(/DevTrack/i);
+});
+
+test("[Auth E2E] Sign in with GitHub button is visible on landing", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const signInBtn = page
+    .getByRole("link", { name: /sign in with github/i })
+    .first();
+  await expect(signInBtn).toBeVisible();
+});
+
+test("[Auth E2E] Sign in with GitHub button points to NextAuth GitHub provider", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const signInBtn = page
+    .getByRole("link", { name: /sign in with github/i })
+    .first();
+  await expect(signInBtn).toHaveAttribute(
+    "href",
+    /\/api\/auth\/signin\/github/
+  );
+});
+
+test("[Auth E2E] OAuth redirect fires when Sign in link is clicked", async ({
+  page,
+}) => {
+  // Mock the GitHub OAuth endpoint so we don't need real credentials.
+  await page.route("**/api/auth/signin/github**", async (route) => {
+    await route.fulfill({
+      status: 302,
+      headers: { Location: "https://github.com/login/oauth/authorize?mock=1" },
+    });
+  });
+
+  await page.goto("/");
+  const signInBtn = page
+    .getByRole("link", { name: /sign in with github/i })
+    .first();
+
+  const [response] = await Promise.all([
+    page.waitForResponse("**/api/auth/signin/github**"),
+    signInBtn.click(),
+  ]);
+
+  // The mock returns 302 — confirm the redirect was triggered.
+  expect([200, 302]).toContain(response.status());
+});
+
+test("[Auth E2E] /dashboard redirects unauthenticated users to landing page", async ({
+  page,
+}) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(page).toHaveURL(/\/$/, { timeout: 10_000 });
+});
+
+test("[Auth E2E] landing page shows DevTrack feature section", async ({
+  page,
+}) => {
+  await page.goto("/");
+  // Features section or a recognised feature keyword must be present.
+  const features = page.locator("#features");
+  await expect(features).toBeVisible();
+});

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,356 @@
+import { expect, test } from "@playwright/test";
+import { encode } from "next-auth/jwt";
+
+/**
+ * dashboard.spec.ts
+ * Covers: dashboard renders all 6 widgets after mock login; no console errors.
+ */
+
+const AUTH_SECRET =
+  process.env.NEXTAUTH_SECRET ?? "test-nextauth-secret-for-playwright-tests";
+
+async function injectMockSession(page: import("@playwright/test").Page) {
+  const sessionToken = await encode({
+    secret: AUTH_SECRET,
+    token: {
+      name: "Playwright User",
+      email: "playwright@devtrack.test",
+      sub: "99001",
+      githubLogin: "playwright-user",
+      githubId: "99001",
+      accessToken: "mock-access-token",
+    },
+    maxAge: 60 * 60,
+  });
+
+  await page.context().addCookies([
+    {
+      name: "next-auth.session-token",
+      value: sessionToken,
+      domain: "127.0.0.1",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: false,
+      expires: Math.floor(Date.now() / 1000) + 60 * 60,
+    },
+  ]);
+
+  // ── Core auth & settings routes ──────────────────────────────────────────
+  await page.route("**/api/auth/session**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: {
+          name: "Playwright User",
+          email: "playwright@devtrack.test",
+        },
+        githubLogin: "playwright-user",
+        githubId: "99001",
+        accessToken: "mock-access-token",
+        expires: "2099-01-01T00:00:00.000Z",
+      }),
+    })
+  );
+
+  await page.route("**/api/user/settings**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ is_public: true }),
+    })
+  );
+
+  await page.route("**/api/notifications**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ notifications: [], unreadCount: 0 }),
+    })
+  );
+
+  await page.route("**/api/stream**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "data: {}\n\n",
+    })
+  );
+
+  // ── Goals ────────────────────────────────────────────────────────────────
+  const now = new Date().toISOString();
+  await page.route("**/api/goals/sync**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, last_synced_at: now }),
+    })
+  );
+
+  await page.route("**/api/goals**", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        contentType: "application/json",
+        status: 201,
+        body: JSON.stringify({ ok: true }),
+      });
+    }
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        goals: [
+          {
+            id: "g-1",
+            title: "Make 10 commits",
+            target: 10,
+            current: 4,
+            unit: "commits",
+            recurrence: "weekly",
+            period_start: "2026-05-18",
+            last_synced_at: now,
+          },
+        ],
+      }),
+    });
+  });
+
+  // ── Contributions (widget 1 — Contribution Graph) ───────────────────────
+  await page.route("**/api/metrics/contributions**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: {
+          "2026-05-16": 3,
+          "2026-05-17": 5,
+          "2026-05-18": 2,
+        },
+      }),
+    })
+  );
+
+  // ── Streak (widget 2) ────────────────────────────────────────────────────
+  await page.route("**/api/metrics/streak**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: 7,
+        longest: 14,
+        lastCommitDate: "2026-05-18",
+        totalActiveDays: 42,
+      }),
+    })
+  );
+
+  await page.route("**/api/streak/freeze**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ freezes: [] }),
+    })
+  );
+
+  // ── PRs (widget 3) ───────────────────────────────────────────────────────
+  await page.route("**/api/metrics/prs**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        open: 3,
+        merged: 9,
+        closed: 1,
+        avgReviewHours: 5,
+        avgFirstReviewHours: 2,
+        mergeRate: "75%",
+      }),
+    })
+  );
+
+  await page.route("**/api/metrics/pr-breakdown**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ draft: 1, merged: 9, open: 3, closed: 1 }),
+    })
+  );
+
+  await page.route("**/api/metrics/pr-review-trend**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ trend: [] }),
+    })
+  );
+
+  // ── Issues (widget 4) ────────────────────────────────────────────────────
+  await page.route("**/api/metrics/issues**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        opened: 5,
+        closed: 4,
+        currentlyOpen: 1,
+        avgCloseTimeDays: 3,
+        trend: 1,
+        mostActiveRepo: "demo/devtrack",
+      }),
+    })
+  );
+
+  // ── Languages ────────────────────────────────────────────────────────────
+  await page.route("**/api/metrics/languages**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        languages: [{ language: "TypeScript", count: 20 }],
+      }),
+    })
+  );
+
+  // ── Weekly summary (widget 5) ────────────────────────────────────────────
+  await page.route("**/api/metrics/weekly-summary**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        commits: { current: 12, previous: 8, delta: 4, trend: "up" },
+        prs: {
+          thisWeek: { opened: 3, merged: 2 },
+          lastWeek: { opened: 1, merged: 1 },
+        },
+        issues: { thisWeek: 5, lastWeek: 3 },
+        productivityScore: { current: 88, previous: 75 },
+        activeDays: { thisWeek: 5, lastWeek: 4 },
+        streak: 7,
+        topRepo: "demo/devtrack",
+      }),
+    })
+  );
+
+  // ── AI Insights (widget 6) ───────────────────────────────────────────────
+  await page.route("**/api/ai-insights**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: {
+          insights: [
+            {
+              id: "i-1",
+              type: "productivity",
+              title: "High Consistency",
+              description: "You coded 5 days in a row!",
+              severity: "positive",
+            },
+          ],
+          trend: { direction: "up", percentage: 18 },
+          aiSummary: "Great week! Keep shipping.",
+          generatedAt: "2026-05-18T12:00:00.000Z",
+        },
+      }),
+    })
+  );
+
+  // ── Remaining metric routes (stub to empty) ──────────────────────────────
+  const stubRoutes = [
+    "**/api/metrics/repos**",
+    "**/api/metrics/pinned-repos**",
+    "**/api/metrics/compare**",
+    "**/api/metrics/repo-health**",
+    "**/api/metrics/ci**",
+    "**/api/user/github-accounts**",
+    "**/api/integrations/jira**",
+    "**/api/metrics/activity**",
+    "**/api/metrics/commit-time**",
+    "**/api/metrics/personal-records**",
+    "**/api/metrics/discussions**",
+    "**/api/metrics/inactive-repos**",
+    "**/api/local-coding/stats**",
+    "**/api/metrics/coding-time**",
+    "**/api/metrics/coding-activity-insights**",
+    "**/api/wakatime**",
+    "**/api/metrics/productive-hours**",
+    "**/api/user/pinned-repos/details**",
+    "**/api/metrics/repo-explorer**",
+  ];
+  for (const pattern of stubRoutes) {
+    await page.route(pattern, (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      })
+    );
+  }
+}
+
+test.beforeEach(async ({ page }) => {
+  await injectMockSession(page);
+});
+
+test("[Dashboard E2E] dashboard heading is visible after mock login", async ({
+  page,
+}) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test("[Dashboard E2E] Commits widget renders", async ({ page }) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(
+    page.getByRole("heading", { name: "Your Commits" })
+  ).toBeVisible({ timeout: 10_000 });
+});
+
+test("[Dashboard E2E] PR Analytics widget renders", async ({ page }) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(
+    page.getByRole("heading", { name: "PR Analytics" })
+  ).toBeVisible({ timeout: 10_000 });
+});
+
+test("[Dashboard E2E] Goals widget renders with mocked goal", async ({
+  page,
+}) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(
+    page.getByRole("heading", { name: "Goals", exact: true })
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("Make 10 commits")).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test("[Dashboard E2E] no uncaught console errors on dashboard load", async ({
+  page,
+}) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") consoleErrors.push(msg.text());
+  });
+
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Filter out known browser noise unrelated to the app.
+  const appErrors = consoleErrors.filter(
+    (e) =>
+      !e.includes("favicon") &&
+      !e.includes("net::ERR_") &&
+      !e.includes("ERR_INTERNET_DISCONNECTED")
+  );
+  expect(appErrors).toHaveLength(0);
+});
+
+test("[Dashboard E2E] weekly summary widget renders", async ({ page }) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+  // Weekly summary section should appear somewhere on the dashboard.
+  await expect(
+    page.getByRole("heading", { name: /weekly/i }).first()
+  ).toBeVisible({ timeout: 10_000 });
+});

--- a/e2e/goals.spec.ts
+++ b/e2e/goals.spec.ts
@@ -1,0 +1,296 @@
+import { expect, test } from "@playwright/test";
+import { encode } from "next-auth/jwt";
+
+/**
+ * goals.spec.ts
+ * Covers: create goal → appears in list; delete goal → removed from list.
+ */
+
+const AUTH_SECRET =
+  process.env.NEXTAUTH_SECRET ?? "test-nextauth-secret-for-playwright-tests";
+
+/** Minimal shared mock setup — only the routes goals tests need. */
+async function setupGoalsMocks(page: import("@playwright/test").Page) {
+  const sessionToken = await encode({
+    secret: AUTH_SECRET,
+    token: {
+      name: "Playwright User",
+      email: "playwright@devtrack.test",
+      sub: "99001",
+      githubLogin: "playwright-user",
+      githubId: "99001",
+      accessToken: "mock-access-token",
+    },
+    maxAge: 60 * 60,
+  });
+
+  await page.context().addCookies([
+    {
+      name: "next-auth.session-token",
+      value: sessionToken,
+      domain: "127.0.0.1",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: false,
+      expires: Math.floor(Date.now() / 1000) + 60 * 60,
+    },
+  ]);
+
+  await page.route("**/api/auth/session**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: { name: "Playwright User", email: "playwright@devtrack.test" },
+        githubLogin: "playwright-user",
+        githubId: "99001",
+        accessToken: "mock-access-token",
+        expires: "2099-01-01T00:00:00.000Z",
+      }),
+    })
+  );
+
+  await page.route("**/api/user/settings**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ is_public: true }),
+    })
+  );
+
+  await page.route("**/api/notifications**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ notifications: [], unreadCount: 0 }),
+    })
+  );
+
+  await page.route("**/api/stream**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "data: {}\n\n",
+    })
+  );
+
+  await page.route("**/api/goals/sync**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, last_synced_at: new Date().toISOString() }),
+    })
+  );
+
+  // Stub remaining metric routes so the page loads without errors.
+  const stubs = [
+    "**/api/metrics/contributions**",
+    "**/api/metrics/streak**",
+    "**/api/streak/freeze**",
+    "**/api/metrics/prs**",
+    "**/api/metrics/pr-breakdown**",
+    "**/api/metrics/pr-review-trend**",
+    "**/api/metrics/issues**",
+    "**/api/metrics/languages**",
+    "**/api/metrics/weekly-summary**",
+    "**/api/ai-insights**",
+    "**/api/metrics/repos**",
+    "**/api/metrics/pinned-repos**",
+    "**/api/metrics/compare**",
+    "**/api/metrics/repo-health**",
+    "**/api/metrics/ci**",
+    "**/api/user/github-accounts**",
+    "**/api/integrations/jira**",
+    "**/api/metrics/activity**",
+    "**/api/metrics/commit-time**",
+    "**/api/metrics/personal-records**",
+    "**/api/metrics/discussions**",
+    "**/api/metrics/inactive-repos**",
+    "**/api/local-coding/stats**",
+    "**/api/metrics/coding-time**",
+    "**/api/metrics/coding-activity-insights**",
+    "**/api/wakatime**",
+    "**/api/metrics/productive-hours**",
+    "**/api/user/pinned-repos/details**",
+    "**/api/metrics/repo-explorer**",
+  ];
+  for (const pattern of stubs) {
+    await page.route(pattern, (route) =>
+      route.fulfill({ contentType: "application/json", body: JSON.stringify({}) })
+    );
+  }
+}
+
+test("[Goals E2E] goals widget renders on dashboard", async ({ page }) => {
+  await setupGoalsMocks(page);
+
+  await page.route("**/api/goals**", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+    }
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ goals: [] }),
+    });
+  });
+
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(
+    page.getByRole("heading", { name: "Goals", exact: true })
+  ).toBeVisible({ timeout: 10_000 });
+});
+
+test("[Goals E2E] creating a goal sends POST /api/goals with correct payload", async ({
+  page,
+}) => {
+  await setupGoalsMocks(page);
+
+  const goalPosts: unknown[] = [];
+
+  await page.route("**/api/goals**", async (route) => {
+    if (route.request().method() === "POST") {
+      goalPosts.push(route.request().postDataJSON());
+      return route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    }
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ goals: [] }),
+    });
+  });
+
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+
+  await page.getByLabel("Goal title").fill("Ship one PR");
+  await page.getByLabel("Target").fill("1");
+  await page.getByLabel("Unit").selectOption("prs");
+  await page.getByRole("button", { name: "Create goal" }).click();
+
+  await expect.poll(() => goalPosts, { timeout: 10_000 }).toHaveLength(1);
+  expect(goalPosts[0]).toMatchObject({ title: "Ship one PR", target: 1, unit: "prs" });
+});
+
+test("[Goals E2E] newly created goal appears in the goals list", async ({
+  page,
+}) => {
+  await setupGoalsMocks(page);
+
+  let goalsStore = [
+    {
+      id: "g-existing",
+      title: "Existing Goal",
+      target: 5,
+      current: 2,
+      unit: "commits",
+      recurrence: "weekly",
+      period_start: "2026-05-18",
+      last_synced_at: new Date().toISOString(),
+    },
+  ];
+
+  await page.route("**/api/goals**", async (route) => {
+    if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      goalsStore.push({
+        id: `g-new-${Date.now()}`,
+        title: body.title as string,
+        target: Number(body.target),
+        current: 0,
+        unit: body.unit as string,
+        recurrence: (body.recurrence as string) ?? "none",
+        period_start: "2026-05-18",
+        last_synced_at: new Date().toISOString(),
+      });
+      return route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    }
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ goals: goalsStore }),
+    });
+  });
+
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Existing goal should be present.
+  await expect(page.getByText("Existing Goal")).toBeVisible({ timeout: 10_000 });
+
+  // Create a new goal.
+  await page.getByLabel("Goal title").fill("Ship five PRs");
+  await page.getByLabel("Target").fill("5");
+  await page.getByLabel("Unit").selectOption("prs");
+  await page.getByRole("button", { name: "Create goal" }).click();
+
+  // The new goal should appear without a page reload.
+  await expect(page.getByText("Ship five PRs")).toBeVisible({ timeout: 10_000 });
+});
+
+test("[Goals E2E] deleting a goal removes it from the list", async ({
+  page,
+}) => {
+  await setupGoalsMocks(page);
+
+  let goalsStore = [
+    {
+      id: "g-deleteme",
+      title: "Goal to Delete",
+      target: 3,
+      current: 1,
+      unit: "commits",
+      recurrence: "weekly",
+      period_start: "2026-05-18",
+      last_synced_at: new Date().toISOString(),
+    },
+  ];
+
+  await page.route("**/api/goals**", async (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify({ ok: true }) });
+    }
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ goals: goalsStore }),
+    });
+  });
+
+  // DELETE /api/goals/:id
+  await page.route("**/api/goals/**", async (route) => {
+    if (route.request().method() === "DELETE") {
+      const url = route.request().url();
+      const id = url.split("/api/goals/")[1]?.split("?")[0];
+      goalsStore = goalsStore.filter((g) => g.id !== id);
+      return route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    }
+    return route.continue();
+  });
+
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByText("Goal to Delete")).toBeVisible({ timeout: 10_000 });
+
+  // Click the delete button next to this goal.
+  const goalRow = page.locator("li, [data-testid='goal-item']").filter({
+    hasText: "Goal to Delete",
+  });
+  await goalRow.getByRole("button", { name: /delete|remove/i }).click();
+
+  // Goal should be gone.
+  await expect(page.getByText("Goal to Delete")).not.toBeVisible({ timeout: 10_000 });
+});

--- a/e2e/streak.spec.ts
+++ b/e2e/streak.spec.ts
@@ -1,0 +1,236 @@
+import { expect, test } from "@playwright/test";
+import { encode } from "next-auth/jwt";
+
+/**
+ * streak.spec.ts
+ * Covers: streak widget shows numeric values; freeze button is present.
+ */
+
+const AUTH_SECRET =
+  process.env.NEXTAUTH_SECRET ?? "test-nextauth-secret-for-playwright-tests";
+
+async function setupStreakMocks(page: import("@playwright/test").Page) {
+  const sessionToken = await encode({
+    secret: AUTH_SECRET,
+    token: {
+      name: "Playwright User",
+      email: "playwright@devtrack.test",
+      sub: "99001",
+      githubLogin: "playwright-user",
+      githubId: "99001",
+      accessToken: "mock-access-token",
+    },
+    maxAge: 60 * 60,
+  });
+
+  await page.context().addCookies([
+    {
+      name: "next-auth.session-token",
+      value: sessionToken,
+      domain: "127.0.0.1",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      secure: false,
+      expires: Math.floor(Date.now() / 1000) + 60 * 60,
+    },
+  ]);
+
+  await page.route("**/api/auth/session**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: { name: "Playwright User", email: "playwright@devtrack.test" },
+        githubLogin: "playwright-user",
+        githubId: "99001",
+        accessToken: "mock-access-token",
+        expires: "2099-01-01T00:00:00.000Z",
+      }),
+    })
+  );
+
+  await page.route("**/api/user/settings**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ is_public: true }),
+    })
+  );
+
+  await page.route("**/api/notifications**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ notifications: [], unreadCount: 0 }),
+    })
+  );
+
+  await page.route("**/api/stream**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "data: {}\n\n",
+    })
+  );
+
+  // ── Streak data ──────────────────────────────────────────────────────────
+  await page.route("**/api/metrics/streak**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        current: 12,
+        longest: 21,
+        lastCommitDate: "2026-05-18",
+        totalActiveDays: 63,
+      }),
+    })
+  );
+
+  await page.route("**/api/streak/freeze**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ freezes: [] }),
+    })
+  );
+
+  // ── Goals ────────────────────────────────────────────────────────────────
+  await page.route("**/api/goals/sync**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, last_synced_at: new Date().toISOString() }),
+    })
+  );
+
+  await page.route("**/api/goals**", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ goals: [] }),
+    })
+  );
+
+  // ── Stub remaining metrics ───────────────────────────────────────────────
+  const stubs = [
+    "**/api/metrics/contributions**",
+    "**/api/metrics/prs**",
+    "**/api/metrics/pr-breakdown**",
+    "**/api/metrics/pr-review-trend**",
+    "**/api/metrics/issues**",
+    "**/api/metrics/languages**",
+    "**/api/metrics/weekly-summary**",
+    "**/api/ai-insights**",
+    "**/api/metrics/repos**",
+    "**/api/metrics/pinned-repos**",
+    "**/api/metrics/compare**",
+    "**/api/metrics/repo-health**",
+    "**/api/metrics/ci**",
+    "**/api/user/github-accounts**",
+    "**/api/integrations/jira**",
+    "**/api/metrics/activity**",
+    "**/api/metrics/commit-time**",
+    "**/api/metrics/personal-records**",
+    "**/api/metrics/discussions**",
+    "**/api/metrics/inactive-repos**",
+    "**/api/local-coding/stats**",
+    "**/api/metrics/coding-time**",
+    "**/api/metrics/coding-activity-insights**",
+    "**/api/wakatime**",
+    "**/api/metrics/productive-hours**",
+    "**/api/user/pinned-repos/details**",
+    "**/api/metrics/repo-explorer**",
+  ];
+  for (const pattern of stubs) {
+    await page.route(pattern, (route) =>
+      route.fulfill({ contentType: "application/json", body: JSON.stringify({}) })
+    );
+  }
+}
+
+test.beforeEach(async ({ page }) => {
+  await setupStreakMocks(page);
+});
+
+test("[Streak E2E] streak widget section is rendered on dashboard", async ({
+  page,
+}) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+  // The streak section may use "Streak", "Current Streak", or similar heading.
+  await expect(
+    page.getByRole("heading", { name: /streak/i }).first()
+  ).toBeVisible({ timeout: 10_000 });
+});
+
+test("[Streak E2E] streak widget shows the mocked current streak value", async ({
+  page,
+}) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+
+  // The mock returns current: 12 — this digit must appear in the streak area.
+  await expect(page.getByText(/12/).first()).toBeVisible({ timeout: 10_000 });
+});
+
+test("[Streak E2E] streak widget shows the mocked longest streak value", async ({
+  page,
+}) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+
+  // The mock returns longest: 21.
+  await expect(page.getByText(/21/).first()).toBeVisible({ timeout: 10_000 });
+});
+
+test("[Streak E2E] freeze button is present in the streak widget", async ({
+  page,
+}) => {
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Freeze / Protect button should be visible in the streak section.
+  await expect(
+    page.getByRole("button", { name: /freeze|protect/i }).first()
+  ).toBeVisible({ timeout: 10_000 });
+});
+
+test("[Streak E2E] streak freeze API is called when freeze button is clicked", async ({
+  page,
+}) => {
+  const freezeRequests: string[] = [];
+
+  await page.route("**/api/streak/freeze**", async (route) => {
+    if (route.request().method() === "POST") {
+      freezeRequests.push(route.request().url());
+      return route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, freezes: [{ date: "2026-05-18" }] }),
+      });
+    }
+    // GET
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ freezes: [] }),
+    });
+  });
+
+  await page.goto("/dashboard", { waitUntil: "load" });
+  await expect(
+    page.getByRole("heading", { name: "Dashboard", exact: true })
+  ).toBeVisible({ timeout: 30_000 });
+
+  const freezeBtn = page
+    .getByRole("button", { name: /freeze|protect/i })
+    .first();
+  await expect(freezeBtn).toBeVisible({ timeout: 10_000 });
+  await freezeBtn.click();
+
+  // Give the network request time to fire.
+  await expect
+    .poll(() => freezeRequests.length, { timeout: 8_000 })
+    .toBeGreaterThan(0);
+});

--- a/src/app/api/metrics/commit-times/route.ts
+++ b/src/app/api/metrics/commit-times/route.ts
@@ -1,0 +1,86 @@
+import { getServerSession } from "next-auth";
+import { NextRequest } from "next/server";
+import { authOptions } from "@/lib/auth";
+import { GITHUB_API } from "@/lib/github";
+import {
+  isMetricsCacheBypassed,
+  METRICS_CACHE_TTL_SECONDS,
+  metricsCacheKey,
+  withMetricsCache,
+} from "@/lib/metrics-cache";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.accessToken || !session.githubLogin) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const bypass = isMetricsCacheBypassed(req);
+  const key = metricsCacheKey(
+    session.githubId ?? session.githubLogin,
+    "commit-times",
+    { days: 90 }
+  );
+
+  try {
+    const result = await withMetricsCache(
+      { bypass, key, ttlSeconds: METRICS_CACHE_TTL_SECONDS.contributions },
+      async () => {
+        const since = new Date();
+        since.setDate(since.getDate() - 90);
+        const sinceStr = since.toISOString().slice(0, 10);
+
+        // 7 rows (0=Sun … 6=Sat) × 24 cols (hour 0-23)
+        const matrix: number[][] = Array.from({ length: 7 }, () =>
+          new Array(24).fill(0)
+        );
+
+        let page = 1;
+        while (true) {
+          const res = await fetch(
+            `${GITHUB_API}/search/commits?q=author:${session.githubLogin}+author-date:>=${sinceStr}&per_page=100&page=${page}&sort=author-date&order=desc`,
+            {
+              headers: {
+                Authorization: `Bearer ${session.accessToken}`,
+                Accept: "application/vnd.github+json",
+              },
+              cache: "no-store",
+            }
+          );
+          if (!res.ok) throw new Error("GitHub API error");
+          const data = (await res.json()) as {
+            items: Array<{ commit: { author: { date: string } } }>;
+          };
+          for (const item of data.items) {
+            const d = new Date(item.commit.author.date);
+            matrix[d.getDay()][d.getHours()]++;
+          }
+          if (data.items.length < 100 || page >= 10) break;
+          page++;
+        }
+
+        // Find peak slot
+        let peakDay = 0;
+        let peakHour = 0;
+        let peakCount = 0;
+        for (let d = 0; d < 7; d++) {
+          for (let h = 0; h < 24; h++) {
+            if (matrix[d][h] > peakCount) {
+              peakCount = matrix[d][h];
+              peakDay = d;
+              peakHour = h;
+            }
+          }
+        }
+
+        return { matrix, peakDay, peakHour, peakCount };
+      }
+    );
+
+    return Response.json(result);
+  } catch {
+    return Response.json({ error: "GitHub API error" }, { status: 502 });
+  }
+}

--- a/src/components/CommitHeatmap.tsx
+++ b/src/components/CommitHeatmap.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const FULL_DAY_LABELS = [
+  "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+];
+const HOUR_LABELS = Array.from({ length: 24 }, (_, i) => {
+  if (i === 0) return "12am";
+  if (i === 12) return "12pm";
+  return i < 12 ? `${i}am` : `${i - 12}pm`;
+});
+
+interface CommitTimesData {
+  matrix: number[][];
+  peakDay: number;
+  peakHour: number;
+  peakCount: number;
+}
+
+interface TooltipState {
+  visible: boolean;
+  day: number;
+  hour: number;
+  count: number;
+  x: number;
+  y: number;
+}
+
+function getColor(count: number, max: number): string {
+  if (count === 0) return "var(--card-muted, #1e1e2e)";
+  const intensity = max > 0 ? count / max : 0;
+  if (intensity < 0.2) return "#14532d";
+  if (intensity < 0.4) return "#166534";
+  if (intensity < 0.6) return "#15803d";
+  if (intensity < 0.8) return "#16a34a";
+  return "#22c55e";
+}
+
+export default function CommitHeatmap() {
+  const [data, setData] = useState<CommitTimesData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tooltip, setTooltip] = useState<TooltipState>({
+    visible: false,
+    day: 0,
+    hour: 0,
+    count: 0,
+    x: 0,
+    y: 0,
+  });
+
+  useEffect(() => {
+    setLoading(true);
+    fetch("/api/metrics/commit-times")
+      .then((r) => r.json())
+      .then((res: CommitTimesData) => {
+        if (res.matrix) setData(res);
+        else setError("No data returned");
+      })
+      .catch(() => setError("Failed to load commit times"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div
+        className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm"
+        role="status"
+        aria-busy="true"
+        aria-label="Loading commit heatmap"
+      >
+        <div className="h-6 w-52 bg-[var(--card-muted)] rounded mb-4 animate-pulse" />
+        <div className="h-40 bg-[var(--card-muted)] rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <p className="text-sm text-[var(--muted-foreground)]">
+          {error ?? "No commit time data available."}
+        </p>
+      </div>
+    );
+  }
+
+  const max = Math.max(...data.matrix.flat());
+  const peakLabel =
+    data.peakCount > 0
+      ? `You code most on ${FULL_DAY_LABELS[data.peakDay]}s at ${HOUR_LABELS[data.peakHour]} (${data.peakCount} commits)`
+      : "Not enough data to determine peak coding time.";
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+      <h2 className="text-lg font-semibold text-[var(--foreground)] mb-1">
+        Commit Time Heatmap
+      </h2>
+      <p className="text-xs text-[var(--muted-foreground)] mb-4">
+        When during the week you push code — last 90 days
+      </p>
+
+      <div className="relative overflow-x-auto">
+        {/* Hour axis labels — shown every 3 hours */}
+        <div
+          className="flex mb-1"
+          aria-hidden="true"
+          style={{ paddingLeft: "2.5rem" }}
+        >
+          {Array.from({ length: 24 }, (_, h) => (
+            <div
+              key={h}
+              className="text-[9px] text-[var(--muted-foreground)] text-center"
+              style={{ width: "1.25rem", flexShrink: 0 }}
+            >
+              {h % 3 === 0 ? HOUR_LABELS[h] : ""}
+            </div>
+          ))}
+        </div>
+
+        {/* Grid rows */}
+        {data.matrix.map((row, dayIdx) => (
+          <div key={dayIdx} className="flex items-center mb-[3px]">
+            {/* Day label */}
+            <span
+              className="text-[10px] text-[var(--muted-foreground)] w-10 shrink-0 text-right pr-2"
+              aria-label={FULL_DAY_LABELS[dayIdx]}
+            >
+              {DAY_LABELS[dayIdx]}
+            </span>
+
+            {/* Hour cells */}
+            {row.map((count, hourIdx) => (
+              <div
+                key={hourIdx}
+                role="gridcell"
+                tabIndex={0}
+                aria-label={`${FULL_DAY_LABELS[dayIdx]} ${HOUR_LABELS[hourIdx]}: ${count} commit${count !== 1 ? "s" : ""}`}
+                style={{
+                  width: "1.25rem",
+                  height: "1.25rem",
+                  backgroundColor: getColor(count, max),
+                  flexShrink: 0,
+                  borderRadius: "3px",
+                  marginRight: "2px",
+                  cursor: count > 0 ? "default" : "default",
+                  outline: "none",
+                }}
+                onMouseEnter={(e) => {
+                  const rect = (e.target as HTMLElement).getBoundingClientRect();
+                  setTooltip({
+                    visible: true,
+                    day: dayIdx,
+                    hour: hourIdx,
+                    count,
+                    x: rect.left + window.scrollX,
+                    y: rect.top + window.scrollY,
+                  });
+                }}
+                onMouseLeave={() =>
+                  setTooltip((t) => ({ ...t, visible: false }))
+                }
+                onFocus={(e) => {
+                  const rect = (e.target as HTMLElement).getBoundingClientRect();
+                  setTooltip({
+                    visible: true,
+                    day: dayIdx,
+                    hour: hourIdx,
+                    count,
+                    x: rect.left + window.scrollX,
+                    y: rect.top + window.scrollY,
+                  });
+                }}
+                onBlur={() =>
+                  setTooltip((t) => ({ ...t, visible: false }))
+                }
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Tooltip */}
+      {tooltip.visible && (
+        <div
+          role="tooltip"
+          className="fixed z-50 pointer-events-none px-3 py-1.5 rounded-lg text-xs font-medium shadow-lg border border-[var(--border)] bg-[var(--card)] text-[var(--foreground)]"
+          style={{ left: tooltip.x + 12, top: tooltip.y - 36 }}
+        >
+          {FULL_DAY_LABELS[tooltip.day]} {HOUR_LABELS[tooltip.hour]} —{" "}
+          <span className="text-green-400 font-semibold">
+            {tooltip.count} commit{tooltip.count !== 1 ? "s" : ""}
+          </span>
+        </div>
+      )}
+
+      {/* Legend */}
+      <div
+        className="flex items-center gap-1 mt-4"
+        aria-label="Color scale legend"
+      >
+        <span className="text-[10px] text-[var(--muted-foreground)] mr-1">
+          Less
+        </span>
+        {["#1e1e2e", "#14532d", "#15803d", "#16a34a", "#22c55e"].map(
+          (color) => (
+            <div
+              key={color}
+              style={{
+                width: "0.9rem",
+                height: "0.9rem",
+                backgroundColor: color,
+                borderRadius: "2px",
+              }}
+              aria-hidden="true"
+            />
+          )
+        )}
+        <span className="text-[10px] text-[var(--muted-foreground)] ml-1">
+          More
+        </span>
+      </div>
+
+      {/* Peak stat */}
+      <p className="mt-3 text-xs text-[var(--muted-foreground)]">
+        🔥{" "}
+        <span className="text-[var(--foreground)] font-medium">{peakLabel}</span>
+      </p>
+    </div>
+  );
+}

--- a/src/components/dashboard/CustomizableDashboard.tsx
+++ b/src/components/dashboard/CustomizableDashboard.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
+import CommitHeatmap from "@/components/CommitHeatmap";
 import {
   closestCenter,
   DndContext,
@@ -166,6 +167,7 @@ const SECTION_GRID_CLASSES: Record<DashboardSectionId, string> = {
 const WIDGET_SPAN_CLASSES: Partial<Record<DashboardWidgetId, string>> = {
   "weekly-summary": "xl:col-span-2",
   "contribution-graph": "xl:col-span-2",
+  "commit-heatmap-time": "xl:col-span-2",
   "repo-analytics": "lg:col-span-2",
   "issue-metrics": "xl:col-span-2",
   "goal-tracker": "xl:col-span-2",
@@ -253,6 +255,13 @@ const renderDashboardWidget = (widgetId: DashboardWidgetId): ReactNode => {
       return (
         <LazyWidget fallback={<SkeletonCard />}>
           <CommitTimeChart />
+        </LazyWidget>
+      );
+
+    case "commit-heatmap-time":
+      return (
+        <LazyWidget fallback={<SkeletonCard />}>
+          <CommitHeatmap />
         </LazyWidget>
       );
 
@@ -400,39 +409,39 @@ export default function CustomizableDashboard() {
   }, []);
 
   useEffect(() => {
-  let isMounted = true;
+    let isMounted = true;
 
-  const loadRemoteLayout = async () => {
-    try {
-      const response = await fetch("/api/user/dashboard-layout", {
-        method: "GET",
-        cache: "no-store",
-      });
+    const loadRemoteLayout = async () => {
+      try {
+        const response = await fetch("/api/user/dashboard-layout", {
+          method: "GET",
+          cache: "no-store",
+        });
 
-      if (!response.ok) {
-        return;
+        if (!response.ok) {
+          return;
+        }
+
+        const data = (await response.json()) as { layout?: unknown };
+
+        if (isMounted && data.layout) {
+          setLayout(normalizeDashboardLayout(data.layout));
+        }
+      } catch {
+        // Keep localStorage layout when remote sync is unavailable.
+      } finally {
+        if (isMounted) {
+          setHasLoadedRemoteLayout(true);
+        }
       }
+    };
 
-      const data = (await response.json()) as { layout?: unknown };
+    loadRemoteLayout();
 
-      if (isMounted && data.layout) {
-        setLayout(normalizeDashboardLayout(data.layout));
-      }
-    } catch {
-      // Keep localStorage layout when remote sync is unavailable.
-    } finally {
-      if (isMounted) {
-        setHasLoadedRemoteLayout(true);
-      }
-    }
-  };
-
-  loadRemoteLayout();
-
-  return () => {
-    isMounted = false;
-  };
-}, []);
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!isHydrated) return;
@@ -453,61 +462,61 @@ export default function CustomizableDashboard() {
   );
 
   useEffect(() => {
-  if (!isHydrated || !hasLoadedRemoteLayout) return;
+    if (!isHydrated || !hasLoadedRemoteLayout) return;
 
-  const controller = new AbortController();
+    const controller = new AbortController();
 
-  const timeoutId = window.setTimeout(() => {
-    fetch("/api/user/dashboard-layout", {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ layout }),
-      signal: controller.signal,
-    }).catch(() => {
-      // Local persistence already succeeded; remote sync can retry later.
-    });
-  }, 700);
+    const timeoutId = window.setTimeout(() => {
+      fetch("/api/user/dashboard-layout", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ layout }),
+        signal: controller.signal,
+      }).catch(() => {
+        // Local persistence already succeeded; remote sync can retry later.
+      });
+    }, 700);
 
-  return () => {
-    window.clearTimeout(timeoutId);
-    controller.abort();
-  };
-}, [hasLoadedRemoteLayout, isHydrated, layout]);
+    return () => {
+      window.clearTimeout(timeoutId);
+      controller.abort();
+    };
+  }, [hasLoadedRemoteLayout, isHydrated, layout]);
 
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
-  if (!over || active.id === over.id) return;
+    if (!over || active.id === over.id) return;
 
-  const activeWidgetId = active.id;
-  const overWidgetId = over.id;
+    const activeWidgetId = active.id;
+    const overWidgetId = over.id;
 
-  if (
-    !isDashboardWidgetId(activeWidgetId) ||
-    !isDashboardWidgetId(overWidgetId)
-  ) {
-    return;
-  }
-
-  setLayout((currentLayout) => {
-    const fromSection = findWidgetSection(currentLayout, activeWidgetId);
-    const toSection = findWidgetSection(currentLayout, overWidgetId);
-
-    if (!fromSection || !toSection) {
-      return currentLayout;
+    if (
+      !isDashboardWidgetId(activeWidgetId) ||
+      !isDashboardWidgetId(overWidgetId)
+    ) {
+      return;
     }
 
-    const overIndex = currentLayout.widgets[toSection].indexOf(overWidgetId);
+    setLayout((currentLayout) => {
+      const fromSection = findWidgetSection(currentLayout, activeWidgetId);
+      const toSection = findWidgetSection(currentLayout, overWidgetId);
 
-    return moveWidget(
-      currentLayout,
-      fromSection,
-      toSection,
-      activeWidgetId,
-      overIndex,
-    );
-  });
-};
+      if (!fromSection || !toSection) {
+        return currentLayout;
+      }
+
+      const overIndex = currentLayout.widgets[toSection].indexOf(overWidgetId);
+
+      return moveWidget(
+        currentLayout,
+        fromSection,
+        toSection,
+        activeWidgetId,
+        overIndex,
+      );
+    });
+  };
 
   const handleHideWidget = (widgetId: DashboardWidgetId) => {
     setLayout((currentLayout) => hideWidget(currentLayout, widgetId));

--- a/src/lib/dashboard-layout.ts
+++ b/src/lib/dashboard-layout.ts
@@ -19,6 +19,7 @@ export type DashboardWidgetId =
   | "local-coding-time"
   | "coding-time"
   | "commit-time"
+  | "commit-heatmap-time"
   | "productive-hours"
   | "repo-analytics"
   | "pr-metrics"
@@ -71,6 +72,7 @@ export const DASHBOARD_WIDGET_LABELS: Record<DashboardWidgetId, string> = {
   "local-coding-time": "Local Coding Time",
   "coding-time": "Coding Time",
   "commit-time": "Commit Time",
+  "commit-heatmap-time": "Commit Time Heatmap",
   "productive-hours": "Productive Hours",
   "repo-analytics": "Repository Analytics",
   "pr-metrics": "PR Metrics",
@@ -105,6 +107,7 @@ export const DEFAULT_DASHBOARD_LAYOUT: DashboardLayoutPreference = {
       "local-coding-time",
       "coding-time",
       "commit-time",
+      "commit-heatmap-time",
       "productive-hours",
     ],
     analytics: [

--- a/src/lib/metrics-cache.ts
+++ b/src/lib/metrics-cache.ts
@@ -18,6 +18,7 @@ export const METRICS_CACHE_TTL_SECONDS = {
   "coding-activity-insights": 30 * 60,
   compare: 30 * 60,
   "weekly-summary": 30 * 60,
+  "commit-times": 30 * 60,
 } as const;
 
 type MetricsCacheEndpoint = keyof typeof METRICS_CACHE_TTL_SECONDS;


### PR DESCRIPTION
## Summary

Implements a 7×24 commit time heatmap that visualizes when during the day/week a user codes most — similar to GitHub's contribution graph but showing time-of-day patterns instead of daily totals.

Closes #2118

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Added `GET /api/metrics/commit-times` route that fetches commit timestamps from the last 90 days via GitHub Search API and returns a `7×24` matrix (`commitTimes[dayOfWeek][hour] = count`)
- Added `src/components/CommitHeatmap.tsx` — renders the 7-row × 24-column grid with green color scale, hover tooltip showing day + hour + commit count, and a "peak coding time" label
- Registered `commit-heatmap-time` widget in `src/lib/dashboard-layout.ts` (type union, labels, default activity section)
- Wired widget into `src/components/dashboard/CustomizableDashboard.tsx` (span class + switch case)
- Added `"commit-times"` TTL entry to `src/lib/metrics-cache.ts` to fix TypeScript type error

---

## How to Test

1. Sign in with a GitHub account that has commits in the last 90 days
2. Navigate to `/dashboard`
3. Scroll to the **Activity & Coding** section
4. Verify the **Commit Time Heatmap** widget renders with a 7×24 grid
5. Hover over cells — tooltip should show `Tuesday 3pm — 12 commits` style text
6. Verify the "You code most on..." peak stat appears below the grid
7. Verify empty (0-commit) slots render as dark empty cells, not broken
8. Hide and re-show the widget using the dashboard layout toolbar

---

## Screenshots (if UI change)

<!-- Please attach a screenshot or short GIF of the heatmap widget on the dashboard -->

---

## Checklist

- [x] Linked issue in summary
- [x] `pnpm run lint` passes locally
- [x] No TypeScript errors (`pnpm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] All grid cells have `aria-label` with day, hour, and commit count
- [x] Keyboard navigation supported (`tabIndex={0}`, `onFocus` tooltip)
- [x] Loading skeleton has `role="status"` and `aria-busy="true"`
- [x] Responsive UI verified

---

## Additional Notes

This widget is distinct from the existing `ContributionHeatmap` (issue #18) which is a date-based calendar. This is a time-pattern matrix showing *when* during the day/week you code, not *how much* on each date.