### PR TITLE
fix: remove unused compare users param

### DIFF
--- a/src/app/compare/[users]/page.tsx
+++ b/src/app/compare/[users]/page.tsx
@@ -70,7 +70,6 @@ export async function generateMetadata({
 export default async function PublicProfileComparePage({
   params,
 }: { params: Promise<{ users: string }> }) {
-  const { users } = await params;
   const parsed = await parseUsers(params);
 
   if (!parsed) {


### PR DESCRIPTION
## Summary
- Removed the unused `users` destructuring from `src/app/compare/[users]/page.tsx`
- Kept `parseUsers(params)` as the single place that awaits and parses the route params

## Why
The page was awaiting `params` once to extract `users`, but that value was never used. `parseUsers(params)` already handles awaiting and decoding the `users` segment, so the extra line was dead code and added confusion.

## Testing
- Ran `npm.cmd run type-check`

Closes #2132 