### PR TITLE
refactor: update DashboardHeader layout and z-index to improve visual…

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -215,10 +215,12 @@ export default function DashboardHeader() {
     : null;
 
   return (
-    <header className="relative mb-8 overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--card)]/95 p-4 shadow-[var(--shadow-soft)] backdrop-blur-md transition-all duration-300 hover:shadow-[var(--shadow-medium)] sm:p-5 md:p-6">
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[var(--accent)]/40 to-transparent" />
-      <div className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full bg-[var(--accent)]/10 blur-3xl" />
-      <div className="relative flex min-w-0 flex-col gap-5 md:flex-row md:items-end md:justify-between">
+    <header className="relative z-50 mb-8 rounded-3xl border border-[var(--border)] bg-[var(--card)]/95 p-4 shadow-[var(--shadow-soft)] backdrop-blur-md transition-all duration-300 hover:shadow-[var(--shadow-medium)] sm:p-5 md:p-6">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-3xl">
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[var(--accent)]/40 to-transparent" />
+        <div className="absolute -right-10 -top-12 h-32 w-32 rounded-full bg-[var(--accent)]/10 blur-3xl" />
+      </div>
+      <div className="relative z-10 flex min-w-0 flex-col gap-5 md:flex-row md:items-end md:justify-between">
 
         {/* Left Section */}
         <div className="min-w-0 pr-12 md:pr-0">


### PR DESCRIPTION
## Summary

This PR fixes a bug where the Keyboard Shortcuts modal was being clipped by the dashboard header and rendering behind adjacent page elements. By removing `overflow-hidden` from the header while introducing an isolated inner container for background gradients, the modal is now free to fully expand. Additionally, `z-50` was explicitly added to the header to ensure it layers above all surrounding content blocks.

Closes #2334

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **`src/components/DashboardHeader.tsx`**: 
  - Removed `overflow-hidden` from the top-level `<header>` wrapper so that absolute positioned dropdowns inside the navigation aren't clipped.
  - Added `z-50` to the `<header>` element to firmly establish its stacking context above adjacent dashboard cards.
  - Moved the glowing background `blur-3xl` gradient elements into an `absolute inset-0 overflow-hidden rounded-3xl` container. This preserves the visual design (so glow doesn't spill over the rounded corners of the header) while permitting dropdowns to freely overflow the header.
  - Added `z-10` to the header's core content wrapper so it stacks correctly over the new gradient layer.

---

## How to Test

1. Sign in to DevTrack.
2. Navigate to the Dashboard.
3. Click the "? Shortcuts" button in the top navigation.
4. Observe the Keyboard Shortcuts modal.

**Expected result:** The entire modal renders cleanly over all underlying page content without any bottom-edge clipping, visual overlap behind cards, or z-index struggles.

---

## Screenshots / Recordings

*N/A — Fixes layering, no new visual UI elements were added.*

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context

No extra dependencies were required; this was cleanly handled with basic DOM structure changes using Tailwind utilities.
