### PR TITLE
feat(a11y): add aria-label and keyboard accessibility to BackToTopButton

### DIFF
--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ArrowUp } from "lucide-react";
 
 export default function BackToTopButton() {
@@ -75,9 +75,15 @@ export default function BackToTopButton() {
             </svg>
             <button
               onClick={scrollToTop}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  scrollToTop();
+                }
+              }}
               type="button"
-              aria-label="Scroll to top"
-              className="flex h-12 w-12 items-center justify-center rounded-full bg-black/50 backdrop-blur-md text-white shadow-lg transition-all duration-300 hover:scale-110 hover:shadow-xl hover:bg-black/70"
+              aria-label="Back to top"
+              className="flex h-12 w-12 items-center justify-center rounded-full bg-black/50 backdrop-blur-md text-white shadow-lg transition-all duration-300 hover:scale-110 hover:shadow-xl hover:bg-black/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             >
               <ArrowUp size={24} aria-hidden="true" className="text-white/90" />
             </button>

--- a/test/components/BackToTopButton.test.tsx
+++ b/test/components/BackToTopButton.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import BackToTopButton from "../../src/components/BackToTopButton";
+
+describe("BackToTopButton", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should not render the button initially when scroll Y is 0", () => {
+    render(<BackToTopButton />);
+    expect(screen.queryByRole("button", { name: "Back to top" })).not.toBeInTheDocument();
+  });
+
+  it("should render the button when scroll Y is greater than 300", async () => {
+    // Mock window scrollY and document height to trigger visibility
+    Object.defineProperty(window, "scrollY", { value: 400, writable: true });
+    
+    render(<BackToTopButton />);
+    
+    // Simulate scroll event
+    fireEvent.scroll(window);
+    
+    const button = screen.getByRole("button", { name: "Back to top" });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("should call window.scrollTo when clicked", () => {
+    Object.defineProperty(window, "scrollY", { value: 400, writable: true });
+    render(<BackToTopButton />);
+    fireEvent.scroll(window);
+
+    const button = screen.getByRole("button", { name: "Back to top" });
+    fireEvent.click(button);
+
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+
+  it("should call window.scrollTo when Enter or Space is pressed on the button", () => {
+    Object.defineProperty(window, "scrollY", { value: 400, writable: true });
+    render(<BackToTopButton />);
+    fireEvent.scroll(window);
+
+    const button = screen.getByRole("button", { name: "Back to top" });
+    
+    // Test Enter key
+    fireEvent.keyDown(button, { key: "Enter" });
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+
+    // Test Space key
+    fireEvent.keyDown(button, { key: " " });
+    expect(window.scrollTo).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #2152
This PR adds accessibility support to the `BackToTopButton` component.

Key changes:
1. Updated the button's `aria-label` to `"Back to top"` for clarity.
2. Added an `onKeyDown` handler to intercept Space and Enter key presses, triggering the scrollToTop behavior.
3. Added styling for focused states (`focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2`) so keyboard/screen-reader users have visual feedback on the button's active focus position.
4. Created a comprehensive vitest suite for the component (`test/components/BackToTopButton.test.tsx`) to verify scroll visibility threshold, mouse clicks, and keyboard interactions (Enter and Space).

*I am contributing on behalf of GSSoc’26.*