### PR TITLE
fix: render shortcuts and notification popups via React portals

### DIFF
--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -12,6 +12,7 @@ export default function KeyboardShortcuts() {
   const { theme, themeDefinition, toggleTheme } = useTheme();
   const keyboardToggleRef = useRef(false);
   const shortcutsRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (keyboardToggleRef.current && theme !== undefined) {
@@ -82,6 +83,7 @@ export default function KeyboardShortcuts() {
       </div>
 
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         className="inline-flex h-10 items-center gap-1.5 rounded-full border border-[var(--border)] bg-[var(--card)] px-3 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--control)] hover:text-[var(--card-foreground)]"
@@ -95,7 +97,7 @@ export default function KeyboardShortcuts() {
         </kbd>
         <span>Shortcuts</span>
       </button>
-      <ShortcutsModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <ShortcutsModal isOpen={isOpen} onClose={() => setIsOpen(false)} anchorRef={triggerRef} />
     </div>
   );
 }

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 
 import { useNotifications } from "@/hooks/useNotifications";
@@ -10,6 +11,11 @@ const EMPTY_NOTIFICATIONS: any[] = [];
 export default function NotificationBell() {
   const { data, loading, error, refetch } = useNotifications();
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => { setMounted(true); }, []);
 
 
   const notifications = data?.notifications ?? EMPTY_NOTIFICATIONS;
@@ -22,6 +28,25 @@ export default function NotificationBell() {
   }, [unreadCountFromApi]);
 
   const [open, setOpen] = useState(false);
+
+  // Recompute anchor position whenever the dropdown opens or window resizes
+  useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const calculate = () => {
+      const rect = triggerRef.current!.getBoundingClientRect();
+      setDropdownPos({
+        top: rect.bottom + 8,
+        right: window.innerWidth - rect.right,
+      });
+    };
+    calculate();
+    window.addEventListener("resize", calculate);
+    window.addEventListener("scroll", calculate, true);
+    return () => {
+      window.removeEventListener("resize", calculate);
+      window.removeEventListener("scroll", calculate, true);
+    };
+  }, [open]);
 
 
 
@@ -120,6 +145,7 @@ export default function NotificationBell() {
 
       {/* Bell button */}
       <button
+        ref={triggerRef}
         type="button"
         onClick={handleOpen}
         className="relative rounded-lg p-2 text-[var(--muted-foreground)] hover:bg-[var(--control)] hover:text-[var(--card-foreground)] transition-all hover:opacity-90 active:scale-95"
@@ -150,9 +176,19 @@ export default function NotificationBell() {
         )}
       </button>
 
