### PR TITLE
fix: shortcuts popup opens behind WrappedExperience section

### DIFF
--- a/src/components/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal.tsx
@@ -114,7 +114,7 @@ export default function ShortcutsModal({
       role="dialog"
       aria-modal="true"
       aria-labelledby="shortcuts-title"
-      className="absolute right-0 top-full z-50 mt-2 w-80 rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
+      className="absolute right-0 top-full z-[9999] mt-2 w-80 rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
     >
       <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
         <h2


### PR DESCRIPTION
## Summary
Fixes #1351

The keyboard shortcuts popup was appearing behind the "View Wrapped" section because its z-index (z-50) was lower than the WrappedExperience section's stacking context.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## What Changed
- `src/components/ShortcutsModal.tsx` line 117: changed `z-50` to `z-[9999]` so the modal always renders above all other page sections

## How to Test
1. Open the dashboard
2. Scroll down to the "View Wrapped" section
3. Press `?` to open the keyboard shortcuts popup

**Expected result:** Shortcuts popup appears fully visible above the Wrapped section instead of behind it

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks