### PR TITLE
Enforce react-hooks/exhaustive-deps as an error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["next/core-web-vitals"]
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "react-hooks/exhaustive-deps": "error"
+  }
 }


### PR DESCRIPTION
Updated .eslintrc.json to enforce exhaustive-deps as an error. Resolves #2562