### PR TITLE
fix(goals): return clear error for duplicate task titles

### DIFF
--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -242,6 +242,23 @@ try {
   const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
+  const { data: existing } = await supabaseAdmin
+    .from("goals")
+    .select("id")
+    .eq("user_id", user.id)
+    .ilike("title", sanitizedTitle)
+    .maybeSingle();
+
+  if (existing) {
+    return Response.json(
+      {
+        error: "Task with this title already exists",
+        code: "DUPLICATE_TASK_TITLE",
+      },
+      { status: 400 }
+    );
+  }
+
   // Pre-check count query using head option for peak performance
   const { count, error: countError } = await supabaseAdmin
     .from("goals")

--- a/src/lib/goal-tracker.ts
+++ b/src/lib/goal-tracker.ts
@@ -42,9 +42,16 @@ export async function submitGoalWithRefresh({
   }
 
   if (!response.ok) {
+    let message = "Failed to create goal. Please try again.";
+    try {
+      const data = (await response.json()) as { error?: string };
+      if (data.error) message = data.error;
+    } catch {
+      // keep fallback message
+    }
     return {
       created: false,
-      error: "Failed to create goal. Please try again.",
+      error: message,
     };
   }
 

--- a/test/GoalTracker.test.ts
+++ b/test/GoalTracker.test.ts
@@ -188,6 +188,11 @@ describe('GoalTracker - useGoalTracker Hook', () => {
         return Promise.resolve({
           ok: false,
           status: 400,
+          json: () =>
+            Promise.resolve({
+              error: 'Task with this title already exists',
+              code: 'DUPLICATE_TASK_TITLE',
+            }),
         } as Response);
       }
       return Promise.resolve({
@@ -211,7 +216,7 @@ describe('GoalTracker - useGoalTracker Hook', () => {
       await result.current.handleCreate();
     });
 
-    expect(result.current.createError).toBe('Failed to create goal. Please try again.');
+    expect(result.current.createError).toBe('Task with this title already exists');
   });
 
   it('handles optimistic deletion and failure rollback', async () => {

--- a/test/goal-tracker-submit-flow.test.ts
+++ b/test/goal-tracker-submit-flow.test.ts
@@ -19,7 +19,10 @@ describe("submitGoalWithRefresh", () => {
   });
 
   it("returns a create error when the POST request fails", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue({ ok: false });
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
     const handleSync = vi.fn();
     const loadGoals = vi.fn();
 
@@ -33,6 +36,34 @@ describe("submitGoalWithRefresh", () => {
     expect(result).toEqual({
       created: false,
       error: "Failed to create goal. Please try again.",
+    });
+    expect(handleSync).not.toHaveBeenCalled();
+    expect(loadGoals).not.toHaveBeenCalled();
+  });
+
+  it("returns the API error message when duplicate title is rejected", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          error: "Task with this title already exists",
+          code: "DUPLICATE_TASK_TITLE",
+        }),
+    });
+    const handleSync = vi.fn();
+    const loadGoals = vi.fn();
+
+    const result = await submitGoalWithRefresh({
+      fetchImpl,
+      payload: basePayload,
+      handleSync,
+      loadGoals,
+    });
+
+    expect(result).toEqual({
+      created: false,
+      error: "Task with this title already exists",
     });
     expect(handleSync).not.toHaveBeenCalled();
     expect(loadGoals).not.toHaveBeenCalled();

--- a/test/goals-crud.test.ts
+++ b/test/goals-crud.test.ts
@@ -151,9 +151,17 @@ describe("POST /api/goals", () => {
   it("creates a goal and returns it with status 201", async () => {
     const createdGoal = buildGoal({ title: "New goal", target: 5, unit: "prs" });
     mocks.supabaseFrom.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ count: 0, error: null }),
-      }),
+      select: vi.fn()
+        .mockReturnValueOnce({
+          eq: vi.fn().mockReturnValue({
+            ilike: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        })
+        .mockReturnValueOnce({
+          eq: vi.fn().mockResolvedValue({ count: 0, error: null }),
+        }),
       insert: vi.fn().mockReturnValue({
         select: vi.fn().mockReturnValue({
           single: vi.fn().mockResolvedValue({ data: createdGoal, error: null }),
@@ -180,11 +188,37 @@ describe("POST /api/goals", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 400 when the user already has the maximum number of goals", async () => {
+  it("returns 400 when a goal with the same title already exists", async () => {
     mocks.supabaseFrom.mockReturnValue({
       select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockResolvedValue({ count: 5, error: null }),
+        eq: vi.fn().mockReturnValue({
+          ilike: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: "goal-existing" }, error: null }),
+          }),
+        }),
       }),
+    });
+    const [req] = makePostRequest({ title: "Read docs", target: 10 });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Task with this title already exists");
+    expect(body.code).toBe("DUPLICATE_TASK_TITLE");
+  });
+
+  it("returns 400 when the user already has the maximum number of goals", async () => {
+    mocks.supabaseFrom.mockReturnValue({
+      select: vi.fn()
+        .mockReturnValueOnce({
+          eq: vi.fn().mockReturnValue({
+            ilike: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        })
+        .mockReturnValueOnce({
+          eq: vi.fn().mockResolvedValue({ count: 5, error: null }),
+        }),
     });
     const [req] = makePostRequest({ title: "Another goal", target: 10 });
     const res = await POST(req);


### PR DESCRIPTION
Reject duplicate goal titles with a structured `DUPLICATE_TASK_TITLE` response and surface the API message in the Goal Tracker create flow.

## Summary

Improves goal creation error handling when a user tries to create a goal with a title that already exists. The API now returns a clear message and structured error code, and the Goal Tracker form displays that message instead of a generic failure string.

Closes #2424 

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **`src/app/api/goals/route.ts`** — Added a case-insensitive duplicate title pre-check before insert. Returns `400` with `{ error: "Task with this title already exists", code: "DUPLICATE_TASK_TITLE" }`.
- **`src/lib/goal-tracker.ts`** — Updated `submitGoalWithRefresh` to parse the API error body on failed POST and surface the server message to the UI.
- **`test/goals-crud.test.ts`** — Added API test for duplicate title rejection and updated mocks for the new pre-check query.
- **`test/goal-tracker-submit-flow.test.ts`** — Added test verifying duplicate error message propagation from API to helper.
- **`test/GoalTracker.test.ts`** — Updated goal creation failure test to assert the specific duplicate-title message is shown.

---

## How to Test

1. Check out `fix/duplicate-task-title-error` and run `npm install` if needed.
2. Start the app with `npm run dev`, sign in, and open the dashboard Goal Tracker widget.
3. Create a goal titled `Read docs`, then try creating another goal with the same title (try different casing, e.g. `read docs`).

**Expected result:** The form shows `Task with this title already exists` instead of `Failed to create goal. Please try again.`

Automated checks:

```bash
npm run lint
npm run type-check
npm test -- test/goals-crud.test.ts test/goal-tracker-submit-flow.test.ts test/GoalTracker.test.ts