### PR TITLE
feat: shareable public profile page /u/[username] with opt-in public stats (#2117)

### DIFF
--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -10,11 +10,21 @@ import { cacheGet, cacheSet, cacheDelete } from "@/lib/metrics-cache";
 
 export const dynamic = "force-dynamic";
 
+const VALID_WIDGETS = ["streak", "contributions", "languages", "prs"] as const;
+type WidgetKey = (typeof VALID_WIDGETS)[number];
+
+function sanitizePublicWidgets(input: unknown): WidgetKey[] {
+  if (!Array.isArray(input)) return ["streak", "contributions"];
+  return input.filter((w): w is WidgetKey =>
+    typeof w === "string" && (VALID_WIDGETS as readonly string[]).includes(w)
+  );
+}
+
 async function fetchUserSettings(userId: string) {
-  // Tier 1: All columns
+  // Tier 1: All columns (including public_widgets added by 20260608000000 migration)
   const res1 = await supabaseAdmin
     .from("users")
-    .select("id, github_login, bio, is_public, public_since, show_weekly_goals, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, weekly_digest_opt_in, discord_webhook_url, timezone, webhook_url, discord_muted_until")
+    .select("id, github_login, bio, is_public, public_since, show_weekly_goals, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, weekly_digest_opt_in, discord_webhook_url, timezone, webhook_url, discord_muted_until, public_widgets")
     .eq("id", userId)
     .single();
 
@@ -30,6 +40,7 @@ async function fetchUserSettings(userId: string) {
       hasBio: true,
       hasWebhookUrl: true,
       hasDiscordMutedUntil: true,
+      hasPublicWidgets: true,
       leaderboard_opt_in: (res1.data as any).leaderboard_opt_in ?? false,
       weekly_digest_opt_in: (res1.data as any).weekly_digest_opt_in ?? false,
       pinned_repos: (res1.data as any).pinned_repos || [],
@@ -39,6 +50,7 @@ async function fetchUserSettings(userId: string) {
       timezone: (res1.data as any).timezone || "UTC",
       webhook_url: (res1.data as any).webhook_url || null,
       discord_muted_until: (res1.data as any).discord_muted_until || null,
+      public_widgets: sanitizePublicWidgets((res1.data as any).public_widgets),
     };
   }
 
@@ -54,6 +66,7 @@ async function fetchUserSettings(userId: string) {
       hasBio: false,
       hasWebhookUrl: false,
       hasDiscordMutedUntil: false,
+      hasPublicWidgets: false,
       leaderboard_opt_in: false,
       weekly_digest_opt_in: false,
       pinned_repos: [] as string[],
@@ -63,13 +76,14 @@ async function fetchUserSettings(userId: string) {
       timezone: "UTC",
       webhook_url: null,
       discord_muted_until: null,
+      public_widgets: ["streak", "contributions"] as WidgetKey[],
     };
   }
 
-  // Tier 2: Without bio, for deployments that have not run the latest migration.
+  // Tier 2: Without public_widgets (deployments that haven't run the latest migration yet)
   const res2 = await supabaseAdmin
     .from("users")
-      .select("id, github_login, is_public, public_since, show_weekly_goals, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, webhook_url")
+    .select("id, github_login, bio, is_public, public_since, show_weekly_goals, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, weekly_digest_opt_in, discord_webhook_url, timezone, webhook_url, discord_muted_until")
     .eq("id", userId)
     .single();
 
@@ -80,20 +94,22 @@ async function fetchUserSettings(userId: string) {
       hasLeaderboardOptIn: true,
       hasPinnedRepos: true,
       hasWakatimeKey: true,
-      hasWeeklyDigestOptIn: false,
-      hasDiscordSettings: false,
-      hasBio: false,
+      hasWeeklyDigestOptIn: true,
+      hasDiscordSettings: true,
+      hasBio: true,
       hasWebhookUrl: true,
-      hasDiscordMutedUntil: false,
+      hasDiscordMutedUntil: true,
+      hasPublicWidgets: false,
       leaderboard_opt_in: (res2.data as any).leaderboard_opt_in ?? false,
-      weekly_digest_opt_in: false,
+      weekly_digest_opt_in: (res2.data as any).weekly_digest_opt_in ?? false,
       pinned_repos: (res2.data as any).pinned_repos || [],
       wakatime_api_key_encrypted: (res2.data as any).wakatime_api_key_encrypted || null,
       wakatime_api_key_iv: (res2.data as any).wakatime_api_key_iv || null,
-      discord_webhook_url: null,
-      timezone: "UTC",
+      discord_webhook_url: (res2.data as any).discord_webhook_url || null,
+      timezone: (res2.data as any).timezone || "UTC",
       webhook_url: (res2.data as any).webhook_url || null,
-      discord_muted_until: null,
+      discord_muted_until: (res2.data as any).discord_muted_until || null,
+      public_widgets: ["streak", "contributions"] as WidgetKey[],
     };
   }
 
@@ -109,6 +125,7 @@ async function fetchUserSettings(userId: string) {
       hasBio: false,
       hasWebhookUrl: false,
       hasDiscordMutedUntil: false,
+      hasPublicWidgets: false,
       leaderboard_opt_in: false,
       weekly_digest_opt_in: false,
       pinned_repos: [] as string[],
@@ -118,13 +135,14 @@ async function fetchUserSettings(userId: string) {
       timezone: "UTC",
       webhook_url: null,
       discord_muted_until: null,
+      public_widgets: ["streak", "contributions"] as WidgetKey[],
     };
   }
 
-  // Tier 3: Without public_since and show_weekly_goals (added by migrations)
+  // Tier 3: Without bio, for deployments that have not run the latest migration.
   const res3 = await supabaseAdmin
     .from("users")
-      .select("id, github_login, is_public, public_since, show_weekly_goals")
+      .select("id, github_login, is_public, public_since, show_weekly_goals, leaderboard_opt_in, pinned_repos, wakatime_api_key_encrypted, wakatime_api_key_iv, webhook_url")
     .eq("id", userId)
     .single();
 
@@ -132,21 +150,25 @@ async function fetchUserSettings(userId: string) {
     return {
       data: res3.data as any,
       error: null,
-      hasLeaderboardOptIn: false,
-      hasPinnedRepos: false,
-      hasWakatimeKey: false,
+      hasLeaderboardOptIn: true,
+      hasPinnedRepos: true,
+      hasWakatimeKey: true,
       hasWeeklyDigestOptIn: false,
       hasDiscordSettings: false,
       hasBio: false,
+      hasWebhookUrl: true,
       hasDiscordMutedUntil: false,
-      leaderboard_opt_in: false,
+      hasPublicWidgets: false,
+      leaderboard_opt_in: (res3.data as any).leaderboard_opt_in ?? false,
       weekly_digest_opt_in: false,
-      pinned_repos: [] as string[],
-      wakatime_api_key_encrypted: null,
-      wakatime_api_key_iv: null,
+      pinned_repos: (res3.data as any).pinned_repos || [],
+      wakatime_api_key_encrypted: (res3.data as any).wakatime_api_key_encrypted || null,
+      wakatime_api_key_iv: (res3.data as any).wakatime_api_key_iv || null,
       discord_webhook_url: null,
       timezone: "UTC",
+      webhook_url: (res3.data as any).webhook_url || null,
       discord_muted_until: null,
+      public_widgets: ["streak", "contributions"] as WidgetKey[],
     };
   }
 
@@ -160,7 +182,9 @@ async function fetchUserSettings(userId: string) {
       hasWeeklyDigestOptIn: false,
       hasDiscordSettings: false,
       hasBio: false,
+      hasWebhookUrl: false,
       hasDiscordMutedUntil: false,
+      hasPublicWidgets: false,
       leaderboard_opt_in: false,
       weekly_digest_opt_in: false,
       pinned_repos: [] as string[],
@@ -168,14 +192,16 @@ async function fetchUserSettings(userId: string) {
       wakatime_api_key_iv: null,
       discord_webhook_url: null,
       timezone: "UTC",
+      webhook_url: null,
       discord_muted_until: null,
+      public_widgets: ["streak", "contributions"] as WidgetKey[],
     };
   }
 
-  // Tier 4: Absolute minimum — columns guaranteed in every schema version
+  // Tier 4: Without public_since and show_weekly_goals (added by migrations)
   const res4 = await supabaseAdmin
     .from("users")
-      .select("id, github_login, is_public")
+      .select("id, github_login, is_public, public_since, show_weekly_goals")
     .eq("id", userId)
     .single();
 
@@ -190,6 +216,7 @@ async function fetchUserSettings(userId: string) {
       hasDiscordSettings: false,
       hasBio: false,
       hasDiscordMutedUntil: false,
+      hasPublicWidgets: false,
       leaderboard_opt_in: false,
       weekly_digest_opt_in: false,
       pinned_repos: [] as string[],
@@ -198,12 +225,68 @@ async function fetchUserSettings(userId: string) {
       discord_webhook_url: null,
       timezone: "UTC",
       discord_muted_until: null,
+      public_widgets: ["streak", "contributions"] as WidgetKey[],
+    };
+  }
+
+  if (res4.error.code !== "42703") {
+    return {
+      data: null,
+      error: res4.error,
+      hasLeaderboardOptIn: false,
+      hasPinnedRepos: false,
+      hasWakatimeKey: false,
+      hasWeeklyDigestOptIn: false,
+      hasDiscordSettings: false,
+      hasBio: false,
+      hasDiscordMutedUntil: false,
+      hasPublicWidgets: false,
+      leaderboard_opt_in: false,
+      weekly_digest_opt_in: false,
+      pinned_repos: [] as string[],
+      wakatime_api_key_encrypted: null,
+      wakatime_api_key_iv: null,
+      discord_webhook_url: null,
+      timezone: "UTC",
+      discord_muted_until: null,
+      public_widgets: ["streak", "contributions"] as WidgetKey[],
+    };
+  }
+
+  // Tier 5: Absolute minimum — columns guaranteed in every schema version
+  const res5 = await supabaseAdmin
+    .from("users")
+      .select("id, github_login, is_public")
+    .eq("id", userId)
+    .single();
+
+  if (!res5.error) {
+    return {
+      data: res5.data as any,
+      error: null,
+      hasLeaderboardOptIn: false,
+      hasPinnedRepos: false,
+      hasWakatimeKey: false,
+      hasWeeklyDigestOptIn: false,
+      hasDiscordSettings: false,
+      hasBio: false,
+      hasDiscordMutedUntil: false,
+      hasPublicWidgets: false,
+      leaderboard_opt_in: false,
+      weekly_digest_opt_in: false,
+      pinned_repos: [] as string[],
+      wakatime_api_key_encrypted: null,
+      wakatime_api_key_iv: null,
+      discord_webhook_url: null,
+      timezone: "UTC",
+      discord_muted_until: null,
+      public_widgets: ["streak", "contributions"] as WidgetKey[],
     };
   }
 
   return {
     data: null,
-    error: res4.error,
+    error: res5.error,
     hasLeaderboardOptIn: false,
     hasPinnedRepos: false,
     hasWakatimeKey: false,
@@ -211,6 +294,7 @@ async function fetchUserSettings(userId: string) {
     hasDiscordSettings: false,
     hasBio: false,
     hasDiscordMutedUntil: false,
+    hasPublicWidgets: false,
     leaderboard_opt_in: false,
     weekly_digest_opt_in: false,
     pinned_repos: [] as string[],
@@ -219,6 +303,7 @@ async function fetchUserSettings(userId: string) {
     discord_webhook_url: null,
     timezone: "UTC",
     discord_muted_until: null,
+    public_widgets: ["streak", "contributions"] as WidgetKey[],
   };
 }
 
@@ -267,6 +352,7 @@ export async function GET(req: NextRequest) {
     timezone: result.timezone,
     webhook_url: result.webhook_url ?? null,
     discord_muted_until: result.discord_muted_until ?? null,
+    public_widgets: result.public_widgets,
   };
 
   await cacheSet(cacheKey, response, SETTINGS_TTL);
@@ -290,14 +376,27 @@ export async function PATCH(req: NextRequest) {
     );
   }
 
-  let body: { is_public?: boolean; show_weekly_goals?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key?: string; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null; discord_muted_until?: string | null };
+  let body: {
+    is_public?: boolean;
+    show_weekly_goals?: boolean;
+    leaderboard_opt_in?: boolean;
+    weekly_digest_opt_in?: boolean;
+    pinned_repos?: string[];
+    wakatime_api_key?: string;
+    discord_webhook_url?: string | null;
+    timezone?: string;
+    bio?: string;
+    webhook_url?: string | null;
+    discord_muted_until?: string | null;
+    public_widgets?: string[];
+  };
   try {
     body = await req.json();
   } catch (e) {
     return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
   }
 
-  const { is_public, show_weekly_goals, leaderboard_opt_in, weekly_digest_opt_in, pinned_repos, wakatime_api_key, discord_webhook_url, timezone, bio, webhook_url, discord_muted_until } = body;
+  const { is_public, show_weekly_goals, leaderboard_opt_in, weekly_digest_opt_in, pinned_repos, wakatime_api_key, discord_webhook_url, timezone, bio, webhook_url, discord_muted_until, public_widgets } = body;
 
   // Retrieve supported columns first
   const settingsResult = await fetchUserSettings(user.id);
@@ -306,8 +405,23 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Failed to update settings" }, { status: 500 });
   }
 
