### PR TITLE
fix README and CONTRIBUTING links to point to canonical repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please note that this project is released with a [Code of Conduct](CODE_OF_CONDU
 
 ## ⚡ Quick Start (Setup in < 10 Steps)
 
-1. **Fork the Repo:** Click the "Fork" button at the top-right of the [DevTrack repository](https://github.com/Priyanshu-byte-coder/devtrack).
+1. **Fork the Repo:** Click the "Fork" button at the top-right of the [DevTrack repository](https://github.com/Umbrella-io/devtrack).
 2. **Clone Your Fork:**
    ```bash
    git clone https://github.com/<your-username>/devtrack.git
@@ -16,7 +16,7 @@ Please note that this project is released with a [Code of Conduct](CODE_OF_CONDU
    ```
 3. **Configure Upstream Remote:**
    ```bash
-   git remote add upstream https://github.com/Priyanshu-byte-coder/devtrack.git
+   git remote add upstream https://github.com/Umbrella-io/devtrack.git
    ```
 4. **Install pnpm (Package Manager):** We use `pnpm` for this project. If you don't have it installed:
    ```bash

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To deploy your own instance, see the **[Self-Hosting Guide](./docs/self-hosting.
 **1. Clone and install**
 
 ```bash
-git clone https://github.com/Priyanshu-byte-coder/devtrack.git
+git clone https://github.com/Umbrella-io/devtrack.git
 cd devtrack
 npm install
 ```


### PR DESCRIPTION
Closes #2507

## Problem
Contributor setup instructions referenced the outdated fork \`Priyanshu-byte-coder/devtrack\` instead of the canonical \`Umbrella-io/devtrack\`, causing new contributors to clone the wrong repo and configure an incorrect upstream remote.

## Changes
- **README.md** Quick Start: \`git clone\` URL now points to \`Umbrella-io/devtrack\`
- **CONTRIBUTING.md** fork link and \`git remote add upstream\` URL now point to \`Umbrella-io/devtrack\`

## Result
Contributors clone the correct repository and configure upstream remotes correctly, keeping onboarding consistent with the active repository."
