### PR TITLE
fix(security): resolve IPv6-mapped IPv4 bypass in SSRF protection

### DIFF
--- a/src/lib/ssrf-protection.ts
+++ b/src/lib/ssrf-protection.ts
@@ -1,7 +1,5 @@
-import dns from "dns";
-import { promisify } from "util";
-
-const resolve = promisify(dns.resolve);
+import dns from "dns/promises";
+import net from "net";
 
 const PRIVATE_RANGES = [
   { start: 0x0a000000, end: 0x0affffff },
@@ -15,7 +13,7 @@ function ipToNumber(ip: string): number {
   const parts = ip.split(".");
   if (parts.length !== 4) return NaN;
   const numParts = parts.map(Number);
-  if (numParts.some(isNaN)) return NaN;
+  if (numParts.some((n) => isNaN(n) || n < 0 || n > 255 || !Number.isInteger(n))) return NaN;
   return ((numParts[0] << 24) | (numParts[1] << 16) | (numParts[2] << 8) | numParts[3]) >>> 0;
 }
 
@@ -62,20 +60,29 @@ export async function isSafeUrl(url: string): Promise<boolean> {
     }
 
     const hostname = parsed.hostname;
-    // Allow basic bypassing localhost blocks if they try to bypass resolution completely
-    if (hostname === "localhost" || hostname === "0.0.0.0" || hostname === "[::1]") {
+    let ipToCheck = hostname;
+    if (ipToCheck.startsWith("[") && ipToCheck.endsWith("]")) {
+      ipToCheck = ipToCheck.slice(1, -1);
+    }
+
+    // Block localhost/unspecified/loopback hostnames before DNS resolution
+    if (hostname === "localhost" || ipToCheck === "0.0.0.0" || ipToCheck === "::1") {
       return false;
+    }
+
+    if (net.isIP(ipToCheck)) {
+      return !isPrivateIP(ipToCheck);
     }
 
     const addresses: string[] = [];
 
     try {
-      const aRecords = await resolve(hostname, "A");
+      const aRecords = await dns.resolve(hostname, "A");
       if (Array.isArray(aRecords)) addresses.push(...(aRecords as string[]));
     } catch {}
 
     try {
-      const aaaaRecords = await resolve(hostname, "AAAA");
+      const aaaaRecords = await dns.resolve(hostname, "AAAA");
       if (Array.isArray(aaaaRecords)) addresses.push(...(aaaaRecords as string[]));
     } catch {}
 

--- a/src/lib/ssrf-protection.ts
+++ b/src/lib/ssrf-protection.ts
@@ -12,16 +12,45 @@ const PRIVATE_RANGES = [
 ];
 
 function ipToNumber(ip: string): number {
-  const parts = ip.split(".").map(Number);
-  return (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3];
+  const parts = ip.split(".");
+  if (parts.length !== 4) return NaN;
+  const numParts = parts.map(Number);
+  if (numParts.some(isNaN)) return NaN;
+  return ((numParts[0] << 24) | (numParts[1] << 16) | (numParts[2] << 8) | numParts[3]) >>> 0;
 }
 
 function isPrivateIP(ip: string): boolean {
-  if (ip === "::1" || ip === "::" || ip.startsWith("fe80:") || ip.startsWith("fc00:") || ip.startsWith("fd00:")) {
+  ip = ip.toLowerCase();
+
+  // Extract IPv4 from IPv6-mapped IPv4 address
+  if (ip.startsWith("::ffff:")) {
+    const ipv4Part = ip.slice(7);
+    if (ipv4Part.includes(".")) {
+      ip = ipv4Part;
+    } else {
+      // Block non-standard encodings of mapped IPv4
+      return true;
+    }
+  }
+
+  // IPv6 private/loopback checks
+  if (
+    ip === "::1" ||
+    ip === "::" ||
+    ip.startsWith("fe80:") ||
+    ip.startsWith("fc00:") ||
+    ip.startsWith("fd00:")
+  ) {
     return true;
   }
 
+  if (ip.includes(":")) {
+    return false; // Public IPv6
+  }
+
   const num = ipToNumber(ip);
+  if (isNaN(num)) return true; // Block invalid formats
+
   return PRIVATE_RANGES.some(({ start, end }) => num >= start && num <= end);
 }
 
@@ -33,11 +62,27 @@ export async function isSafeUrl(url: string): Promise<boolean> {
     }
 
     const hostname = parsed.hostname;
-    if (hostname === "localhost" || hostname === "0.0.0.0") {
+    // Allow basic bypassing localhost blocks if they try to bypass resolution completely
+    if (hostname === "localhost" || hostname === "0.0.0.0" || hostname === "[::1]") {
       return false;
     }
 
-    const addresses = await resolve(hostname, "A");
+    const addresses: string[] = [];
+
+    try {
+      const aRecords = await resolve(hostname, "A");
+      if (Array.isArray(aRecords)) addresses.push(...(aRecords as string[]));
+    } catch {}
+
+    try {
+      const aaaaRecords = await resolve(hostname, "AAAA");
+      if (Array.isArray(aaaaRecords)) addresses.push(...(aaaaRecords as string[]));
+    } catch {}
+
+    if (addresses.length === 0) {
+      return false;
+    }
+
     for (const addr of addresses) {
       if (isPrivateIP(addr)) {
         return false;

--- a/test/ssrf-protection.test.ts
+++ b/test/ssrf-protection.test.ts
@@ -1,5 +1,12 @@
-import { validateUrlBasic } from "../src/lib/ssrf-protection";
-import { describe, it, expect } from "vitest";
+import { validateUrlBasic, isSafeUrl } from "../src/lib/ssrf-protection";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import dns from "dns";
+
+vi.mock("dns", () => ({
+  default: {
+    resolve: vi.fn(),
+  },
+}));
 
 describe("ssrf-protection", () => {
   describe("validateUrlBasic", () => {
@@ -52,6 +59,64 @@ describe("ssrf-protection", () => {
     it("should handle URLs with fragments", () => {
       expect(validateUrlBasic("https://example.com#section")).toBe(true);
       expect(validateUrlBasic("https://example.com/path#section")).toBe(true);
+    });
+  });
+
+  describe("isSafeUrl", () => {
+    const mockResolve = dns.resolve as any;
+
+    beforeEach(() => {
+      mockResolve.mockReset();
+    });
+
+    it("should return false for invalid protocol", async () => {
+      expect(await isSafeUrl("ftp://example.com")).toBe(false);
+    });
+
+    it("should return false for localhost and 0.0.0.0 bypasses", async () => {
+      expect(await isSafeUrl("http://localhost")).toBe(false);
+      expect(await isSafeUrl("http://0.0.0.0")).toBe(false);
+      expect(await isSafeUrl("http://[::1]")).toBe(false);
+    });
+
+    it("should return true for public IPs", async () => {
+      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
+        if (rrtype === "A") cb(null, ["8.8.8.8"]);
+        else cb(new Error("ENOTFOUND"));
+      });
+      expect(await isSafeUrl("http://example.com")).toBe(true);
+    });
+
+    it("should return false for private IPv4", async () => {
+      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
+        if (rrtype === "A") cb(null, ["10.0.0.1"]);
+        else cb(new Error("ENOTFOUND"));
+      });
+      expect(await isSafeUrl("http://internal.com")).toBe(false);
+    });
+
+    it("should return false for IPv6-mapped IPv4 private address", async () => {
+      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
+        if (rrtype === "AAAA") cb(null, ["::ffff:192.168.1.1"]);
+        else cb(new Error("ENOTFOUND"));
+      });
+      expect(await isSafeUrl("http://internal.com")).toBe(false);
+    });
+
+    it("should return false for IPv6 loopback and link-local", async () => {
+      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
+        if (rrtype === "AAAA") cb(null, ["fe80::1"]);
+        else cb(new Error("ENOTFOUND"));
+      });
+      expect(await isSafeUrl("http://internal.com")).toBe(false);
+    });
+
+    it("should return true for public IPv6", async () => {
+      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
+        if (rrtype === "AAAA") cb(null, ["2001:4860:4860::8888"]);
+        else cb(new Error("ENOTFOUND"));
+      });
+      expect(await isSafeUrl("http://example.com")).toBe(true);
     });
   });
 });

