### PR TITLE
feat: add Copy Link, Twitter/X and LinkedIn share buttons to dashboar…

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -289,16 +289,83 @@ export default function DashboardHeader() {
         {/* Right Section */}
         <div className="w-full min-w-0 md:w-auto">
           <div className="flex w-full min-w-0 items-center gap-3 overflow-x-auto pb-1 md:w-auto md:justify-end md:overflow-visible md:pb-0">
-            {isPublic === true && session?.githubLogin && (
-              <a
-                href={`/u/${session.githubLogin}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={buttonVariants({ variant: "default" })}
-                title="View your public profile"
-              >
-                Share Profile
-              </a>
+            {session?.githubLogin && (
+              <div className="flex items-center gap-2">
+                {/* Copy Link Button */}
+                <button
+                  type="button"
+                  onClick={handleCopyLink}
+                  title="Copy your profile link"
+                  className="flex items-center justify-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--control)] px-4 py-2 text-sm font-medium text-[var(--card-foreground)] transition-all hover:border-[var(--accent)] active:scale-95"
+                >
+                  {copied ? (
+                    <svg className="w-4 h-4 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                  )}
+                  {copied ? "Copied!" : "Copy Link"}
+                </button>
+
+                {/* Twitter/X Share Button */}
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!session?.githubLogin) return;
+                    const profileUrl = `${window.location.origin}/u/${session.githubLogin}`;
+                    const tweet = encodeURIComponent(
+                      `🔥 Check out my DevTrack stats!\n` +
+                      `Track your GitHub streaks, PRs & coding goals 👇\n` +
+                      `${profileUrl}\n\n#GitHub #DevTrack #GSSoC`
+                    );
+                    window.open(`https://twitter.com/intent/tweet?text=${tweet}`, '_blank');
+                  }}
+                  title="Share on X (Twitter)"
+                  className="flex items-center justify-center gap-2 rounded-lg border border-[var(--border)] bg-black px-4 py-2 text-sm font-medium text-white transition-all hover:bg-zinc-800 active:scale-95"
+                >
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.737-8.835L1.254 2.25H8.08l4.261 5.632 5.903-5.632Zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                  </svg>
+                  Post on X
+                </button>
+
+                {/* LinkedIn Share Button */}
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!session?.githubLogin) return;
+                    const profileUrl = encodeURIComponent(
+                      `${window.location.origin}/u/${session.githubLogin}`
+                    );
+                    window.open(
+                      `https://www.linkedin.com/sharing/share-offsite/?url=${profileUrl}`,
+                      '_blank'
+                    );
+                  }}
+                  title="Share on LinkedIn"
+                  className="flex items-center justify-center gap-2 rounded-lg border border-[#0A66C2]/50 bg-[#0A66C2] px-4 py-2 text-sm font-medium text-white transition-all hover:bg-[#0958a8] active:scale-95"
+                >
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 23.2 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+                  </svg>
+                  LinkedIn
+                </button>
+
+                {isPublic === true && (
+                  <a
+                    href={`/u/${session.githubLogin}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={buttonVariants({ variant: "default" })}
+                    title="View your public profile"
+                  >
+                    Share Profile
+                  </a>
+                )}
+              </div>
             )}
 
             <div className="flex shrink-0 items-center gap-2 rounded-2xl border border-[var(--border)] bg-[var(--card-muted)]/50 p-2 shadow-sm backdrop-blur-sm">
@@ -394,17 +461,39 @@ export default function DashboardHeader() {
             </div>
           </div>
 
-          {isPublic === true && session?.githubLogin && (
-            <a
-              href={`/u/${session.githubLogin}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={buttonVariants({ variant: "default", className: "w-full" })}
-              title="View your public profile"
-              onClick={() => setMenuOpen(false)}
-            >
-              Share Profile
-            </a>
+          {session?.githubLogin && (
+            <div className="flex flex-col gap-2 w-full">
+              <button
+                type="button"
+                onClick={() => { handleCopyLink(); setMenuOpen(false); }}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--control)] px-4 py-2 text-sm font-medium transition-all hover:border-[var(--accent)] active:scale-95"
+              >
+                {copied ? "✓ Copied!" : "Copy Profile Link"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  const profileUrl = `${window.location.origin}/u/${session.githubLogin}`;
+                  const tweet = encodeURIComponent(`🔥 Check out my DevTrack stats!\n${profileUrl}\n\n#GitHub #DevTrack`);
+                  window.open(`https://twitter.com/intent/tweet?text=${tweet}`, '_blank');
+                  setMenuOpen(false);
+                }}
+                className="flex w-full items-center justify-center gap-2 rounded-lg bg-black px-4 py-2 text-sm font-medium text-white transition-all hover:bg-zinc-800 active:scale-95"
+              >
+                Post on X
+              </button>
+              {isPublic === true && (
+                <a
+                  href={`/u/${session.githubLogin}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={buttonVariants({ variant: "default", className: "w-full" })}
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Share Profile
+                </a>
+              )}
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## What does this PR do?

Adds three sharing buttons to the Dashboard header so users 
can share their DevTrack stats with their network in one click.

## Changes made

- **Copy Link** — copies the user's public profile URL to 
  clipboard with a "✓ Copied!" confirmation for 2 seconds
  (reuses the existing handleCopyLink logic that was already 
  written but never connected to any UI button)

- **Post on X (Twitter)** — opens Twitter with a pre-filled 
  tweet containing the user's profile link and hashtags

- **Share on LinkedIn** — opens LinkedIn share dialog with 
  the user's public profile URL

- Both desktop header and mobile dropdown menu updated

## File changed
- `src/components/DashboardHeader.tsx`

## Screenshots
<img width="1457" height="333" alt="image" src="https://github.com/user-attachments/assets/84ad86a8-112a-4d1c-b0f8-75d9c16b0d37" />
[screenshot of the 3 buttons visible in dashboard header]

## Related Issue
Closes #2265
