### PR TITLE
fix(rooms): wire ?after= param to getRoomMessagesSince in messages GET route

### DIFF
--- a/src/app/api/rooms/[roomId]/messages/route.ts
+++ b/src/app/api/rooms/[roomId]/messages/route.ts
@@ -1,6 +1,6 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { getRoomById, getRoomMessages, sendRoomMessage } from '@/lib/supabase-rooms';
+import { getRoomById, getRoomMessages, getRoomMessagesSince, sendRoomMessage } from '@/lib/supabase-rooms';
 import { validateTextInput } from '@/lib/sanitize';
 import { NextResponse } from 'next/server';
 
@@ -15,8 +15,11 @@ export async function GET(
   const room = await getRoomById(roomId, session.user.name);
   if (!room) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   const url = new URL(req.url);
+  const after = url.searchParams.get('after') ?? undefined;
   const before = url.searchParams.get('before') ?? undefined;
-  const messages = await getRoomMessages(roomId, 50, before);
+  const messages = after
+    ? await getRoomMessagesSince(roomId, after)
+    : await getRoomMessages(roomId, 50, before);
   return NextResponse.json(messages);
 }
 


### PR DESCRIPTION
## Summary

The room chat polling loop in `MessageFeed` sends `?after=<timestamp>` to fetch only messages newer than the last seen one. The GET handler was reading `?before=` exclusively, so `after` was silently ignored — every poll returned the same last-50 messages instead of only the new ones. This PR wires the `after` param to the already-existing `getRoomMessagesSince` helper.

Closes #2301

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---

## What Changed

- `src/app/api/rooms/[roomId]/messages/route.ts` — added `after` param read from query string; branched to `getRoomMessagesSince(roomId, after)` for incremental polls and kept `getRoomMessages(roomId, 50, before)` for initial loads and reverse pagination
- Added `getRoomMessagesSince` to the import from `@/lib/supabase-rooms`

---

## How to Test

1. Open a collaboration room that already has some messages.
2. Open the browser Network tab and filter by the room's message endpoint.
3. In another browser session (same room), send a new message.
4. Observe the polling request: the response should now contain **only the new message**, not the full history.
5. Confirm the new message appears in the first session within ~5 seconds.

**Expected result:** Each poll response returns only messages sent after the last-known timestamp. Initial page load still returns the most recent 50 messages as before.

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] No TypeScript errors (`pnpm run type-check` — errors shown are all pre-existing)
- [x] No new tests required — the logic change is a direct routing fix to an already-tested helper (`getRoomMessagesSince` has existing coverage in `test/rooms-messages.test.ts`)