-  const { hasLeaderboardOptIn, hasPinnedRepos, hasWakatimeKey, hasWeeklyDigestOptIn, hasDiscordSettings, hasBio, hasWebhookUrl, hasDiscordMutedUntil } = settingsResult;
-  const updates: { is_public?: boolean; public_since?: string | null; show_weekly_goals?: boolean; leaderboard_opt_in?: boolean; weekly_digest_opt_in?: boolean; pinned_repos?: string[]; wakatime_api_key_encrypted?: string | null; wakatime_api_key_iv?: string | null; discord_webhook_url?: string | null; timezone?: string; bio?: string; webhook_url?: string | null; discord_muted_until?: string | null } = {};
+  const { hasLeaderboardOptIn, hasPinnedRepos, hasWakatimeKey, hasWeeklyDigestOptIn, hasDiscordSettings, hasBio, hasWebhookUrl, hasDiscordMutedUntil, hasPublicWidgets } = settingsResult;
+  const updates: {
+    is_public?: boolean;
+    public_since?: string | null;
+    show_weekly_goals?: boolean;
+    leaderboard_opt_in?: boolean;
+    weekly_digest_opt_in?: boolean;
+    pinned_repos?: string[];
+    wakatime_api_key_encrypted?: string | null;
+    wakatime_api_key_iv?: string | null;
+    discord_webhook_url?: string | null;
+    timezone?: string;
+    bio?: string;
+    webhook_url?: string | null;
+    discord_muted_until?: string | null;
+    public_widgets?: WidgetKey[];
+  } = {};
 
   if (is_public !== undefined && is_public !== null && typeof is_public === "boolean") {
     updates.is_public = is_public;
@@ -422,6 +536,11 @@ export async function PATCH(req: NextRequest) {
     }
   }
 
