### PR TITLE
fix: resolve SSRF vulnerability via dns.lookup in ssrf protection utility (#2422)

### DIFF
--- a/src/lib/ssrf-protection.ts
+++ b/src/lib/ssrf-protection.ts
@@ -77,14 +77,13 @@ export async function isSafeUrl(url: string): Promise<boolean> {
     const addresses: string[] = [];
 
     try {
-      const aRecords = await dns.resolve(hostname, "A");
-      if (Array.isArray(aRecords)) addresses.push(...(aRecords as string[]));
-    } catch {}
-
-    try {
-      const aaaaRecords = await dns.resolve(hostname, "AAAA");
-      if (Array.isArray(aaaaRecords)) addresses.push(...(aaaaRecords as string[]));
-    } catch {}
+      const lookupResults = await dns.lookup(hostname, { all: true });
+      if (Array.isArray(lookupResults)) {
+        addresses.push(...lookupResults.map((r) => r.address));
+      }
+    } catch {
+      return false;
+    }
 
     if (addresses.length === 0) {
       return false;

--- a/test/ssrf-protection.test.ts
+++ b/test/ssrf-protection.test.ts
@@ -4,7 +4,7 @@ import dns from "dns/promises";
 
 vi.mock("dns/promises", () => ({
   default: {
-    resolve: vi.fn(),
+    lookup: vi.fn(),
   },
 }));
 
@@ -63,10 +63,10 @@ describe("ssrf-protection", () => {
   });
 
   describe("isSafeUrl", () => {
-    const mockResolve = dns.resolve as any;
+    const mockLookup = dns.lookup as any;
 
     beforeEach(() => {
-      mockResolve.mockReset();
+      mockLookup.mockReset();
     });
 
     it("should return false for invalid protocol", async () => {
@@ -85,42 +85,27 @@ describe("ssrf-protection", () => {
     });
 
     it("should return true for public IPs via DNS", async () => {
-      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
-        if (rrtype === "A") return ["8.8.8.8"];
-        throw new Error("ENOTFOUND");
-      });
+      mockLookup.mockResolvedValue([{ address: "8.8.8.8", family: 4 }]);
       expect(await isSafeUrl("http://example.com")).toBe(true);
     });
 
     it("should return false for private IPv4", async () => {
-      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
-        if (rrtype === "A") return ["10.0.0.1"];
-        throw new Error("ENOTFOUND");
-      });
+      mockLookup.mockResolvedValue([{ address: "10.0.0.1", family: 4 }]);
       expect(await isSafeUrl("http://internal.com")).toBe(false);
     });
 
     it("should return false for IPv6-mapped IPv4 private address", async () => {
-      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
-        if (rrtype === "AAAA") return ["::ffff:192.168.1.1"];
-        throw new Error("ENOTFOUND");
-      });
+      mockLookup.mockResolvedValue([{ address: "::ffff:192.168.1.1", family: 6 }]);
       expect(await isSafeUrl("http://internal.com")).toBe(false);
     });
 
     it("should return false for IPv6 loopback and link-local", async () => {
-      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
-        if (rrtype === "AAAA") return ["fe80::1"];
-        throw new Error("ENOTFOUND");
-      });
+      mockLookup.mockResolvedValue([{ address: "fe80::1", family: 6 }]);
       expect(await isSafeUrl("http://internal.com")).toBe(false);
     });
 
     it("should return true for public IPv6", async () => {
-      mockResolve.mockImplementation(async (hostname: string, rrtype: string) => {
-        if (rrtype === "AAAA") return ["2001:4860:4860::8888"];
-        throw new Error("ENOTFOUND");
-      });
+      mockLookup.mockResolvedValue([{ address: "2001:4860:4860::8888", family: 6 }]);
       expect(await isSafeUrl("http://example.com")).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

This PR resolves a security gap in the SSRF protection utility. The utility previously used `dns.resolve` separately for `A` and `AAAA` records, which could allow hostname checks to pass for a dual-stack setup (public IPv4 and private IPv6) if one check failed to resolve, but subsequently allow Node's `fetch` to connect to the private IPv6 loopback. We migrated the name resolution to `dns.lookup`, which queries the hostnames using the exact OS-level resolution mechanism (`getaddrinfo`) that Node.js `fetch` uses under the hood.

Closes #2422

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **SSRF Protection Refactoring** (`src/lib/ssrf-protection.ts`):
  - Migrated from `dns.resolve` to `dns.lookup` with `{ all: true }` to guarantee validation matches actual request-time resolution.
  - Ensures all resolved addresses (IPv4 and IPv6) are validated against private IP ranges.
- **SSRF Tests** (`test/ssrf-protection.test.ts`):
  - Updated mocked imports to stub `dns.lookup` instead of `dns.resolve`.
  - Refactored test assertions to align with lookup objects.

---

## How to Test

1. Check out the branch `fix/ssrf-dns-lookup-2422`.
2. Run the unit test suite to verify SSRF cases:
   ```bash
   npx vitest run test/ssrf-protection.test.ts
   ```
3. Run the overall tests to check for regressions:
   ```bash
   npm run test
   ```

**Expected result:**
All unit tests pass successfully and verify all loopback, link-local, and private IP blocks.

---

## Screenshots / Recordings

*Not applicable (Backend security fix).*

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [ ] Keyboard navigation works correctly
- [ ] Color contrast meets WCAG AA standard
- [ ] ARIA labels / roles added where needed
- [ ] Tested on mobile / responsive layout

---

## Additional Context

- Using `dns.lookup` respects local resolution files (like `/etc/hosts`), preventing local mapping bypasses that `dns.resolve` missed.