### PR TITLE
fix: remove commits-only guard in GoalTracker auto-sync (closes #2410)

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -105,7 +105,7 @@ export function useGoalTracker() {
     loadGoals()
       .then(async (fetchedGoals) => {
         const needsSync = fetchedGoals.some((g: Goal) => {
-          if (g.unit !== "commits") return false;
+          // auto-sync applies to all goal types
           if (!g.last_synced_at) return true;
           const syncedAt = new Date(g.last_synced_at).getTime();
           return Date.now() - syncedAt > 15 * 60 * 1000;


### PR DESCRIPTION
## Summary

The `GoalTracker` component's auto-sync logic silently skipped all goal types except `unit === "commits"`. This meant streak, PR, review, and other goal types never triggered background sync, leaving them perpetually stale.

This fix removes the guard clause `if (g.unit !== "commits") return false;` and replaces it with a comment clarifying that auto-sync applies to all goal types.

Closes #2410

## Type of Change
- [x] Bug fix