### PR TITLE
fix: resolve double response body read in handleSync 

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -71,23 +71,25 @@ export function useGoalTracker() {
     try {
       const res = await fetch("/api/goals/sync", { method: "POST" });
       if (!res.ok) {
-        let msg = "Sync failed. Please try again.";
+        // Read the body exactly once — the Fetch API body stream can only be
+        // consumed once, so we must store the result before branching on status.
+        let errData: { error?: string } = {};
         try {
-          const errData = await res.json();
-          if (errData && errData.error) {
-            msg = errData.error;
-          }
-        } catch (e) {}
-        if (res.status === 401) {
-          msg = "Unauthorized. Please log in again.";
-        } else if (res.status === 502) {
-          msg = "GitHub sync failed: Expired token or missing repo scope.";
-        }
+          errData = await res.json();
+        } catch (_) {}
+
         if (res.status === 429) {
-          const data = await res.json();
-          setSyncError(data.error ?? "GitHub rate limit reached. Please try again later.");
+          setSyncError(
+            errData.error ?? "GitHub rate limit reached. Please try again later."
+          );
+        } else if (res.status === 401) {
+          setSyncError("Unauthorized. Please log in again.");
+        } else if (res.status === 502) {
+          setSyncError(
+            "GitHub sync failed: Expired token or missing repo scope."
+          );
         } else {
-          setSyncError("Failed to sync goals. Please try again.");
+          setSyncError(errData.error ?? "Sync failed. Please try again.");
         }
         return;
       }


### PR DESCRIPTION
## Description
This PR fixes a bug in the `handleSync` function where the fetch response body was being consumed twice when the API returned an HTTP `429 Too Many Requests` status code. 

Previously, the first `.json()` call inside the initial `try/catch` consumed the response stream, causing a subsequent `.json()` call in the `429` status check block to throw a `TypeError: body stream already read`. This swallowed the intended rate limit error message and resulted in a generic `"Network error. Failed to sync goals."` being shown to the user.

## Changes Made
- Refactored `handleSync` in `src/components/GoalTracker.tsx` to read the response body exactly once into an `errData` variable.
- Used the stored `errData` to properly branch on `res.status` (`429`, `401`, `502`, etc.) without re-reading the stream.
- Removed dead code (the unused `msg` variable).
- Ensured the fallback error message matches the existing `test/GoalTracker.test.ts` expectations (`"Sync failed. Please try again."`).

## Testing
- Verified that all unit tests in `test/GoalTracker.test.ts` pass successfully.
- Verified that TypeScript compilation (`tsc --noEmit`) passes with zero errors.

closes #2283
