### PR TITLE
Refactor filter checks to use searchParams

### DIFF
--- a/src/components/leaderboard/LeaderboardFilters.tsx
+++ b/src/components/leaderboard/LeaderboardFilters.tsx
@@ -44,7 +44,7 @@ export default function LeaderboardFilters() {
   const rawPeriod = searchParams.get("period");
   const period: Period = isPeriod(rawPeriod) ? rawPeriod : "all";
 
-  const hasFilters = language !== "" || period !== "all";
+  const hasFilters = searchParams.has("lang") || searchParams.has("period");
 
   const currentFilters = useMemo(
     () => ({ lang: language, period }),
@@ -71,6 +71,7 @@ export default function LeaderboardFilters() {
         if (parsed.lang) {
           nextParams.set("lang", parsed.lang);
         }
+
         const storedPeriod = parsed.period ?? null;
         if (isPeriod(storedPeriod) && storedPeriod !== "all") {
           nextParams.set("period", storedPeriod);
@@ -146,6 +147,7 @@ export default function LeaderboardFilters() {
           <div className="grid grid-cols-3 gap-1 rounded-lg border border-[var(--border)] bg-[var(--control)] p-1">
             {periods.map((item) => {
               const active = item.value === period;
+
               return (
                 <button
                   key={item.value}


### PR DESCRIPTION
## Summary

<!-- Briefly describe what this PR does and why. 1–3 sentences is enough. -->

Closes #2578 

---

## Type of Change

<!-- Check all that apply -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [x] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

<!-- List the key changes made. Be specific — mention file names or functions where helpful. -->

* Updated `LeaderboardFilters` to determine active filters based on whether `lang` or `period` exists in the URL query params.
* Fixed an edge case where invalid URL values, such as `/leaderboard?period=bad-value`, caused the Clear filters button to remain disabled.
* Kept existing valid filter behavior unchanged for language selection, time range selection, local storage persistence, and clearing filters.

---

## How to Test

<!-- Steps a reviewer can follow to verify your changes work correctly. -->

1. Open `/leaderboard?period=bad-value` and verify the Clear filters button is enabled.
2. Click Clear filters and confirm the invalid `period` query param is removed from the URL.
3. Test valid filters such as `/leaderboard?period=week` and `/leaderboard?lang=typescript` to confirm filtering and clearing still work correctly.

**Expected result:**

The Clear filters button should be enabled whenever `lang` or `period` exists in the URL, even if the value is invalid. Clicking Clear filters should remove those query params and return the leaderboard to the default unfiltered state.

---

## Checklist

<!-- Complete before requesting review. -->

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---