+  // Handle public_widgets update
+  if (hasPublicWidgets && public_widgets !== undefined && Array.isArray(public_widgets)) {
+    updates.public_widgets = sanitizePublicWidgets(public_widgets);
+  }
+
   // If there are no updates (or none that are supported by the schema)
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({
@@ -439,6 +558,7 @@ export async function PATCH(req: NextRequest) {
       timezone: settingsResult.timezone,
       webhook_url: settingsResult.webhook_url ?? null,
       discord_muted_until: settingsResult.discord_muted_until ?? null,
+      public_widgets: settingsResult.public_widgets,
     });
   }
 
@@ -455,6 +575,7 @@ export async function PATCH(req: NextRequest) {
   if (hasDiscordSettings) selectCols.push("discord_webhook_url", "timezone");
   if (hasDiscordMutedUntil) selectCols.push("discord_muted_until");
   if (hasWebhookUrl) selectCols.push("webhook_url");
+  if (hasPublicWidgets) selectCols.push("public_widgets");
 
   const { data: updated, error: updateError } = await supabaseAdmin
     .from("users")
@@ -502,5 +623,8 @@ export async function PATCH(req: NextRequest) {
     timezone: (updated as any).timezone || "UTC",
     webhook_url: (updated as any).webhook_url ?? null,
     discord_muted_until: (updated as any).discord_muted_until ?? null,
+    public_widgets: hasPublicWidgets
+      ? sanitizePublicWidgets((updated as any).public_widgets)
+      : settingsResult.public_widgets,
   });
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -24,6 +24,7 @@ interface UserSettings {
   is_public: boolean;
   public_since?: string | null;
   show_weekly_goals?: boolean;
+  public_widgets?: string[];
   leaderboard_opt_in: boolean;
   weekly_digest_opt_in: boolean;
   has_wakatime_key?: boolean;
@@ -187,6 +188,8 @@ function SettingsPageContent() {
   const [discordMutedUntil, setDiscordMutedUntil] = useState<string | null>(null);
   const [muteDuration, setMuteDuration] = useState<number>(1);
   const [isDirty, setIsDirty] = useState(false);
+  const [publicWidgets, setPublicWidgets] = useState<string[]>(["streak", "contributions"]);
+  const [savingWidgets, setSavingWidgets] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [pendingPath, setPendingPath] = useState<string | null>(null);
 
@@ -294,6 +297,7 @@ function SettingsPageContent() {
           setTimezone(data.timezone || "UTC");
           setDiscordMutedUntil(data.discord_muted_until ?? null);
           setWebhookUrl(data.webhook_url ?? null);
+          setPublicWidgets(data.public_widgets ?? ["streak", "contributions"]);
         }
       } catch (error) {
         console.error("Failed to load settings:", error);
@@ -483,6 +487,45 @@ function SettingsPageContent() {
       console.error("Error updating weekly digest setting:", error);
     } finally {
       setSaving(false);
+    }
+  };
+
+  const WIDGET_OPTIONS = [
+    { key: "streak", label: "Streak stats", description: "Current streak, longest streak, active days" },
+    { key: "contributions", label: "Contribution graph", description: "30-day commit activity heatmap" },
+    { key: "languages", label: "Top languages", description: "Language breakdown from recent repos" },
+    { key: "prs", label: "Pull requests", description: "Total PRs authored" },
+  ] as const;
+
+  const handleToggleWidget = (key: string, checked: boolean) => {
+    setPublicWidgets((prev) =>
+      checked ? [...prev, key] : prev.filter((w) => w !== key)
+    );
+    setIsDirty(true);
+  };
+
+  const handleSaveWidgets = async () => {
+    if (!settings) return;
+    setSavingWidgets(true);
+    try {
+      const res = await fetch("/api/user/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ public_widgets: publicWidgets }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        setSettings(updated);
+        setPublicWidgets(updated.public_widgets ?? ["streak", "contributions"]);
+        setIsDirty(false);
+        toast.success("Widget visibility saved!");
+      } else {
+        toast.error("Failed to save widget settings.");
+      }
+    } catch {
+      toast.error("Failed to save widget settings.");
+    } finally {
+      setSavingWidgets(false);
     }
   };
 
@@ -912,6 +955,47 @@ function SettingsPageContent() {
                   </div>
                 </label>
               </div>
+            </div>
+          )}
+
+          {/* ── Public Widget Selector ────────────────────────────────── */}
+          {settings.is_public && (
+            <div className="mt-6 pt-6 border-t border-[var(--border)]">
+              <div className="mb-3">
+                <h3 className="text-sm font-semibold text-[var(--card-foreground)]">
+                  Visible Widgets
+                </h3>
+                <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                  Choose which stats are shown on your public profile.
+                </p>
+              </div>
+              <div className="space-y-3">
+                {WIDGET_OPTIONS.map(({ key, label, description }) => (
+                  <label
+                    key={key}
+                    className="flex items-start gap-3 cursor-pointer rounded-lg border border-[var(--border)] bg-[var(--control)] px-4 py-3 transition-colors hover:bg-[var(--control)]/80"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={publicWidgets.includes(key)}
+                      onChange={(e) => handleToggleWidget(key, e.target.checked)}
+                      className="mt-0.5 accent-[var(--accent)]"
+                    />
+                    <div>
+                      <div className="text-sm font-medium text-[var(--card-foreground)]">{label}</div>
+                      <div className="text-xs text-[var(--muted-foreground)]">{description}</div>
+                    </div>
+                  </label>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={handleSaveWidgets}
+                disabled={savingWidgets}
+                className="mt-4 rounded-lg bg-[var(--accent)] px-4 py-2 text-sm font-medium text-[var(--accent-foreground)] transition-opacity hover:opacity-90 disabled:opacity-60"
+              >
+                {savingWidgets ? "Saving..." : "Save Widget Settings"}
+              </button>
             </div>
           )}
 

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import ProfileThemeWrapper from "@/components/ProfileThemeWrapper";
 import { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import BadgeSection from "@/components/BadgeSection";
@@ -18,6 +19,7 @@ import { getUserByGithubId, getUserByUsername } from "@/lib/supabase";
 import {
   fetchPublicProfile as fetchPublicProfileLib,
   type PublicProfileData,
+  type PublicWidgetKey,
 } from "@/lib/public-profile-data";
 
 // Extend tracking structures to forward gamification flags seamlessly downstream
@@ -43,6 +45,7 @@ function getVisualRegressionMockProfile(
     bio: "Mock public profile used for deterministic visual regression coverage.",
     isSponsor: true,
     publicGists: 4,
+    memberSince: "2023-01-15T00:00:00Z",
     repos: [
       {
         name: "playwright-user/devtrack-ui",
@@ -98,6 +101,7 @@ function getVisualRegressionMockProfile(
       total: 4,
       percentage: 75,
     },
+    publicWidgets: ["streak", "contributions", "languages", "prs"],
     isNightOwl: true,
     isEarlyBird: false,
   };
@@ -288,6 +292,7 @@ export default async function PublicProfilePage({
   const avatarUrl = `https://avatars.githubusercontent.com/${profile.username}`;
   const topRepo = profile.repos[0]?.name ?? "";
   const gistsUrl = `https://gist.github.com/${profile.username}`;
+  const githubUrl = `https://github.com/${profile.username}`;
   const showCompareButton =
     loggedInUsername !== null &&
     loggedInUsername.toLowerCase() !== profile.username.toLowerCase();
@@ -298,20 +303,48 @@ export default async function PublicProfilePage({
     `/u/${profile.username}`
   )}`;
 
+  const widgets = profile.publicWidgets ?? ["streak", "contributions"];
+  const showStreak = widgets.includes("streak");
+  const showContributions = widgets.includes("contributions");
+  const showLanguages = widgets.includes("languages");
+  const showPRs = widgets.includes("prs");
+
+  const memberSinceFormatted = profile.memberSince
+    ? new Date(profile.memberSince).toLocaleDateString("en-US", {
+        month: "long",
+        year: "numeric",
+      })
+    : null;
+
   return (
     <ProfileThemeWrapper>
     <div className="min-h-screen bg-[var(--background)] p-4 text-[var(--foreground)] transition-colors md:p-8">
-      <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
-        <div>
+
+      {/* ── Header: Avatar + Identity ── */}
+      <div className="mb-8 flex flex-wrap items-start gap-5">
+        {/* GitHub avatar */}
+        <div className="shrink-0">
+          <Image
+            src={avatarUrl}
+            alt={`${profile.username}'s GitHub avatar`}
+            width={80}
+            height={80}
+            className="rounded-full border-2 border-[var(--border)] shadow-md"
+            unoptimized
+          />
+        </div>
+
+        {/* Identity block */}
+        <div className="flex-1 min-w-0">
           <div className="flex flex-wrap items-center gap-3">
             <h1 className="text-3xl md:text-4xl font-bold text-[var(--foreground)] flex flex-wrap items-center gap-2">
-              <span>@{profile.username}&apos;s Profile</span>
+              <span>@{profile.username}</span>
               {profile.isSponsor && <SponsorBadge />}
-              
-              {/* 🎯 Render Server-Calculated Time Distribution Badges Safely on Public Profile View */}
+
+              {/* Night Owl / Early Bird badges */}
               {profile.isNightOwl && (
-                <span 
-                  title="Night Owl Milestone Badge" 
+                <span
+                  title="Night Owl Milestone Badge"
                   className="inline-flex items-center gap-1 rounded-full bg-indigo-500/10 border border-indigo-500/30 px-2.5 py-0.5 text-xs font-bold text-indigo-400"
                 >
                   <Moon className="h-3 w-3" />
@@ -319,8 +352,8 @@ export default async function PublicProfilePage({
                 </span>
               )}
               {profile.isEarlyBird && (
-                <span 
-                  title="Early Bird Milestone Badge" 
+                <span
+                  title="Early Bird Milestone Badge"
                   className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 border border-amber-500/30 px-2.5 py-0.5 text-xs font-bold text-amber-400"
                 >
                   <Sun className="h-3 w-3" />
@@ -330,41 +363,62 @@ export default async function PublicProfilePage({
             </h1>
             <CopyLinkButton url={profileUrl} />
           </div>
-          <p className="mt-2 text-[var(--muted-foreground)]">
+
+          <p className="mt-1 text-[var(--muted-foreground)]">
             GitHub activity and coding stats
           </p>
-          {profile.publicGists > 0 && (
-            <div className="mt-3 flex flex-wrap items-center gap-2">
+
+          {/* Member since + View on GitHub */}
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-[var(--muted-foreground)]">
+            {memberSinceFormatted && (
+              <span>Member since {memberSinceFormatted}</span>
+            )}
+            <a
+              href={githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] bg-[var(--control)] px-3 py-1 text-xs font-medium text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)] hover:border-[var(--accent)]"
+            >
+              <svg viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5" aria-hidden="true">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+              </svg>
+              View on GitHub
+            </a>
+            {profile.publicGists > 0 && (
               <a
                 href={gistsUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center rounded-full border border-[var(--border)] bg-[var(--control)] px-3 py-1.5 text-sm font-medium text-[var(--card-foreground)] transition-colors hover:bg-[var(--control)]/80 hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]/50"
+                className="inline-flex items-center rounded-full border border-[var(--border)] bg-[var(--control)] px-3 py-1 text-xs font-medium text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)]"
               >
                 {profile.publicGists} Gists
               </a>
-            </div>
-          )}
-          {compareHref && (
-            <Link
-              href={compareHref}
-              className="primary-button mt-4 inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
-            >
-              Compare with me
-            </Link>
-          )}
-          {!loggedInUsername && (
-            <Link
-              href={signInToCompareHref}
-              className="secondary-button mt-4 inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
-            >
-              Log in to compare
-            </Link>
-          )}
+            )}
+          </div>
+
+          {/* Compare buttons */}
+          <div className="mt-3 flex flex-wrap gap-2">
+            {compareHref && (
+              <Link
+                href={compareHref}
+                className="primary-button inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
+              >
+                Compare with me
+              </Link>
+            )}
+            {!loggedInUsername && (
+              <Link
+                href={signInToCompareHref}
+                className="secondary-button inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
+              >
+                Log in to compare
+              </Link>
+            )}
+          </div>
         </div>
-        <div className="flex items-center gap-3">
-        {/* Download stats card button — client component */}
-        <div className="flex flex-wrap items-center gap-3">
+
+        {/* Stats card download */}
+        <div className="shrink-0">
           <StatsCard
             username={profile.username}
             avatarUrl={avatarUrl}
@@ -374,9 +428,9 @@ export default async function PublicProfilePage({
             topRepo={topRepo}
           />
         </div>
-        </div>
       </div>
 
+      {/* Share section */}
       <div className="mb-8">
         <ShareProfileSection
           username={profile.username}
@@ -385,15 +439,35 @@ export default async function PublicProfilePage({
         />
       </div>
 
-      {/* Row 1: Contribution graph + Streak */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-2">
-          <PublicContributionGraph data={profile.contributions} />
+      {/* Row 1: Contribution graph + Streak (gated by public_widgets) */}
+      {(showContributions || showStreak) && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {showContributions && (
+            <div className="lg:col-span-2">
+              <PublicContributionGraph data={profile.contributions} />
+            </div>
+          )}
+          {showStreak && (
+            <div className={showContributions ? "" : "lg:col-span-3"}>
+              <PublicStreakTracker streak={profile.streak} />
+            </div>
+          )}
         </div>
-        <div className="flex flex-col gap-6">
-          <PublicStreakTracker streak={profile.streak} />
+      )}
+
+      {/* Languages (gated) */}
+      {showLanguages && profile.topLanguages.length > 0 && (
+        <div className="mt-6">
+          <PublicLanguageBreakdown languages={profile.topLanguages} />
         </div>
-      </div>
+      )}
+
+      {/* Pull Requests (gated) */}
+      {showPRs && (
+        <div className="mt-6">
+          <PublicPRCount pullRequests={profile.pullRequests} />
+        </div>
+      )}
 
       {/* Custom Spotlight Repositories */}
       {profile.spotlightRepos?.length ? (
@@ -412,12 +486,12 @@ export default async function PublicProfilePage({
         </div>
       )}
 
-      {/* Row 2: Top repos */}
+      {/* Top repos */}
       <div className="mt-6">
         <PublicTopRepos repos={profile.repos} />
       </div>
 
-      {/* Row 3: GitHub achievements */}
+      {/* GitHub achievements */}
       <div className="mt-6">
         <GitHubAchievements
           achievements={profile.achievements}
@@ -425,9 +499,24 @@ export default async function PublicProfilePage({
         />
       </div>
 
-      {/* Row 4: Get your badge */}
+      {/* Get your badge */}
       <div className="mt-6">
         <BadgeSection username={profile.username} />
+      </div>
+
+      {/* Powered by DevTrack footer badge */}
+      <div className="mt-10 flex justify-center">
+        <a
+          href="https://devtrack-delta.vercel.app"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--card)] px-4 py-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] hover:border-[var(--accent)]"
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor" className="h-3.5 w-3.5 text-[var(--accent)]" aria-hidden="true">
+            <path d="M13 10V3L4 14h7v7l9-11h-7z" />
+          </svg>
+          Powered by DevTrack
+        </a>
       </div>
     </div>
     </ProfileThemeWrapper>
@@ -557,6 +646,50 @@ function PublicStreakTracker({ streak }: { streak: any }) {
             )}
           </div>
         ))}
+      </div>
+    </div>
+  );
+}
+
+function PublicLanguageBreakdown({
+  languages,
+}: {
+  languages: Array<{ name: string; count: number; percentage: number }>;
+}) {
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-[var(--shadow-soft)]">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)]">
+        Top Languages
+      </h2>
+      <div className="space-y-3">
+        {languages.map((lang) => (
+          <div key={lang.name}>
+            <div className="flex items-center justify-between text-sm mb-1">
+              <span className="font-medium text-[var(--card-foreground)]">{lang.name}</span>
+              <span className="text-[var(--muted-foreground)]">{lang.percentage}%</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-[var(--control)]">
+              <div
+                className="h-full rounded-full bg-[var(--accent)] transition-all duration-500"
+                style={{ width: `${lang.percentage}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PublicPRCount({ pullRequests }: { pullRequests: number }) {
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-[var(--shadow-soft)]">
+      <h2 className="mb-2 text-lg font-semibold text-[var(--card-foreground)]">
+        Pull Requests
+      </h2>
+      <div className="flex items-end gap-2">
+        <span className="text-4xl font-bold text-[var(--accent)]">{pullRequests.toLocaleString()}</span>
+        <span className="mb-1 text-sm text-[var(--muted-foreground)]">total PRs authored</span>
       </div>
     </div>
   );

--- a/src/lib/public-profile-data.ts
+++ b/src/lib/public-profile-data.ts
@@ -38,11 +38,14 @@ export interface WeeklyGoalProgress {
   percentage: number;
 }
 
+export type PublicWidgetKey = "streak" | "contributions" | "languages" | "prs";
+
 export interface PublicProfileData {
   username: string;
   bio: string | null;
   isSponsor: boolean;
   publicGists: number;
+  memberSince: string | null;
   repos: TopRepo[];
   contributions: ContributionData;
   streak: StreakData;
@@ -53,6 +56,7 @@ export interface PublicProfileData {
   spotlightRepos?: PinnedRepoDetails[];
   contributionMilestones?: { label: string; achievedAt: string | null }[];
   weeklyGoalProgress: WeeklyGoalProgress | null;
+  publicWidgets: PublicWidgetKey[];
 }
 
 async function ghFetch(url: string, token?: string): Promise<Response> {
@@ -332,11 +336,30 @@ export async function fetchPublicProfile(
     .order("streak_count", { ascending: false })
     .limit(5);
 
+  // Fetch public_widgets preference (added by 20260608000000 migration; falls back gracefully)
+  let publicWidgets: PublicWidgetKey[] = ["streak", "contributions"];
+  try {
+    const { data: widgetsRow } = await supabaseAdmin
+      .from("users")
+      .select("public_widgets")
+      .eq("id", user.id)
+      .single();
+    if (widgetsRow?.public_widgets && Array.isArray(widgetsRow.public_widgets)) {
+      const valid: PublicWidgetKey[] = ["streak", "contributions", "languages", "prs"];
+      publicWidgets = (widgetsRow.public_widgets as string[]).filter(
+        (w): w is PublicWidgetKey => valid.includes(w as PublicWidgetKey)
+      );
+    }
+  } catch {
+    // Column may not exist yet; use defaults
+  }
+
   return {
     username: user.github_login,
     bio: user.bio ?? null,
     isSponsor: user.is_sponsor ?? false,
     publicGists,
+    memberSince: user.created_at ?? null,
     repos,
     contributions,
     streak,
@@ -350,5 +373,6 @@ export async function fetchPublicProfile(
       achievedAt: m.achieved_at ?? null,
     })),
     weeklyGoalProgress,
+    publicWidgets,
   };
 }

--- a/supabase/migrations/20260608000000_add_public_widgets.sql
+++ b/supabase/migrations/20260608000000_add_public_widgets.sql
@@ -3,7 +3,8 @@
 -- Default shows streak and contributions; languages and PRs are opt-in.
 ALTER TABLE users
   ADD COLUMN IF NOT EXISTS public_widgets jsonb NOT NULL DEFAULT '["streak","contributions"]'::jsonb;
-
+ 
 COMMENT ON COLUMN users.public_widgets IS
   'Array of widget keys the user wants visible on their public /u/[username] page. '
   'Allowed values: "streak", "contributions", "languages", "prs".';
+ 

--- a/supabase/migrations/20260608000000_add_public_widgets.sql
+++ b/supabase/migrations/20260608000000_add_public_widgets.sql
@@ -1,0 +1,9 @@
+-- Add public_widgets jsonb column to users table
+-- This stores which widgets the user has opted to show on their public profile.
+-- Default shows streak and contributions; languages and PRs are opt-in.
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS public_widgets jsonb NOT NULL DEFAULT '["streak","contributions"]'::jsonb;
+
+COMMENT ON COLUMN users.public_widgets IS
+  'Array of widget keys the user wants visible on their public /u/[username] page. '
+  'Allowed values: "streak", "contributions", "languages", "prs".';


### PR DESCRIPTION
## Summary
Implements the shareable public profile page at `/u/[username]` with opt-in public stats as described in #2117.

Closes #2117

---
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---
## Changes Made
- Added `public_widgets` jsonb column migration with default `["streak", "contributions"]`
- Updated settings API route to handle `public_widgets` in GET and PATCH with graceful tier fallback
- Updated `public-profile-data.ts` to expose `PublicWidgetKey` type, `memberSince`, and `publicWidgets` fields
- Updated public profile page to show GitHub avatar, member-since date, View on GitHub link, language breakdown, PR count, and Powered by DevTrack footer badge
- Updated settings page to add widget selector checkboxes inside the Public Profile card

---
## How to Test
1. Enable Public Profile in `/dashboard/settings`
2. Select which widgets to show using the new checkboxes and click Save
3. Visit `/u/[your-github-username]` and verify only selected widgets appear
4. Disable public profile and visit the same URL and verify 404 page appears
5. Call `GET /api/public/[username]` without auth and verify it returns stats

---
## Screenshots (if UI change)
N/A

---
## Checklist
- [x] Linked issue in summary
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---
## Accessibility Checklist
- [x] Proper keyboard navigation tested
- [x] Responsive UI verified
- [x] Accessibility labels added where needed

---
## Additional Notes
The `public_widgets` column falls back gracefully if the migration has not been run yet so no breaking changes for existing deployments.
