### PR TITLE
feat: add duplicate milestone quick action

### DIFF
--- a/src/components/MilestonePlanner.tsx
+++ b/src/components/MilestonePlanner.tsx
@@ -1,7 +1,18 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { Target, Plus, Trash2, TrendingUp, Clock, CheckCircle2, AlertTriangle, ChevronDown, ChevronUp } from 'lucide-react';
+import {
+  Target,
+  Plus,
+  Trash2,
+  Copy,
+  TrendingUp,
+  Clock,
+  CheckCircle2,
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp
+} from 'lucide-react';
 
 interface Milestone {
   id: string;
@@ -136,6 +147,23 @@ export default function MilestonePlanner() {
     setMilestones(updated);
     saveMilestones(updated);
   }, [milestones]);
+  const handleDuplicate = useCallback((id: string) => {
+  const milestone = milestones.find(m => m.id === id);
+
+  if (!milestone) return;
+
+  const duplicate: Milestone = {
+    ...milestone,
+    id: `${Date.now()}`,
+    title: `${milestone.title} (Copy)`,
+    createdAt: new Date().toISOString(),
+  };
+
+  const updated = [...milestones, duplicate];
+
+  setMilestones(updated);
+  saveMilestones(updated);
+}, [milestones]);
 
   const statusCounts = milestones.reduce((acc, m) => {
     acc[getStatus(m)] = (acc[getStatus(m)] || 0) + 1;
@@ -283,6 +311,20 @@ export default function MilestonePlanner() {
                     </button>
                     <button onClick={() => setExpanded(isExpanded ? null : m.id)} style={{ padding: '4px 8px', borderRadius: '6px', border: '1px solid var(--border)', background: 'transparent', color: 'var(--muted-foreground)', cursor: 'pointer' }}>
                       {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                    </button>
+                    <button
+                      onClick={() => handleDuplicate(m.id)}
+                      style={{
+                        padding: '4px 8px',
+                        borderRadius: '6px',
+                        border: '1px solid var(--border)',
+                        background: 'transparent',
+                        color: 'var(--foreground)',
+                        cursor: 'pointer'
+                      }}
+                      title="Duplicate milestone"
+                    >
+                      <Copy size={14} />
                     </button>
                     <button onClick={() => handleDelete(m.id)} style={{ padding: '4px 8px', borderRadius: '6px', border: '1px solid transparent', background: 'transparent', color: '#ef4444', cursor: 'pointer' }}>
                       <Trash2 size={14} />


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2><p>Added a duplicate action to the Milestone Planner, allowing users to quickly create a copy of an existing milestone. The duplicated milestone retains the original data while generating a new ID and appending "(Copy)" to the title.</p><p>Closes #2345</p><hr><h2>Type of Change</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> ✨ New feature (non-breaking change that adds functionality)</p></li></ul><hr><h2>What Changed</h2><ul><li><p>Added a <code inline="">handleDuplicate</code> function in <code inline="">src/components/MilestonePlanner.tsx</code></p></li><li><p>Added a duplicate button with the <code inline="">Copy</code> icon alongside existing milestone actions</p></li><li><p>Implemented milestone duplication with a new ID and "(Copy)" suffix in the title</p></li></ul><hr><h2>How to Test</h2><ol><li><p>Run the application with <code inline="">npm run dev</code></p></li><li><p>Navigate to the dashboard and create a milestone</p></li><li><p>Click the new duplicate (copy) button on the milestone card</p></li></ol><p><strong>Expected result:</strong><br>A new milestone is created with the same details as the original, and its title is suffixed with "(Copy)".</p><hr><h2>Screenshots / Recordings</h2>
Before | After
-- | --
No duplicate option available | Duplicate button available and creates a copied milestone

<hr><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Linked the related issue above</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Self-reviewed my own diff</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> No unnecessary <code inline="">console.log</code>, debug code, or commented-out blocks</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> <code inline="">npm run lint</code> passes locally</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> No TypeScript errors (<code inline="">npm run type-check</code>)</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Added or updated tests where applicable</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Updated documentation / comments if behavior changed</p></li></ul><hr><h2>Accessibility (UI changes only)</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Keyboard navigation works correctly</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Color contrast meets WCAG AA standard</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> ARIA labels / roles added where needed</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Tested on mobile / responsive layout</p></li></ul><hr><h2>Additional Context</h2><p>The issue description referenced task duplication. During implementation, the planner functionality was found in <code inline="">MilestonePlanner.tsx</code>, and the duplicate action was added there to provide the requested duplication workflow.</p></body></html>