### PR TITLE
test: add locale detection unit tests

### DIFF
--- a/src/i18n/detection.ts
+++ b/src/i18n/detection.ts
@@ -7,9 +7,9 @@ export type LocaleResolution = {
   source: LocaleSource;
 };
 
-function normalizeLocale(value: string | null | undefined): AppLocale | null {
+export function normalizeLocale(value: string | null | undefined): AppLocale | null {
   if (!value) return null;
-  const [language] = value.toLowerCase().split("-");
+  const [language] = value.trim().toLowerCase().split("-");
   return isValidLocale(language) ? language : null;
 }
 

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, it } from "vitest";
-import { detectBrowserLocale, detectLocale } from "@/i18n/detection";
+import { detectBrowserLocale, detectLocale, normalizeLocale } from "@/i18n/detection";
 import { translateMessage } from "@/i18n/translate";
 
-describe("i18n locale detection", () => {
-  it("uses user preference before cookie or browser language", () => {
+describe("normalizeLocale", () => {
+  it("normalizes valid locales", () => {
+    expect(normalizeLocale("en")).toBe("en");
+    expect(normalizeLocale("es")).toBe("es");
+  });
+
+  it("normalizes valid locales with region/case", () => {
+    expect(normalizeLocale("en-US")).toBe("en");
+    expect(normalizeLocale("EN-US")).toBe("en");
+    expect(normalizeLocale("es-ES")).toBe("es");
+  });
+
+  it("returns null for invalid locale strings", () => {
+    expect(normalizeLocale("fr")).toBe(null);
+    expect(normalizeLocale("invalid")).toBe(null);
+    expect(normalizeLocale("123")).toBe(null);
+  });
+
+  it("returns null for null, undefined, and empty string", () => {
+    expect(normalizeLocale(null)).toBe(null);
+    expect(normalizeLocale(undefined)).toBe(null);
+    expect(normalizeLocale("")).toBe(null);
+  });
+
+  it("handles edge cases like whitespace", () => {
+    expect(normalizeLocale("  en  ")).toBe("en");
+  });
+});
+
+describe("detectLocale", () => {
+  it("prioritizes preferredLocale > cookieLocale > browserLocale > default", () => {
     expect(
       detectLocale({
         preferredLocale: "es",
@@ -13,25 +42,66 @@ describe("i18n locale detection", () => {
     ).toEqual({ locale: "es", source: "preference" });
   });
 
-  it("uses cookie before browser language", () => {
-    expect(
-      detectLocale({
-        cookieLocale: "es",
-        acceptLanguage: "en-US,en;q=0.9",
-      })
-    ).toEqual({ locale: "es", source: "cookie" });
+  it("uses preferredLocale when provided", () => {
+    expect(detectLocale({ preferredLocale: "es" })).toEqual({
+      locale: "es",
+      source: "preference",
+    });
   });
 
-  it("detects supported browser languages from Accept-Language", () => {
-    expect(detectBrowserLocale("fr-CA,es;q=0.8,en;q=0.7")).toBe("es");
+  it("uses cookieLocale when preferredLocale is missing", () => {
+    expect(detectLocale({ cookieLocale: "es" })).toEqual({
+      locale: "es",
+      source: "cookie",
+    });
+    expect(detectLocale({ preferredLocale: null, cookieLocale: "es" })).toEqual({
+      locale: "es",
+      source: "cookie",
+    });
   });
 
-  it("falls back to English for unsupported languages", () => {
+  it("uses browserLocale when preferred and cookie are missing", () => {
+    expect(detectLocale({ acceptLanguage: "es-ES,es;q=0.8" })).toEqual({
+      locale: "es",
+      source: "browser",
+    });
+  });
+
+  it("returns default when nothing exists or matches", () => {
+    expect(detectLocale({})).toEqual({ locale: "en", source: "default" });
     expect(
       detectLocale({
-        acceptLanguage: "fr-CA,fr;q=0.9",
+        preferredLocale: "fr",
+        cookieLocale: "de",
+        acceptLanguage: "it",
       })
     ).toEqual({ locale: "en", source: "default" });
+  });
+});
+
+describe("detectBrowserLocale", () => {
+  it("parses accept-language header correctly", () => {
+    expect(detectBrowserLocale("es,en;q=0.9")).toBe("es");
+    expect(detectBrowserLocale("en,es;q=0.9")).toBe("en");
+  });
+
+  it("respects quality values (q values)", () => {
+    expect(detectBrowserLocale("en;q=0.5,es;q=0.8")).toBe("es");
+    expect(detectBrowserLocale("en;q=0.9,es;q=0.1")).toBe("en");
+  });
+
+  it("handles mixed case locales", () => {
+    expect(detectBrowserLocale("ES-es,en;Q=0.5")).toBe("es");
+  });
+
+  it("returns null when no supported languages are found", () => {
+    expect(detectBrowserLocale("fr-FR,fr;q=0.9")).toBe(null);
+    expect(detectBrowserLocale(null)).toBe(null);
+    expect(detectBrowserLocale("")).toBe(null);
+  });
+
+  it("detects supported browser languages from complex Accept-Language", () => {
+    expect(detectBrowserLocale("fr-CA,es;q=0.8,en;q=0.7")).toBe("es");
   });
 });
 


### PR DESCRIPTION
## Description

Adds comprehensive unit tests for locale detection logic in `src/i18n/detection.ts`.

### Changes

* Added tests for `normalizeLocale`

  * valid locale tags
  * invalid locale values
  * null, undefined, and empty string inputs
  * whitespace handling

* Added tests for `detectLocale`

  * verifies priority order:
    `preferredLocale > cookieLocale > browserLocale > default`

* Added tests for `detectBrowserLocale`

  * Accept-Language header parsing
  * quality (`q`) value handling
  * mixed-case locale handling
  * fallback behavior for unsupported locales

### Additional Fix

* Updated `normalizeLocale` to trim whitespace inputs discovered during testing.
* Exported `normalizeLocale` for direct unit testing.

### Testing

```bash
npx vitest test/i18n.test.ts
```

Result: 18 tests passed.

### Related Issue

Closes #2487
