### PR TITLE
test: add unit tests for DashboardHeader component

### DIFF
--- a/test/components/DashboardHeader.test.tsx
+++ b/test/components/DashboardHeader.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import "@testing-library/jest-dom/vitest";
-// @ts-ignore
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import DashboardHeader from "../../src/components/DashboardHeader";
@@ -34,6 +33,19 @@ vi.mock("@/components/KeyboardShortcuts", () => ({
   default: () => <div>KeyboardShortcuts</div>,
 }));
 
+vi.mock("@/hooks/useRealtimeSync", () => ({
+  useRealtimeSync: () => ({
+    isLive: false,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 const mockedUseSession = useSession as any;
 
 function renderDashboardHeader() {
@@ -62,7 +74,20 @@ describe("DashboardHeader", () => {
     renderDashboardHeader();
 
     expect(
-      screen.getByRole("heading", { name: "Dashboard" })
+      screen.getByRole("heading", { name: /dashboard/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders dashboard overview text", () => {
+    mockedUseSession.mockReturnValue({
+      data: null,
+      status: "unauthenticated",
+    });
+
+    renderDashboardHeader();
+
+    expect(
+      screen.getByText(/dashboard overview/i)
     ).toBeInTheDocument();
   });
 
@@ -109,6 +134,102 @@ describe("DashboardHeader", () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith("/api/user/settings");
+    });
+  });
+
+  it("shows share profile button when profile is public", async () => {
+    mockedUseSession.mockReturnValue({
+      data: {
+        githubLogin: "testuser",
+      },
+      status: "authenticated",
+    });
+
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        is_public: true,
+      }),
+    });
+
+    renderDashboardHeader();
+
+    expect(
+      await screen.findByText(/share profile/i)
+    ).toBeInTheDocument();
+  });
+
+  it("hides share profile button when profile is private", async () => {
+    mockedUseSession.mockReturnValue({
+      data: {
+        githubLogin: "testuser",
+      },
+      status: "authenticated",
+    });
+
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        is_public: false,
+      }),
+    });
+
+    renderDashboardHeader();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/share profile/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("uses correct profile url", async () => {
+    mockedUseSession.mockReturnValue({
+      data: {
+        githubLogin: "testuser",
+      },
+      status: "authenticated",
+    });
+
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        is_public: true,
+      }),
+    });
+
+    renderDashboardHeader();
+
+    const link = await screen.findByRole("link", {
+      name: /share profile/i,
+    });
+
+    expect(link).toHaveAttribute(
+      "href",
+      "/u/testuser"
+    );
+  });
+
+  it("handles fetch failure gracefully", async () => {
+    mockedUseSession.mockReturnValue({
+      data: {
+        githubLogin: "testuser",
+      },
+      status: "authenticated",
+    });
+
+    (fetch as any).mockRejectedValue(
+      new Error("Network Error")
+    );
+
+    renderDashboardHeader();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", {
+          name: /dashboard/i,
+        })
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for the `DashboardHeader` component using Vitest and React Testing Library. These tests improve coverage for rendering, session-based behavior, profile visibility, API interactions, and error handling.

Closes #1042

---

## Type of Change

* [x] 🧪 Tests only

---

## What Changed

* Added additional unit tests in `test/components/DashboardHeader.test.tsx`
* Added test coverage for authenticated and unauthenticated user states
* Added tests for public/private profile visibility and settings fetch behavior
* Added error handling test cases for failed API requests
* Verified DashboardHeader rendering and key UI elements

---

## How to Test

1. Install dependencies:

   ```bash
   npm install
   ```

2. Run the DashboardHeader test suite:

   ```bash
   npx vitest test/components/DashboardHeader.test.tsx
   ```

3. Verify all tests pass successfully.

**Expected result:**

All DashboardHeader tests pass without failures and component behavior is validated across different session and API states.

---

## Screenshots / Recordings

Not applicable (tests only).

---

## Checklist

* [x] Linked the related issue above
* [x] Self-reviewed my own diff
* [x] No unnecessary `console.log`, debug code, or commented-out blocks
* [x] `npm run lint` passes locally
* [x] No TypeScript errors introduced by this change
* [x] Added or updated tests where applicable
* [ ] Updated documentation / comments if behavior changed (not applicable)

---

## Accessibility (UI changes only)

Not applicable (tests only).

---

## Additional Context

The test suite now covers:

* Dashboard heading and overview rendering
* Authenticated vs unauthenticated states
* User settings fetch behavior
* Public profile visibility logic
* Profile URL generation
* Graceful handling of API failures

All tests pass locally using Vitest.
