### PR TITLE
fix(profile-card): render real bio and empty-state hint on profile page

### DIFF
--- a/src/app/profile-card/page.tsx
+++ b/src/app/profile-card/page.tsx
@@ -1,11 +1,10 @@
-import React from "react";
-import ProfileCardDemo from "@/components/ProfileCardDemo";
+import ProfileCardPageClient from "@/components/ProfileCardPageClient";
 
 export default function Page() {
   return (
-    <main style={{ padding: 24 }}>
-      <h1 style={{ color: "white", marginBottom: 12 }}>Profile Card Demo</h1>
-      <ProfileCardDemo />
+    <main className="min-h-screen bg-[var(--background)] p-6 text-[var(--foreground)]">
+      <h1 className="mb-4 text-2xl font-bold">Profile Card</h1>
+      <ProfileCardPageClient />
     </main>
   );
 }

--- a/src/components/ProfileCard.css
+++ b/src/components/ProfileCard.css
@@ -106,6 +106,22 @@
   flex: 1 1 auto;
 }
 
+.profile-card__bio--empty{
+  font-style: italic;
+  opacity: 0.85;
+}
+
+.profile-card__bio--empty a{
+  color: var(--accent);
+  text-decoration: none;
+  font-style: normal;
+  font-weight: 600;
+}
+
+.profile-card__bio--empty a:hover{
+  text-decoration: underline;
+}
+
 .profile-card__body{
   display: flex;
   gap: 18px;

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import Link from "next/link";
 import "./ProfileCard.css";
 
 export type SocialLink = {
@@ -15,6 +16,7 @@ type Props = {
   avatarUrl?: string;
   socials?: SocialLink[];
   className?: string;
+  showAddBioHint?: boolean;
 };
 
 export default function ProfileCard({
@@ -25,7 +27,10 @@ export default function ProfileCard({
   avatarUrl,
   socials = [],
   className = "",
+  showAddBioHint = false,
 }: Props) {
+  const displayBio = bio?.trim() ?? "";
+
   return (
     <article className={`profile-card ${className}`.trim()} aria-label={`Profile card: ${name}`}>
       <div className="profile-card__left">
@@ -47,7 +52,13 @@ export default function ProfileCard({
       </div>
 
       <div className="profile-card__body">
-        {bio && <p className="profile-card__bio">{bio}</p>}
+        {displayBio ? (
+          <p className="profile-card__bio">{displayBio}</p>
+        ) : showAddBioHint ? (
+          <p className="profile-card__bio profile-card__bio--empty">
+            <Link href="/dashboard/settings">Add a bio</Link> in Settings.
+          </p>
+        ) : null}
       </div>
 
       {socials.length > 0 && (

--- a/src/components/ProfileCardPageClient.tsx
+++ b/src/components/ProfileCardPageClient.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import ProfileCard from "@/components/ProfileCard";
+import { useUserSettings } from "@/hooks/useUserSettings";
+
+export default function ProfileCardPageClient() {
+  const { data: session, status: sessionStatus } = useSession();
+  const { data: settings, loading: settingsLoading, error } = useUserSettings();
+
+  if (sessionStatus === "loading" || settingsLoading) {
+    return (
+      <p className="text-[var(--muted-foreground)]" role="status">
+        Loading profile…
+      </p>
+    );
+  }
+
+  if (sessionStatus === "unauthenticated" || !session) {
+    return (
+      <div className="surface-card max-w-md rounded-xl p-6 text-center">
+        <p className="text-[var(--muted-foreground)] mb-4">
+          Sign in to view your profile card.
+        </p>
+        <Link
+          href="/auth/signin?callbackUrl=/profile-card"
+          className="primary-button inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
+        >
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-[var(--destructive)]" role="alert">
+        Failed to load profile settings.
+      </p>
+    );
+  }
+
+  const githubLogin = session.githubLogin ?? settings?.github_login;
+  const name = session.user?.name ?? githubLogin ?? "Developer";
+  const bio = settings?.bio ?? "";
+  const avatarUrl =
+    session.user?.image ??
+    (githubLogin
+      ? `https://avatars.githubusercontent.com/${githubLogin}`
+      : undefined);
+
+  return (
+    <ProfileCard
+      name={name}
+      handle={githubLogin ?? undefined}
+      bio={bio}
+      avatarUrl={avatarUrl ?? undefined}
+      showAddBioHint={!bio.trim()}
+      socials={
+        githubLogin
+          ? [{ href: `https://github.com/${githubLogin}`, label: "GitHub" }]
+          : []
+      }
+    />
+  );
+}

--- a/test/components/ProfileCard.test.tsx
+++ b/test/components/ProfileCard.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import ProfileCard from "@/components/ProfileCard";
+
+describe("ProfileCard", () => {
+  it("renders trimmed bio text when provided", () => {
+    render(
+      <ProfileCard name="Alice" bio="  Full-stack developer  " />,
+    );
+
+    expect(screen.getByText("Full-stack developer")).toBeInTheDocument();
+  });
+
+  it("renders nothing for whitespace-only bio", () => {
+    const { container } = render(
+      <ProfileCard name="Alice" bio="   " />,
+    );
+
+    expect(container.querySelector(".profile-card__bio")).toBeNull();
+  });
+
+  it("shows add bio hint when bio is empty and showAddBioHint is true", () => {
+    render(
+      <ProfileCard name="Alice" showAddBioHint />,
+    );
+
+    const link = screen.getByRole("link", { name: "Add a bio" });
+    expect(link).toHaveAttribute("href", "/dashboard/settings");
+    expect(screen.getByText(/in Settings/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing in body when bio is empty and hint is disabled", () => {
+    const { container } = render(<ProfileCard name="Alice" />);
+
+    expect(container.querySelector(".profile-card__bio")).toBeNull();
+  });
+});


### PR DESCRIPTION
Trim bio before display, add optional Add a bio hint, and wire `/profile-card` to session settings instead of hardcoded demo copy.

## Summary

Fixes `ProfileCard` showing fake demo bio text on `/profile-card`. The component now trims and renders the user's real bio from settings, or shows a subtle **Add a bio** hint linking to Settings when empty. Whitespace-only bios no longer render an empty paragraph.

Closes #1880 

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [x] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [x] 🧪 Tests only

---

## What Changed

- Updated `src/components/ProfileCard.tsx` — trim `bio` before render; added `showAddBioHint` prop with **Add a bio** link to `/dashboard/settings`
- Updated `src/components/ProfileCard.css` — muted empty-state styling for bio hint
- Added `src/components/ProfileCardPageClient.tsx` — loads session + `/api/user/settings` and passes real bio to `ProfileCard`
- Updated `src/app/profile-card/page.tsx` — replaced `ProfileCardDemo` with `ProfileCardPageClient`; renamed page title to **Profile Card**
- Added `test/components/ProfileCard.test.tsx` — covers trimmed bio, whitespace-only bio, empty hint, and no-hint cases

---

## How to Test

1. Check out `feat/profile-card-bio-empty-state` and run `npm run dev`
2. Sign in, clear your bio in **Dashboard → Settings**, then visit `/profile-card`
3. Add a bio in Settings and refresh `/profile-card`

**Expected result:** With no bio, you see **Add a bio in Settings.** (no demo placeholder text). With a bio set, the card shows your real bio text. Whitespace-only bios show nothing (or the hint when `showAddBioHint` is enabled).

Also run:

```bash
npm run type-check
npm run lint
npm test -- test/components/ProfileCard.test.tsx