-      {/* dropdown */}
-      {open && (
-        <div className="absolute right-0 top-full mt-2 w-80 rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl z-50">
+      {/* dropdown via portal so it escapes overflow:hidden ancestors */}
+      {open && mounted && createPortal(
+        <div
+          ref={dropdownRef}
+          style={{
+            position: "fixed",
+            top: dropdownPos?.top ?? 64,
+            right: dropdownPos?.right ?? 16,
+            zIndex: 9999,
+            width: 320,
+          }}
+          className="rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
+        >
           <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border)]">
             <h3 className="text-sm font-semibold text-[var(--card-foreground)]">
               Notifications
@@ -186,7 +222,7 @@ export default function NotificationBell() {
             </div>
           </div>
 
-          <ul className="max-h-72 overflow-y-auto divide-y divide-[var(--border)]  scrollbar-thin">
+          <ul className="max-h-72 overflow-y-auto divide-y divide-[var(--border)] scrollbar-thin">
             {loading ? (
               <li className="px-4 py-6 text-center text-sm text-[var(--muted-foreground)]">
                 Loading notifications…
@@ -217,7 +253,8 @@ export default function NotificationBell() {
               ))
             )}
           </ul>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/src/components/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 interface ShortcutsModalProps {
   isOpen: boolean;
@@ -24,17 +25,42 @@ const SHORTCUTS: ShortcutItem[] = [
 export default function ShortcutsModal({
   isOpen,
   onClose,
-}: ShortcutsModalProps) {
+  anchorRef,
+}: ShortcutsModalProps & { anchorRef?: React.RefObject<HTMLElement | null> }) {
   const modalRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const [isMac, setIsMac] = useState(false);
+  const [position, setPosition] = useState<{ top: number; right: number } | null>(null);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    setMounted(true);
     if (typeof window !== "undefined" && typeof navigator !== "undefined") {
       setIsMac(/Mac|iPod|iPhone|iPad/.test(navigator.userAgent));
     }
   }, []);
+
+  // Recalculate position whenever the modal opens or the window resizes
+  useEffect(() => {
+    if (!isOpen || !anchorRef?.current) return;
+
+    const calculate = () => {
+      const rect = anchorRef.current!.getBoundingClientRect();
+      setPosition({
+        top: rect.bottom + 8,
+        right: window.innerWidth - rect.right,
+      });
+    };
+
+    calculate();
+    window.addEventListener("resize", calculate);
+    window.addEventListener("scroll", calculate, true);
+    return () => {
+      window.removeEventListener("resize", calculate);
+      window.removeEventListener("scroll", calculate, true);
+    };
+  }, [isOpen, anchorRef]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -106,15 +132,20 @@ export default function ShortcutsModal({
     };
   }, [isOpen, onClose]);
 
-  if (!isOpen) return null;
+  if (!isOpen || !mounted) return null;
 
-  return (
+  const style: React.CSSProperties = position
+    ? { position: "fixed", top: position.top, right: position.right }
+    : { position: "fixed", top: 64, right: 16 };
+
+  const modal = (
     <div
       ref={modalRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="shortcuts-title"
-      className="absolute right-0 top-full z-[9999] mt-2 w-80 rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
+      style={{ ...style, zIndex: 9999, width: 320 }}
+      className="rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
     >
       <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
         <h2
@@ -130,7 +161,7 @@ export default function ShortcutsModal({
           className="rounded-lg p-1 text-[var(--muted-foreground)] transition-all hover:bg-[var(--control)] hover:text-[var(--card-foreground)] hover:opacity-90 active:scale-95"
           aria-label="Close shortcuts"
         >
-          x
+          ✕
         </button>
       </div>
 
@@ -161,4 +192,6 @@ export default function ShortcutsModal({
       </div>
     </div>
   );
+
+  return createPortal(modal, document.body);
 }


### PR DESCRIPTION
## Summary

Fixes the dashboard header popup clipping issue by rendering the **Keyboard Shortcuts modal** and **Notifications dropdown** through React Portals instead of within the header container.

Closes #2321

---

## Type of Change

* [x] 🐛 Bug fix (non-breaking change)

---

## What Changed

### Keyboard Shortcuts Modal

* Rendered the modal using `createPortal()` into `document.body`
* Switched positioning from in-container absolute positioning to viewport-based fixed positioning
* Added anchor-based positioning using `getBoundingClientRect()`
* Added resize and scroll listeners to keep the modal aligned with its trigger button
* Added mounted guard to prevent hydration issues

### Notifications Dropdown

* Applied the same portal-based rendering approach
* Added trigger reference and viewport-based positioning
* Increased overlay stacking priority using a dedicated z-index
* Preserved existing dismissal and interaction behavior

### Keyboard Shortcuts Trigger

* Added trigger reference and passed it to the modal for accurate positioning

---

## Root Cause

The dashboard header uses `overflow: hidden` for styling purposes. Since both popups were rendered as descendants of the header using `position: absolute`, they were clipped by the header's overflow boundary regardless of z-index.

Using React Portals moves the popup elements outside the header's DOM hierarchy, preventing clipping while preserving component state and event handling.

---

## How to Test

1. Open the Dashboard page.
2. Click the **Shortcuts** button.
3. Verify the Keyboard Shortcuts modal is fully visible and not clipped.
4. Click the **Notifications** bell icon.
5. Verify the notifications dropdown is fully visible.
6. Resize the browser window and confirm both overlays remain correctly positioned.
7. Scroll the page and verify positioning remains accurate.
8. Test outside-click and Escape-key dismissal.

### Expected Result

Both overlays render above all dashboard content without being clipped by the header container.

---

## Screenshots

### Before

* Keyboard Shortcuts modal partially hidden by dashboard header
* Notifications dropdown clipped by header boundary

<img width="2320" height="297" alt="image" src="https://github.com/user-attachments/assets/0f972458-46d5-4751-bc41-76ade3d6a7cc" />
<img width="2392" height="797" alt="prev" src="https://github.com/user-attachments/assets/cb0ae8e5-e5ca-41c6-8764-c83fc9cc96b5" />



### After

* Keyboard Shortcuts modal fully visible
* Notifications dropdown fully visible
* Proper overlay behavior across viewport sizes

<img width="2419" height="1025" alt="after-1" src="https://github.com/user-attachments/assets/f28d0b03-451d-41d1-b6d5-c577445702dd" />

<img width="1214" height="233" alt="image" src="https://github.com/user-attachments/assets/efcdba70-b0a9-4582-b185-9492b0ac2022" />


---

## Checklist

* [x] Linked related issue
* [x] Self-reviewed changes
* [x] No debug code or unnecessary changes
* [x] Lint passes locally
* [x] Type checking passes locally
* [x] No breaking API or behavioral changes
* [ ] Added tests (if applicable)

---

## Additional Notes

This change only affects how the overlays are rendered. Existing keyboard shortcuts, focus handling, accessibility attributes, and dismissal behavior remain unchanged.
