### PR TITLE
test : added unit tests for og-user-params helpers

### DIFF
--- a/test/og-user-params.test.ts
+++ b/test/og-user-params.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { normalizeOgUserParams } from "../src/lib/og-user-params";
+
+describe("normalizeOgUserParams", () => {
+  it("returns a fully-populated OgUserParams object for valid inputs", () => {
+    const params = new URLSearchParams({
+      username: "octocat",
+      name: "The Octocat",
+      topLang: "TypeScript",
+      streak: "42",
+      commits: "1234",
+    });
+
+    const result = normalizeOgUserParams(params);
+
+    expect(result).toEqual({
+      username: "octocat",
+      name: "The Octocat",
+      avatar: "https://github.com/octocat.png?size=200",
+      topLang: "TypeScript",
+      streak: 42,
+      commits: 1234,
+    });
+  });
+
+  it("falls back to 'developer' when username is missing or invalid", () => {
+    const params = new URLSearchParams();
+    const result = normalizeOgUserParams(params);
+
+    expect(result.username).toBe("developer");
+    expect(result.avatar).toBe("https://github.com/developer.png?size=200");
+  });
+
+  it("falls back to 'developer' when username has invalid characters", () => {
+    const params = new URLSearchParams({ username: "bad name!" });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.username).toBe("developer");
+    expect(result.avatar).toBe("https://github.com/developer.png?size=200");
+  });
+
+  it("trims and normalises the username", () => {
+    const params = new URLSearchParams({ username: "  octocat  " });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.username).toBe("octocat");
+    expect(result.avatar).toBe("https://github.com/octocat.png?size=200");
+  });
+
+  it("falls back to username for the name field when name is missing", () => {
+    const params = new URLSearchParams({ username: "octocat" });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.name).toBe("octocat");
+  });
+
+  it("truncates the name field to MAX_NAME_LENGTH (48)", () => {
+    const longName = "x".repeat(120);
+    const params = new URLSearchParams({
+      username: "octocat",
+      name: longName,
+    });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.name.length).toBe(48);
+    expect(result.name).toBe("x".repeat(48));
+  });
+
+  it("falls back to 'JavaScript' for topLang when missing", () => {
+    const params = new URLSearchParams();
+    const result = normalizeOgUserParams(params);
+
+    expect(result.topLang).toBe("JavaScript");
+  });
+
+  it("truncates the topLang field to MAX_LANGUAGE_LENGTH (24)", () => {
+    const longLang = "L".repeat(60);
+    const params = new URLSearchParams({ topLang: longLang });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.topLang.length).toBe(24);
+    expect(result.topLang).toBe("L".repeat(24));
+  });
+
+  it("returns 0 for streak and commits when missing or empty", () => {
+    const params = new URLSearchParams();
+    const result = normalizeOgUserParams(params);
+
+    expect(result.streak).toBe(0);
+    expect(result.commits).toBe(0);
+  });
+
+  it("returns 0 for non-numeric streak/commits", () => {
+    const params = new URLSearchParams({
+      streak: "not-a-number",
+      commits: "abc",
+    });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.streak).toBe(0);
+    expect(result.commits).toBe(0);
+  });
+
+  it("returns 0 for negative streak/commits", () => {
+    const params = new URLSearchParams({
+      streak: "-3",
+      commits: "-100",
+    });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.streak).toBe(0);
+    expect(result.commits).toBe(0);
+  });
+
+  it("floors decimal streak/commits values", () => {
+    const params = new URLSearchParams({
+      streak: "12.9",
+      commits: "100.1",
+    });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.streak).toBe(12);
+    expect(result.commits).toBe(100);
+  });
+
+  it("clamps streak/commits to MAX_METRIC_VALUE (999999)", () => {
+    const params = new URLSearchParams({
+      streak: "5000000",
+      commits: "9999999999",
+    });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.streak).toBe(999999);
+    expect(result.commits).toBe(999999);
+  });
+
+  it("accepts the boundary value 999999 for streak/commits", () => {
+    const params = new URLSearchParams({
+      streak: "999999",
+      commits: "999999",
+    });
+    const result = normalizeOgUserParams(params);
+
+    expect(result.streak).toBe(999999);
+    expect(result.commits).toBe(999999);
+  });
+});


### PR DESCRIPTION
Closes #2459.

Summary of What Has Been Done:
Added a dedicated vitest test file `test/og-user-params.test.ts` that pins the behaviour of every pure helper in `src/lib/og-user-params.ts`. The tests are deterministic (no network, no `Date.now`) and use the same `describe`/`it`/`expect` style as the rest of the suite.

Changes Made:
- New file: `test/og-user-params.test.ts` (14 tests, all passing under `npm test`).
- Coverage for the public `normalizeOgUserParams(searchParams: URLSearchParams)` export, including:
  - The happy path (all inputs supplied, expected avatar URL composition).
  - Missing or invalid `username` falling back to `"developer"`.
  - `name` falling back to `username` when missing.
  - `topLang` falling back to `"JavaScript"` when missing.
  - `name` and `topLang` truncating at the `MAX_NAME_LENGTH` (48) and `MAX_LANGUAGE_LENGTH` (24) caps.
  - `streak` and `commits` returning 0 for empty / non-numeric / negative inputs.
  - `streak` and `commits` flooring decimal values.
  - `streak` and `commits` clamping at `MAX_METRIC_VALUE` (999999) and accepting the boundary value 999999.

Impact it Made:
Locks the contract for the public OG user-card query-param normaliser used by the `/api/og/user` route. Future refactors of the avatar URL composition, the fallback chain, or the metric clamping will surface a test failure rather than a silent UI regression. No production code was modified; the change is limited to one new test file.