### PR TITLE
fix: add missing space between issue count and text

### DIFF
--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -1152,7 +1152,7 @@ function ContributeSection({ stats }: { stats: RepoStats }) {
           who actually use it. Every widget, every metric, every API was contributed by
           someone in this list. {stats.goodFirstIssues > 0 && (
             <span style={{ color: TEXT }}>
-              {stats.goodFirstIssues} issues are tagged good&nbsp;first&nbsp;issue and waiting right now.
+              {stats.goodFirstIssues}{" "} issues are tagged good&nbsp;first&nbsp;issue and waiting right now.
             </span>
           )}
         </p>


### PR DESCRIPTION
## Description
Fixed a minor typography bug on the landing page where the dynamic issue count and the word "issues" were rendering without a space between them (e.g., displaying as "57issues" instead of "57 issues").

## Related Issue
Closes #2320 

## Changes Made
- Updated `src/components/landing/LandingPage.tsx` to add an explicit space `{" "}` right after the `{stats.goodFirstIssues}` variable expression to ensure proper rendering across browsers.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The fix renders correctly on a local development environment