### PR TITLE
fix(security): prevent tab-napping by auditing all external links and adding regression test

### DIFF
--- a/src/components/ShareProfileSection.tsx
+++ b/src/components/ShareProfileSection.tsx
@@ -103,7 +103,7 @@ return (
           <a
             href={xShareUrl}
             target="_blank"
-            rel="noreferrer noopener"
+            rel="noopener noreferrer"
             aria-label={`Share ${username}'s profile on X`}
             className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--control)] px-3 py-2 text-sm font-medium text-[var(--card-foreground)] transition-colors hover:bg-[var(--control)]/80"
           >
@@ -114,7 +114,7 @@ return (
           <a
             href={linkedInShareUrl}
             target="_blank"
-            rel="noreferrer noopener"
+            rel="noopener noreferrer"
             aria-label={`Share ${username}'s profile on LinkedIn`}
             className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--control)] px-3 py-2 text-sm font-medium text-[var(--card-foreground)] transition-colors hover:bg-[var(--control)]/80"
           >

--- a/test/check-links.test.ts
+++ b/test/check-links.test.ts
@@ -1,0 +1,68 @@
+import fs from "fs";
+import path from "path";
+import { describe, it, expect } from "vitest";
+
+function getFiles(dir: string): string[] {
+  let results: string[] = [];
+  const list = fs.readdirSync(dir);
+  list.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+    if (stat && stat.isDirectory()) {
+      if (file !== "node_modules" && file !== ".next" && file !== ".git") {
+        results = results.concat(getFiles(filePath));
+      }
+    } else {
+      if (
+        file.endsWith(".tsx") ||
+        file.endsWith(".ts") ||
+        file.endsWith(".js") ||
+        file.endsWith(".jsx")
+      ) {
+        results.push(filePath);
+      }
+    }
+  });
+  return results;
+}
+
+describe("Security Link Audit", () => {
+  it("verifies all target='_blank' links have noopener and noreferrer attributes", () => {
+    const srcDir = path.resolve(__dirname, "../src");
+    const files = getFiles(srcDir);
+    const failures: string[] = [];
+
+    files.forEach((file) => {
+      const content = fs.readFileSync(file, "utf8");
+      let index = 0;
+      while (true) {
+        const aIndex = content.indexOf("<a", index);
+        if (aIndex === -1) break;
+
+        const closeIndex = content.indexOf(">", aIndex);
+        if (closeIndex === -1) {
+          index = aIndex + 2;
+          continue;
+        }
+
+        const tagContent = content.substring(aIndex, closeIndex + 1);
+        const hasTargetBlank = /target\s*=\s*["']_blank["']/i.test(tagContent);
+
+        if (hasTargetBlank) {
+          const hasNoopener = /noopener/i.test(tagContent);
+          const hasNoreferrer = /noreferrer/i.test(tagContent);
+
+          if (!hasNoopener || !hasNoreferrer) {
+            const linesBefore = content.substring(0, aIndex).split("\n");
+            const relativePath = path.relative(path.resolve(__dirname, ".."), file);
+            failures.push(`${relativePath}:L${linesBefore.length} - ${tagContent.replace(/\s+/g, " ")}`);
+          }
+        }
+
+        index = closeIndex + 1;
+      }
+    });
+
+    expect(failures, `Found links missing 'noopener' and/or 'noreferrer':\n${failures.join("\n")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #2155
This PR audits all external links using `target="_blank"` to ensure they have the proper security attributes `rel="noopener noreferrer"` to prevent tab-napping security vulnerabilities.

Key changes:
1. Standardized X and LinkedIn share links in `src/components/ShareProfileSection.tsx` to use `rel="noopener noreferrer"`.
2. Created an automated security test suite `test/check-links.test.ts` that recursively audits all source files to verify that all links targeting `_blank` specify both `noopener` and `noreferrer`. This prevents any future pull requests from introducing insecure external links.

*I am contributing on behalf of GSSoc’26.*