### PR TITLE
fix(vercel): pin Node.js to 20.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "js-yaml": ">=4.1.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": "20.x"
   },
   "optionalDependencies": {
     "@esbuild/linux-x64": "^0.28.0",


### PR DESCRIPTION
## Summary
- `engines.node` changed from `>=20.0.0` to `20.x`
- Vercel was auto-selecting Node 24, causing `tree-sitter` native addon (`cppgc` API incompatibility) build failure
- Pinning to `20.x` locks Vercel to Node 20 LTS

## Test plan
- [ ] Trigger Vercel deployment after merge, confirm build succeeds on Node 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)