### PR TITLE
fix(security): Harden Content-Security-Policy header — add base-uri, object-src, Supabase connect-src

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -164,7 +164,27 @@ const nextConfig = {
           { key: "X-DNS-Prefetch-Control", value: "off" },
           {
             key: "Content-Security-Policy",
-            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://avatars.githubusercontent.com https://github.githubassets.com; connect-src 'self' https://api.github.com https://groq.com https://api.groq.com; frame-ancestors 'none';",
+            // base-uri 'none' — blocks <base> tag injection that could hijack
+            //   relative URLs for scripts/links.
+            // object-src 'none' — blocks legacy Flash/plugin XSS vectors.
+            // upgrade-insecure-requests — instructs the browser to upgrade
+            //   any http:// sub-resource requests to https:// automatically.
+            // worker-src blob: — required for next-pwa service worker registration.
+            // connect-src includes Supabase so authenticated API calls succeed,
+            //   and Upstash Redis for the rate-limiter health checks.
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+              "font-src 'self' https://fonts.gstatic.com",
+              "img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.githubassets.com",
+              "connect-src 'self' https://api.github.com https://groq.com https://api.groq.com https://*.supabase.co wss://*.supabase.co https://*.upstash.io",
+              "frame-ancestors 'none'",
+              "base-uri 'none'",
+              "object-src 'none'",
+              "upgrade-insecure-requests",
+              "worker-src blob:",
+            ].join("; "),
           },
         ],
       },


### PR DESCRIPTION
## Summary

Closes #2148

This PR hardens the existing `Content-Security-Policy` (CSP) header in `next.config.mjs` by closing several attack vectors that the current policy left open.

## Changes

| Directive | Before | After | Why |
|---|---|---|---|
| `base-uri` | *(missing)* | `'none'` | Prevents `<base>` tag injection — an attacker-controlled `<base href>` can redirect all relative URLs (scripts, links) to a malicious domain |
| `object-src` | *(missing)* | `'none'` | Disables legacy Flash/Java plugin execution, a well-known XSS vector |
| `upgrade-insecure-requests` | *(missing)* | ✅ present | Instructs browsers to upgrade HTTP sub-resource requests to HTTPS automatically, preventing mixed-content downgrade |
| `connect-src` | `api.github.com`, `groq.com` | + `*.supabase.co`, `wss://*.supabase.co`, `*.upstash.io` | Supabase realtime WebSocket and REST calls were blocked in strict CSP environments; Upstash Redis health-check calls similarly |
| `img-src` | `data:` | + `blob:` | Canvas-generated image exports (e.g., ExportButton) use `blob:` object URLs |
| `worker-src` | *(missing)* | `blob:` | Required for `next-pwa` service worker registration |
| Format | Single long string | Array joined with `'; '` | Dramatically improves readability and diff-ability of future CSP changes |

## Testing

- ✅ No TypeScript errors (`pnpm run type-check`)
- ✅ Lint clean (`pnpm run lint`)
- ✅ Manually verified header is served in dev mode

## GSSoc'26

> 🙋 Contributing on behalf of **GSSoc'26**. This is a `level3` + `type:security` contribution.