--- a/test/ssrf-protection.test.ts
+++ b/test/ssrf-protection.test.ts
@@ -1,8 +1,8 @@
 import { validateUrlBasic, isSafeUrl } from "../src/lib/ssrf-protection";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import dns from "dns";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import dns from "dns/promises";
 
-vi.mock("dns", () => ({
+vi.mock("dns/promises", () => ({
   default: {
     resolve: vi.fn(),
   },
@@ -79,42 +79,47 @@ describe("ssrf-protection", () => {
       expect(await isSafeUrl("http://[::1]")).toBe(false);
     });
 
-    it("should return true for public IPs", async () => {
-      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
-        if (rrtype === "A") cb(null, ["8.8.8.8"]);
-        else cb(new Error("ENOTFOUND"));
+    it("should return true for public IP literals directly without DNS", async () => {
+      expect(await isSafeUrl("http://8.8.8.8")).toBe(true);
+      expect(await isSafeUrl("http://[2001:4860:4860::8888]")).toBe(true);
+    });
+
+    it("should return true for public IPs via DNS", async () => {
+      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
+        if (rrtype === "A") return ["8.8.8.8"];
+        throw new Error("ENOTFOUND");
       });
       expect(await isSafeUrl("http://example.com")).toBe(true);
     });
 
     it("should return false for private IPv4", async () => {
-      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
-        if (rrtype === "A") cb(null, ["10.0.0.1"]);
-        else cb(new Error("ENOTFOUND"));
+      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
+        if (rrtype === "A") return ["10.0.0.1"];
+        throw new Error("ENOTFOUND");
       });
       expect(await isSafeUrl("http://internal.com")).toBe(false);
     });
 
     it("should return false for IPv6-mapped IPv4 private address", async () => {
-      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
-        if (rrtype === "AAAA") cb(null, ["::ffff:192.168.1.1"]);
-        else cb(new Error("ENOTFOUND"));
+      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
+        if (rrtype === "AAAA") return ["::ffff:192.168.1.1"];
+        throw new Error("ENOTFOUND");
       });
       expect(await isSafeUrl("http://internal.com")).toBe(false);
     });
 
     it("should return false for IPv6 loopback and link-local", async () => {
-      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
-        if (rrtype === "AAAA") cb(null, ["fe80::1"]);
-        else cb(new Error("ENOTFOUND"));
+      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
+        if (rrtype === "AAAA") return ["fe80::1"];
+        throw new Error("ENOTFOUND");
       });
       expect(await isSafeUrl("http://internal.com")).toBe(false);
     });
 
     it("should return true for public IPv6", async () => {
-      mockResolve.mockImplementation((hostname: string, rrtype: string, cb: Function) => {
-        if (rrtype === "AAAA") cb(null, ["2001:4860:4860::8888"]);
-        else cb(new Error("ENOTFOUND"));
+      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
+        if (rrtype === "AAAA") return ["2001:4860:4860::8888"];
+        throw new Error("ENOTFOUND");
       });
       expect(await isSafeUrl("http://example.com")).toBe(true);
     });


