### PR TITLE
fix(ui): add visual active-indicator underline to ContributionGraph chart toggle (#213)

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -612,13 +612,19 @@ export default function ContributionGraph() {
                   type="button"
                   onClick={() => setChartType(chart.key)}
                   aria-pressed={chartType === chart.key}
-                  className={`px-3 py-1 rounded-md transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+                  className={`relative px-3 py-1 rounded-md transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                     chartType === chart.key
-                      ? "bg-[var(--accent)] text-[var(--background)]"
+                      ? "bg-[var(--accent)] text-[var(--background)] font-semibold"
                       : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
                   }`}
                 >
                   {chart.label}
+                  {chartType === chart.key && (
+                    <span
+                      aria-hidden="true"
+                      className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-[3px] h-0.5 w-4 rounded-full bg-[var(--background)]"
+                    />
+                  )}
                 </button>
               ))}
             </div>


### PR DESCRIPTION
## Summary
Adds a 2px accent-colored underline indicator below the active chart-type button (Bar/Line/Area) in ContributionGraph, combined with font-semibold for accessibility. Color is now supplementary, not the sole indicator.

Closes #213

---

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed
- `src/components/ContributionGraph.tsx`: Added `relative` positioning to chart toggle buttons
- Added conditional `<span>` underline (`h-0.5 w-4 rounded-full bg-[var(--accent)]`) below active button label
- Added `font-semibold` to active button so color is not the sole visual indicator (WCAG AA)
- `aria-hidden="true"` on the span — decorative only, `aria-pressed` already handles screen readers

---

## How to Test
1. Run `npm run dev` and open `http://localhost:3000`
2. Sign in with GitHub and go to the dashboard
3. Scroll to the ContributionGraph section
4. Click Bar / Line / Area buttons one at a time

**Expected result:** The active button shows a short underline below its label + bold text. Inactive buttons have no underline.

---

## Screenshots / Recordings
| Before | After |
|--------|-------|
| Active button: only background color change | Active button: background + bold text + 2px underline indicator |

<img width="1267" height="700" alt="image" src="https://github.com/user-attachments/assets/5b389335-43e3-4533-8392-7a456f493c3e" />


---

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)
- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context
Single-file change in ContributionGraph.tsx. The underline uses `bg-[var(--background)]` to contrast against the accent-colored active button background, making it visible in both light and dark themes.