### PR TITLE
fix(goals): align PATCH recurrence validator with system values

### DIFF
--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -72,9 +72,9 @@ export async function PATCH(
   }
 
   if (recurrence !== undefined) {
-    if (recurrence !== "daily" && recurrence !== "weekly" && recurrence !== "monthly") {
+    if (recurrence !== "none" && recurrence !== "weekly" && recurrence !== "monthly") {
       return Response.json(
-        { error: "recurrence must be 'daily', 'weekly', or 'monthly'" },
+        { error: "recurrence must be 'none', 'weekly', or 'monthly'" },
         { status: 400 }
       );
     }


### PR DESCRIPTION
## Summary
Closes #2131

## Problem
The `PATCH /api/goals/[id]` endpoint had a misaligned recurrence validator:

- It **accepted** `"daily"` — a value that **does not exist** in the system. The POST route and period-reset logic in the GET handler only support `"none" | "weekly" | "monthly"`. A goal PATCHed with `recurrence: "daily"` would be silently written to the DB but **never reset**, creating an invisible dead state.
- It **rejected** `"none"` — which is a **valid** system value used throughout the codebase.

**Buggy code (before):**
```typescript
if (recurrence !== "daily" && recurrence !== "weekly" && recurrence !== "monthly") {
  return Response.json({ error: "recurrence must be 'daily', 'weekly', or 'monthly'" }, ...);
}
```

## Solution
Updated the PATCH validator to accept `["none", "weekly", "monthly"]`, matching the POST route and the rest of the recurrence system. Also corrected the error message to reflect the valid values.

**Fixed code (after):**
```typescript
if (recurrence !== "none" && recurrence !== "weekly" && recurrence !== "monthly") {
  return Response.json({ error: "recurrence must be 'none', 'weekly', or 'monthly'" }, ...);
}
```

## Changes
- `src/app/api/goals/[id]/route.ts`: Replace `"daily"` with `"none"` in the recurrence validation check (~line 73); update the error message to match.

## Testing
1. `PATCH /api/goals/:id` with `{ "recurrence": "daily" }` → should now return **400** (was previously accepted — the bug).
2. `PATCH /api/goals/:id` with `{ "recurrence": "none" }` → should now return **200** (was previously rejected — also the bug).
3. `PATCH /api/goals/:id` with `{ "recurrence": "weekly" }` → **200** (unchanged, still valid).
4. `PATCH /api/goals/:id` with `{ "recurrence": "monthly" }` → **200** (unchanged, still valid).
5. `PATCH /api/goals/:id` with `{ "recurrence": "invalid" }` → **400** (still correctly rejected).
