### PR TITLE
fix: add maxLength to goal title input to prevent unbounded text

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -697,7 +697,7 @@ export default function GoalTracker() {
             id="goal-title"
             type="text"
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            onChange={(e) => setTitle(e.target.value)} maxLength={100}
             placeholder="Make 10 commits"
             required
             disabled={creating}


### PR DESCRIPTION
## Summary
Fixes #384

The goal title input had no character limit on the frontend, allowing users to type unlimited text which could break the UI layout and cause database issues.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## What Changed
- `src/components/GoalTracker.tsx` line 700: added `maxLength={100}` to the goal title input field to match the existing backend validation of MAX_TITLE_LEN = 100

## How to Test
1. Open the dashboard and navigate to Goal Tracker
2. Click to create a new goal
3. Try typing more than 100 characters in the title field

**Expected result:** Input stops accepting characters after 100

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks