### PR TITLE
fix: invalidate leaderboard cache when settings change

### DIFF
--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -347,7 +347,10 @@ export const getCachedLeaderboard = (filters: LeaderboardFilters = {}) => {
   return unstable_cache(
     async () => buildLeaderboard(filters),
     ["leaderboard", period],
-    { revalidate: CACHE_REFRESH_SECONDS }
+    {
+      revalidate: CACHE_REFRESH_SECONDS,
+      tags: ["leaderboard"],
+    }
   )();
 };
 
@@ -356,7 +359,7 @@ export async function getLeaderboardData(
   filters: LeaderboardFilters = {}
 ): Promise<LeaderboardPayload | null> {
   const period = filters.period ?? DEFAULT_PERIOD;
-  
+
   if (bypass) {
     try {
       const payload = await buildLeaderboard(filters);


### PR DESCRIPTION
## Related Issue
Fixes #2497

## Problem
When a user disabled leaderboard participation from Settings, the leaderboard could continue showing stale data until refresh.

## Root Cause
The leaderboard cache was invalidated using `revalidateTag("leaderboard")`, but the unstable cache entry was not associated with the "leaderboard" tag.

Because of this, cache invalidation did not reliably refresh leaderboard data.

## Solution
Added the leaderboard cache tag to the unstable_cache configuration.

Now:
- leaderboard cache is tagged with "leaderboard"
- settings changes can correctly invalidate cached leaderboard data
- users opting in/out of leaderboard visibility see updated results immediately

## Testing
- ✅ npm run build
- ⚠️ npm test has existing unrelated failures in Anthropic service mocking