### PR TITLE
fix: prevent leaderboard streak truncation from commit history limits

### DIFF
--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -242,6 +242,42 @@ async function fetchCommitStats(username: string, since?: string) {
   }>(`/search/commits?${query}`);
 }
 
+async function fetchAllCommitDatesForStreak(
+  username: string,
+  since: string
+): Promise<string[]> {
+  const PER_PAGE = 100;
+  const seenDays = new Set<string>();
+  let page = 1;
+
+  while (true) {
+    const query = new URLSearchParams({
+      q: `author:${username} author-date:>=${since}`,
+      per_page: String(PER_PAGE),
+      page: String(page),
+      sort: "author-date",
+      order: "desc",
+    });
+
+    const data = await fetchGitHubJson<{
+      total_count: number;
+      items: Array<{ commit: { author: { date: string } } }>;
+    }>(`/search/commits?${query}`);
+
+    if (!data || data.items.length === 0) break;
+
+    for (const item of data.items) {
+      seenDays.add(item.commit.author.date.slice(0, 10));
+    }
+
+    // Stop when we have fetched all available results
+    if (page * PER_PAGE >= data.total_count || data.items.length < PER_PAGE) break;
+    page++;
+  }
+
+  return Array.from(seenDays);
+}
+
 async function fetchPrCount(username: string, since?: string): Promise<number> {
   const query = new URLSearchParams({
     q: [
@@ -286,15 +322,13 @@ export async function buildLeaderboard(
     safeUsers,
     USER_CONCURRENCY,
     async (user) => {
-      const [monthlyCommits, streakCommits, prs] = await Promise.all([
+      const [monthlyCommits, streakDates, prs] = await Promise.all([
         fetchCommitStats(user.github_login, periodStart),
-        fetchCommitStats(user.github_login, streakStart),
+        fetchAllCommitDatesForStreak(user.github_login, streakStart),
         fetchPrCount(user.github_login, periodStart),
       ]);
 
-      const streak = calculateCurrentStreak(
-        streakCommits?.items.map((item) => item.commit.author.date) ?? []
-      );
+      const streak = calculateCurrentStreak(streakDates);
       const commits = monthlyCommits?.total_count ?? 0;
       const score = streak * 5 + commits + prs * 3;
 


### PR DESCRIPTION
## Summary

Fixes leaderboard streak calculations for high-volume contributors by ensuring streak reconstruction uses the complete contribution history available within the evaluation period instead of a potentially truncated commit dataset.

Closes #2277

---

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---

## What Changed

* Updated leaderboard contribution retrieval logic to avoid streak calculations being based on an incomplete commit history.
* Ensured streak reconstruction processes all contribution data available within the configured evaluation window.
* Preserved existing leaderboard behavior while improving accuracy for high-activity contributors.

---

## How to Test

1. Run leaderboard synchronization for a user with a large number of commits within the evaluation period.
2. Verify that all contribution history within the configured window is included during streak calculation.
3. Compare the calculated streak with the user's actual contribution activity.

**Expected result:**

* Streak values accurately reflect the user's complete contribution history.
* High-volume contributors receive the correct streak value.
* Leaderboard rankings remain consistent regardless of contribution volume.

---

## Screenshots / Recordings

Not applicable (backend logic change).

---

## Checklist

* [x] Linked the related issue above
* [x] Self-reviewed my own diff
* [x] No unnecessary `console.log`, debug code, or commented-out blocks
* [x] `npm run lint` passes locally
* [x] No TypeScript errors (`npm run type-check`)
* [ ] Added or updated tests where applicable
* [ ] Updated documentation / comments if behavior changed

---

## Additional Context

This change focuses only on leaderboard streak computation and contribution-history aggregation. No UI components, styling, or unrelated functionality were modified.