### PR DESCRIPTION
## Summary

Fixed a critical SSRF vulnerability bypass involving IPv6-mapped IPv4 addresses and AAAA-only hosts, and patched an underlying 32-bit signed integer overflow bug in the IP evaluation logic.

Closes #2151

---

## Type of Change

- [x] Bug fix
- [x] Security patch
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- **Bitwise Signed Integer Overflow Fix:** Patched `ipToNumber` to return a 32-bit unsigned integer (via `>>> 0`). Previously, calculating `192 << 24` resulted in a negative number, allowing internal IPs like `192.168.x.x` to silently bypass the bounds check.
- **IPv6 Mapped IPv4:** Added logic to extract the IPv4 portion from IPv6-mapped addresses (e.g., `::ffff:192.168.1.1`) and validate it normally.
- **IPv6 Loopback & Link-local Protection:** Explicitly blocked common IPv6 private networks (`::1`, `::`, `fe80::`, `fc00::`, `fd00::`).
- **AAAA Record Validation:** Enhanced `isSafeUrl` to resolve both `A` and `AAAA` records. If any resolved IP points to a private/internal network, the request is blocked.
- **Expanded Test Coverage:** Added comprehensive Vitest test cases mocking `dns.resolve` to verify behavior for IPv6, mapped IPv4, and public/private resolutions.

---

## How to Test

1. Run `npm run test` locally and verify that the `ssrf-protection.test.ts` suite passes, including all the new `isSafeUrl` test cases.
2. Confirm that public domains continue to resolve correctly while resolving an `AAAA` record like `::ffff:169.254.169.254` returns `false`.

---

## Screenshots (if UI change)

N/A

---

## Checklist

- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [x] Added/updated tests if applicable