### PR TITLE
feat: add AI Code Personality Report (#2367)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -20,6 +20,7 @@
     "main": "Main navigation",
     "overview": "Overview",
     "resume": "Resume",
+    "personality": "Personality",
     "leaderboard": "Leaderboard",
     "home": "Home",
     "features": "Features",

--- a/messages/es.json
+++ b/messages/es.json
@@ -20,6 +20,7 @@
     "main": "Navegación principal",
     "overview": "Resumen",
     "resume": "CV",
+    "personality": "Personalidad",
     "leaderboard": "Clasificación",
     "home": "Inicio",
     "features": "Funciones",

--- a/src/app/api/personality/route.ts
+++ b/src/app/api/personality/route.ts
@@ -1,0 +1,295 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase";
+import { resolveAppUser } from "@/lib/resolve-user";
+import { personalityReportPrompt } from "@/lib/ai-prompts";
+import {
+    computePersonalityDimensions,
+    buildFallbackReport,
+    type PersonalityReport,
+    type PersonalityInputMetrics,
+} from "@/lib/personality-analysis";
+import {
+    upstashRateLimitFixedWindow,
+    getUpstashConfig,
+} from "@/lib/upstash-rest";
+import { createMemoryFixedWindowRateLimiter } from "@/lib/rate-limit";
+
+const PERSONALITY_INSIGHT_TYPE = "personality";
+const PERSONALITY_LIMIT = 5;
+const PERSONALITY_WINDOW_SECONDS = 60 * 60; // 1 hour
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours, matches ai-insights
+
+// In-memory fallback used only when Upstash Redis is not configured.
+const memoryLimiter = createMemoryFixedWindowRateLimiter({
+    windowMs: PERSONALITY_WINDOW_SECONDS * 1000,
+    pruneIntervalMs: PERSONALITY_WINDOW_SECONDS * 1000,
+    maxEntries: 10_000,
+});
+
+export const dynamic = "force-dynamic";
+
+interface TimeBlocksResponse {
+    morning?: number;
+    afternoon?: number;
+    evening?: number;
+    night?: number;
+}
+
+interface ContributionsApiResponse {
+    data?: Record<string, number>;
+    timeBlocks?: TimeBlocksResponse;
+}
+
+interface PRsApiResponse {
+    open?: number;
+    merged?: number;
+    avgReviewHours?: number;
+}
+
+interface StreakApiResponse {
+    current?: number;
+    longest?: number;
+    totalActiveDays?: number;
+}
+
+interface RepoSummary {
+    name: string;
+    commits: number;
+}
+
+interface ReposApiResponse {
+    repos?: RepoSummary[];
+}
+
+function parseGroqReport(raw: string): Partial<PersonalityReport> | null {
+    try {
+        // Groq is asked to return raw JSON, but strip code fences defensively
+        // in case the model wraps its answer anyway.
+        const cleaned = raw.replace(/```json|```/g, "").trim();
+        const parsed = JSON.parse(cleaned);
+
+        if (
+            typeof parsed.archetype !== "string" ||
+            typeof parsed.tagline !== "string" ||
+            typeof parsed.description !== "string" ||
+            !Array.isArray(parsed.strengths) ||
+            typeof parsed.funFact !== "string"
+        ) {
+            return null;
+        }
+
+        return {
+            archetype: parsed.archetype,
+            tagline: parsed.tagline,
+            description: parsed.description,
+            strengths: parsed.strengths.slice(0, 4).map((s: unknown) => String(s)),
+            funFact: parsed.funFact,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export async function GET(request: Request) {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.githubId) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Keyed on the application user UUID (not session.githubId) so cached
+    // rows are removed via ON DELETE CASCADE when the account is deleted —
+    // same rationale as /api/ai-insights (see migration fixing ai_insights
+    // ownership for the history here).
+    const user = await resolveAppUser(session.githubId, session.githubLogin);
+    if (!user) {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const userId = user.id;
+    const { searchParams } = new URL(request.url);
+    const forceRefresh = searchParams.get("refresh") === "true";
+
+    // Check the cache before touching the rate-limit counter so repeated
+    // reads of an already-generated report never consume quota.
+    if (!forceRefresh) {
+        const { data: cached } = await supabaseAdmin
+            .from("ai_insights")
+            .select("*")
+            .eq("user_id", userId)
+            .eq("insight_type", PERSONALITY_INSIGHT_TYPE)
+            .gte("expires_at", new Date().toISOString())
+            .order("generated_at", { ascending: false })
+            .limit(1)
+            .maybeSingle();
+
+        if (cached) {
+            return NextResponse.json({ data: cached.content, cached: true });
+        }
+    }
+
+    // No valid cache (or refresh requested) — enforce the rate limit only
+    // when a fresh generation is actually needed.
+    let rateLimitDenied = false;
+    let retryAfterSeconds = PERSONALITY_WINDOW_SECONDS;
+
+    if (getUpstashConfig()) {
+        const result = await upstashRateLimitFixedWindow({
+            key: `personality:${userId}`,
+            limit: PERSONALITY_LIMIT,
+            windowSeconds: PERSONALITY_WINDOW_SECONDS,
+        });
+        if (!result.allowed) {
+            rateLimitDenied = true;
+            retryAfterSeconds = result.retryAfter ?? PERSONALITY_WINDOW_SECONDS;
+        }
+    } else {
+        const result = memoryLimiter.check(`personality:${userId}`, PERSONALITY_LIMIT);
+        if (!result.allowed) {
+            rateLimitDenied = true;
+            retryAfterSeconds = Math.max(result.reset - Math.floor(Date.now() / 1000), 1);
+        }
+    }
+
+    if (rateLimitDenied) {
+        return NextResponse.json(
+            { error: "Rate limit exceeded. Try again later." },
+            {
+                status: 429,
+                headers: { "Retry-After": String(retryAfterSeconds) },
+            }
+        );
+    }
+
+    const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+    const cookie = request.headers.get("cookie") ?? "";
+    const headers = { Cookie: cookie };
+
+    const [contributionsRes, prsRes, streakRes, reposRes] = await Promise.all([
+        fetch(`${baseUrl}/api/metrics/contributions?days=90`, {
+            headers,
+            cache: "no-store",
+        }),
+        fetch(`${baseUrl}/api/metrics/prs`, { headers, cache: "no-store" }),
+        fetch(`${baseUrl}/api/metrics/streak`, { headers, cache: "no-store" }),
+        fetch(`${baseUrl}/api/metrics/repos?days=90`, {
+            headers,
+            cache: "no-store",
+        }),
+    ]);
+
+    const [contributionsRaw, prsRaw, streakRaw, reposRaw]: [
+        ContributionsApiResponse,
+        PRsApiResponse,
+        StreakApiResponse,
+        ReposApiResponse,
+    ] = await Promise.all([
+        contributionsRes.ok ? contributionsRes.json() : {},
+        prsRes.ok ? prsRes.json() : {},
+        streakRes.ok ? streakRes.json() : {},
+        reposRes.ok ? reposRes.json() : {},
+    ]);
+
+    const commitsByDay: Record<string, number> = contributionsRaw.data ?? {};
+    const commitsArray = Object.entries(commitsByDay)
+        .map(([date, count]) => ({ date, count }))
+        .sort((a, b) => a.date.localeCompare(b.date));
+    const totalCommits = commitsArray.reduce((s, d) => s + d.count, 0);
+
+    const metrics: PersonalityInputMetrics = {
+        timeBlocks: {
+            morning: contributionsRaw.timeBlocks?.morning ?? 0,
+            afternoon: contributionsRaw.timeBlocks?.afternoon ?? 0,
+            evening: contributionsRaw.timeBlocks?.evening ?? 0,
+            night: contributionsRaw.timeBlocks?.night ?? 0,
+        },
+        totalCommits,
+        activeDays: streakRaw.totalActiveDays ?? 0,
+        longestStreak: streakRaw.longest ?? 0,
+        currentStreak: streakRaw.current ?? 0,
+        prsMerged: prsRaw.merged ?? 0,
+        prsOpen: prsRaw.open ?? 0,
+        avgMergeTimeDays: (prsRaw.avgReviewHours ?? 0) / 24,
+        topRepoName: reposRaw.repos?.[0]?.name ?? "your top repo",
+        repoCount: reposRaw.repos?.length ?? 0,
+        commitsByDay: commitsArray,
+    };
+
+    const dimensions = computePersonalityDimensions(metrics);
+    let report: PersonalityReport = buildFallbackReport(dimensions, {
+        topRepoName: metrics.topRepoName,
+        longestStreak: metrics.longestStreak,
+        prsMerged: metrics.prsMerged,
+    });
+
+    if (process.env.GROQ_API_KEY) {
+        try {
+            const prompt = personalityReportPrompt({
+                workingStyle: dimensions.workingStyle,
+                commitPattern: dimensions.commitPattern,
+                collaborationStyle: dimensions.collaborationStyle,
+                perfectionismScore: dimensions.perfectionismScore,
+                nightCommitPct: dimensions.nightCommitPct,
+                morningCommitPct: dimensions.morningCommitPct,
+                totalCommits: metrics.totalCommits,
+                activeDays: metrics.activeDays,
+                longestStreak: metrics.longestStreak,
+                prsMerged: metrics.prsMerged,
+                avgMergeTimeDays: metrics.avgMergeTimeDays,
+                topRepoName: metrics.topRepoName,
+                repoCount: metrics.repoCount,
+            });
+
+            const groqRes = await fetch(
+                "https://api.groq.com/openai/v1/chat/completions",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${process.env.GROQ_API_KEY}`,
+                    },
+                    body: JSON.stringify({
+                        model: "llama-3.3-70b-versatile",
+                        max_tokens: 400,
+                        temperature: 0.8,
+                        messages: [{ role: "user", content: prompt }],
+                    }),
+                }
+            );
+
+            if (groqRes.ok) {
+                const groqData = (await groqRes.json()) as {
+                    choices?: Array<{ message?: { content?: string } }>;
+                };
+                const content = groqData.choices?.[0]?.message?.content;
+                const parsed = content ? parseGroqReport(content) : null;
+
+                if (parsed) {
+                    report = { ...dimensions, ...parsed, source: "ai" } as PersonalityReport;
+                }
+            } else {
+                console.error("Groq API error", groqRes.status, await groqRes.text());
+            }
+        } catch (err) {
+            console.error("Groq API error — falling back to rule-based report", err);
+        }
+    }
+
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + CACHE_TTL_MS);
+
+    await supabaseAdmin.from("ai_insights").upsert(
+        {
+            user_id: userId,
+            insight_type: PERSONALITY_INSIGHT_TYPE,
+            content: report,
+            generated_at: now.toISOString(),
+            expires_at: expiresAt.toISOString(),
+        },
+        { onConflict: "user_id,insight_type" }
+    );
+
+    return NextResponse.json({ data: report, cached: false });
+}

--- a/src/app/dashboard/personality/page.tsx
+++ b/src/app/dashboard/personality/page.tsx
@@ -1,0 +1,10 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import PersonalityReport from "@/components/personality/PersonalityReport";
+
+export default async function PersonalityPage() {
+    const session = await getServerSession(authOptions);
+    if (!session) redirect("/");
+    return <PersonalityReport />;
+}

--- a/src/components/AppNavbar.tsx
+++ b/src/components/AppNavbar.tsx
@@ -46,11 +46,11 @@ export default function AppNavbar() {
   useEffect(() => { setMobileOpen(false); }, [pathname]);
 
   useEffect(() => {
-  const fn = () => setScrolled(window.scrollY > 20);
-  fn();
-  window.addEventListener("scroll", fn, { passive: true });
-  return () => window.removeEventListener("scroll", fn);
-}, [pathname]);
+    const fn = () => setScrolled(window.scrollY > 20);
+    fn();
+    window.addEventListener("scroll", fn, { passive: true });
+    return () => window.removeEventListener("scroll", fn);
+  }, [pathname]);
 
   const isAuthenticated = status === "authenticated" && Boolean(session);
   const isDashboardRoute = pathname.startsWith("/dashboard");
@@ -63,6 +63,7 @@ export default function AppNavbar() {
       return [
         { href: "/dashboard", label: t("overview") },
         { href: "/dashboard/career-intelligence", label: t("resume") },
+        { href: "/dashboard/personality", label: t("personality") },
         { href: "/leaderboard", label: t("leaderboard") },
       ];
     }
@@ -73,7 +74,7 @@ export default function AppNavbar() {
     ];
   }, [isAuthenticated, t]);
 
-// The wrapped experience provides its own navigation
+  // The wrapped experience provides its own navigation
   if (pathname === "/wrapped") return null;
 
   const headerStyle: React.CSSProperties = {
@@ -217,7 +218,7 @@ export default function AppNavbar() {
                 </Link>
               );
             })}
-            
+
             {isAuthenticated && (
               <Link
                 href="/dashboard/settings"

--- a/src/components/PersonalityCard.tsx
+++ b/src/components/PersonalityCard.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { toPng } from "html-to-image";
+import { Download, Sparkles, Moon, Sunrise, Clock, Zap, Users } from "lucide-react";
+import type { PersonalityReport } from "@/lib/personality-analysis";
+
+interface Props {
+    report: PersonalityReport;
+    username: string;
+}
+
+const WORKING_STYLE_ICON: Record<string, typeof Moon> = {
+    "Night Owl": Moon,
+    "Early Bird": Sunrise,
+    "9-to-5 Developer": Clock,
+};
+
+/** Beautiful, shareable archetype card with a one-click PNG download. */
+export default function PersonalityCard({ report, username }: Props) {
+    const cardRef = useRef<HTMLDivElement>(null);
+    const [downloading, setDownloading] = useState(false);
+
+    const handleDownload = useCallback(async () => {
+        if (!cardRef.current) return;
+        try {
+            setDownloading(true);
+            const dataUrl = await toPng(cardRef.current, {
+                cacheBust: true,
+                pixelRatio: 2,
+                style: { margin: "0" },
+            });
+            const link = document.createElement("a");
+            link.download = `devtrack-personality-${username}.png`;
+            link.href = dataUrl;
+            link.click();
+        } catch (err) {
+            console.error("[PersonalityCard] Failed to generate image:", err);
+        } finally {
+            setDownloading(false);
+        }
+    }, [username]);
+
+    const WorkingStyleIcon = WORKING_STYLE_ICON[report.workingStyle] ?? Clock;
+
+    return (
+        <div className="space-y-4">
+            <div
+                ref={cardRef}
+                className="relative overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] p-8 md:p-10 shadow-xl"
+            >
+                <div className="absolute inset-0 bg-gradient-to-br from-[var(--accent)]/10 via-transparent to-transparent pointer-events-none" />
+
+                <div className="relative z-10 space-y-6">
+                    <div className="flex items-center justify-between">
+                        <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--accent)]/30 bg-[var(--accent)]/10 px-3 py-1 text-xs font-semibold text-[var(--accent)]">
+                            <Sparkles size={12} />
+                            Code Personality Report
+                        </span>
+                        <span className="text-xs font-medium text-[var(--muted-foreground)]">
+                            devtrack.app/u/{username}
+                        </span>
+                    </div>
+
+                    <div>
+                        <h2 className="text-3xl md:text-4xl font-extrabold tracking-tight text-[var(--card-foreground)]">
+                            {report.archetype}
+                        </h2>
+                        <p className="mt-2 text-base text-[var(--muted-foreground)]">{report.tagline}</p>
+                    </div>
+
+                    <p className="text-sm leading-relaxed text-[var(--card-foreground)]/90">
+                        {report.description}
+                    </p>
+
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                        <TraitBox icon={WorkingStyleIcon} label="Working Style" value={report.workingStyle} />
+                        <TraitBox icon={Zap} label="Commit Pattern" value={report.commitPattern} />
+                        <TraitBox icon={Users} label="Collaboration" value={report.collaborationStyle} />
+                    </div>
+
+                    {report.strengths.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                            {report.strengths.map((s) => (
+                                <span
+                                    key={s}
+                                    className="rounded-full bg-[var(--control)] px-3 py-1 text-xs font-medium text-[var(--card-foreground)]"
+                                >
+                                    {s}
+                                </span>
+                            ))}
+                        </div>
+                    )}
+
+                    {report.funFact && (
+                        <p className="rounded-xl border border-[var(--border)] bg-[var(--card-muted,var(--control))] px-4 py-3 text-xs text-[var(--muted-foreground)] italic">
+                            {report.funFact}
+                        </p>
+                    )}
+                </div>
+            </div>
+
+            <button
+                type="button"
+                onClick={handleDownload}
+                disabled={downloading}
+                aria-label="Download personality card as PNG"
+                className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--card)] px-4 py-2 text-sm font-medium text-[var(--card-foreground)] hover:bg-[var(--control)] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+            >
+                {downloading ? (
+                    <>
+                        <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                        Generating…
+                    </>
+                ) : (
+                    <>
+                        <Download size={16} />
+                        Download as PNG
+                    </>
+                )}
+            </button>
+        </div>
+    );
+}
+
+function TraitBox({
+    icon: Icon,
+    label,
+    value,
+}: {
+    icon: typeof Moon;
+    label: string;
+    value: string;
+}) {
+    return (
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--control)]/40 px-4 py-3">
+            <div className="flex items-center gap-2 text-[var(--muted-foreground)]">
+                <Icon size={14} />
+                <span className="text-[11px] font-medium uppercase tracking-wide">{label}</span>
+            </div>
+            <div className="mt-1 text-sm font-semibold text-[var(--card-foreground)]">{value}</div>
+        </div>
+    );
+}

--- a/src/components/PersonalityRadar.tsx
+++ b/src/components/PersonalityRadar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { memo } from "react";
+import {
+    Radar,
+    RadarChart,
+    PolarGrid,
+    PolarAngleAxis,
+    ResponsiveContainer,
+} from "recharts";
+import type { PersonalityReport } from "@/lib/personality-analysis";
+
+interface Props {
+    report: PersonalityReport;
+}
+
+interface RadarDatum {
+    metric: string;
+    value: number;
+}
+
+/**
+ * Translates the personality dimensions into five 0-100 axes so they sit
+ * on a single radar chart. Categorical dimensions (working style, commit
+ * pattern, collaboration style) are mapped to a representative intensity
+ * score rather than plotted as raw enums.
+ */
+function toRadarData(report: PersonalityReport): RadarDatum[] {
+    const nightOwlIntensity =
+        report.workingStyle === "Night Owl"
+            ? Math.max(report.nightCommitPct, 60)
+            : report.workingStyle === "Early Bird"
+                ? 100 - Math.max(report.morningCommitPct, 60)
+                : 50;
+
+    const sprintIntensity = report.commitPattern === "Sprinter" ? 80 : 35;
+
+    const collaborationIntensity =
+        report.collaborationStyle === "Open Source Hero"
+            ? 90
+            : report.collaborationStyle === "Team Player"
+                ? 60
+                : 25;
+
+    return [
+        { metric: "Night Owl", value: nightOwlIntensity },
+        { metric: "Sprint Energy", value: sprintIntensity },
+        { metric: "Collaboration", value: collaborationIntensity },
+        { metric: "Perfectionism", value: report.perfectionismScore },
+        { metric: "Consistency", value: report.commitPattern === "Marathoner" ? 80 : 45 },
+    ];
+}
+
+function PersonalityRadar({ report }: Props) {
+    const data = toRadarData(report);
+    const color = "var(--accent)";
+
+    return (
+        <ResponsiveContainer width="100%" height={260}>
+            <RadarChart
+                data={data}
+                margin={{ top: 10, right: 30, bottom: 10, left: 30 }}
+                aria-label="Developer personality radar chart"
+            >
+                <PolarGrid stroke="var(--border)" />
+                <PolarAngleAxis
+                    dataKey="metric"
+                    tick={{
+                        fontSize: 12,
+                        fill: "var(--muted-foreground)",
+                    }}
+                />
+                <Radar
+                    name="Score"
+                    dataKey="value"
+                    stroke={color}
+                    fill={color}
+                    fillOpacity={0.2}
+                    strokeWidth={2}
+                    dot={{ r: 3, fill: color, strokeWidth: 0 }}
+                />
+            </RadarChart>
+        </ResponsiveContainer>
+    );
+}
+
+export default memo(PersonalityRadar);

--- a/src/components/personality/PersonalityReport.tsx
+++ b/src/components/personality/PersonalityReport.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { useSession } from "next-auth/react";
+import { toast } from "sonner";
+import { Sparkles, ChevronRight, RefreshCw } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import PersonalityCard from "@/components/PersonalityCard";
+import PersonalityRadar from "@/components/PersonalityRadar";
+import type { PersonalityReport as PersonalityReportData } from "@/lib/personality-analysis";
+
+type Step = "idle" | "loading" | "ready";
+
+export default function PersonalityReport() {
+    const { data: session } = useSession();
+    const [step, setStep] = useState<Step>("idle");
+    const [report, setReport] = useState<PersonalityReportData | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const username = session?.githubLogin ?? "you";
+
+    async function fetchReport(refresh = false) {
+        setStep("loading");
+        setError(null);
+
+        try {
+            const res = await fetch(`/api/personality${refresh ? "?refresh=true" : ""}`);
+
+            if (res.status === 429) {
+                const retryAfter = res.headers.get("Retry-After");
+                throw new Error(
+                    retryAfter
+                        ? `Rate limit reached. Try again in ${Math.ceil(Number(retryAfter) / 60)} min.`
+                        : "Rate limit reached. Try again later."
+                );
+            }
+
+            if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error || "Failed to generate your personality report");
+            }
+
+            const json = await res.json();
+            setReport(json.data as PersonalityReportData);
+            setStep("ready");
+            toast.success("Your code personality report is ready!");
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            setError(message);
+            setStep("idle");
+            toast.error(message);
+        }
+    }
+
+    return (
+        <div className="space-y-8 max-w-4xl mx-auto p-4 md:p-8 animate-in fade-in duration-500">
+            <div className="relative overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] p-8 md:p-12 shadow-2xl flex flex-col md:flex-row justify-between items-center gap-8">
+                <div className="absolute inset-0 bg-gradient-to-r from-[var(--accent)]/5 to-transparent pointer-events-none" />
+                <div className="space-y-4 max-w-2xl relative z-10">
+                    <Badge
+                        variant="outline"
+                        className="text-xs px-3 py-1 border-[var(--accent)]/30 bg-[var(--accent)]/10 text-[var(--accent)]"
+                    >
+                        AI-Powered · Discover What Kind of Developer You Are
+                    </Badge>
+                    <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight bg-gradient-to-r from-[var(--foreground)] to-[var(--foreground)]/70 bg-clip-text text-transparent">
+                        Code Personality Report
+                    </h1>
+                    <p className="text-sm md:text-base text-[var(--muted-foreground)] leading-relaxed">
+                        We&apos;ll analyze your commit times, streak, PR habits, and top repos to reveal your
+                        developer archetype — a fun, shareable take on how you actually work.
+                    </p>
+                </div>
+            </div>
+
+            {error && step === "idle" && (
+                <div className="p-4 rounded-xl border border-rose-500/20 bg-rose-500/5 text-rose-400 text-sm flex gap-3 items-center">
+                    <span className="font-semibold">Error:</span>
+                    <span>{error}</span>
+                </div>
+            )}
+
+            {step === "idle" && (
+                <Card className="border-[var(--border)] bg-[var(--card)] hover:shadow-2xl transition-all duration-300">
+                    <CardHeader className="text-center py-8 space-y-2">
+                        <CardTitle className="text-xl font-bold">Discover Your Developer Archetype</CardTitle>
+                        <CardDescription className="max-w-md mx-auto">
+                            Uses your existing GitHub stats already tracked in DevTrack — no extra setup, no new
+                            permissions.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="flex justify-center pb-8">
+                        <button
+                            type="button"
+                            onClick={() => fetchReport(false)}
+                            className="group relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-bold bg-gradient-to-r from-violet-600 to-indigo-600 text-white shadow-lg shadow-indigo-500/20 px-8 py-3.5 hover:scale-[1.03] transition-all duration-300 active:scale-[0.98]"
+                        >
+                            <Sparkles className="h-4.5 w-4.5" />
+                            Generate My Personality Report
+                            <ChevronRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
+                        </button>
+                    </CardContent>
+                </Card>
+            )}
+
+            {step === "loading" && (
+                <Card className="border-[var(--border)] bg-[var(--card)] p-8">
+                    <div className="py-12 flex flex-col items-center justify-center gap-4">
+                        <div className="h-10 w-10 animate-spin rounded-full border-4 border-violet-500 border-t-transparent" />
+                        <div className="text-center space-y-1">
+                            <p className="text-sm font-bold">Analyzing your coding patterns…</p>
+                            <p className="text-xs text-[var(--muted-foreground)]">
+                                Crunching commit times, PR history, and streaks.
+                            </p>
+                        </div>
+                    </div>
+                </Card>
+            )}
+
+            {step === "ready" && report && (
+                <div className="space-y-6 animate-in slide-in-from-bottom duration-500">
+                    <PersonalityCard report={report} username={username} />
+
+                    <Card className="border-[var(--border)] bg-[var(--card)] p-6 md:p-8">
+                        <h3 className="text-base font-bold mb-1">Your Personality Radar</h3>
+                        <p className="text-xs text-[var(--muted-foreground)] mb-4">
+                            How your traits compare across five dimensions.
+                        </p>
+                        <PersonalityRadar report={report} />
+                    </Card>
+
+                    <div className="flex justify-center">
+                        <button
+                            type="button"
+                            onClick={() => fetchReport(true)}
+                            className="inline-flex items-center gap-2 text-sm font-medium text-[var(--muted-foreground)] hover:text-[var(--card-foreground)] transition-colors"
+                        >
+                            <RefreshCw className="h-3.5 w-3.5" />
+                            Regenerate report
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/lib/ai-prompts.ts
+++ b/src/lib/ai-prompts.ts
@@ -23,3 +23,46 @@ Here is their data:
 
 Write a warm, concise 3-sentence weekly summary. Start with a highlight, add one observation, end with one actionable tip. Address the developer as "you". No bullet points.`;
 }
+
+export interface PersonalityReportPromptParams {
+  workingStyle: string;
+  commitPattern: string;
+  collaborationStyle: string;
+  perfectionismScore: number;
+  nightCommitPct: number;
+  morningCommitPct: number;
+  totalCommits: number;
+  activeDays: number;
+  longestStreak: number;
+  prsMerged: number;
+  avgMergeTimeDays: number;
+  topRepoName: string;
+  repoCount: number;
+}
+
+/**
+ * Builds the prompt for the AI Code Personality Report. The model is asked
+ * to return strict JSON so the API route can parse it directly into the
+ * PersonalityReport shape without additional text wrangling.
+ */
+export function personalityReportPrompt(params: PersonalityReportPromptParams): string {
+  return `You are a witty developer-culture analyst generating a fun, shareable "Code Personality Report" for a software engineer based on their real GitHub activity.
+
+Their computed traits:
+- Working style: ${params.workingStyle} (${params.nightCommitPct}% of commits after 9pm, ${params.morningCommitPct}% before 9am)
+- Commit pattern: ${params.commitPattern}
+- Collaboration style: ${params.collaborationStyle}
+- Perfectionism score: ${params.perfectionismScore}/100 (based on PR review thoroughness and commit frequency)
+- Total commits (90d): ${params.totalCommits}, active days: ${params.activeDays}, longest streak: ${params.longestStreak}
+- PRs merged: ${params.prsMerged}, avg merge time: ${params.avgMergeTimeDays.toFixed(1)} days
+- Top repository: ${params.topRepoName} (active across ${params.repoCount} repos)
+
+Respond with ONLY valid JSON, no markdown fences, no commentary, matching exactly this shape:
+{
+  "archetype": "a punchy 2-4 word developer archetype name, e.g. 'The Midnight Architect'",
+  "tagline": "one short punchy sentence capturing their coding identity",
+  "description": "2-3 sentences, second person ('you'), warm and specific to the data above, no generic filler",
+  "strengths": ["short strength phrase", "short strength phrase", "short strength phrase"],
+  "funFact": "one playful one-line observation derived from the data"
+}`;
+}

--- a/src/lib/personality-analysis.ts
+++ b/src/lib/personality-analysis.ts
@@ -1,0 +1,165 @@
+/**
+ * Deterministic scoring for the AI Code Personality Report.
+ *
+ * Every dimension here is computed directly from metrics DevTrack already
+ * gathers (no new GitHub API calls). This module is the single source of
+ * truth for the *numbers* — the Groq prompt only ever turns these numbers
+ * into prose/an archetype name. If Groq is unavailable, `buildFallbackReport`
+ * produces a complete report from these same dimensions so the page never
+ * dead-ends on a missing AI key or a rate limit.
+ */
+
+export interface PersonalityTimeBlocks {
+    morning: number;
+    afternoon: number;
+    evening: number;
+    night: number;
+}
+
+export interface PersonalityInputMetrics {
+    timeBlocks: PersonalityTimeBlocks;
+    totalCommits: number;
+    activeDays: number;
+    longestStreak: number;
+    currentStreak: number;
+    prsMerged: number;
+    prsOpen: number;
+    avgMergeTimeDays: number;
+    topRepoName: string;
+    repoCount: number;
+    commitsByDay: { date: string; count: number }[];
+}
+
+export type WorkingStyle = "Night Owl" | "Early Bird" | "9-to-5 Developer";
+export type CommitPattern = "Sprinter" | "Marathoner";
+export type CollaborationStyle = "Solo Coder" | "Team Player" | "Open Source Hero";
+
+export interface PersonalityDimensions {
+    workingStyle: WorkingStyle;
+    commitPattern: CommitPattern;
+    collaborationStyle: CollaborationStyle;
+    perfectionismScore: number; // 0-100
+    nightCommitPct: number; // 0-100
+    morningCommitPct: number; // 0-100
+}
+
+export interface PersonalityReport extends PersonalityDimensions {
+    archetype: string;
+    tagline: string;
+    description: string;
+    strengths: string[];
+    funFact: string;
+    source: "ai" | "fallback";
+}
+
+function pct(part: number, total: number): number {
+    if (total <= 0) return 0;
+    return Math.round((part / total) * 100);
+}
+
+/**
+ * Standard deviation of daily commit counts, normalised against the mean,
+ * gives a simple "burstiness" signal: a high coefficient of variation means
+ * a few huge days (Sprinter), a low one means steady daily output (Marathoner).
+ */
+function commitBurstiness(commitsByDay: { count: number }[]): number {
+    const counts = commitsByDay.map((d) => d.count);
+    const n = counts.length;
+    if (n === 0) return 0;
+
+    const mean = counts.reduce((s, c) => s + c, 0) / n;
+    if (mean === 0) return 0;
+
+    const variance =
+        counts.reduce((s, c) => s + (c - mean) ** 2, 0) / n;
+    const stdDev = Math.sqrt(variance);
+
+    return stdDev / mean; // coefficient of variation
+}
+
+export function computePersonalityDimensions(
+    metrics: PersonalityInputMetrics
+): PersonalityDimensions {
+    const { timeBlocks, prsMerged, avgMergeTimeDays, repoCount, activeDays, totalCommits } =
+        metrics;
+
+    const totalTimedCommits =
+        timeBlocks.morning + timeBlocks.afternoon + timeBlocks.evening + timeBlocks.night;
+
+    const nightCommitPct = pct(timeBlocks.night, totalTimedCommits);
+    const morningCommitPct = pct(timeBlocks.morning, totalTimedCommits);
+
+    let workingStyle: WorkingStyle = "9-to-5 Developer";
+    if (nightCommitPct >= 35) {
+        workingStyle = "Night Owl";
+    } else if (morningCommitPct >= 35) {
+        workingStyle = "Early Bird";
+    }
+
+    const burstiness = commitBurstiness(metrics.commitsByDay);
+    const commitPattern: CommitPattern = burstiness >= 1.1 ? "Sprinter" : "Marathoner";
+
+    let collaborationStyle: CollaborationStyle = "Solo Coder";
+    if (repoCount >= 8 || prsMerged >= 15) {
+        collaborationStyle = "Open Source Hero";
+    } else if (prsMerged >= 4) {
+        collaborationStyle = "Team Player";
+    }
+
+    // Perfectionism proxy: thorough (slower) PR turnaround + consistent daily
+    // cadence both read as "careful", scaled to a 0-100 band. Capped inputs
+    // keep one extreme value (e.g. a single 30-day-old PR) from dominating.
+    const reviewThoroughness = Math.min(avgMergeTimeDays / 3, 1) * 60; // up to 60 pts
+    const consistency = Math.min(activeDays / Math.max(totalCommits, 1), 1) * 40; // up to 40 pts
+    const perfectionismScore = Math.round(reviewThoroughness + consistency);
+
+    return {
+        workingStyle,
+        commitPattern,
+        collaborationStyle,
+        perfectionismScore: Math.max(0, Math.min(100, perfectionismScore)),
+        nightCommitPct,
+        morningCommitPct,
+    };
+}
+
+const ARCHETYPE_BY_STYLE: Record<WorkingStyle, Record<CommitPattern, string>> = {
+    "Night Owl": {
+        Sprinter: "The Midnight Architect",
+        Marathoner: "The Nocturnal Craftsman",
+    },
+    "Early Bird": {
+        Sprinter: "The Dawn Raider",
+        Marathoner: "The Sunrise Strategist",
+    },
+    "9-to-5 Developer": {
+        Sprinter: "The Deadline Sprinter",
+        Marathoner: "The Steady Builder",
+    },
+};
+
+/**
+ * Used when Groq is not configured, rate-limited, or returns malformed
+ * output. Keeps the dimensions identical to the AI path — only the prose
+ * is templated instead of generated — so the report is never empty.
+ */
+export function buildFallbackReport(
+    dims: PersonalityDimensions,
+    metrics: Pick<PersonalityInputMetrics, "topRepoName" | "longestStreak" | "prsMerged">
+): PersonalityReport {
+    const archetype = ARCHETYPE_BY_STYLE[dims.workingStyle][dims.commitPattern];
+
+    return {
+        ...dims,
+        archetype,
+        tagline: `${dims.workingStyle} energy meets ${dims.commitPattern.toLowerCase()} habits.`,
+        description: `You do most of your best work as a ${dims.workingStyle.toLowerCase()}, with a ${dims.commitPattern.toLowerCase()} commit rhythm. Your collaboration style leans toward "${dims.collaborationStyle}", and your longest streak of ${metrics.longestStreak} days shows real follow-through on ${metrics.topRepoName}.`,
+        strengths: [
+            dims.commitPattern === "Sprinter" ? "Fast under pressure" : "Reliable, steady output",
+            dims.collaborationStyle === "Solo Coder" ? "Deep focus work" : "Strong collaborator",
+            dims.perfectionismScore >= 50 ? "Careful, thorough reviewer" : "Ships quickly",
+        ],
+        funFact: `${metrics.prsMerged} merged PRs and counting — your commit history tells a clearer story than your resume.`,
+        source: "fallback",
+    };
+}


### PR DESCRIPTION
## Description

Adds an AI-generated "Code Personality Report" page that turns a user's existing GitHub metrics (already tracked by DevTrack) into a fun, shareable developer archetype. Closes #2367.

## Approach

This reuses existing DevTrack infrastructure end-to-end rather than introducing anything new:

- **Data**: all inputs come from metrics endpoints DevTrack already exposes (`/api/metrics/contributions`, `/prs`, `/streak`, `/repos`) — no new GitHub API calls or scopes.
- **Caching/rate-limiting**: reuses the `ai_insights` table (new `insight_type: "personality"`, no migration needed — the type column has no DB-level CHECK constraint) and the same Upstash/in-memory rate-limit pattern as `/api/ai-insights`.
- **AI**: uses the existing `GROQ_API_KEY` / `llama-3.3-70b-versatile` setup already used by `/api/ai-insights`.
- **UI patterns**: the radar chart follows `RepoHealthRadar.tsx`, the PNG export follows `StreakTracker.tsx`/`StatsCard.tsx` (`html-to-image`), and the page flow (idle → loading → ready) follows `CareerIntelligence.tsx`.

## How it works

1. `src/lib/personality-analysis.ts` computes four dimensions deterministically from metrics already on hand:
   - **Working Style** (Night Owl / Early Bird / 9-to-5) from the `timeBlocks` breakdown already returned by `/api/metrics/contributions`
   - **Commit Pattern** (Sprinter / Marathoner) from the coefficient of variation of daily commit counts
   - **Collaboration Style** (Solo Coder / Team Player / Open Source Hero) from merged PRs and active repo count
   - **Perfectionism Score** (0–100) from average PR merge time + commit consistency
2. `src/app/api/personality/route.ts` computes these dimensions, then asks Groq to turn them into an archetype name, tagline, description, strengths, and a fun fact — returned as strict JSON.
3. If Groq is unavailable, rate-limited, returns malformed JSON, or `GROQ_API_KEY` isn't set, a templated fallback report is built from the same dimensions so the feature degrades gracefully instead of failing.
4. `PersonalityCard` renders the result with a one-click PNG download; `PersonalityRadar` plots the five dimensions on a Recharts radar chart.

## Testing

- [x] `npm run lint` passes (0 errors; 5 pre-existing warnings unrelated to this change)
- [x] `npm run type-check` passes
- [x] Manually verified the full flow in dev: generate → card renders → radar renders → PNG download works
- [x] Manually verified the no-`GROQ_API_KEY` fallback path produces a complete, sensible report
- [x] Verified a zero-activity (brand new) account doesn't produce `NaN`/divide-by-zero in the scoring
- [ ] (Add screenshot/GIF of the report page here)

## Acceptance criteria (from #2367)

- [x] New `/dashboard/personality` page accessible from dashboard nav
- [x] AI generates a personality report based on the user's GitHub metrics
- [x] Radar chart shows scores across personality dimensions
- [x] Personality card is visually appealing and downloadable as PNG
- [x] Works for authenticated users with GitHub data (page redirects unauthenticated users to `/`)
- [x] Mobile responsive (Tailwind responsive classes throughout, follows existing `CareerIntelligence` breakpoints)

## Notes for reviewers

- No database migration required — `ai_insights.insight_type` has no DB-level CHECK constraint, only app-level validation, so the new `"personality"` value is accepted as-is.
- Rate limit: 5 generations/hour per user, same ceiling as `/api/ai-insights`, to bound Groq spend.

Closes #2367