### PR TITLE
refactor: extract magic rate-limit constants to a named config object

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,22 +14,33 @@ import {
 export const runtime = "nodejs";
 
 const isDev = process.env.NODE_ENV === "development";
-const WINDOW_SECONDS = 60;
 
-/* ============================================================
-   SECURITY NOTICE: DEVELOPMENT MODE RATE-LIMIT SCALING
-   These high thresholds are configured STRICTLY for local mock
-   testing pipelines to handle high concurrent local dashboard refreshes.
-   NOTE: In Next.js, process.env.NODE_ENV is a compile-time constant.
-   It is baked into the bundle at build time and cannot change at runtime.
-   Therefore, in production builds, isDev is always false and the
-   AUTHENTICATED_LIMIT/ANONYMOUS_LIMIT will always be 60/10 respectively.
-   In development (next dev), NODE_ENV is "development" so the higher
-   limits apply during local testing only.
-   ==========================================
-   ============================================================ */
-const AUTHENTICATED_LIMIT = isDev ? 5000 : 60;
-const ANONYMOUS_LIMIT = isDev ? 1000 : 10;
+/**
+ * Configuration constants for API rate limits and window sizes.
+ * Values are scaled in development mode (scaled auth: 1000, authenticated metrics: 5000, anonymous metrics: 1000)
+ * to prevent developer/testing workflow interruptions under rapid mock API loading.
+ */
+const RATE_LIMIT_CONFIG = {
+  /**
+   * The sliding rate limit window size in seconds.
+   */
+  WINDOW_SECONDS: 60,
+
+  /**
+   * Maximum allowed API metrics requests for authenticated users in the window.
+   */
+  AUTHENTICATED_LIMIT: isDev ? 5000 : 60,
+
+  /**
+   * Maximum allowed API metrics requests for anonymous users in the window.
+   */
+  ANONYMOUS_LIMIT: isDev ? 1000 : 10,
+
+  /**
+   * Maximum allowed sign-in attempts for authentication routes in the window.
+   */
+  AUTH_LIMIT: isDev ? 1000 : AUTH_LIMIT,
+} as const;
 
 const memoryBuckets = new Map<string, number[]>();
 
@@ -70,7 +81,7 @@ function pruneMemoryBuckets(now: number) {
     return;
   }
 
-  const cutoff = now - WINDOW_SECONDS * 1000;
+  const cutoff = now - RATE_LIMIT_CONFIG.WINDOW_SECONDS * 1000;
   for (const [key, values] of Array.from(memoryBuckets.entries())) {
     const active = values.filter((timestamp: number) => timestamp > cutoff);
     if (active.length === 0) {
@@ -88,11 +99,11 @@ function checkMemoryLimit(
 ): RateLimitResult {
   pruneMemoryBuckets(now);
 
-  const cutoff = now - WINDOW_SECONDS * 1000;
+  const cutoff = now - RATE_LIMIT_CONFIG.WINDOW_SECONDS * 1000;
   const active = (memoryBuckets.get(key) ?? []).filter(
     (timestamp) => timestamp > cutoff
   );
-  const reset = Math.ceil(((active[0] ?? now) + WINDOW_SECONDS * 1000) / 1000);
+  const reset = Math.ceil(((active[0] ?? now) + RATE_LIMIT_CONFIG.WINDOW_SECONDS * 1000) / 1000);
 
   if (active.length >= limit) {
     memoryBuckets.set(key, active);
@@ -125,8 +136,8 @@ async function checkUpstashLimit(
     return null;
   }
 
-  const cutoff = now - WINDOW_SECONDS * 1000;
-  const reset = Math.ceil((now + WINDOW_SECONDS * 1000) / 1000);
+  const cutoff = now - RATE_LIMIT_CONFIG.WINDOW_SECONDS * 1000;
+  const reset = Math.ceil((now + RATE_LIMIT_CONFIG.WINDOW_SECONDS * 1000) / 1000);
   const memberToken = `${now}:${Math.random().toString(36).slice(2)}`;
 
   const luaScript = `
@@ -157,7 +168,7 @@ async function checkUpstashLimit(
       body: JSON.stringify({
         script: luaScript,
         keys: [key],
-        args: [String(cutoff), String(now), String(limit), String(WINDOW_SECONDS), memberToken],
+        args: [String(cutoff), String(now), String(limit), String(RATE_LIMIT_CONFIG.WINDOW_SECONDS), memberToken],
       }),
       cache: "no-store",
     });
@@ -249,7 +260,7 @@ export async function middleware(req: NextRequest) {
 
   if (isAuthSensitivePath(pathname)) {
     const ip = getIp(req);
-    const authLimit = isDev ? 1000 : AUTH_LIMIT;
+    const authLimit = RATE_LIMIT_CONFIG.AUTH_LIMIT;
     const authResult = checkAuthRateLimit(ip, authLimit);
 
     if (!authResult.allowed) {
@@ -273,7 +284,7 @@ export async function middleware(req: NextRequest) {
 
   const githubId = typeof token?.githubId === "string" ? token.githubId : null;
   const identifier = githubId ? `user:${githubId}` : `ip:${getIp(req)}`;
-  const limit = githubId ? AUTHENTICATED_LIMIT : ANONYMOUS_LIMIT;
+  const limit = githubId ? RATE_LIMIT_CONFIG.AUTHENTICATED_LIMIT : RATE_LIMIT_CONFIG.ANONYMOUS_LIMIT;
 
   const result = await checkRateLimit(identifier, limit);
   const headers = buildHeaders(result);


### PR DESCRIPTION
## Summary
Closes #2156
This PR refactors `src/middleware.ts` to extract inline magic numbers representing rate limiting settings into a single, clean, and typed configuration constant.

Key changes:
1. Created `RATE_LIMIT_CONFIG` containing:
   - `WINDOW_SECONDS` (sliding window size)
   - `AUTHENTICATED_LIMIT` (limit for logged-in requests)
   - `ANONYMOUS_LIMIT` (limit for unauthenticated requests)
   - `AUTH_LIMIT` (limit for sign-in endpoint attempts)
2. Replaced all occurrences of these constants throughout the file with fields of `RATE_LIMIT_CONFIG`.
3. Added helpful JSDoc documentation to each setting explaining its purpose and development scaling behavior.

*I am contributing on behalf of GSSoc’26.*