### PR TITLE
refactor: update DashboardHeader responsive breakpoints from md to lg…

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -218,10 +218,10 @@ export default function DashboardHeader() {
     <header className="relative mb-8 overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--card)]/95 p-4 shadow-[var(--shadow-soft)] backdrop-blur-md transition-all duration-300 hover:shadow-[var(--shadow-medium)] sm:p-5 md:p-6">
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[var(--accent)]/40 to-transparent" />
       <div className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full bg-[var(--accent)]/10 blur-3xl" />
-      <div className="relative flex min-w-0 flex-col gap-5 md:flex-row md:items-end md:justify-between">
+      <div className="relative z-10 flex min-w-0 flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
 
         {/* Left Section */}
-        <div className="min-w-0 pr-12 md:pr-0">
+        <div className="min-w-0 pr-12 lg:pr-0">
           <div className="mb-1 flex min-w-0 flex-wrap items-center gap-2">
             <div className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-[var(--accent)]/20 bg-[var(--accent)]/10 px-2.5 py-0.5 text-xs font-semibold text-[var(--accent)] transition-all duration-300">
               <span className="relative flex h-1.5 w-1.5">
@@ -287,8 +287,8 @@ export default function DashboardHeader() {
 
         {/* Right Section */}
         {/* Right Section */}
-        <div className="w-full min-w-0 md:w-auto">
-          <div className="flex w-full min-w-0 items-center gap-3 overflow-x-auto pb-1 md:w-auto md:justify-end md:overflow-visible md:pb-0">
+        <div className="w-full min-w-0 lg:w-auto">
+          <div className="flex w-full min-w-0 items-center gap-3 overflow-x-auto pb-1 lg:w-auto lg:justify-end lg:overflow-visible lg:pb-0">
             {isPublic === true && session?.githubLogin && (
               <a
                 href={`/u/${session.githubLogin}`}


### PR DESCRIPTION
## Summary

This PR resolves a layout bug on tablet viewports (iPad Air, iPad Mini) where the dashboard header title overlapped the navigation controls. The responsive layout switch was previously triggering a `flex-row` side-by-side arrangement at the `md:` breakpoint (768px), which proved too narrow for the content. The layout shift has been bumped to the `lg:` breakpoint (1024px) so that the elements stack neatly in a `flex-col` layout on all tablet sizes.

Closes #2335

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **`src/components/DashboardHeader.tsx`**: 
  - Changed `md:flex-row`, `md:items-end`, and `md:justify-between` to their `lg:` equivalents on the main header wrapper.
  - Updated the padding constraint `md:pr-0` to `lg:pr-0` on the left section to properly match the new flex transition.
  - Bumped the right section's container constraints from `md:w-auto` / `md:justify-end` / `md:overflow-visible` / `md:pb-0` to their `lg:` equivalents to ensure the buttons span full-width with proper horizontal scrolling spacing when stacked on tablets.

---

## How to Test

1. Open DevTrack dashboard.
2. Open your browser's responsive design mode (DevTools).
3. Select iPad Air (820px) or iPad Mini (768px) viewports.
4. Verify that the "Dashboard" title and text are placed directly above the navigation controls.
5. Resize the window to verify that the components transition to a side-by-side layout cleanly only *after* passing 1024px.

**Expected result:** The dashboard heading and navigation controls remain properly separated on tablet viewports by stacking vertically, avoiding any overlap or misaligned content.

---

## Screenshots / Recordings

*N/A — Responsive CSS fix.*

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [ ] Keyboard navigation works correctly
- [ ] Color contrast meets WCAG AA standard
- [ ] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context

By letting the components stack naturally as columns until `1024px`, we also leave ample breathing room for users with exceptionally long display names who might have otherwise experienced overlaps even on slightly wider screens.
