### PR TITLE
test : added unit tests for achievement-estimators helper functions

### DIFF
--- a/src/lib/achievement-estimators.ts
+++ b/src/lib/achievement-estimators.ts
@@ -12,14 +12,14 @@ export interface AchievementEstimate {
 const TIERS_STANDARD = [1, 16, 128, 1024];
 const TIERS_STARSTRUCK = [16, 128, 512, 4096];
 
-function calculateNextTier(current: number, tiers: number[]): number | null {
+export function calculateNextTier(current: number, tiers: number[]): number | null {
   for (const tier of tiers) {
     if (current < tier) return tier;
   }
   return null; // Maxed out
 }
 
-function calculatePercentage(current: number, nextTier: number | null): number {
+export function calculatePercentage(current: number, nextTier: number | null): number {
   if (nextTier === null || current >= nextTier) return 100;
   return Math.floor((current / nextTier) * 100);
 }

--- a/test/achievement-estimators.test.ts
+++ b/test/achievement-estimators.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateNextTier,
+  calculatePercentage,
+} from "../src/lib/achievement-estimators";
+
+describe("calculateNextTier", () => {
+  const tiers = [1, 16, 128, 1024];
+
+  it("returns the first tier when current is below all tiers", () => {
+    expect(calculateNextTier(0, tiers)).toBe(1);
+    expect(calculateNextTier(0, tiers)).toBe(1);
+  });
+
+  it("returns the next tier when current is below a tier", () => {
+    expect(calculateNextTier(5, tiers)).toBe(16);
+    expect(calculateNextTier(15, tiers)).toBe(128);
+  });
+
+  it("returns the next tier when current equals a tier", () => {
+    expect(calculateNextTier(1, tiers)).toBe(16);
+    expect(calculateNextTier(16, tiers)).toBe(128);
+    expect(calculateNextTier(128, tiers)).toBe(1024);
+  });
+
+  it("returns null when current is above all tiers (maxed out)", () => {
+    expect(calculateNextTier(1024, tiers)).toBe(null);
+    expect(calculateNextTier(5000, tiers)).toBe(null);
+  });
+
+  it("returns null for empty tiers array", () => {
+    expect(calculateNextTier(10, [])).toBe(null);
+  });
+
+  it("returns first tier when current is negative", () => {
+    expect(calculateNextTier(-5, tiers)).toBe(1);
+  });
+});
+
+describe("calculatePercentage", () => {
+  it("returns 0 when nextTier is null (maxed)", () => {
+    expect(calculatePercentage(100, null)).toBe(100);
+  });
+
+  it("returns 100 when current exceeds nextTier", () => {
+    expect(calculatePercentage(200, 100)).toBe(100);
+  });
+
+  it("returns floor of the ratio when current is below nextTier", () => {
+    expect(calculatePercentage(50, 100)).toBe(50);
+    expect(calculatePercentage(1, 3)).toBe(33);
+    expect(calculatePercentage(1, 4)).toBe(25);
+  });
+
+  it("returns 100 when current equals nextTier", () => {
+    expect(calculatePercentage(100, 100)).toBe(100);
+  });
+
+  it("handles 0 current gracefully", () => {
+    expect(calculatePercentage(0, 100)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #2695.

Summary of What Has Been Done: Added unit tests for calculateNextTier and calculatePercentage — the two pure helper functions in src/lib/achievement-estimators.ts. Exported both functions from the source module so they can be imported in tests.

Changes Made:
- Exported calculateNextTier and calculatePercentage from src/lib/achievement-estimators.ts
- Created test/achievement-estimators.test.ts with 11 test cases covering: tier progression below/equal/above tiers, maxed-out tiers, empty tiers array, negative inputs, and percentage floor calculation

Impact it Made: Closes the gap in unit test coverage for achievement-estimators. These functions are central to achievement progress calculation; the tests provide regression protection for tier boundary logic.