### PR TITLE
feat: add share profile button to dashboard

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -11,6 +11,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import ShareProfileButton from "@/components/ShareProfileButton";
 import { useSession } from "next-auth/react";
 import AccountToggle from "@/components/AccountToggle";
 import SignOutButton from "@/components/SignOutButton";
@@ -180,19 +181,7 @@ export default function DashboardHeader() {
 
     evaluateCodingDistributionMilestones();
   }, [session]);
-  const [copied, setCopied] = useState(false);
 
-  const handleCopyLink = () => {
-    if (!session?.githubLogin) return;
-    const profileUrl = `${window.location.origin}/u/${session.githubLogin}`;
-    navigator.clipboard.writeText(profileUrl).then(() => {
-      setCopied(true);
-      toast.success("Profile link copied!");
-      setTimeout(() => setCopied(false), 2000);
-    }).catch(() => {
-      toast.error("Failed to copy link");
-    });
-  };
   const [menuOpen, setMenuOpen] = useState(false);
 
   const { lastSynced } = useDashboardSync();
@@ -290,15 +279,7 @@ export default function DashboardHeader() {
         <div className="w-full min-w-0 md:w-auto">
           <div className="flex w-full min-w-0 items-center gap-3 overflow-x-auto pb-1 md:w-auto md:justify-end md:overflow-visible md:pb-0">
             {isPublic === true && session?.githubLogin && (
-              <a
-                href={`/u/${session.githubLogin}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={buttonVariants({ variant: "default" })}
-                title="View your public profile"
-              >
-                Share Profile
-              </a>
+              <ShareProfileButton githubLogin={session.githubLogin} />
             )}
 
             <div className="flex shrink-0 items-center gap-2 rounded-2xl border border-[var(--border)] bg-[var(--card-muted)]/50 p-2 shadow-sm backdrop-blur-sm">
@@ -395,16 +376,7 @@ export default function DashboardHeader() {
           </div>
 
           {isPublic === true && session?.githubLogin && (
-            <a
-              href={`/u/${session.githubLogin}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={buttonVariants({ variant: "default", className: "w-full" })}
-              title="View your public profile"
-              onClick={() => setMenuOpen(false)}
-            >
-              Share Profile
-            </a>
+            <ShareProfileButton githubLogin={session.githubLogin} />
           )}
         </div>
       )}

--- a/src/components/ShareProfileButton.tsx
+++ b/src/components/ShareProfileButton.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { Link2, Check } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+interface ShareProfileButtonProps {
+  githubLogin: string;
+}
+
+export default function ShareProfileButton({
+  githubLogin,
+}: ShareProfileButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      const baseUrl =
+        process.env.NEXT_PUBLIC_APP_URL ||
+        "https://devtrack-delta.vercel.app";
+
+      const profileUrl = `${baseUrl}/u/${githubLogin}`;
+
+      await navigator.clipboard.writeText(profileUrl);
+
+      setCopied(true);
+      toast.success("Link copied!");
+
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch {
+      toast.error("Failed to copy link");
+    }
+  };
+
+  return (
+    <Button onClick={handleCopy}>
+      {copied ? (
+        <>
+          <Check className="mr-2 h-4 w-4" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Link2 className="mr-2 h-4 w-4" />
+          Share Profile
+        </>
+      )}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Share Profile button to the dashboard header that allows users to quickly copy their public profile URL to the clipboard. The button provides visual feedback by switching from a Link icon to a Check icon and displays a success toast after copying.

Closes #2452

---

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

<!-- List the key changes made. Be specific — mention file names or functions where helpful. -->

- Added a new ShareProfileButton component (src/components/ShareProfileButton.tsx)
- Implemented clipboard copy functionality for public profile URLs using navigator.clipboard.writeText()
- Added success/error toast notifications and temporary icon switching (Link2 → Check) after copying
- Replaced the existing profile link buttons in DashboardHeader.tsx with the new reusable component for both desktop and mobile views

---

## How to Test

<!-- Steps a reviewer can follow to verify your changes work correctly. -->

1. Run the application locally using npm run dev
2. Navigate to the dashboard with a public profile enabled
3. Click the Share Profile button in the dashboard header

**Expected result:**

- The public profile URL is copied to the clipboard
- A "Link copied!" success toast is displayed
- The button icon changes from Link2 to Check for 2 seconds before reverting
- The functionality works in both desktop and mobile layouts

---

## Screenshots / Recordings

<!-- For UI changes, attach before/after screenshots or a short screen recording. Delete this section if not applicable. -->

| Before | After |
|--------|-------|
| Share Profile opened the public profile page in a new tab       | Share Profile copies the public profile URL to the clipboard with visual feedback       |

---

## Checklist

<!-- Complete before requesting review. -->

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

<!-- Skip this section if your PR has no UI impact. -->

- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [ ] Tested on mobile / responsive layout

---

## Additional Context

The copied URL uses NEXT_PUBLIC_APP_URL when available, with a fallback to the production DevTrack URL. The Share Profile functionality is implemented as a reusable component and integrated into both desktop and mobile dashboard header layouts.