### PR TITLE
perf: defer below-the-fold dashboard widgets using LazyWidget

### DIFF
--- a/src/components/DashboardWidgets.tsx
+++ b/src/components/DashboardWidgets.tsx
@@ -22,6 +22,8 @@ import WeeklySummaryCard from "@/components/WeeklySummaryCard";
 import ExportButton from "@/components/ExportButton";
 import PersonalRecords from "@/components/PersonalRecords";
 import WidgetErrorBoundary from "@/components/WidgetErrorBoundary";
+import LazyWidget from "@/components/LazyWidget";
+import { Skeleton } from "@/components/Skeleton";
 
 function DashboardWidgets() { return (
     <>
@@ -100,33 +102,43 @@ function DashboardWidgets() { return (
 
       {/* Row 3 */}
       <div className="mt-6">
-        <WidgetErrorBoundary>
-          <IssueMetrics />
-        </WidgetErrorBoundary>
+        <LazyWidget fallback={<Skeleton className="h-48 w-full" />}>
+          <WidgetErrorBoundary>
+            <IssueMetrics />
+          </WidgetErrorBoundary>
+        </LazyWidget>
       </div>
 
       
 
       {/* Row 4 */}
       <div className="mt-6">
-        <WidgetErrorBoundary>
-          <PinnedRepos />
-        </WidgetErrorBoundary>
+        <LazyWidget fallback={<Skeleton className="h-48 w-full" />}>
+          <WidgetErrorBoundary>
+            <PinnedRepos />
+          </WidgetErrorBoundary>
+        </LazyWidget>
       </div>
 
       {/* Row 5 */}
       <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <WidgetErrorBoundary>
-          <TopRepos />
-        </WidgetErrorBoundary>
+        <LazyWidget fallback={<Skeleton className="h-48 w-full" />}>
+          <WidgetErrorBoundary>
+            <TopRepos />
+          </WidgetErrorBoundary>
+        </LazyWidget>
 
-        <WidgetErrorBoundary>
-          <LanguageBreakdown />
-        </WidgetErrorBoundary>
+        <LazyWidget fallback={<Skeleton className="h-48 w-full" />}>
+          <WidgetErrorBoundary>
+            <LanguageBreakdown />
+          </WidgetErrorBoundary>
+        </LazyWidget>
 
-        <WidgetErrorBoundary>
-          <GoalTracker />
-        </WidgetErrorBoundary>
+        <LazyWidget fallback={<Skeleton className="h-48 w-full" />}>
+          <WidgetErrorBoundary>
+            <GoalTracker />
+          </WidgetErrorBoundary>
+        </LazyWidget>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

This PR defers the rendering of below-the-fold dashboard widgets by wrapping them in the pre-existing `LazyWidget` component. Previously, all widgets were loading eagerly on page mount, which caused a large volume of simultaneous API requests and degraded the initial dashboard load performance.

Closes #2408

---

## Type of Change

- [x] ⚡ Performance improvement
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---

## What Changed

- **`src/components/DashboardWidgets.tsx`**: Imported `LazyWidget` and `Skeleton` components.
- **`src/components/DashboardWidgets.tsx`**: Wrapped `IssueMetrics`, `PinnedRepos`, `TopRepos`, `LanguageBreakdown`, and `GoalTracker` (Rows 3, 4, and 5) in `<LazyWidget>` with a Skeleton fallback.

---

## How to Test

1. Navigate to the dashboard.
2. Open your browser's DevTools and go to the **Network** tab.
3. Refresh the page and observe the initial network requests.
4. Scroll down the page and observe the network tab again.

**Expected result:**
You should see that the API requests for `IssueMetrics`, `PinnedRepos`, `TopRepos`, `LanguageBreakdown`, and `GoalTracker` are completely deferred until you scroll down and their corresponding skeleton placeholders enter the viewport.

---
