### PR TITLE
fix(security): prevent IPv6 SSRF bypasses including IPv4-mapped addresses

### DIFF
--- a/src/lib/ssrf-protection.ts
+++ b/src/lib/ssrf-protection.ts
@@ -1,28 +1,70 @@
 import dns from "dns";
 import { promisify } from "util";
 
-const resolve = promisify(dns.resolve);
+const resolve4 = promisify(dns.resolve4);
+const resolve6 = promisify(dns.resolve6);
 
 const PRIVATE_RANGES = [
-  { start: 0x0a000000, end: 0x0affffff },
-  { start: 0xac100000, end: 0xac1fffff },
-  { start: 0xc0a80000, end: 0xc0a8ffff },
-  { start: 0x7f000000, end: 0x7fffffff },
-  { start: 0xa9fe0000, end: 0xa9feffff },
+  { start: 0x0a000000, end: 0x0affffff }, // 10.0.0.0/8
+  { start: 0xac100000, end: 0xac1fffff }, // 172.16.0.0/12
+  { start: 0xc0a80000, end: 0xc0a8ffff }, // 192.168.0.0/16
+  { start: 0x7f000000, end: 0x7fffffff }, // 127.0.0.0/8 (loopback)
+  { start: 0xa9fe0000, end: 0xa9feffff }, // 169.254.0.0/16 (link-local)
+  { start: 0x00000000, end: 0x00000000 }, // 0.0.0.0
 ];
 
-function ipToNumber(ip: string): number {
-  const parts = ip.split(".").map(Number);
-  return (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3];
+/**
+ * Returns true when the given IPv4 dotted-decimal string falls within any
+ * IANA-reserved private or loopback range.
+ */
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return false;
+  const nums = parts.map(Number);
+  if (nums.some((n) => isNaN(n) || n < 0 || n > 255)) return false;
+
+  const num = ((nums[0] << 24) | (nums[1] << 16) | (nums[2] << 8) | nums[3]) >>> 0;
+  return PRIVATE_RANGES.some(({ start, end }) => num >= start && num <= end);
 }
 
