### PR TITLE
fix: show at least 1% progress for fractional goal completion

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -495,7 +495,7 @@ export default function GoalTracker() {
           {goals.map((goal) => {
             const pct =
               goal.current > 0
-                ? Math.max(1, Math.min(Math.round((goal.current / goal.target) * 100), 100))
+                ? (() => { if (!goal.target || goal.target <= 0) return 0; const raw = (goal.current / goal.target) * 100; if (raw <= 0) return 0; if (raw < 1) return 1; return Math.min(Math.round(raw), 100); })()
                 : 0;
             const isDeleting = deletingId === goal.id;
             const completed = goal.current >= goal.target;

--- a/src/lib/goals/share.ts
+++ b/src/lib/goals/share.ts
@@ -3,7 +3,7 @@ export function getGoalProgressPercent(current: number, target: number) {
     return 0;
   }
 
-  return Math.min(100, Math.max(0, Math.round((current / target) * 100)));
+  if (!target || target <= 0) return 0; const raw = (current / target) * 100; if (raw <= 0) return 0; if (raw < 1) return 1; return Math.min(Math.round(raw), 100);
 }
 
 export function buildPublicGoalSharePath(username: string, goalId: string) {


### PR DESCRIPTION
## Summary
Fix GoalTracker showing 0% progress for goals with fractional completion below 0.5%.

Closes #1895

---
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---
## What Changed
- `src/components/GoalTracker.tsx` line 498: replaced `Math.round()` with a guard that returns minimum 1% for any real progress, and 0% if target is missing or zero
- `src/lib/goals/share.ts` line 6: same fix applied to the shared progress calculation utility

---
## How to Test
1. Create a goal with a large target (e.g. 500 commits)
2. Set current progress to a small value (e.g. 2)
3. Check the progress bar

**Expected result:** Progress bar shows 1% instead of 0%

---
## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks