### PR TITLE
fix(security): Prefer __Secure- cookie in production middleware token lookup

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -190,19 +190,32 @@ async function checkRateLimit(identifier: string, limit: number) {
 export async function middleware(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
 
+  // In production (HTTPS), NextAuth.js writes the session to the
+  // __Secure-next-auth.session-token cookie (Secure flag set).
+  // We must try the secure cookie first; the plain cookie is only
+  // present in local development (HTTP, no Secure flag).
+  const isProduction = process.env.NODE_ENV === "production";
+
   let token = await getToken({
     req,
     secret: process.env.NEXTAUTH_SECRET,
-    secureCookie: false,
-    cookieName: "next-auth.session-token",
+    secureCookie: isProduction,
+    cookieName: isProduction
+      ? "__Secure-next-auth.session-token"
+      : "next-auth.session-token",
   });
 
   if (!token) {
+    // Fallback: try the opposite cookie name to handle edge cases such as
+    // a production build served over HTTP (e.g. a staging environment without TLS)
+    // or a dev build that somehow received a Secure cookie.
     token = await getToken({
       req,
       secret: process.env.NEXTAUTH_SECRET,
-      secureCookie: true,
-      cookieName: "__Secure-next-auth.session-token",
+      secureCookie: !isProduction,
+      cookieName: !isProduction
+        ? "__Secure-next-auth.session-token"
+        : "next-auth.session-token",
     });
   }
 


### PR DESCRIPTION
## Summary

Closes #2150

## Problem

In `src/middleware.ts`, the primary `getToken()` call used `secureCookie: false`, meaning it always looked for `next-auth.session-token` first.

In production (HTTPS), NextAuth.js stores the session in `__Secure-next-auth.session-token` (the `Secure` flag is set automatically when `secureCookie: true`). So the **primary lookup always fails in production**, and the code silently falls back to the secure cookie. This is:

1. **Inefficient** — adds an unnecessary failed lookup on every middleware invocation
2. **Potentially misleading** — if the plain cookie is somehow set in production (misconfiguration), it would be silently used instead of the secure one, bypassing the Secure flag protection

## Fix

Derive `isProduction` from `NODE_ENV` and use it to select the correct cookie name and `secureCookie` flag as the **primary** lookup. The fallback retains the old behavior for edge cases (staging over HTTP, development with an unexpected Secure cookie).

```ts
// Before (always tries plain cookie first)
let token = await getToken({ secureCookie: false, cookieName: 'next-auth.session-token' });
if (!token) token = await getToken({ secureCookie: true, cookieName: '__Secure-...' });

// After (production tries secure cookie first)
const isProduction = process.env.NODE_ENV === 'production';
let token = await getToken({ secureCookie: isProduction, cookieName: isProduction ? '__Secure-...' : 'next-auth.session-token' });
if (!token) token = await getToken({ /* fallback */ });
```

## Testing
- ✅ Lint clean
- ✅ No TypeScript errors
- ✅ Development auth flow unaffected (still uses plain cookie)

## GSSoc'26
> 🙋 Contributing on behalf of **GSSoc'26**. This is a `level2` + `type:security` contribution.