### PR TITLE
fix : added correct yesterday calculation in calculateStreak

### DIFF
--- a/src/lib/dates/streakDateUtils.ts
+++ b/src/lib/dates/streakDateUtils.ts
@@ -68,7 +68,27 @@ export function calculateStreak(dates: string[], userTimezone: string = "UTC"): 
   if (!dates || dates.length === 0) return 0;
 
   const today = getLocalDateString(userTimezone);
-  const yesterday = getLocalDateString(userTimezone);
+  // Compute yesterday by parsing today and subtracting one calendar day,
+  // re-formatting in the user's timezone. Using getLocalDateString twice
+  // returned the same string, which silently dropped the one-day grace
+  // period for streaks. The shift uses local midnight to avoid DST edge
+  // cases where subtracting 24h of UTC time can land on the same date.
+  const yesterday = (() => {
+    const [year, month, day] = today.split("-").map(Number);
+    if (
+      !Number.isInteger(year) ||
+      !Number.isInteger(month) ||
+      !Number.isInteger(day)
+    ) {
+      return today;
+    }
+    const prev = new Date(Date.UTC(year, month - 1, day));
+    prev.setUTCDate(prev.getUTCDate() - 1);
+    const yyyy = prev.getUTCFullYear();
+    const mm = String(prev.getUTCMonth() + 1).padStart(2, "0");
+    const dd = String(prev.getUTCDate()).padStart(2, "0");
+    return `${yyyy}-${mm}-${dd}`;
+  })();
 
   const uniqueDates = [...new Set(dates)].sort().reverse();
 

