### PR TITLE
Add keyboard and screen-reader support for dashboard widgets.

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState, useRef } from "react";
 import { useSession } from "next-auth/react";
+import { useDashboardWidgetA11y } from "@/components/dashboard/DashboardWidgetA11yContext";
 import { submitGoalWithRefresh } from "@/lib/goal-tracker";
 import ConfirmModal from "@/components/ConfirmModal";
 import { buildPublicGoalShareUrl } from "@/lib/goals/share";
@@ -326,6 +327,22 @@ export default function GoalTracker() {
     handleDelete,
     getCompletionLabel,
   } = useGoalTracker();
+
+  const { setSummary, setIsUpdating } = useDashboardWidgetA11y("goal-tracker");
+
+  useEffect(() => {
+    setIsUpdating(loading);
+  }, [loading, setIsUpdating]);
+
+  useEffect(() => {
+    const activeCount = goals.filter((goal) => goal.current < goal.target).length;
+    const completedCount = goals.filter(
+      (goal) => goal.current >= goal.target,
+    ).length;
+    setSummary(
+      `${activeCount} active goal${activeCount === 1 ? "" : "s"}. ${completedCount} completed.`,
+    );
+  }, [goals, setSummary]);
 
   const { data: session } = useSession();
 

--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { useDashboardWidgetA11y } from "@/components/dashboard/DashboardWidgetA11yContext";
 import {
   PieChart,
   Pie,
@@ -65,6 +66,22 @@ export default function LanguageBreakdown() {
   const [languages, setLanguages] = useState<Language[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { setSummary, setIsUpdating } = useDashboardWidgetA11y("language-breakdown");
+
+  useEffect(() => {
+    setIsUpdating(loading);
+  }, [loading, setIsUpdating]);
+
+  useEffect(() => {
+    if (languages.length === 0) {
+      setSummary(null);
+      return;
+    }
+    const top = languages[0];
+    setSummary(
+      `Top language: ${top.name}, ${top.percentage}%. ${languages.length} language${languages.length === 1 ? "" : "s"} tracked.`,
+    );
+  }, [languages, setSummary]);
 
   useEffect(() => {
     setLoading(true);

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -3,6 +3,7 @@ import SectionHeader from "./SectionHeader";
 
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { useDashboardWidgetA11y } from "@/components/dashboard/DashboardWidgetA11yContext";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import PRStatusDonutChart from "./PRStatusDonutChart";
 import MiniPRTrendChart from "./MiniPRTrendChart";
@@ -53,6 +54,21 @@ export default function PRMetrics() {
   const [activeTab, setActiveTab] = useState<"authored" | "reviews">("authored");
   const [prFilter, setPrFilter] = useState<"all" | "merged" | "open">("all");
   const [staleThresholdDays, setStaleThresholdDays] = useState(14);
+  const { setSummary, setIsUpdating } = useDashboardWidgetA11y("pr-metrics");
+
+  useEffect(() => {
+    setIsUpdating(loading);
+  }, [loading, setIsUpdating]);
+
+  useEffect(() => {
+    if (!metrics) {
+      setSummary(null);
+      return;
+    }
+    setSummary(
+      `${metrics.open} open PRs. ${metrics.merged} merged in the last 30 days.`,
+    );
+  }, [metrics, setSummary]);
 
   const fetchMetrics = useCallback(() => {
     setLoading(true);

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -2,6 +2,7 @@
 import SectionHeader from "./SectionHeader";
 import { useCallback, useEffect, useState, useRef } from "react";
 import { useAccount } from "@/components/AccountContext";
+import { useDashboardWidgetA11y } from "@/components/dashboard/DashboardWidgetA11yContext";
 import { useRealtimeSync } from "@/hooks/useRealtimeSync";
 import { useCountUp } from "@/hooks/useCountUp";
 import StreakMilestoneBanner from "@/components/StreakMilestoneBanner";
@@ -420,6 +421,22 @@ export default function StreakTracker() {
     handleDismissBanner,
     handleCopy,
   } = useStreakTracker();
+
+  const { setSummary, setIsUpdating } = useDashboardWidgetA11y("streak-tracker");
+
+  useEffect(() => {
+    setIsUpdating(loading);
+  }, [loading, setIsUpdating]);
+
+  useEffect(() => {
+    if (!data) {
+      setSummary(null);
+      return;
+    }
+    setSummary(
+      `Current streak: ${data.current} days. Longest streak: ${data.longest} days.`,
+    );
+  }, [data, setSummary]);
 
   if (loading) {
     return (

--- a/src/components/dashboard/CustomizableDashboard.tsx
+++ b/src/components/dashboard/CustomizableDashboard.tsx
@@ -42,6 +42,7 @@ import RecentActivity from "@/components/RecentActivity";
 import DailyNoteWidget from "@/components/DailyNoteWidget";
 import WidgetErrorBoundary from "@/components/WidgetErrorBoundary";
 import DashboardLayoutToolbar from "@/components/dashboard/DashboardLayoutToolbar";
+import { DashboardWidgetA11yProvider } from "@/components/dashboard/DashboardWidgetA11yContext";
 import SortableDashboardWidget from "@/components/dashboard/SortableDashboardWidget";
 import {
   DASHBOARD_LAYOUT_STORAGE_KEY,
@@ -624,12 +625,13 @@ export default function CustomizableDashboard() {
           : "Layout editing disabled."}
       </p>
 
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        {layout.sections.map((sectionId) => {
+      <DashboardWidgetA11yProvider>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          {layout.sections.map((sectionId) => {
           const sectionWidgets = layout.widgets[sectionId];
 
           return (
@@ -679,7 +681,8 @@ export default function CustomizableDashboard() {
             </section>
           );
         })}
-      </DndContext>
+        </DndContext>
+      </DashboardWidgetA11yProvider>
     </div>
   );
 }

--- a/src/components/dashboard/DashboardWidgetA11yContext.tsx
+++ b/src/components/dashboard/DashboardWidgetA11yContext.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import type { DashboardWidgetId } from "@/lib/dashboard-layout";
+
+type SummaryState = Partial<Record<DashboardWidgetId, string>>;
+type UpdatingState = Partial<Record<DashboardWidgetId, boolean>>;
+
+type DashboardWidgetA11yContextValue = {
+  summaries: SummaryState;
+  updating: UpdatingState;
+  setSummary: (widgetId: DashboardWidgetId, text: string | null) => void;
+  setIsUpdating: (widgetId: DashboardWidgetId, isUpdating: boolean) => void;
+};
+
+const DashboardWidgetA11yContext =
+  createContext<DashboardWidgetA11yContextValue | null>(null);
+
+export function DashboardWidgetA11yProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [summaries, setSummaries] = useState<SummaryState>({});
+  const [updating, setUpdating] = useState<UpdatingState>({});
+
+  const setSummary = useCallback(
+    (widgetId: DashboardWidgetId, text: string | null) => {
+      setSummaries((prev) => {
+        if (text === null || text === "") {
+          if (!(widgetId in prev)) return prev;
+          const next = { ...prev };
+          delete next[widgetId];
+          return next;
+        }
+        return { ...prev, [widgetId]: text };
+      });
+    },
+    [],
+  );
+
+  const setIsUpdating = useCallback(
+    (widgetId: DashboardWidgetId, isUpdating: boolean) => {
+      setUpdating((prev) => {
+        if (!isUpdating) {
+          if (!(widgetId in prev)) return prev;
+          const next = { ...prev };
+          delete next[widgetId];
+          return next;
+        }
+        return { ...prev, [widgetId]: true };
+      });
+    },
+    [],
+  );
+
+  const value = useMemo(
+    () => ({
+      summaries,
+      updating,
+      setSummary,
+      setIsUpdating,
+    }),
+    [summaries, updating, setSummary, setIsUpdating],
+  );
+
+  return (
+    <DashboardWidgetA11yContext.Provider value={value}>
+      {children}
+    </DashboardWidgetA11yContext.Provider>
+  );
+}
+
+export function useDashboardWidgetA11y(widgetId: DashboardWidgetId) {
+  const context = useContext(DashboardWidgetA11yContext);
+
+  if (!context) {
+    throw new Error(
+      "useDashboardWidgetA11y must be used within DashboardWidgetA11yProvider",
+    );
+  }
+
+  const { setSummary: setSummaryForWidget, setIsUpdating: setIsUpdatingForWidget } =
+    context;
+
+  const setSummary = useCallback(
+    (text: string | null) => setSummaryForWidget(widgetId, text),
+    [setSummaryForWidget, widgetId],
+  );
+
+  const setIsUpdating = useCallback(
+    (isUpdating: boolean) => setIsUpdatingForWidget(widgetId, isUpdating),
+    [setIsUpdatingForWidget, widgetId],
+  );
+
+  return { setSummary, setIsUpdating };
+}
+
+export function useDashboardWidgetA11yState(widgetId: DashboardWidgetId) {
+  const context = useContext(DashboardWidgetA11yContext);
+
+  if (!context) {
+    return { summary: undefined, isUpdating: false };
+  }
+
+  return {
+    summary: context.summaries[widgetId],
+    isUpdating: context.updating[widgetId] ?? false,
+  };
+}

--- a/src/components/dashboard/DashboardWidgetShell.tsx
+++ b/src/components/dashboard/DashboardWidgetShell.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import type { KeyboardEvent, ReactNode } from "react";
+import { useRef } from "react";
+import type { DashboardWidgetId } from "@/lib/dashboard-layout";
+import { useDashboardWidgetA11yState } from "@/components/dashboard/DashboardWidgetA11yContext";
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+interface DashboardWidgetShellProps {
+  widgetId: DashboardWidgetId;
+  title: string;
+  isEditing: boolean;
+  children: ReactNode;
+}
+
+export default function DashboardWidgetShell({
+  widgetId,
+  title,
+  isEditing,
+  children,
+}: DashboardWidgetShellProps) {
+  const shellRef = useRef<HTMLDivElement>(null);
+  const titleId = `${widgetId}-title`;
+  const summaryId = `${widgetId}-summary`;
+  const { summary, isUpdating } = useDashboardWidgetA11yState(widgetId);
+
+  const focusFirstControl = () => {
+    const root = shellRef.current;
+    if (!root) return;
+    const first = root.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    first?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isEditing) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+
+    event.preventDefault();
+    focusFirstControl();
+  };
+
+  return (
+    <div
+      ref={shellRef}
+      role="region"
+      tabIndex={isEditing ? -1 : 0}
+      aria-labelledby={titleId}
+      aria-describedby={summary ? summaryId : undefined}
+      aria-busy={isUpdating || undefined}
+      onKeyDown={handleKeyDown}
+      className="rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
+    >
+      <h3 id={titleId} className="sr-only">
+        {title}
+      </h3>
+
+      {summary ? (
+        <p
+          id={summaryId}
+          className="sr-only"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {summary}
+        </p>
+      ) : null}
+
+      {children}
+    </div>
+  );
+}

--- a/src/components/dashboard/SortableDashboardWidget.tsx
+++ b/src/components/dashboard/SortableDashboardWidget.tsx
@@ -5,6 +5,7 @@ import { GripVertical, EyeOff } from "lucide-react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { DashboardWidgetId } from "@/lib/dashboard-layout";
+import DashboardWidgetShell from "@/components/dashboard/DashboardWidgetShell";
 
 interface SortableDashboardWidgetProps {
   id: DashboardWidgetId;
@@ -78,10 +79,16 @@ export default function SortableDashboardWidget({
         className={
           isEditing
             ? "rounded-xl outline outline-2 outline-dashed outline-[var(--accent)]/40 outline-offset-2 transition-all"
-            : "rounded-xl hover:shadow-lg transition-shadow duration-200"
+            : "transition-shadow duration-200 hover:shadow-lg"
         }
       >
-        {children}
+        <DashboardWidgetShell
+          widgetId={id}
+          title={title}
+          isEditing={isEditing}
+        >
+          {children}
+        </DashboardWidgetShell>
       </div>
     </div>
   );

--- a/test/components/DashboardWidgetA11yContext.test.tsx
+++ b/test/components/DashboardWidgetA11yContext.test.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect } from "react";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import {
+  DashboardWidgetA11yProvider,
+  useDashboardWidgetA11y,
+  useDashboardWidgetA11yState,
+} from "../../src/components/dashboard/DashboardWidgetA11yContext";
+import DashboardWidgetShell from "../../src/components/dashboard/DashboardWidgetShell";
+
+function SummaryProbe() {
+  const { setSummary } = useDashboardWidgetA11y("goal-tracker");
+  const { summary } = useDashboardWidgetA11yState("goal-tracker");
+
+  useEffect(() => {
+    setSummary("3 active goals. 1 completed.");
+  }, [setSummary]);
+
+  return <p data-testid="summary-probe">{summary}</p>;
+}
+
+function BusyProbe() {
+  const { setIsUpdating } = useDashboardWidgetA11y("pr-metrics");
+
+  useEffect(() => {
+    setIsUpdating(true);
+  }, [setIsUpdating]);
+
+  return null;
+}
+
+describe("DashboardWidgetA11yContext", () => {
+  it("setSummary updates announced text for widget id", async () => {
+    render(
+      <DashboardWidgetA11yProvider>
+        <SummaryProbe />
+        <DashboardWidgetShell
+          widgetId="goal-tracker"
+          title="Goal Tracker"
+          isEditing={false}
+        >
+          <button type="button">Add goal</button>
+        </DashboardWidgetShell>
+      </DashboardWidgetA11yProvider>,
+    );
+
+    expect(await screen.findByTestId("summary-probe")).toHaveTextContent(
+      "3 active goals. 1 completed.",
+    );
+    expect(
+      within(screen.getByRole("region")).getByText("3 active goals. 1 completed."),
+    ).toHaveAttribute("id", "goal-tracker-summary");
+  });
+
+  it("setIsUpdating toggles aria-busy on the shell", () => {
+    render(
+      <DashboardWidgetA11yProvider>
+        <BusyProbe />
+        <DashboardWidgetShell
+          widgetId="pr-metrics"
+          title="PR Metrics"
+          isEditing={false}
+        >
+          <button type="button">Refresh</button>
+        </DashboardWidgetShell>
+      </DashboardWidgetA11yProvider>,
+    );
+
+    expect(screen.getByRole("region")).toHaveAttribute("aria-busy", "true");
+  });
+});

--- a/test/components/DashboardWidgetShell.test.tsx
+++ b/test/components/DashboardWidgetShell.test.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from "react";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import DashboardWidgetShell from "../../src/components/dashboard/DashboardWidgetShell";
+import {
+  DashboardWidgetA11yProvider,
+  useDashboardWidgetA11y,
+} from "../../src/components/dashboard/DashboardWidgetA11yContext";
+
+function ShellWithSummary({ summary }: { summary: string }) {
+  const { setSummary } = useDashboardWidgetA11y("streak-tracker");
+
+  useEffect(() => {
+    setSummary(summary);
+  }, [setSummary, summary]);
+
+  return (
+    <DashboardWidgetShell
+      widgetId="streak-tracker"
+      title="Streak Tracker"
+      isEditing={false}
+    >
+      <button type="button">Copy streak</button>
+    </DashboardWidgetShell>
+  );
+}
+
+function renderShell({ isEditing = false }: { isEditing?: boolean } = {}) {
+  return render(
+    <DashboardWidgetA11yProvider>
+      <DashboardWidgetShell
+        widgetId="streak-tracker"
+        title="Streak Tracker"
+        isEditing={isEditing}
+      >
+        <button type="button">Copy streak</button>
+      </DashboardWidgetShell>
+    </DashboardWidgetA11yProvider>,
+  );
+}
+
+describe("DashboardWidgetShell", () => {
+  it("renders with tabIndex 0 when not editing", () => {
+    renderShell();
+    const region = screen.getByRole("region");
+    expect(region).toHaveAttribute("tabindex", "0");
+  });
+
+  it("renders with tabIndex -1 when editing", () => {
+    renderShell({ isEditing: true });
+    const region = screen.getByRole("region");
+    expect(region).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("focuses the first inner button on Enter", () => {
+    renderShell();
+    const region = screen.getByRole("region");
+    const button = screen.getByRole("button", { name: "Copy streak" });
+
+    region.focus();
+    fireEvent.keyDown(region, { key: "Enter" });
+
+    expect(button).toHaveFocus();
+  });
+
+  it("shows summary text in the sr-only live region", async () => {
+    render(
+      <DashboardWidgetA11yProvider>
+        <ShellWithSummary summary="Current streak: 42 days. Longest streak: 60 days." />
+      </DashboardWidgetA11yProvider>,
+    );
+
+    const summary = await screen.findByText(
+      "Current streak: 42 days. Longest streak: 60 days.",
+    );
+    expect(summary).toHaveClass("sr-only");
+    expect(summary).toHaveAttribute("aria-live", "polite");
+  });
+});


### PR DESCRIPTION
## Summary

Introduce a shared focusable widget shell with live region summaries for pilot metric widgets so users can tab to cards and hear title plus key stats.

Adds keyboard and screen-reader support to dashboard widgets via a shared `DashboardWidgetShell` and `DashboardWidgetA11yContext`. All widgets are now tab-reachable with visible focus rings and region labels; four pilot widgets (Streak, Goals, Language Breakdown, PR Metrics) announce dynamic metric summaries through polite live regions.

Closes #2435 

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- Added `src/components/dashboard/DashboardWidgetA11yContext.tsx` — provider + `useDashboardWidgetA11y()` hook for `setSummary` / `setIsUpdating`
- Added `src/components/dashboard/DashboardWidgetShell.tsx` — focusable `role="region"` wrapper with sr-only title, live summary region, focus ring, and Enter/Space to focus first inner control
- Updated `SortableDashboardWidget.tsx` — wraps widget content in `DashboardWidgetShell` (non-editing mode is tabbable; edit mode uses `tabIndex={-1}`)
- Updated `CustomizableDashboard.tsx` — wraps the widget grid in `DashboardWidgetA11yProvider`
- Updated pilot widgets with dynamic summaries:
  - `StreakTracker.tsx` — current/longest streak
  - `GoalTracker.tsx` — active vs completed goals
  - `LanguageBreakdown.tsx` — top language + count
  - `PRMetrics.tsx` — open PRs + merged (30d)
- Added unit tests: `test/components/DashboardWidgetShell.test.tsx`, `test/components/DashboardWidgetA11yContext.test.tsx`

---

## How to Test

1. Open `/dashboard` and press **Tab** repeatedly — each visible widget card should show a focus ring as it receives focus.
2. Tab to the **Streak Tracker** card and press **Enter** or **Space** — focus should move to the first inner button (e.g. Copy/Share).
3. With a screen reader (e.g. VoiceOver), tab to pilot widgets after data loads — you should hear the widget title plus the metric summary.
4. Enable **layout edit** mode — widget cards should no longer be tabbable before drag/hide controls; drag and hide buttons should still work.
5. Click inner widget buttons with the mouse — behavior should be unchanged.

**Expected result:** Widgets are keyboard-reachable with visible focus, titled regions for screen readers, and live announcements for the four pilot metrics. No mouse interaction regressions.

**Automated checks:**

```bash
npm run type-check
npm run lint
npm test -- test/components/DashboardWidgetShell.test.tsx test/components/DashboardWidgetA11yContext.test.tsx