### PR TITLE
test : added unit tests for i18n/detection.ts

### DIFF
--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -48,3 +48,89 @@ describe("i18n translation lookup", () => {
     await expect(translateMessage("es", "missing.example")).resolves.toBe("missing.example");
   });
 });
+
+describe("detectLocale edge cases", () => {
+  it("returns default when all inputs are null", () => {
+    expect(
+      detectLocale({
+        preferredLocale: null,
+        cookieLocale: null,
+        acceptLanguage: null,
+      })
+    ).toEqual({ locale: "en", source: "default" });
+  });
+
+  it("returns default when all inputs are undefined", () => {
+    expect(
+      detectLocale({
+        preferredLocale: undefined,
+        cookieLocale: undefined,
+        acceptLanguage: undefined,
+      })
+    ).toEqual({ locale: "en", source: "default" });
+  });
+
+  it("returns default when all inputs are empty string", () => {
+    expect(
+      detectLocale({
+        preferredLocale: "",
+        cookieLocale: "",
+        acceptLanguage: "",
+      })
+    ).toEqual({ locale: "en", source: "default" });
+  });
+
+  it("ignores language region suffix and normalises to base tag", () => {
+    expect(
+      detectLocale({
+        preferredLocale: "en-US",
+        cookieLocale: null,
+        acceptLanguage: null,
+      })
+    ).toEqual({ locale: "en", source: "preference" });
+  });
+
+  it("rejects invalid locale strings", () => {
+    expect(
+      detectLocale({
+        preferredLocale: "fr",
+        cookieLocale: null,
+        acceptLanguage: null,
+      })
+    ).toEqual({ locale: "en", source: "default" });
+  });
+});
+
+describe("detectBrowserLocale edge cases", () => {
+  it("returns null for null input", () => {
+    expect(detectBrowserLocale(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(detectBrowserLocale(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(detectBrowserLocale("")).toBeNull();
+  });
+
+  it("returns null when no locale in header is supported", () => {
+    expect(detectBrowserLocale("fr-FR,de-DE,it-IT")).toBeNull();
+  });
+
+  it("sorts by quality value descending", () => {
+    expect(detectBrowserLocale("en;q=0.5,es;q=0.9,fr;q=0.7")).toBe("es");
+  });
+
+  it("defaults quality to 1 when not specified", () => {
+    expect(detectBrowserLocale("en,es;q=0.9")).toBe("en");
+  });
+
+  it("handles case-insensitive language tags", () => {
+    expect(detectBrowserLocale("EN-US,ES;q=0.8")).toBe("en");
+  });
+
+  it("returns first supported locale even when it has low quality", () => {
+    expect(detectBrowserLocale("fr;q=0.9,en;q=0.1")).toBe("en");
+  });
+});


### PR DESCRIPTION
Closes #2487.

Summary of What Has Been Done: Extended test/i18n.test.ts with comprehensive edge case coverage for src/i18n/detection.ts.

Changes Made:
- Test detectLocale with null, undefined, and empty string inputs for all parameters.
- Test locale normalisation: en-US normalises to en, invalid locales fall through to default.
- Test detectBrowserLocale with null, undefined, empty string, unsupported locales, quality value sorting, case insensitivity, and low-quality first-match precedence.

Impact it Made: Ensures locale detection is correct across all supported sources, preventing i18n fallback bugs in production.