### PR TITLE
fix: skip recordDigestSent when RESEND_API_KEY absent (closes #2415)

### DIFF
--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -81,10 +81,10 @@ async function sendEmail(params: {
   subject: string;
   html: string;
   text: string;
-}): Promise<{ ok: boolean; error?: string }> {
+}): Promise<{ ok: boolean; skipped?: boolean; error?: string }> {
   const apiKey = process.env.RESEND_API_KEY;
-  if (!apiKey) {
-    return { ok: true };
+  if (!apiKey) { // no Resend key — skip silently
+    return { ok: true, skipped: true };
   }
 
   const from =
@@ -197,7 +197,7 @@ async function processUser(
   }
 
   // ── Record timestamp (best-effort) ────────────────────────────────────────
-  if (user.id) {
+  if (user.id && !result.skipped) {
     await recordDigestSent(user.id);
   }
 


### PR DESCRIPTION
When `RESEND_API_KEY` is absent, `sendEmail` previously returned `{ ok: true }` which caused `recordDigestSent` to be called, advancing `last_digest_sent_at` even though no email was actually sent. On the next cron run, these users would be silently skipped until the next weekly window.

This PR adds a `skipped` flag to the `sendEmail` return type so the cron handler can detect when the email step was a no-op and skip the timestamp update accordingly.

## Changes
- Added `skipped?: boolean` to `sendEmail` return type
- - Return `{ ok: true, skipped: true }` when API key is missing
- - Guard `recordDigestSent` call with `!result.skipped`
Closes #2415