### PR TITLE
fix: preserve HTTP status in streak API error for rate-limit detectio…

### DIFF
--- a/src/app/api/metrics/streak/route.ts
+++ b/src/app/api/metrics/streak/route.ts
@@ -77,7 +77,7 @@ async function fetchActiveDates(
         // Both are thrown here so the outer GET handler returns HTTP 502 to the client,
         // which shows an error state rather than a misleading 0-day streak.
         if (!searchRes.ok) {
-          throw new Error("GitHub API error");
+          const apiErr = Object.assign(new Error("GitHub API error"), { status: searchRes.status }); throw apiErr;
         }
 
         const data = (await searchRes.json()) as {


### PR DESCRIPTION
## Summary

Fixes streak API silently returning 502 for all GitHub error statuses. The thrown error now carries the HTTP status code so the caller can return 429 for rate limits vs 502 for other errors.

Closes #2409

## Type of Change

- [x] Bug fix