### PR TITLE
feat(dashboard): add error boundary with Try Again button (#2250)

### DIFF
--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface ErrorBoundaryProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function DashboardError({ error, reset }: ErrorBoundaryProps) {
+  useEffect(() => {
+    console.error("[Dashboard Error Boundary]", error);
+  }, [error]);
+
+  return (
+    <div
+      className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-4"
+      role="alert"
+      aria-live="assertive"
+    >
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 shadow-sm text-center max-w-md w-full">
+        <div className="mb-4 text-4xl" aria-hidden="true">
+          ⚠️
+        </div>
+        <h2 className="text-xl font-semibold text-[var(--card-foreground)] mb-2">
+          Something went wrong
+        </h2>
+        <p className="text-sm text-[var(--muted-foreground)] mb-6">
+          The dashboard ran into an unexpected error. Your data is safe — this
+          is just a display issue.
+        </p>
+        <button
+          onClick={reset}
+          className="inline-flex items-center justify-center rounded-lg bg-[var(--accent)] px-5 py-2.5 text-sm font-medium text-[var(--accent-foreground)] transition-colors hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-[var(--ring)] focus:ring-offset-2"
+          aria-label="Try loading the dashboard again"
+        >
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?
Creates src/app/dashboard/error.tsx as a Next.js App Router error boundary so any dashboard widget crash shows a friendly fallback UI instead of a blank page.

## Related issue
Closes #2250

## Changes made
- Created `src/app/dashboard/error.tsx` following Next.js App Router error boundary convention
- Friendly error message styled with var(--card), var(--foreground), var(--accent) to match dashboard theme
- "Try Again" button calls reset() to retry rendering
- Error logged via console.error in useEffect for debugging
- role="alert" and aria-live="assertive" for screen reader accessibility
- Keyboard-focusable button with focus ring and aria-label

## How to test
1. Temporarily add `throw new Error("test")` inside any dashboard widget
2. Navigate to /dashboard
3. Instead of blank page, the error boundary UI appears with "Try Again" button
4. Click "Try Again" — page retries rendering

## Screenshots
<img width="956" height="407" alt="image" src="https://github.com/user-attachments/assets/b2989556-123f-4a63-98ae-4a037618126d" />


## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] Uses console.error intentionally for debugging
- [x] npm run type-check passes (7 pre-existing upstream errors unrelated to this change)
- [x] Follows Next.js App Router error.tsx conventions exactly
- [x] Styled with CSS variables matching dashboard theme
- [x] Accessible — role="alert", aria-live, keyboard focusable button with aria-label