### PR TITLE
docs: move caching guidelines from README to docs/caching.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,59 +443,7 @@ Want to contribute? Pick an item below and open an issue or start a PR.
 ---
 
 
-## 📦 GSSoC Caching Guidelines Reference Manual
-
-Efficient caching improves performance, reduces server load, and enhances user experience in modern web applications.
-
----
-
-### API Response Caching
-
-Use caching for GET requests where data does not change frequently.
-
-Example:
-Cache-Control: public, max-age=300, stale-while-revalidate=600
-
-
----
-
-### Frontend Caching
-
-Use tools like React Query or SWR to cache API responses and reduce unnecessary network requests.
-
----
-
-### Server-Side Caching
-
-Use Redis or in-memory caching for:
-- expensive computations
-- repeated database queries
-- frequently accessed data
-
----
-
-### Static Asset Caching
-
-Enable long-term caching for static assets:
-Cache-Control: public, max-age=31536000, immutable
-
-
----
-
-### Cache Invalidation Strategy
-
-Always invalidate cache when underlying data changes using:
-- versioning
-- timestamps
-- manual invalidation
-
----
-
-### Best Practices
-
-- Do not cache sensitive data
-- Always define TTL (Time To Live)
-- Monitor cache hit/miss ratio for performance optimization
+For caching best practices used in this project, see [Caching Guidelines](docs/caching.md).
 
 ## Contributing
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,45 @@
+# Caching Guidelines
+
+Efficient caching improves performance, reduces server load, and enhances user experience in DevTrack.
+
+## API Response Caching
+
+Use caching for GET requests where data does not change frequently.
+
+```http
+Cache-Control: public, max-age=300, stale-while-revalidate=600
+```
+
+## Frontend Caching
+
+Use tools like **React Query** or **SWR** to cache API responses and reduce unnecessary network requests.
+
+## Server-Side Caching
+
+Use Redis or in-memory caching for:
+
+- Expensive computations
+- Repeated database queries
+- Frequently accessed data
+
+## Static Asset Caching
+
+Enable long-term caching for static assets:
+
+```http
+Cache-Control: public, max-age=31536000, immutable
+```
+
+## Cache Invalidation Strategy
+
+Always invalidate cache when underlying data changes using:
+
+- Versioning
+- Timestamps
+- Manual invalidation
+
+## Best Practices
+
+- Do not cache sensitive data
+- Always define TTL (Time To Live)
+- Monitor cache hit/miss ratio for performance optimization


### PR DESCRIPTION
## Summary

Moves the GSSoC Caching Guidelines section out of README.md into a dedicated 
docs/caching.md file. Replaces the bulky section in README with a clean link.

Closes #2274 




## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [X ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed
- Created `docs/caching.md` with full caching guidelines content
- Removed large caching section from `README.md`
- Added a one-line reference link in README pointing to `docs/caching.md`

## How to Test
1. Open README.md and find the section between Roadmap and Contributing
2. Verify the caching block is replaced with a single link
3. Click the link and confirm it opens docs/caching.md with full content

**Expected result:**
README is cleaner, caching guidelines are accessible via the link.

## Screenshots / Recordings
delete that whole section — no UI changes here.

## Checklist

<!-- Complete before requesting review. -->

- [X ] Linked the related issue above
- [X ] Self-reviewed my own diff
- [ ] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ X] Updated documentation / comments if behavior changed



CC @Priyanshu-byte-coder — please review and tag this for GSSoC 2026.


