### PR TITLE
fix(rooms): add input length validation and per-user room ownership cap

### DIFF
--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,8 +1,17 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { createRoom, getRoomsForUser } from '@/lib/supabase-rooms';
+import { supabaseAdmin } from '@/lib/supabase-admin';
 import { NextResponse } from 'next/server';
 import type { CreateRoomPayload } from '@/types/rooms';
+
+const MAX_ROOMS_PER_USER = 20;
+const MAX_NAME_LEN = 100;
+const MAX_DESCRIPTION_LEN = 500;
+
+// GitHub enforces username ≤ 39 chars and repo name ≤ 100 chars.
+const GITHUB_USERNAME_RE = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$|^[a-zA-Z0-9]$/;
+const GITHUB_REPO_RE = /^[a-zA-Z0-9._-]{1,100}$/;
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -11,8 +20,9 @@ export async function GET() {
   try {
     const rooms = await getRoomsForUser(session.user.name);
     return NextResponse.json(rooms);
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
@@ -20,13 +30,61 @@ export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.name)
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  const body: CreateRoomPayload = await req.json();
-  if (!body.name?.trim() || !body.repo_owner?.trim() || !body.repo_name?.trim())
-    return NextResponse.json({ error: 'name, repo_owner, and repo_name are required' }, { status: 400 });
+
+  let body: CreateRoomPayload;
   try {
-    const room = await createRoom(body, session.user.name);
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const name = body.name?.trim() ?? '';
+  const repoOwner = body.repo_owner?.trim() ?? '';
+  const repoName = body.repo_name?.trim() ?? '';
+  const description = body.description?.trim() ?? '';
+
+  if (!name)
+    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  if (name.length > MAX_NAME_LEN)
+    return NextResponse.json({ error: `name must be ${MAX_NAME_LEN} characters or fewer` }, { status: 400 });
+
+  if (!repoOwner)
+    return NextResponse.json({ error: 'repo_owner is required' }, { status: 400 });
+  if (!GITHUB_USERNAME_RE.test(repoOwner))
+    return NextResponse.json({ error: 'repo_owner must be a valid GitHub username (1–39 alphanumeric characters or hyphens, cannot start or end with a hyphen)' }, { status: 400 });
+
+  if (!repoName)
+    return NextResponse.json({ error: 'repo_name is required' }, { status: 400 });
+  if (!GITHUB_REPO_RE.test(repoName))
+    return NextResponse.json({ error: 'repo_name must be a valid GitHub repository name (1–100 characters, alphanumeric, hyphens, underscores, or dots)' }, { status: 400 });
+
+  if (description.length > MAX_DESCRIPTION_LEN)
+    return NextResponse.json({ error: `description must be ${MAX_DESCRIPTION_LEN} characters or fewer` }, { status: 400 });
+
+  // Enforce per-user room ownership cap.
+  const { count, error: countError } = await supabaseAdmin
+    .from('room_members')
+    .select('*', { count: 'exact', head: true })
+    .eq('github_username', session.user.name)
+    .eq('role', 'owner');
+
+  if (countError)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+
+  if ((count ?? 0) >= MAX_ROOMS_PER_USER)
+    return NextResponse.json(
+      { error: `You can own at most ${MAX_ROOMS_PER_USER} rooms` },
+      { status: 429 }
+    );
+
+  try {
+    const room = await createRoom(
+      { name, repo_owner: repoOwner, repo_name: repoName, description: description || undefined },
+      session.user.name
+    );
     return NextResponse.json(room, { status: 201 });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/components/rooms/CreateRoomModal.tsx
+++ b/src/components/rooms/CreateRoomModal.tsx
@@ -41,7 +41,7 @@ export default function CreateRoomModal({ onClose, onCreated }: Props) {
 
       onCreated(data);
       onClose();
-    } catch (err) {
+    } catch {
       setError('Failed to create room');
     } finally {
       setLoading(false);
@@ -62,6 +62,7 @@ export default function CreateRoomModal({ onClose, onCreated }: Props) {
               placeholder="e.g. Frontend Team"
               value={form.name}
               onChange={(e) => setForm({ ...form, name: e.target.value })}
+              maxLength={100}
               required
             />
           </div>
@@ -73,6 +74,9 @@ export default function CreateRoomModal({ onClose, onCreated }: Props) {
               placeholder="e.g. vercel"
               value={form.repo_owner}
               onChange={(e) => setForm({ ...form, repo_owner: e.target.value })}
+              maxLength={39}
+              pattern="[a-zA-Z0-9]([a-zA-Z0-9\-]{0,37}[a-zA-Z0-9])?|[a-zA-Z0-9]"
+              title="Valid GitHub username: 1–39 alphanumeric characters or hyphens, cannot start or end with a hyphen"
               required
             />
           </div>
@@ -84,6 +88,9 @@ export default function CreateRoomModal({ onClose, onCreated }: Props) {
               placeholder="e.g. next.js"
               value={form.repo_name}
               onChange={(e) => setForm({ ...form, repo_name: e.target.value })}
+              maxLength={100}
+              pattern="[a-zA-Z0-9._\-]{1,100}"
+              title="Valid GitHub repository name: 1–100 alphanumeric characters, hyphens, underscores, or dots"
               required
             />
           </div>
@@ -96,6 +103,7 @@ export default function CreateRoomModal({ onClose, onCreated }: Props) {
               placeholder="What is this room for?"
               value={form.description ?? ''}
               onChange={(e) => setForm({ ...form, description: e.target.value })}
+              maxLength={500}
             />
           </div>
 
@@ -120,7 +128,7 @@ export default function CreateRoomModal({ onClose, onCreated }: Props) {
         </form>
       </div>
     </div>
-    
+
     </>
   );
 }


### PR DESCRIPTION
## Summary

The `POST /api/rooms` handler only checked that the three required fields were non-empty. There were no maximum-length constraints on any field and no limit on how many rooms a single user could create, unlike the goals API which explicitly enforces `MAX_GOALS_PER_USER = 5`.

This PR adds server-side validation matching GitHub's documented constraints and caps room ownership at 20 per user, with matching `maxLength` and `pattern` attributes on the form inputs for immediate client-side feedback.

Closes #2213

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup

---

## Changes Made

**`src/app/api/rooms/route.ts`**
- `name`: required, ≤ 100 characters
- `repo_owner`: required, validates against GitHub username rules (1–39 chars, alphanumeric + hyphens, no leading/trailing hyphen)
- `repo_name`: required, validates against GitHub repository name rules (1–100 chars, alphanumeric + `_`, `-`, `.`)
- `description`: optional, ≤ 500 characters
- Enforces `MAX_ROOMS_PER_USER = 20` by counting owned rooms before insert; returns `429` when exceeded
- JSON parse wrapped in `try/catch` to return `400` on malformed input
- Removed `any` cast from error catch blocks

**`src/components/rooms/CreateRoomModal.tsx`**
- Added `maxLength={100}` on Room Name
- Added `maxLength={39}` + `pattern` + `title` on GitHub Repo Owner for native browser validation hint
- Added `maxLength={100}` + `pattern` + `title` on Repository Name
- Added `maxLength={500}` on Description
- Cleaned up unused catch binding

---

## How to Test

1. Open the **New Room** modal.
2. Try submitting a room name longer than 100 characters — the browser should prevent submission via the `maxLength` constraint.
3. Enter `my--repo` or `-bad` as the repo owner — the browser should show the `title` tooltip as a hint.
4. Via `curl` or DevTools, POST directly to `/api/rooms` with an overly long name — confirm `400` is returned with a descriptive message.
5. Create 20 rooms (or update `MAX_ROOMS_PER_USER` to 1 temporarily) — the 21st creation attempt should return `429` with the error message "You can own at most 20 rooms".

---

## Screenshots (if UI change)

No visual changes to the rendered form — only browser-native `maxLength` truncation and `pattern` validation tooltip added.

---

## Checklist

- [x] Linked issue in summary (`Closes #2213`)
- [x] `pnpm run lint` passes (no new errors)
- [x] No new TypeScript errors in changed files
- [x] Self-reviewed the diff

---

## Accessibility Checklist

- [x] `title` attributes on pattern-constrained inputs provide screen-reader-accessible format hints