### PR TITLE
feat: add DELETE endpoint to notifications API (closes #2411)

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -106,3 +106,40 @@ export async function PATCH() {
     );
   }
 }
+
+
+    // DELETE — dismiss (delete) all notifications for the current user
+export async function DELETE() {
+    try {
+          const session = await getServerSession(authOptions);
+          if (!session?.githubId) {
+                  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+          }
+
+      const userId = await getUserId(session.githubId);
+          if (!userId) {
+                  return NextResponse.json({ success: true });
+          }
+
+      const { error } = await supabaseAdmin
+            .from("notifications")
+            .delete()
+            .eq("user_id", userId);
+
+      if (error) {
+              console.error("Failed to delete notifications:", error);
+              return NextResponse.json(
+                { error: "Failed to delete notifications" },
+                { status: 500 }
+                      );
+      }
+
+      return NextResponse.json({ success: true });
+    } catch (error) {
+          console.error("Unexpected error in notifications DELETE:", error);
+          return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+                );
+    }
+}


### PR DESCRIPTION
## Summary

The notifications API had GET (fetch) and PATCH (mark-as-read) handlers but no DELETE endpoint, making it impossible for clients to dismiss or clear notifications. This PR adds a `DELETE` handler that deletes all notifications for the authenticated user.

Closes #2411

## Type of Change
- [x] New feature (adds missing REST endpoint)