### PR TITLE
fix(security): prevent Unicode look-alike bypasses in stripHtml

### DIFF
--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,5 +1,6 @@
 export function stripHtml(value: string): string {
   return value
+    .normalize("NFKC")
     .replace(/<[^>]*>/g, "")
     .replace(/&(?:lt|gt|amp|quot|#x27|#39);/gi, (m) => {
       const map: Record<string, string> = {

--- a/test/sanitize.test.ts
+++ b/test/sanitize.test.ts
@@ -29,6 +29,11 @@ describe("stripHtml", () => {
   it("returns empty string for empty input", () => {
     expect(stripHtml("")).toBe("");
   });
+
+  it("normalizes and strips Unicode look-alike full-width angle brackets", () => {
+    expect(stripHtml("＜script＞alert(1)＜/script＞")).toBe("alert(1)");
+    expect(stripHtml("＜b＞Hello＜/b＞")).toBe("Hello");
+  });
 });
 
 describe("validateTextInput", () => {


### PR DESCRIPTION
## Summary
Closes #2153
This PR fixes a security vulnerability where unicode look-alike characters (such as full-width angle brackets `＜` and `＞`) bypassed HTML sanitization in `src/lib/sanitize.ts`'s `stripHtml`.

Key changes:
1. Normalizes input strings using standard `String.prototype.normalize('NFKC')` as the very first step in `stripHtml`. This decomposes compatibility characters into their standard counterparts (e.g. converting full-width angle brackets to standard `<` and `>`), allowing the subsequent HTML tag regular expression replace logic to detect and remove them.
2. Added comprehensive unit tests in `test/sanitize.test.ts` to verify that full-width angle brackets and embedded scripts are correctly normalized and stripped.

*I am contributing on behalf of GSSoc’26.*