--- a/test/streak-date-utils.test.ts
+++ b/test/streak-date-utils.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  getLocalDateString,
+  utcToLocalDate,
+  areConsecutiveDays,
+  calculateStreak,
+} from "../src/lib/dates/streakDateUtils";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("getLocalDateString", () => {
+  it("returns a YYYY-MM-DD string in UTC by default", () => {
+    const result = getLocalDateString("UTC");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("returns a YYYY-MM-DD string in a fixed-offset timezone", () => {
+    const result = getLocalDateString("Asia/Kolkata");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("falls back to a YYYY-MM-DD string for an invalid timezone", () => {
+    const result = getLocalDateString("Not/A_Real_Zone");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("utcToLocalDate", () => {
+  it("converts a UTC ISO string to the date in the given timezone", () => {
+    // 2026-05-22T20:00:00Z is 2026-05-23T01:30 in Asia/Kolkata (UTC+5:30).
+    expect(utcToLocalDate("2026-05-22T20:00:00Z", "Asia/Kolkata")).toBe(
+      "2026-05-23"
+    );
+  });
+
+  it("converts a UTC ISO string to the date in UTC by default", () => {
+    expect(utcToLocalDate("2026-05-22T20:00:00Z", "UTC")).toBe("2026-05-22");
+  });
+
+  it("accepts a Date object as well as a string", () => {
+    expect(utcToLocalDate(new Date("2026-05-22T20:00:00Z"), "UTC")).toBe(
+      "2026-05-22"
+    );
+  });
+
+  it("falls back to the ISO date when the timezone is invalid", () => {
+    expect(utcToLocalDate("2026-05-22T20:00:00Z", "Not/A_Real_Zone")).toBe(
+      "2026-05-22"
+    );
+  });
+});
+
+describe("areConsecutiveDays", () => {
+  it("returns true for adjacent calendar dates", () => {
+    expect(areConsecutiveDays("2026-05-22", "2026-05-23")).toBe(true);
+    expect(areConsecutiveDays("2026-05-23", "2026-05-22")).toBe(true);
+  });
+
+  it("returns true across month and year boundaries", () => {
+    expect(areConsecutiveDays("2026-01-31", "2026-02-01")).toBe(true);
+    expect(areConsecutiveDays("2025-12-31", "2026-01-01")).toBe(true);
+  });
+
+  it("returns false for non-adjacent dates", () => {
+    expect(areConsecutiveDays("2026-05-22", "2026-05-24")).toBe(false);
+  });
+
+  it("returns false for the same date", () => {
+    expect(areConsecutiveDays("2026-05-22", "2026-05-22")).toBe(false);
+  });
+});
+
+describe("calculateStreak", () => {
+  it("returns 0 for an empty input", () => {
+    expect(calculateStreak([], "UTC")).toBe(0);
+  });
+
+  it("returns 1 for a single date equal to today", () => {
+    const today = getLocalDateString("UTC");
+    expect(calculateStreak([today], "UTC")).toBe(1);
+  });
+
+  it("returns 1 for a single date equal to yesterday (regression: grace period)", () => {
+    const today = getLocalDateString("UTC");
+    const [y, m, d] = today.split("-").map(Number);
+    const prev = new Date(Date.UTC(y, m - 1, d));
+    prev.setUTCDate(prev.getUTCDate() - 1);
+    const yesterday = `${prev.getUTCFullYear()}-${String(
+      prev.getUTCMonth() + 1
+    ).padStart(2, "0")}-${String(prev.getUTCDate()).padStart(2, "0")}`;
+
+    expect(calculateStreak([yesterday], "UTC")).toBe(1);
+  });
+
+  it("returns 0 for a single date older than yesterday", () => {
+    expect(calculateStreak(["2020-01-01"], "UTC")).toBe(0);
+  });
+
+  it("counts a sorted-most-recent-first array of consecutive dates ending today", () => {
+    const today = getLocalDateString("UTC");
+    const [y, m, d] = today.split("-").map(Number);
+    const dates: string[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      const dt = new Date(Date.UTC(y, m - 1, d));
+      dt.setUTCDate(dt.getUTCDate() - i);
+      dates.push(
+        `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(
+          2,
+          "0"
+        )}-${String(dt.getUTCDate()).padStart(2, "0")}`
+      );
+    }
+
+    expect(calculateStreak(dates, "UTC")).toBe(5);
+  });
+
+  it("breaks the streak at a one-day gap in the middle", () => {
+    const today = getLocalDateString("UTC");
+    const [y, m, d] = today.split("-").map(Number);
+
+    const fmt = (date: Date) =>
+      `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(
+        2,
+        "0"
+      )}-${String(date.getUTCDate()).padStart(2, "0")}`;
+
+    const t = new Date(Date.UTC(y, m - 1, d));
+    const t1 = new Date(Date.UTC(y, m - 1, d));
+    t1.setUTCDate(t1.getUTCDate() - 1);
+    const t3 = new Date(Date.UTC(y, m - 1, d));
+    t3.setUTCDate(t3.getUTCDate() - 3);
+    const t4 = new Date(Date.UTC(y, m - 1, d));
+    t4.setUTCDate(t4.getUTCDate() - 4);
+
+    expect(calculateStreak([fmt(t), fmt(t1), fmt(t3), fmt(t4)], "UTC")).toBe(2);
+  });
+
+  it("de-duplicates repeated dates", () => {
+    const today = getLocalDateString("UTC");
+    expect(calculateStreak([today, today, today], "UTC")).toBe(1);
+  });
+
+  it("ignores the order of input dates (sorts internally)", () => {
+    const today = getLocalDateString("UTC");
+    const [y, m, d] = today.split("-").map(Number);
+    const t1 = new Date(Date.UTC(y, m - 1, d));
+    t1.setUTCDate(t1.getUTCDate() - 1);
+    const yesterday = `${t1.getUTCFullYear()}-${String(
+      t1.getUTCMonth() + 1
+    ).padStart(2, "0")}-${String(t1.getUTCDate()).padStart(2, "0")}`;
+
+    expect(calculateStreak([yesterday, today], "UTC")).toBe(2);
+    expect(calculateStreak([today, yesterday], "UTC")).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #2463.

Summary of What Has Been Done:
Fixed a silent bug in `calculateStreak` (`src/lib/dates/streakDateUtils.ts`) where the local variable `yesterday` was assigned the result of `getLocalDateString(userTimezone)` *without* offsetting by one day — so the grace-period check `uniqueDates[0] !== today && uniqueDates[0] !== yesterday` always passed the `yesterday` branch trivially (the two strings were identical). The practical effect was that any user whose most recent contribution was exactly the calendar day before today in their timezone would have their streak reported as 0. Added a deterministic vitest test file covering the entire module.

Changes Made:
- `src/lib/dates/streakDateUtils.ts`: replaced the broken `const yesterday = getLocalDateString(userTimezone)` with a calculation that parses `today`, subtracts one calendar day in UTC, and re-formats the result as `YYYY-MM-DD`. The shift is anchored on local midnight to avoid DST edge cases where subtracting 24h of UTC time can land on the same date.
- New file: `test/streak-date-utils.test.ts` (19 tests, all passing under `npm test`).
- Coverage:
  - `getLocalDateString`: UTC, a fixed-offset timezone (`Asia/Kolkata`), and the invalid-timezone fallback all return a `YYYY-MM-DD` string.
  - `utcToLocalDate`: a UTC ISO timestamp is converted to the right date in `Asia/Kolkata` (UTC+5:30) and UTC; a `Date` object works; an invalid timezone falls back to the ISO date.
  - `areConsecutiveDays`: adjacent dates return true (forward and reverse, including month and year boundaries), the same date returns false, and dates with a one-day gap return false.
  - `calculateStreak`:
    - empty input → 0
    - single date equal to today → 1
    - single date equal to **yesterday** → 1 (regression case: the previous code returned 0)
    - single date older than yesterday → 0
    - sorted-most-recent-first array of 5 consecutive dates ending today → 5
    - a 1-day gap in the middle breaks the streak at the gap
    - repeated dates are de-duplicated
    - input order does not matter
- All other functions and call sites in the codebase are untouched.

Impact it Made:
Restores the documented one-day grace period for streaks. Eliminates a silent bug where users (especially non-UTC ones) saw their streak drop to zero at the end of the day in their own timezone. Adds unit coverage for the entire module so future changes cannot regress it silently.