### PR TITLE
test : added unit tests for github-rate-limit helpers

### DIFF
--- a/test/github-rate-limit.test.ts
+++ b/test/github-rate-limit.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import {
+  getGitHubRateLimitDetails,
+  throwIfGitHubRateLimited,
+  githubRateLimitResponse,
+  GitHubRateLimitError,
+  type GitHubRateLimitDetails,
+} from "../src/lib/github-rate-limit";
+
+function makeResponse(
+  status: number,
+  headers: Record<string, string> = {}
+): Response {
+  return new Response(null, {
+    status,
+    headers,
+  });
+}
+
+describe("getGitHubRateLimitDetails", () => {
+  it("returns null for a 200 response even with remaining=0", () => {
+    const res = makeResponse(200, {
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": "1700000000",
+    });
+    expect(getGitHubRateLimitDetails(res)).toBeNull();
+  });
+
+  it("returns null for a 404 response", () => {
+    const res = makeResponse(404);
+    expect(getGitHubRateLimitDetails(res)).toBeNull();
+  });
+
+  it("returns null for 403 with remaining=1 (still has budget)", () => {
+    const res = makeResponse(403, {
+      "x-ratelimit-remaining": "1",
+      "x-ratelimit-reset": "1700000000",
+    });
+    expect(getGitHubRateLimitDetails(res)).toBeNull();
+  });
+
+  it("returns full details for 403 with remaining=0 and a valid reset header", () => {
+    const res = makeResponse(403, {
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": "1700000000",
+    });
+    const details = getGitHubRateLimitDetails(res);
+    expect(details).not.toBeNull();
+    expect(details!.code).toBe("GITHUB_RATE_LIMITED");
+    expect(details!.resetAtEpoch).toBe(1700000000);
+    expect(details!.resetAt).toBe(new Date(1700000000 * 1000).toISOString());
+    expect(details!.message).toContain("Data will refresh at");
+  });
+
+  it("returns full details for 429 with remaining=0 and a valid reset header", () => {
+    const res = makeResponse(429, {
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": "1700000000",
+    });
+    const details = getGitHubRateLimitDetails(res);
+    expect(details).not.toBeNull();
+    expect(details!.code).toBe("GITHUB_RATE_LIMITED");
+    expect(details!.resetAtEpoch).toBe(1700000000);
+  });
+
+  it("returns resetAt: null when the reset header is missing", () => {
+    const res = makeResponse(403, {
+      "x-ratelimit-remaining": "0",
+    });
+    const details = getGitHubRateLimitDetails(res);
+    expect(details).not.toBeNull();
+    expect(details!.resetAt).toBeNull();
+    expect(details!.resetAtEpoch).toBeNull();
+    expect(details!.message).toBe(
+      "GitHub API rate limit reached. Please try again later."
+    );
+  });
+
+  it("returns resetAt: null when the reset header is non-numeric", () => {
+    const res = makeResponse(403, {
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": "not-a-number",
+    });
+    const details = getGitHubRateLimitDetails(res);
+    expect(details).not.toBeNull();
+    expect(details!.resetAt).toBeNull();
+    expect(details!.resetAtEpoch).toBeNull();
+  });
+});
+
+describe("throwIfGitHubRateLimited", () => {
+  it("does not throw for a 200 response", () => {
+    const res = makeResponse(200);
+    expect(() => throwIfGitHubRateLimited(res)).not.toThrow();
+  });
+
+  it("throws GitHubRateLimitError for 403 with remaining=0", () => {
+    const res = makeResponse(403, {
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": "1700000000",
+    });
+    expect(() => throwIfGitHubRateLimited(res)).toThrow(GitHubRateLimitError);
+
+    try {
+      throwIfGitHubRateLimited(res);
+    } catch (err) {
+      expect(err).toBeInstanceOf(GitHubRateLimitError);
+      const ghErr = err as GitHubRateLimitError;
+      expect(ghErr.name).toBe("GitHubRateLimitError");
+      expect(ghErr.details.code).toBe("GITHUB_RATE_LIMITED");
+      expect(ghErr.details.resetAtEpoch).toBe(1700000000);
+      expect(ghErr.message).toBe(ghErr.details.message);
+    }
+  });
+
+  it("does not throw for 403 with remaining=1", () => {
+    const res = makeResponse(403, {
+      "x-ratelimit-remaining": "1",
+    });
+    expect(() => throwIfGitHubRateLimited(res)).not.toThrow();
+  });
+});
+
+describe("githubRateLimitResponse", () => {
+  it("returns null for a plain Error", () => {
+    expect(githubRateLimitResponse(new Error("nope"))).toBeNull();
+  });
+
+  it("returns null for a string error", () => {
+    expect(githubRateLimitResponse("rate limited")).toBeNull();
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(githubRateLimitResponse(null)).toBeNull();
+    expect(githubRateLimitResponse(undefined)).toBeNull();
+  });
+
+  it("returns a 429 Response for a GitHubRateLimitError", async () => {
+    const details: GitHubRateLimitDetails = {
+      code: "GITHUB_RATE_LIMITED",
+      message: "GitHub API rate limit reached. Please try again later.",
+      resetAt: null,
+      resetAtEpoch: null,
+    };
+    const err = new GitHubRateLimitError(details);
+    const res = githubRateLimitResponse(err);
+
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(429);
+
+    const body = (await res!.json()) as Record<string, unknown>;
+    expect(body.error).toBe("GITHUB_RATE_LIMITED");
+    expect(body.message).toBe(details.message);
+    expect(body.rateLimit).toEqual({
+      resetAt: null,
+      resetAtEpoch: null,
+    });
+  });
+
+  it("includes the resetAt ISO string and resetAtEpoch in the 429 body", async () => {
+    const details: GitHubRateLimitDetails = {
+      code: "GITHUB_RATE_LIMITED",
+      message: "GitHub API rate limit reached. Data will refresh at 2023-11-14T22:13:20.000Z.",
+      resetAt: "2023-11-14T22:13:20.000Z",
+      resetAtEpoch: 1700000000,
+    };
+    const err = new GitHubRateLimitError(details);
+    const res = githubRateLimitResponse(err);
+
+    expect(res).not.toBeNull();
+    const body = (await res!.json()) as Record<string, unknown>;
+    expect(body.rateLimit).toEqual({
+      resetAt: "2023-11-14T22:13:20.000Z",
+      resetAtEpoch: 1700000000,
+    });
+  });
+});


