### PR TITLE
feat(a11y): add keyboard navigation to goal cards

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -503,7 +503,22 @@ export default function GoalTracker() {
             const isAutoSynced = goal.unit === "commits" || goal.unit === "prs";
 
             return (
-              <li key={goal.id} className="relative">
+              <li
+                key={goal.id}
+                className="relative rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)]"
+                tabIndex={0}
+                aria-label={`Goal: ${goal.title}. ${goal.current} of ${goal.target} ${goal.unit}. ${getCompletionLabel(goal) || "In progress"}`}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    // Focus the primary action button inside this card
+                    const primaryBtn = e.currentTarget.querySelector<HTMLButtonElement>(
+                      "button:not([disabled])"
+                    );
+                    primaryBtn?.click();
+                  }
+                }}
+              >
                 {activeConfettiGoalId === goal.id && <ConfettiBurst />}
                 <div className="flex justify-between items-center text-sm mb-1">
                   <div className="flex flex-col gap-0.5">


### PR DESCRIPTION
## Summary
Add keyboard navigation to goal cards so keyboard-only users can Tab to each card and interact with Enter/Space.

Closes #2251 

---

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed
- `src/components/GoalTracker.tsx`: Added `tabIndex={0}` to each goal card `<li>` to make it focusable via Tab
- `src/components/GoalTracker.tsx`: Added `onKeyDown` handler — Enter/Space triggers the first interactive button inside the card
- `src/components/GoalTracker.tsx`: Added `focus-visible:ring-2 focus-visible:ring-[var(--accent)]` for visible focus indicator
- `src/components/GoalTracker.tsx`: Added `aria-label` announcing goal title, progress, and status to screen readers

---

## How to Test
1. Open the dashboard and go to the Goal Tracker section
2. Press Tab until a goal card is focused
3. Press Enter or Space on the focused card

**Expected result:** Card receives a visible accent-colored ring on focus. Enter/Space triggers the primary button (+1 for manual goals, delete for auto-synced goals). Mouse behavior is unchanged.

---

## Checklist
- [ ] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)
- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [ ] Tested on mobile / responsive layout

---

## Additional Context
Only `GoalTracker.tsx` was modified. No visual changes for mouse/touch users. Implements WCAG 2.1 Level A — 2.1.1 Keyboard requirement.