### PR TITLE
fix: dashboard-layout API passes AppUser object instead of user.id to Supabase (closes #2405)

### DIFF
--- a/src/app/api/user/dashboard-layout/route.ts
+++ b/src/app/api/user/dashboard-layout/route.ts
@@ -4,78 +4,89 @@ import { authOptions } from "@/lib/auth";
 import { resolveAppUser } from "@/lib/resolve-user";
 import { supabaseAdmin } from "@/lib/supabase";
 import {
-  getDefaultDashboardLayout,
-  normalizeDashboardLayout,
+    getDefaultDashboardLayout,
+    normalizeDashboardLayout,
 } from "@/lib/dashboard-layout";
 
 export async function GET() {
-  try {
-    const session = await getServerSession(authOptions);
+    try {
+          const session = await getServerSession(authOptions);
 
-    if (!session?.githubId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+      if (!session?.githubId) {
+              return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
 
-    const appUserId = await resolveAppUser(session.githubId, session.githubLogin);
+      const appUser = await resolveAppUser(session.githubId, session.githubLogin);
 
-    const { data, error } = await supabaseAdmin
-      .from("users")
-      .select("dashboard_layout")
-      .eq("id", appUserId)
-      .single();
+      if (!appUser) {
+              return NextResponse.json({ layout: getDefaultDashboardLayout(), source: "default" });
+      }
 
-    if (error) {
+      const { data, error } = await supabaseAdmin
+            .from("users")
+            .select("dashboard_layout")
+            .eq("id", appUser.id)
+            .single();
+
+      if (error) {
+              return NextResponse.json({
+                        layout: getDefaultDashboardLayout(),
+                        source: "default",
+              });
+      }
+
       return NextResponse.json({
-        layout: getDefaultDashboardLayout(),
-        source: "default",
+              layout: normalizeDashboardLayout(data?.dashboard_layout),
+              source: "database",
       });
+    } catch {
+          return NextResponse.json({
+                  layout: getDefaultDashboardLayout(),
+                  source: "fallback",
+          });
     }
-
-    return NextResponse.json({
-      layout: normalizeDashboardLayout(data?.dashboard_layout),
-      source: "database",
-    });
-  } catch {
-    return NextResponse.json({
-      layout: getDefaultDashboardLayout(),
-      source: "fallback",
-    });
-  }
 }
 
 export async function PATCH(request: Request) {
-  try {
-    const session = await getServerSession(authOptions);
+    try {
+          const session = await getServerSession(authOptions);
 
-    if (!session?.githubId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      if (!session?.githubId) {
+              return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
+
+      const body = (await request.json()) as { layout?: unknown };
+          const layout = normalizeDashboardLayout(body.layout);
+
+      const appUser = await resolveAppUser(session.githubId, session.githubLogin);
+
+      if (!appUser) {
+              return NextResponse.json(
+                { error: "User not found" },
+                { status: 404 },
+                      );
+      }
+
+      const { error } = await supabaseAdmin
+            .from("users")
+            .update({
+                      dashboard_layout: layout,
+                      updated_at: new Date().toISOString(),
+            })
+            .eq("id", appUser.id);
+
+      if (error) {
+              return NextResponse.json(
+                { error: "Failed to save dashboard layout" },
+                { status: 500 },
+                      );
+      }
+
+      return NextResponse.json({ layout });
+    } catch {
+          return NextResponse.json(
+            { error: "Failed to save dashboard layout" },
+            { status: 500 },
+                );
     }
-
-    const body = (await request.json()) as { layout?: unknown };
-    const layout = normalizeDashboardLayout(body.layout);
-
-    const appUserId = await resolveAppUser(session.githubId, session.githubLogin);
-
-    const { error } = await supabaseAdmin
-      .from("users")
-      .update({
-        dashboard_layout: layout,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", appUserId);
-
-    if (error) {
-      return NextResponse.json(
-        { error: "Failed to save dashboard layout" },
-        { status: 500 },
-      );
-    }
-
-    return NextResponse.json({ layout });
-  } catch {
-    return NextResponse.json(
-      { error: "Failed to save dashboard layout" },
-      { status: 500 },
-    );
-  }
 }


### PR DESCRIPTION
## Summary

Fixes a type bug in `src/app/api/user/dashboard-layout/route.ts` where `resolveAppUser()` returns `AppUser | null` (an object `{ id: string }`), but both the `GET` and `PATCH` handlers were passing the full object directly to `.eq("id", appUserId)` instead of `.eq("id", appUser.id)`. This caused Supabase to silently fail on every dashboard layout save and load — users always fell through to the default layout.

Closes #2405

## Changes

- `GET`: renamed `appUserId` → `appUser`, added null guard, changed `.eq("id", appUserId)` → `.eq("id", appUser.id)`
- - `PATCH`: same fix applied
## Type of Change

- [x] Bug fix
## Testing

- Verified the fix matches the pattern used in all other API routes (`settings/route.ts`, `goals/route.ts`, `notifications/route.ts`) which all correctly use `user.id`