### PR TITLE
fix(accessibility): implement focus trap and ARIA dialog roles in Sho…

### DIFF
--- a/src/components/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal.tsx
@@ -46,9 +46,11 @@ export default function ShortcutsModal({
       return;
     }
 
-    // Save previous active element to restore later
-    previousFocusRef.current = document.activeElement as HTMLElement | null;
-    closeBtnRef.current?.focus();
+    // Save previous active element to restore later, only on initial open
+    if (!previousFocusRef.current) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null;
+      closeBtnRef.current?.focus();
+    }
 
     const handleClickOutside = (e: MouseEvent | TouchEvent) => {
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {

--- a/src/components/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 interface ShortcutsModalProps {
   isOpen: boolean;
@@ -27,6 +27,7 @@ export default function ShortcutsModal({
 }: ShortcutsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
   const [isMac, setIsMac] = useState(false);
 
   useEffect(() => {
@@ -35,63 +36,81 @@ export default function ShortcutsModal({
     }
   }, []);
 
-   useEffect(() => {
-    if (!isOpen) return;
+  useEffect(() => {
+    if (!isOpen) {
+      // Restore focus on close
+      if (previousFocusRef.current) {
+        previousFocusRef.current.focus();
+        previousFocusRef.current = null;
+      }
+      return;
+    }
 
-     closeBtnRef.current?.focus();
+    // Save previous active element to restore later
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    closeBtnRef.current?.focus();
 
     const handleClickOutside = (e: MouseEvent | TouchEvent) => {
-       if (
-        modalRef.current &&
-        !modalRef.current.contains(e.target as Node)
-       ) {
-         onClose();
-       }
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        onClose();
+      }
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
-       if (e.key === "Escape") {
-         onClose();
-         return;
-     }
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
 
-     if (e.key === "Tab") {
+      if (e.key === "Tab") {
         if (!modalRef.current) return;
 
-         const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
-         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         );
 
-     if (focusableElements.length === 0) return;
+        if (focusableElements.length === 0) return;
 
-       const firstElement = focusableElements[0];
-         const lastElement = focusableElements[focusableElements.length - 1];
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
 
         if (e.shiftKey && document.activeElement === firstElement) {
-         lastElement.focus();
-         e.preventDefault();
+          lastElement.focus();
+          e.preventDefault();
         } else if (!e.shiftKey && document.activeElement === lastElement) {
           firstElement.focus();
-           e.preventDefault();
-         }
-       }
-     };
-
-     document.addEventListener("keydown", handleKeyDown);
-     document.addEventListener("mousedown", handleClickOutside);
-     document.addEventListener("touchstart", handleClickOutside);
-    return () => {
-       document.removeEventListener("keydown", handleKeyDown);
-       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("touchstart", handleClickOutside);
+          e.preventDefault();
+        }
+      }
     };
-   }, [isOpen, onClose]);
+
+    // Prevent focus from escaping the modal programmatically or via browser UI interactions
+    const handleFocusIn = (e: FocusEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        closeBtnRef.current?.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+    document.addEventListener("focusin", handleFocusIn);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   return (
     <div
       ref={modalRef}
       role="dialog"
+      aria-modal="true"
       aria-labelledby="shortcuts-title"
       className="absolute right-0 top-full z-50 mt-2 w-80 rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
     >

--- a/test/components/ShortcutsModal.test.tsx
+++ b/test/components/ShortcutsModal.test.tsx
@@ -49,6 +49,7 @@ describe("ShortcutsModal Accessibility", () => {
     const focusableElements = screen.getByRole("dialog").querySelectorAll<HTMLElement>(
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
     );
+    expect(focusableElements.length).toBeGreaterThan(0);
     
     const firstElement = focusableElements[0];
     const lastElement = focusableElements[focusableElements.length - 1];
@@ -70,6 +71,7 @@ describe("ShortcutsModal Accessibility", () => {
     const focusableElements = screen.getByRole("dialog").querySelectorAll<HTMLElement>(
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
     );
+    expect(focusableElements.length).toBeGreaterThan(0);
     
     const firstElement = focusableElements[0];
     const lastElement = focusableElements[focusableElements.length - 1];

--- a/test/components/ShortcutsModal.test.tsx
+++ b/test/components/ShortcutsModal.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ShortcutsModal from "@/components/ShortcutsModal";
+
+describe("ShortcutsModal Accessibility", () => {
+  const onCloseMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should have role='dialog' and aria-modal='true'", () => {
+    render(<ShortcutsModal isOpen={true} onClose={onCloseMock} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("should close when Escape key is pressed", () => {
+    render(<ShortcutsModal isOpen={true} onClose={onCloseMock} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should restore focus to the previous active element when closed", () => {
+    const buttonOutside = document.createElement("button");
+    document.body.appendChild(buttonOutside);
+    buttonOutside.focus();
+
+    const { rerender } = render(<ShortcutsModal isOpen={true} onClose={onCloseMock} />);
+    
+    // Focus should move to the close button inside the modal
+    const closeBtn = screen.getByLabelText("Close shortcuts");
+    expect(document.activeElement).toBe(closeBtn);
+
+    // Close the modal
+    rerender(<ShortcutsModal isOpen={false} onClose={onCloseMock} />);
+    
+    // Focus should be restored to the button outside
+    expect(document.activeElement).toBe(buttonOutside);
+    document.body.removeChild(buttonOutside);
+  });
+
+  it("should trap focus and cycle forward when Tab is pressed", () => {
+    render(<ShortcutsModal isOpen={true} onClose={onCloseMock} />);
+    
+    const focusableElements = screen.getByRole("dialog").querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    // Focus last element
+    lastElement.focus();
+    expect(document.activeElement).toBe(lastElement);
+
+    // Press Tab
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: false });
+
+    // Should cycle to first element
+    expect(document.activeElement).toBe(firstElement);
+  });
+
+  it("should trap focus and cycle backward when Shift+Tab is pressed", () => {
+    render(<ShortcutsModal isOpen={true} onClose={onCloseMock} />);
+    
+    const focusableElements = screen.getByRole("dialog").querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    // Focus first element
+    firstElement.focus();
+    expect(document.activeElement).toBe(firstElement);
+
+    // Press Shift+Tab
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+
+    // Should cycle to last element
+    expect(document.activeElement).toBe(lastElement);
+  });
+
+  it("should recover focus if moved outside programmatically", () => {
+    render(<ShortcutsModal isOpen={true} onClose={onCloseMock} />);
+    
+    const outsideElement = document.createElement("input");
+    document.body.appendChild(outsideElement);
+    
+    // Attempt to focus outside
+    outsideElement.focus();
+    
+    // The handleFocusIn listener should intercept and pull focus back to the close button
+    const closeBtn = screen.getByLabelText("Close shortcuts");
+    expect(document.activeElement).toBe(closeBtn);
+    
+    document.body.removeChild(outsideElement);
+  });
+});


### PR DESCRIPTION
## Summary

Implemented a robust keyboard focus trap and added necessary ARIA attributes to the `ShortcutsModal` to comply with WCAG accessibility guidelines.

Closes #1457

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- Added `role="dialog"` and `aria-modal="true"` to the modal wrapper container.
- Implemented a focus trap to prevent keyboard focus from escaping the modal via Tab/Shift+Tab navigation.
- Added a global `focusin` event listener to programmatically intercept focus moving outside the modal and snap it back inside.
- Ensured focus is properly restored to the previous active element when the modal is closed.
- Added a new vitest test suite (`test/components/ShortcutsModal.test.tsx`) to verify Tab cycling, Escape cleanup, and focus recovery.

---

## How to Test

Steps for the reviewer to verify this works:

1. Open the application and press `?` to open the Shortcuts Modal.
2. Press `Tab` and `Shift+Tab` repeatedly; verify that focus cycles continuously within the modal's buttons and never escapes to the background page.
3. Press the `Escape` key; verify the modal closes and keyboard focus is immediately returned to whatever element was active before the modal opened.
4. Run `npm run test` or `npx vitest` to execute the newly added automated accessibility tests and see them pass.

---

## Screenshots (if UI change)

N/A

---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] Proper keyboard navigation tested
- [x] Responsive UI verified
- [x] Accessibility labels added where needed

---

## Additional Notes

The tests added not only verify standard Tab navigation but also explicitly test that programmatic focus escapes are properly trapped and recovered.