### PR TITLE
fix: address copilot review suggestions for rbac middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-﻿import { getToken } from "next-auth/jwt";
+import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
 import {
   checkAuthRateLimit,
@@ -223,12 +223,30 @@ export async function middleware(req: NextRequest) {
     (route) => pathname === route || pathname.startsWith(`${route}/`)
   );
 
+  const adminRoutes = ["/admin"];
+  const isAdminRoute = adminRoutes.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  );
+
   if (isProtectedRoute) {
     if (!token) {
       const url = req.nextUrl.clone();
       url.pathname = "/";
       url.search = "";
       return NextResponse.redirect(url);
+    }
+    return NextResponse.next();
+  }
+
+  if (isAdminRoute) {
+    if (!token) {
+      const url = req.nextUrl.clone();
+      url.pathname = "/";
+      url.search = "";
+      return NextResponse.redirect(url);
+    }
+    if (token.role !== "admin") {
+      return new NextResponse("Forbidden: Admin access required", { status: 403 });
     }
     return NextResponse.next();
   }
@@ -295,6 +313,8 @@ export const config = {
     "/dashboard/:path*",
     "/settings",
     "/settings/:path*",
+    "/admin",
+    "/admin/:path*",
     "/api/:path*",
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -228,24 +228,20 @@ export async function middleware(req: NextRequest) {
     (route) => pathname === route || pathname.startsWith(`${route}/`)
   );
 
+  if ((isProtectedRoute || isAdminRoute) && !token) {
+    const url = req.nextUrl.clone();
+    url.pathname = "/";
+    url.search = "";
+    return NextResponse.redirect(url);
+  }
+
   if (isProtectedRoute) {
-    if (!token) {
-      const url = req.nextUrl.clone();
-      url.pathname = "/";
-      url.search = "";
-      return NextResponse.redirect(url);
-    }
     return NextResponse.next();
   }
 
   if (isAdminRoute) {
-    if (!token) {
-      const url = req.nextUrl.clone();
-      url.pathname = "/";
-      url.search = "";
-      return NextResponse.redirect(url);
-    }
-    if (token.role !== "admin") {
+    // Check if token explicitly has the admin role
+    if (!token?.role || token.role !== "admin") {
       return new NextResponse("Forbidden: Admin access required", { status: 403 });
     }
     return NextResponse.next();


### PR DESCRIPTION
Implementing changes for branch feat/issue-1933-rbac:

fix: address copilot review suggestions for rbac middleware

feat: implement Role-Based Access Control (RBAC) middleware (Issue #1933)

feat(csrf): add Origin/Referer CSRF protection for state-changing API routes
feat: persist daily focus goals in database with GET/POST/DELETE API route

* fix: persist daily focus goals in database

* fix: resolve app user for daily focus

---------

Co-authored-by: nishupr <nishupundir073.com>
feat: add confetti celebration for personal records and unit tests for PersonalRecords component

* feat: add confetti animation when user hits a new personal record (#1902)

* fix(e2e): resolve playwright smoke test failures by mocking unhandled API endpoints and landing page fetch rates

* fix(e2e): update theme tests to match new multi-theme palette selector UI
test: add comprehensive unit tests and E2E mock routes for date-utils and new API endpoints

* test: add comprehensive unit tests for date-utils.ts and fix timezone sensitivity in existing dateUtils tests

* fix(e2e): resolve playwright smoke test failures by mocking unhandled API endpoints and landing page fetch rates

* fix(e2e): update theme tests to match new multi-theme palette selector UI
feat: add secure POST /api/leaderboard/rebuild endpoint with persistent Supabase cache

* leaderboard: add persistent Supabase cache, dedupe builds, and scheduled rebuild endpoint

* tsconfig: target ES2022 and include vitest types
perf: debounce repo search input and fix GoalTracker percentage

* perf: debounce repo search input in RepoAnalyticsExplorer

* fix: show minimum 1% progress for non-zero goal completion

* Update GoalTracker.tsx
feat: add rich tooltip to TopRepos showing name, description, and language
chore(deps): bump actions/github-script from 7 to 9 (#2000)

Bumps [actions/github-script](https://github.com/actions/github-script) from 7 to 9.
- [Release notes](https://github.com/actions/github-script/releases)
- [Commits](https://github.com/actions/github-script/compare/v7...v9)

---
updated-dependencies:
- dependency-name: actions/github-script
  dependency-version: '9'
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
chore(deps): bump actions/first-interaction from 1 to 3 (#1999)

Bumps [actions/first-interaction](https://github.com/actions/first-interaction) from 1 to 3.
- [Release notes](https://github.com/actions/first-interaction/releases)
- [Commits](https://github.com/actions/first-interaction/compare/v1...v3)

---
updated-dependencies:
- dependency-name: actions/first-interaction
  dependency-version: '3'
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
chore(deps): bump actions/setup-node from 4 to 6 (#1998)

Bumps [actions/setup-node](https://github.com/actions/setup-node) from 4 to 6.
- [Release notes](https://github.com/actions/setup-node/releases)
- [Commits](https://github.com/actions/setup-node/compare/v4...v6)

---
updated-dependencies:
- dependency-name: actions/setup-node
  dependency-version: '6'
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
chore(deps): bump actions/checkout from 4 to 6 (#1997)

Bumps [actions/checkout](https://github.com/actions/checkout) from 4 to 6.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v4...v6)

---
updated-dependencies:
- dependency-name: actions/checkout
  dependency-version: '6'
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
chore(deps): bump actions/stale from 9 to 10 (#1996)

Bumps [actions/stale](https://github.com/actions/stale) from 9 to 10.
- [Release notes](https://github.com/actions/stale/releases)
- [Changelog](https://github.com/actions/stale/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/stale/compare/v9...v10)

---
updated-dependencies:
- dependency-name: actions/stale
  dependency-version: '10'
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
fix: extend streak lookback from 90 to 365 days to prevent silent breaks

* [Test] : Base schema.sql is out of sync with recent migrations, causing 500 Errors for local setups

* [BUG] Streak tracker silently breaks
docs: document schema.sql sync requirement and add leaderboard index
feat(public-profile): add public_since audit column and weekly goal progress

- Add public_since timestamptz column to users table with migration
- Add show_weekly_goals boolean column with migration
- Set/clear public_since in settings PATCH when toggling is_public
- Add show_weekly_goals toggle to settings page UI
- Extend PublicProfileData with weeklyGoalProgress field
- Add fetchPublicWeeklyGoalProgress query to public-profile-data
- Render weekly goal completion ring on /u/[username] page
- Update User interface and supabase queries for new columns
feat(ui): add multiple dashboard themes with CSS custom properties

* feat: add multiple dashboard themes

* fix: add sharp for standalone production build

* fix: align theme system with latest main

* fix: migrate ci workflow to pnpm

* fix: migrate github workflows to pnpm

* revert: restore npm workflows and lockfile
feat: add empty states for dashboard widgets with no data

* feat: add empty states for dashboard widgets

* fix: resolve CIAnalytics JSX issues

* feat: add empty state for CI analytics widget
feat: add pagination to RecentActivity widget

* feat: add pagination to RecentActivity widget (#1901)

* fix: address PR review feedback on pagination
chore: enhance Dependabot config with groups, reviewer, and proper quoting
fix: remove redundant Sign In button from navbar for unauthenticated users

Drop the duplicate SIGN IN CTA from the global header; sign-in remains on the landing hero and auth routes.
fix: hide StreakAtRiskBanner when streak freeze is active or loading

The StreakAtRiskBanner was incorrectly showing even when a user had an
active streak freeze applied. This was caused by a race condition:
streak data loaded before freeze status, so the banner briefly rendered
with hasStreakFreezeState=undefined (falsy), and could persist if the
freeze API call failed silently.

Fix: Add a render-level guard that checks hasStreakFreezeState !== false,
ensuring the banner is hidden both when freeze is active (true) and while
freeze status is still loading (undefined). The banner now only renders
when we have confirmed the user has no freeze (explicit false).

Fixes #1900

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
fix: replace redundant tabIndex with focus-visible ring on UserAvatar
fix(auth): add rate limiting for authentication endpoints and harden cron auth

* fix(security): remove development auth bypass from cron routes

Closes #1657

Three cron/sync endpoints bypassed authentication when NODE_ENV was
development. The condition used was:

  if (authHeader !== Bearer-secret AND process.env.NODE_ENV !== development)

This made the authorization check a no-op in dev mode, allowing any
unauthenticated caller to trigger bulk operations: sponsors sync,
WakaTime stats sync, and Discord notifications.

Root cause: a developer-convenience shortcut never removed before deploy.

Fix: created src/lib/cron-auth.ts with validateCronRequest() that
enforces a consistent, environment-independent fail-closed check:
  - CRON_SECRET not configured -> 500
  - Authorization header missing or wrong -> 401
  - Correct secret -> null (proceed)
No NODE_ENV bypass in any environment.

Affected routes (all fixed):
  src/app/api/wakatime/sync/route.ts
  src/app/api/sponsors/sync/route.ts
  src/app/api/notifications/discord-sync/route.ts

Already-correct (no change needed):
  src/app/api/cron/weekly-digest/route.ts

Local development: set CRON_SECRET in .env.local and supply the
matching Authorization header when calling endpoints manually.
Documented in .env.example.

Tests added:
  test/cron-auth.test.ts (17 tests) - unit tests for validateCronRequest
    and integration regression tests for discord-sync covering all cases
    including development environment enforcement
  test/wakatime-sync-auth.test.ts (12 tests) - replaced bypass test
    with enforcement tests for dev environment
  test/sponsors-sync.test.ts (12 tests) - auth and dev enforcement

* fix(auth): add rate limiting for authentication endpoints

Closes #1303

Security analysis
-----------------
DevTrack authenticates exclusively via GitHub OAuth; there is no
password, email, or OTP flow. Despite this, the NextAuth endpoints
responsible for initiating and completing the OAuth handshake were
entirely unprotected:

  POST /api/auth/signin/github         - initiates the OAuth redirect
  GET  /api/auth/callback/github       - exchanges the code for a token
  GET  /api/auth/link-github           - secondary account link initiation
  GET  /api/auth/link-github/callback  - secondary account link callback

Flooding these routes can exhaust GitHub token-exchange quota for the
application, probe for valid OAuth codes, or generate high server load.

Endpoints deliberately excluded from rate limiting:
  GET /api/auth/session  - polled on every page render
  GET /api/auth/csrf     - CSRF token fetch, not an attack surface
  GET /api/auth/signout  - termination, not initiation

Authentication flows discovered
---------------------------------
GitHub OAuth only. No password, email/OTP, or magic-link flows exist.

Rate limiting strategy
----------------------
5 requests per IP per 15-minute fixed window (issue #1303).
Allows two complete sign-in flows (initiation + callback) plus one
spare before throttling. In development the limit is raised to 1000.

Uses the shared createMemoryFixedWindowRateLimiter factory from
@/lib/rate-limit. Key namespace auth:<ip> is isolated from the
metrics-rate-limit:* namespace to prevent interference.

429 responses carry X-RateLimit-* and Retry-After headers. Body:
  { error: 'Too many authentication attempts. Please try again later.' }

Protected endpoints
-------------------
Four auth-sensitive paths added to the Next.js middleware matcher and
handled by the auth rate limiter before the general metrics gate.

Files changed
-------------
src/lib/auth-rate-limit.ts  (new)
  Exports checkAuthRateLimit(), isAuthSensitivePath(), AUTH_LIMIT,
  AUTH_WINDOW_MS, AUTH_SENSITIVE_PREFIXES. No new dependencies.

src/middleware.ts  (modified)
  Imports auth limiter; inserts auth rate-limit block after the
  protected-route check; adds auth paths to the matcher config.

Tests added
-----------
test/auth-rate-limit.test.ts - 22 tests:
  isAuthSensitivePath (9) - protected vs excluded path classification
  basic behaviour (5) - allow/block, remaining, 429-compatible status
  window expiry (2) - counter resets after window, not before
  IP isolation (2) - independent counters per IP
  custom limit override (2) - dev/test relaxation
  reset timestamp (2) - window-boundary reset, shared within window

Verification
------------
  tsc --noEmit  clean (no errors in changed files)
  next lint     warnings only (all pre-existing)
  vitest run    22/22 tests passed

* merge: resolve middleware conflict for auth rate limiting

Upstream rewrote the in-memory rate-limiter: replaced the external
createMemoryFixedWindowRateLimiter factory with inline memoryBuckets,
added pruneMemoryBuckets, and inlined getIp header extraction.  This
PR added per-IP rate limiting on OAuth auth endpoints using
checkAuthRateLimit / isAuthSensitivePath / AUTH_LIMIT.  Both edits
touched the same lines in src/middleware.ts.

Resolution keeps all upstream improvements:
  - inline memoryBuckets / pruneMemoryBuckets / checkMemoryLimit
  - getIp reads headers directly (no external getClientIp)
  - removes createMemoryFixedWindowRateLimiter dependency from middleware

And preserves all PR auth rate-limiting functionality:
  - checkAuthRateLimit / isAuthSensitivePath / AUTH_LIMIT imports
  - runtime = nodejs
  - isAuthSensitivePath block intercepting OAuth endpoints
  - /api/:path* matcher so auth paths are covered
fix: resolve E2E 500 error from incomplete weekly-summary mock

Align auth patterns across e2e spec files; add missing issues and
productivityScore fields to weekly-summary mock; add defensive
guard in WeeklySummaryCard for optional issues section.
fix(api): propagate database errors correctly with 500 status codes
feat: add search filter to TopRepos widget with accessible clear button
test: add goals CRUD API coverage

Closes #1907

Signed-off-by: Abhisumat Kashyap <abhisumatkashyap@gmail.com>
fix: close SSE stream on abort and add max-duration timeout
feat: add End-to-End Type Safety using Supabase Typegen (#1968)

* feat: add End-to-End Type Safety using Supabase Typegen (Issue #1931)

* fix: pin supabase cli version and add header to generated types
fix: wrap dashboard widget with error boundary (#1965)

* fix: wrap dashboard widget with error boundary

* fix: install sharp for standalone build
fix: prevent LanguageBreakdown legend overflow on mobile (#1964)
test: add edge case coverage for dateDiffDays (#1963)
fix: persist recurring goal history on reset (#1969)

Co-authored-by: nishupr <nishupundir073.com>
feat(leaderboard): async cache refresh via cron endpoint (#1962)

Adds refreshLeaderboardCache() to src/lib/leaderboard.ts, a new GET /api/leaderboard/refresh cron endpoint with CRON_SECRET Bearer auth, and rewrites the GET handler to cache-only flow. Closes #1799.
[Fix] #1312 Streak logic duplication resolved - core logic abstracted to src/lib/streak.ts. (#1876)
feat(activity): add GitHub Discussions to RecentActivity (#1939)

* test: add regression tests for local-coding API key auth mismatch (#1748)

Root cause (confirmed)
----------------------
The initial migration created local_coding_api_keys with a single column
api_key to store SHA-256 hashes. A later migration added api_key_hash as
a nullable column. At the time issue #1748 was filed, the code was split:

  Creation  → insert({ api_key: hash })         # only api_key written
  Auth      → .eq("api_key_hash", hash)          # only api_key_hash read

Every key generated through the UI was therefore permanently invalid;
authentication always returned "Invalid API key".

Applied fix (in place on main branch)
--------------------------------------
Key creation now writes the same SHA-256 hash to BOTH columns:

  insert({ api_key: hash, api_key_hash: hash })

Authentication queries BOTH columns with an OR filter so that pre-existing
rows (with only api_key populated) and newly created rows (with both
populated) authenticate identically:

  .or("api_key_hash.eq.<hash>,api_key.eq.<hash>")

This preserves backward compatibility with any deployment that had keys
created before the api_key_hash column existed.

Regression test suite — test/local-coding-auth-regression.test.ts (9 tests)
-----------------------------------------------------------------------------
Tests added in this commit provide explicit coverage that was absent:

  * Key creation writes hash to api_key AND api_key_hash.
  * POST /local-coding/sync uses OR filter across both columns.
  * Legacy row (api_key only, api_key_hash NULL) still authenticates.
  * Invalid key is rejected by both POST and GET sync handlers.
  * GET /local-coding/sync was previously untested; 4 tests now cover:
      - missing Authorization header → 401
      - invalid key → 401
      - valid key → 200 with session data
      - same OR filter used as POST
  * Hash function consistency: verifies the hash written during creation
    would satisfy the filter used during authentication.

The pre-existing tests in test/local-coding-keys.test.ts and
test/local-coding-sync.test.ts continue to pass unchanged.

Closes #1748

* feat(activity): add GitHub Discussions to RecentActivity feed

Add parallel GraphQL fetch alongside the REST events endpoint to
reliably surface discussion-comment activity in RecentActivity.

- activity-formatter.ts: GraphQLDiscussionCommentNode interface,
  formatGraphQLDiscussionComment() normalizer, mergeActivityItems()
  dedup+sort helper
- metrics/activity/route.ts: DISCUSSION_COMMENTS_QUERY via
  viewer.repositoryDiscussionComments(first:20); fetchDiscussionItems
  ViaGraphQL() silently returns [] on error; both fetchFormatted
  Activity() and the public-events fallback path run REST + GraphQL
  in parallel via Promise.all
- test/activity-formatter.test.ts: 15 new tests for
  formatGraphQLDiscussionComment and mergeActivityItems