### PR TITLE
fix(goals): align PATCH recurrence validator with system-wide valid values

### DIFF
--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -11,6 +11,13 @@ export const dynamic = "force-dynamic";
 // client-supplied progress updates must be rejected to prevent fabrication.
 const ACTIVITY_DERIVED_UNITS = new Set(["commits", "prs"]);
 
+// Canonical recurrence values — must stay in sync with the POST route and
+// the GET period-reset logic, neither of which has a branch for "daily".
+// Accepting "daily" here would write an unrecognised value to the DB that
+// the reset logic silently ignores, leaving the goal stuck forever.
+const VALID_RECURRENCES = ["none", "weekly", "monthly"] as const;
+type Recurrence = (typeof VALID_RECURRENCES)[number];
+
 export async function PATCH(
   req: Request,
   { params }: { params: { id: string } }
@@ -72,9 +79,9 @@ export async function PATCH(
   }
 
   if (recurrence !== undefined) {
-    if (recurrence !== "daily" && recurrence !== "weekly" && recurrence !== "monthly") {
+    if (!VALID_RECURRENCES.includes(recurrence as Recurrence)) {
       return Response.json(
-        { error: "recurrence must be 'daily', 'weekly', or 'monthly'" },
+        { error: "recurrence must be 'none', 'weekly', or 'monthly'" },
         { status: 400 }
       );
     }


### PR DESCRIPTION
## Summary
Fix a validation mismatch in PATCH /api/goals/[id] where the recurrence validator accepted "daily" (which doesn't exist anywhere in the system) and rejected "none" (which is fully valid throughout the codebase).

Closes #2131

## Type of Change
 Bug fix

## Changes Made
- Replaced the hand-rolled !== "daily" && !== "weekly" && !== "monthly" check with a VALID_RECURRENCES.includes(...) check, mirroring the pattern already used in the POST route
- Defined VALID_RECURRENCES = ["none", "weekly", "monthly"] as const and a local Recurrence type at the top of the file — single source of truth, easy to keep in sync with the rest of the system
- Updated the error message to accurately list the accepted values: 'none', 'weekly', or 'monthly'

## How to Test
- Sign in, create a goal with recurrence "weekly" or "monthly"
- Send a PATCH /api/goals/:id request with { "recurrence": "daily" }
- Before this fix: request succeeds, "daily" is written to the DB, the goal never resets (period-reset logic in GET has no "daily" branch)
- After this fix: request returns 400 with "recurrence must be 'none', 'weekly', or 'monthly'"
- Also verify that PATCH with { "recurrence": "none" } now succeeds (previously returned 400 incorrectly)