### PR TITLE
fix: increase language color dot size for better visibility on retina displays

### DIFF
--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -190,8 +190,8 @@ export default function LanguageBreakdown() {
                 className="flex items-center gap-2 text-sm"
               >
                 <svg
-                  width="10"
-                  height="10"
+                  width="12"
+                  height="12"
                   viewBox="0 0 10 10"
                   className="shrink-0"
                   role="img"


### PR DESCRIPTION
## Summary
Fixes #1058

The colored dot indicators next to language names in the language breakdown widget used fixed 10px dimensions. On high-DPI (retina/HiDPI) displays, these dots appeared blurry and very small.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## What Changed
- `src/components/LanguageBreakdown.tsx` line 193: increased SVG dot width and height from 10 to 12 pixels for sharper rendering on retina displays

## How to Test
1. Open the dashboard on a retina/HiDPI display (MacBook, 4K monitor)
2. Scroll to the Language Breakdown widget
3. Check the colored dots next to each language name

**Expected result:** Dots appear crisp and clearly visible instead of blurry and tiny

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks