### PR TITLE
fix(security): enable RLS on daily_notes and use stable users.id as user_id

### DIFF
--- a/src/app/api/daily-note/route.ts
+++ b/src/app/api/daily-note/route.ts
@@ -1,16 +1,21 @@
 import { NextResponse, NextRequest } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
-import { getToken } from "next-auth/jwt";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { resolveAppUser } from "@/lib/resolve-user";
+
+export const dynamic = "force-dynamic";
+
+async function getAppUserId(req: NextRequest): Promise<string | null> {
+  const session = await getServerSession(authOptions);
+  if (!session?.githubId) return null;
+  const user = await resolveAppUser(session.githubId, session.githubLogin);
+  return user?.id ?? null;
+}
 
 export async function GET(req: NextRequest) {
   try {
-    const token = await getToken({
-      req,
-      secret: process.env.NEXTAUTH_SECRET,
-    });
-
-    const userId = token?.githubId;
-
+    const userId = await getAppUserId(req);
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -30,7 +35,6 @@ export async function GET(req: NextRequest) {
       .single();
 
     if (todayError && todayError.code !== "PGRST116") {
-      console.error("Failed to fetch today's daily note:", todayError);
       return NextResponse.json(
         { error: "Failed to fetch daily notes" },
         { status: 500 }
@@ -45,7 +49,6 @@ export async function GET(req: NextRequest) {
       .single();
 
     if (yesterdayError && yesterdayError.code !== "PGRST116") {
-      console.error("Failed to fetch yesterday's daily note:", yesterdayError);
       return NextResponse.json(
         { error: "Failed to fetch daily notes" },
         { status: 500 }
@@ -63,13 +66,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const token = await getToken({
-      req,
-      secret: process.env.NEXTAUTH_SECRET,
-    });
-
-    const userId = token?.githubId;
-
+    const userId = await getAppUserId(req);
     if (!userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }

--- a/supabase/migrations/20260608000000_add_daily_notes_rls.sql
+++ b/supabase/migrations/20260608000000_add_daily_notes_rls.sql
@@ -1,0 +1,32 @@
+-- Migration: enable Row Level Security on daily_notes and align user_id to users.id
+--
+-- The daily_notes table was created without RLS in 20260515000002_add_daily_notes.sql.
+-- This migration:
+--   1. Enables RLS so the table is protected from direct client access by default.
+--   2. Adds the four standard CRUD policies matching the pattern used by daily_focus.
+--
+-- NOTE: The API route (src/app/api/daily-note/route.ts) has been updated in the same
+-- PR to resolve users.id (a stable UUID) via resolveAppUser() instead of storing the
+-- raw GitHub numeric ID. Existing rows that used the GitHub numeric ID as user_id will
+-- no longer be matched by the updated API, effectively orphaning them. This is
+-- acceptable for daily notes (ephemeral, low-stakes data) and avoids a risky in-place
+-- data migration. A future cleanup migration can delete orphaned rows if needed.
+
+ALTER TABLE daily_notes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own daily_notes"
+  ON daily_notes FOR SELECT
+  USING (auth.uid()::text = user_id);
+
+CREATE POLICY "Users can insert own daily_notes"
+  ON daily_notes FOR INSERT
+  WITH CHECK (auth.uid()::text = user_id);
+
+CREATE POLICY "Users can update own daily_notes"
+  ON daily_notes FOR UPDATE
+  USING (auth.uid()::text = user_id)
+  WITH CHECK (auth.uid()::text = user_id);
+
+CREATE POLICY "Users can delete own daily_notes"
+  ON daily_notes FOR DELETE
+  USING (auth.uid()::text = user_id);


### PR DESCRIPTION
## Summary

- Adds a new migration (`20260608000000_add_daily_notes_rls.sql`) that enables Row Level Security on the `daily_notes` table and creates four CRUD policies matching the pattern already used by `daily_focus`
- Updates `src/app/api/daily-note/route.ts` to resolve the stable Supabase UUID (`users.id`) via `resolveAppUser()` instead of writing the raw GitHub numeric ID, which is mutable and can be recycled by GitHub for deleted accounts
- Switches the route from `getToken` to `getServerSession`, consistent with every other API route in the codebase
- Adds `export const dynamic = "force-dynamic"` which was missing from this route

Closes #2210

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- `supabase/migrations/20260608000000_add_daily_notes_rls.sql` — new migration: enables RLS, adds SELECT / INSERT / UPDATE / DELETE policies
- `src/app/api/daily-note/route.ts` — resolves `users.id` UUID via `resolveAppUser()`, switches to `getServerSession`, removes stray `console.error` calls, adds `force-dynamic`

---

## How to Test

1. Apply the migration to your local Supabase instance (`supabase db push` or run the SQL manually in the Supabase SQL editor).
2. Verify in the Supabase Dashboard → Table Editor → `daily_notes` that RLS is shown as enabled.
3. Start the dev server (`pnpm dev`) and navigate to the daily notes widget on the dashboard.
4. Create a note — it should save and reload without errors.
5. Confirm via the Supabase Dashboard that the saved row's `user_id` is now a UUID (matching `users.id`) rather than a raw GitHub numeric ID.

---

## Screenshots (if UI change)

No UI changes.

---

## Checklist

- [x] Linked issue in summary (`Closes #2210`)
- [x] `pnpm run lint` passes (no new errors introduced)
- [x] No new TypeScript errors in changed files (`pnpm run type-check`)
- [x] Self-reviewed the diff
- [ ] Added/updated tests if applicable

---

## Accessibility Checklist

- [x] No UI changes — not applicable

---

## Additional Notes

The migration includes a note explaining that existing rows (which stored the GitHub numeric ID in `user_id`) will be orphaned after this change. This is intentional and acceptable for daily notes, which are ephemeral and low-stakes. A follow-up cleanup migration can remove orphaned rows if needed.