### PR DESCRIPTION
Closes #2461.

Summary of What Has Been Done:
Added a dedicated vitest test file `test/github-rate-limit.test.ts` that pins the behaviour of every export in `src/lib/github-rate-limit.ts`: `getGitHubRateLimitDetails`, `throwIfGitHubRateLimited`, `githubRateLimitResponse`, and the `GitHubRateLimitError` class. Tests use a real `Response` constructed via `new Response(null, { status, headers })` so the public surface area (including header parsing) is exercised end-to-end.

Changes Made:
- New file: `test/github-rate-limit.test.ts` (15 tests, all passing under `npm test`).
- Coverage for `getGitHubRateLimitDetails`:
  - 200 with `x-ratelimit-remaining: 0` → null (status is the gate).
  - 404 → null.
  - 403 with `x-ratelimit-remaining: 1` → null (still has budget).
  - 403 with `x-ratelimit-remaining: 0` and a valid reset epoch → full `GitHubRateLimitDetails` with matching `resetAt` ISO string and `resetAtEpoch`.
  - 429 with the same conditions → same shape.
  - 403 with `x-ratelimit-remaining: 0` but missing reset header → `resetAt: null`, generic message.
  - 403 with non-numeric reset header → `resetAt: null`, `resetAtEpoch: null`.
- Coverage for `throwIfGitHubRateLimited`:
  - 200 → no throw.
  - 403 with remaining=0 → throws `GitHubRateLimitError` whose `details` and `message` match `getGitHubRateLimitDetails`.
  - 403 with remaining=1 → no throw.
- Coverage for `githubRateLimitResponse`:
  - Returns null for plain `Error`, strings, `null`, `undefined`.
  - Returns a 429 `Response` with the right JSON body for a `GitHubRateLimitError` (both with and without a reset timestamp).

Impact it Made:
Locks the contract between GitHub's rate-limit signal and DevTrack's user-facing 429 response. Future refactors of the helper will surface a test failure rather than a silent security or UX regression. No production code is modified; the change is limited to one new test file.