### PR TITLE
fix(a11y): add ARIA attributes to goal progress bar (#950)

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -690,6 +690,11 @@ export default function GoalTracker() {
                       completed ? "bg-emerald-500" : "bg-[var(--accent)]"
                     }`}
                     style={{ width: `${Math.max(0, Math.min(pct, 100))}%` }}
+                    role="progressbar"
+                    aria-valuenow={goal.current}
+                    aria-valuemin={0}
+                    aria-valuemax={goal.target}
+                    aria-label={`Goal progress: ${goal.current} of ${goal.target} ${goal.unit}`}
                   />
                 </div>
 


### PR DESCRIPTION
## What does this PR do?
Adds WCAG 2.1 Level A required ARIA attributes to the goal progress bar so screen readers can announce current progress to users.

## Related issue
Closes #950

## Changes made
- Added `role="progressbar"` to the progress bar inner div
- Added `aria-valuenow={goal.current}` for current progress value
- Added `aria-valuemin={0}` for minimum value
- Added `aria-valuemax={goal.target}` for maximum value
- Added `aria-label="Goal progress: X of Y commits"` using real goal unit (commits, prs, hours, etc.)

## How to test
1. Enable ChromeVox or NVDA screen reader
2. Navigate to the Goals section on the dashboard
3. Tab to any goal's progress bar
4. Screen reader should announce e.g. "Goal progress: 3 of 10 commits, progressbar"

## Screenshots
N/A — no visual change, ARIA attributes are invisible to sighted users

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No console.log or debug code
- [x] npm run type-check passes
- [x] WCAG 2.1 Level A compliant (1.3.1 Info and Relationships)