### PR TITLE
fix(api): replace in-memory rate limiter in ai-insights with Upstash Redis

### DIFF
--- a/src/app/api/ai-insights/route.ts
+++ b/src/app/api/ai-insights/route.ts
@@ -9,11 +9,21 @@ import {
   computeTrends,
   DeveloperMetrics,
 } from "@/lib/ai-mentor";
+import {
+  upstashRateLimitFixedWindow,
+  getUpstashConfig,
+} from "@/lib/upstash-rest";
+import { createMemoryFixedWindowRateLimiter } from "@/lib/rate-limit";
 
-const aiInsightsRateLimit = new Map<
-  string,
-  { count: number; resetTime: number }
->();
+const AI_INSIGHTS_LIMIT = 5;
+const AI_INSIGHTS_WINDOW_SECONDS = 60 * 60; // 1 hour
+
+// In-memory fallback used only when Upstash Redis is not configured.
+const memoryLimiter = createMemoryFixedWindowRateLimiter({
+  windowMs: AI_INSIGHTS_WINDOW_SECONDS * 1000,
+  pruneIntervalMs: AI_INSIGHTS_WINDOW_SECONDS * 1000,
+  maxEntries: 10_000,
+});
 
 export const dynamic = "force-dynamic";
 
@@ -71,10 +81,6 @@ export async function GET(request: Request) {
 
   const userId = user.id;
 
-  const currentTime = Date.now();
-  const WINDOW_MS = 60 * 60 * 1000;
-  const MAX_REQUESTS = 5;
-
   const { searchParams } = new URL(request.url);
   const rawType = searchParams.get("type") ?? "weekly_summary";
 
@@ -105,26 +111,38 @@ export async function GET(request: Request) {
   }
 
   // No valid cache — enforce the rate limit only when a fresh generation is needed.
-  let existing = aiInsightsRateLimit.get(userId);
-  if (!existing || currentTime > existing.resetTime) {
-    existing = { count: 0, resetTime: currentTime + WINDOW_MS };
-    aiInsightsRateLimit.set(userId, existing);
+  // Use Upstash Redis when configured (durable across serverless cold starts);
+  // fall back to an in-memory limiter for local development without Redis.
+  let rateLimitDenied = false;
+  let retryAfterSeconds = AI_INSIGHTS_WINDOW_SECONDS;
+
+  if (getUpstashConfig()) {
+    const result = await upstashRateLimitFixedWindow({
+      key: `ai-insights:${userId}`,
+      limit: AI_INSIGHTS_LIMIT,
+      windowSeconds: AI_INSIGHTS_WINDOW_SECONDS,
+    });
+    if (!result.allowed) {
+      rateLimitDenied = true;
+      retryAfterSeconds = result.retryAfter ?? AI_INSIGHTS_WINDOW_SECONDS;
+    }
+  } else {
+    const result = memoryLimiter.check(`ai-insights:${userId}`, AI_INSIGHTS_LIMIT);
+    if (!result.allowed) {
+      rateLimitDenied = true;
+      retryAfterSeconds = Math.max(result.reset - Math.floor(Date.now() / 1000), 1);
+    }
   }
 
-  if (existing.count >= MAX_REQUESTS) {
+  if (rateLimitDenied) {
     return NextResponse.json(
-      { error: "Rate limit exceeded" },
+      { error: "Rate limit exceeded. Try again later." },
       {
         status: 429,
-        headers: {
-          "Retry-After": String(
-            Math.ceil((existing.resetTime - currentTime) / 1000)
-          ),
-        },
+        headers: { "Retry-After": String(retryAfterSeconds) },
       }
     );
   }
-  existing.count += 1;
 
   const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
   const cookie = request.headers.get("cookie") ?? "";


### PR DESCRIPTION
## Summary

The `/api/ai-insights` endpoint enforced a 5-requests-per-hour rate limit using a module-level `Map`. In serverless environments (Vercel), each function invocation may run in a fresh container — the `Map` resets on every cold start, making the limit trivially bypassable and exposing the project's AI API keys to unbounded usage.

This PR replaces the ad-hoc `Map` with `upstashRateLimitFixedWindow()` — the same primitive already used by the metrics cache and other rate-limited routes. When Upstash Redis is not configured (local development), it falls back to `createMemoryFixedWindowRateLimiter` from the shared `src/lib/rate-limit.ts`, which is more robust than the hand-rolled `Map` logic it replaces.

The rate limit (5 requests per user per hour) is unchanged.

Closes #2212

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

- `src/app/api/ai-insights/route.ts`
  - Removed module-level `aiInsightsRateLimit` Map and all related inline logic
  - Added `upstashRateLimitFixedWindow` (Redis, primary) with `createMemoryFixedWindowRateLimiter` (in-memory, fallback) using `getUpstashConfig()` to detect which path to take
  - Extracted `AI_INSIGHTS_LIMIT` and `AI_INSIGHTS_WINDOW_SECONDS` constants for readability

---

## How to Test

**With Redis configured (`UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` set):**
1. Call `GET /api/ai-insights?type=weekly_summary` six times in quick succession.
2. The 6th call should return `429` with a `Retry-After` header.
3. Wait for the window to expire (or manually delete the key in Upstash) and confirm requests are accepted again.
4. Restart the Next.js server between requests 5 and 6 — the counter should persist (previously it would reset).

**Without Redis (local dev):**
1. Omit `UPSTASH_REDIS_REST_URL` from `.env.local`.
2. Repeat the same test — the in-memory fallback should enforce the limit within the same process lifetime.

---

## Screenshots (if UI change)

No UI changes.

---

## Checklist

- [x] Linked issue in summary (`Closes #2212`)
- [x] `pnpm run lint` passes (no new errors)
- [x] No new TypeScript errors in changed files
- [x] Self-reviewed the diff

---

## Accessibility Checklist

- [x] No UI changes — not applicable