-function isPrivateIP(ip: string): boolean {
-  if (ip === "::1" || ip === "::" || ip.startsWith("fe80:") || ip.startsWith("fc00:") || ip.startsWith("fd00:")) {
-    return true;
+/**
+ * Returns true when the given IPv6 address is a reserved or private address:
+ *   - ::1              (loopback)
+ *   - ::               (unspecified)
+ *   - ::ffff:x.x.x.x  (IPv4-mapped; delegates to isPrivateIPv4)
+ *   - fe80::/10        (link-local)
+ *   - fc00::/7         (unique-local, covers fc00:: and fd00::)
+ *   - 2001:db8::/32    (documentation)
+ *   - 100::/64         (discard prefix)
+ */
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+
+  if (lower === "::1" || lower === "::") return true;
+
+  // IPv4-mapped IPv6 address: ::ffff:a.b.c.d
+  const mappedMatch = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mappedMatch) return isPrivateIPv4(mappedMatch[1]);
+
+  // IPv4-mapped in hex form: ::ffff:0a00:0001 etc. — normalise via prefix check
+  if (lower.startsWith("::ffff:")) {
+    // Hex form: convert the remaining two 16-bit groups to a.b.c.d
+    const hexPart = lower.slice(7).replace(/:/g, "");
+    if (/^[0-9a-f]{8}$/i.test(hexPart)) {
+      const a = parseInt(hexPart.slice(0, 2), 16);
+      const b = parseInt(hexPart.slice(2, 4), 16);
+      const c = parseInt(hexPart.slice(4, 6), 16);
+      const d = parseInt(hexPart.slice(6, 8), 16);
+      return isPrivateIPv4(`${a}.${b}.${c}.${d}`);
+    }
   }
 
-  const num = ipToNumber(ip);
-  return PRIVATE_RANGES.some(({ start, end }) => num >= start && num <= end);
+  if (lower.startsWith("fe80:")) return true; // link-local fe80::/10
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // unique-local fc00::/7
+  if (lower.startsWith("2001:db8:")) return true; // documentation
+  if (lower.startsWith("100::")) return true; // discard
+
+  return false;
 }
 
 export async function isSafeUrl(url: string): Promise<boolean> {
@@ -37,11 +79,24 @@ export async function isSafeUrl(url: string): Promise<boolean> {
       return false;
     }
 
-    const addresses = await resolve(hostname, "A");
-    for (const addr of addresses) {
-      if (isPrivateIP(addr)) {
-        return false;
-      }
+    // Resolve both A (IPv4) and AAAA (IPv6) records to prevent bypass via
+    // IPv6-mapped private addresses (e.g. ::ffff:10.0.0.1) or IPv6-only hosts.
+    const [ipv4Addresses, ipv6Addresses] = await Promise.all([
+      resolve4(hostname).catch(() => [] as string[]),
+      resolve6(hostname).catch(() => [] as string[]),
+    ]);
+
+    for (const addr of ipv4Addresses) {
+      if (isPrivateIPv4(addr)) return false;
+    }
+
+    for (const addr of ipv6Addresses) {
+      if (isPrivateIPv6(addr)) return false;
+    }
+
+    // Reject if DNS returned no addresses at all (hostname does not exist).
+    if (ipv4Addresses.length === 0 && ipv6Addresses.length === 0) {
+      return false;
     }
 
     return true;

--- a/test/ssrf-protection.test.ts
+++ b/test/ssrf-protection.test.ts
@@ -1,5 +1,17 @@
-import { validateUrlBasic } from "../src/lib/ssrf-protection";
-import { describe, it, expect } from "vitest";
+import { validateUrlBasic, isSafeUrl } from "../src/lib/ssrf-protection";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import dns from "dns";
+
+vi.mock("dns", () => {
+  const resolve4Mock = vi.fn();
+  const resolve6Mock = vi.fn();
+  return {
+    default: {
+      resolve4: resolve4Mock,
+      resolve6: resolve6Mock,
+    },
+  };
+});
 
 describe("ssrf-protection", () => {
   describe("validateUrlBasic", () => {
@@ -52,6 +64,65 @@ describe("ssrf-protection", () => {
     it("should handle URLs with fragments", () => {
       expect(validateUrlBasic("https://example.com#section")).toBe(true);
       expect(validateUrlBasic("https://example.com/path#section")).toBe(true);
+    });
+  });
+
+  describe("isSafeUrl", () => {
+    beforeEach(() => {
+      vi.mocked(dns.resolve4).mockReset();
+      vi.mocked(dns.resolve6).mockReset();
+    });
+
+    it("should return false for localhost or 0.0.0.0 directly", async () => {
+      expect(await isSafeUrl("http://localhost")).toBe(false);
+      expect(await isSafeUrl("http://0.0.0.0")).toBe(false);
+    });
+
+    it("should return false if both IPv4 and IPv6 resolutions fail", async () => {
+      vi.mocked(dns.resolve4).mockImplementation((host, cb: any) => cb(new Error("DNS error")));
+      vi.mocked(dns.resolve6).mockImplementation((host, cb: any) => cb(new Error("DNS error")));
+      expect(await isSafeUrl("http://nonexistent.domain")).toBe(false);
+    });
+
+    it("should return true for a safe public IP (IPv4 or IPv6)", async () => {
+      vi.mocked(dns.resolve4).mockImplementation((host, cb: any) => cb(null, ["93.184.216.34"]));
+      vi.mocked(dns.resolve6).mockImplementation((host, cb: any) => cb(null, ["2606:2800:220:1:248:1893:25c8:1946"]));
+      expect(await isSafeUrl("https://example.com")).toBe(true);
+    });
+
+    it("should return false if resolved IPv4 is in private range", async () => {
+      vi.mocked(dns.resolve4).mockImplementation((host, cb: any) => cb(null, ["192.168.1.1"]));
+      vi.mocked(dns.resolve6).mockImplementation((host, cb: any) => cb(null, []));
+      expect(await isSafeUrl("https://myprivate.com")).toBe(false);
+    });
+
+    it("should return false if resolved IPv6 is in unique-local or link-local range", async () => {
+      vi.mocked(dns.resolve4).mockImplementation((host, cb: any) => cb(null, []));
+      // fc00::1 (unique local)
+      vi.mocked(dns.resolve6).mockImplementation((host, cb: any) => cb(null, ["fc00::1"]));
+      expect(await isSafeUrl("https://myprivate6.com")).toBe(false);
+
+      vi.mocked(dns.resolve6).mockImplementation((host, cb: any) => cb(null, ["fe80::1"]));
+      expect(await isSafeUrl("https://myprivate6.com")).toBe(false);
+    });
+
+    it("should return false if resolved IPv6 is an IPv4-mapped private address (standard or hex format)", async () => {
+      vi.mocked(dns.resolve4).mockImplementation((host, cb: any) => cb(null, []));
+      
+      // Standard format: ::ffff:10.0.0.1
+      vi.mocked(dns.resolve6).mockImplementation((host, cb: any) => cb(null, ["::ffff:10.0.0.1"]));
+      expect(await isSafeUrl("https://mapped-bypass.com")).toBe(false);
+
+      // Hex format: ::ffff:0a00:0001 (10.0.0.1 in hex)
+      vi.mocked(dns.resolve6).mockImplementation((host, cb: any) => cb(null, ["::ffff:0a00:0001"]));
+      expect(await isSafeUrl("https://mapped-bypass.com")).toBe(false);
+    });
+
+    it("should return true if resolved IPv6 is an IPv4-mapped public address", async () => {
+      vi.mocked(dns.resolve4).mockImplementation((host, cb: any) => cb(null, []));
+      // 8.8.8.8 mapped to IPv6 (::ffff:0808:0808)
+      vi.mocked(dns.resolve6).mockImplementation((host, cb: any) => cb(null, ["::ffff:8.8.8.8"]));
+      expect(await isSafeUrl("https://mapped-public.com")).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
Closes #4
This PR improves the SSRF protection mechanism in `src/lib/ssrf-protection.ts` to prevent bypasses using IPv6 addresses or IPv6-mapped IPv4 addresses (e.g., `::ffff:10.0.0.1` or hex equivalent). 

Key changes:
1. Resolves both `A` (IPv4) and `AAAA` (IPv6) records for input hosts.
2. Implements detailed IPv6 check for private and loopback address ranges (including Unique Local, Link Local, loopback, documentation, and discard prefixes).
3. Normalizes and checks standard and hex-encoded IPv4-mapped IPv6 formats (like `::ffff:10.0.0.1` and `::ffff:0a00:0001`) to map them to the proper IPv4 private address ranges.
4. Fixed a JS signedness bug: JavaScript's left shift operator `<<` treats operands as 32-bit signed integers. When matching `192.168.x.x` or `172.16.x.x` ranges, the result became negative, bypassing the comparison against positive hex ranges (e.g., `0xc0a80000`). Coerced the shift to an unsigned 32-bit integer with `>>> 0`.
5. Added comprehensive test coverage for all of these SSRF bypass vectors.

*I am contributing on behalf of GSSoc’26.*