### PR TITLE
Add theme selector to landing page

### DIFF
--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -644,7 +644,7 @@ function HeroSection() {
           </div>
           {/* Bento Content */}
           <div style={{ padding: 20 }}>
-          646 <div
+          <div
   style={{
     width: '100%',
     maxWidth: 380,

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -644,12 +644,7 @@ function HeroSection() {
           </div>
           {/* Bento Content */}
           <div style={{ padding: 20 }}>
-          <div
-  style={{
-    width: '100%',
-    maxWidth: 380,
-  }}
-><BentoGrid /></div>
+            <BentoGrid />
           </div>
         </div>
       </div>

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import Image from "next/image";
 import Link from 'next/link';
 import { Activity, GitPullRequest, Goal, Share2, Flame, FolderGit2, LogIn, LayoutDashboard, Target, type LucideIcon } from "lucide-react";
+import ThemeToggle from "@/components/ThemeToggle";
 
 /* ═══════════════════════════════════════════════════════════
    PUBLIC TYPES
@@ -618,7 +619,8 @@ function HeroSection() {
       </div>
 
       {/* Right: bento window frame */}
-      <div style={{ flex: '1 1 340px', display: 'flex', justifyContent: 'center', position: 'relative', zIndex: 2 }}>
+      <div style={{ flex: '1 1 340px', display: 'flex', flexDirection: 'column',alignItems: 'flex-end', gap: 24, position: 'relative', zIndex: 2 }}>
+        <ThemeToggle />
         <div style={{
           background: 'rgba(255,255,255,0.02)',
           border: '1px solid rgba(255,255,255,0.05)',
@@ -642,7 +644,12 @@ function HeroSection() {
           </div>
           {/* Bento Content */}
           <div style={{ padding: 20 }}>
-            <BentoGrid />
+          646 <div
+  style={{
+    width: '100%',
+    maxWidth: 380,
+  }}
+><BentoGrid /></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary



Closes #2255 

---

## Type of Change



- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed
Added a theme selector to the landing page, allowing users to preview and switch themes before signing in.
- Added ThemeToggle component to the landing page
- Reused existing theme persistence logic
- Verified theme persistence across page refreshes
- Verified theme persistence across route navigation


---

## Checklist


- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

- [ ] Keyboard navigation works correctly
- [ ] Color contrast meets WCAG AA standard
- [ ] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context

<!-- Anything else reviewers should know: trade-offs made, follow-up issues, related PRs, etc. Leave blank if none. -->