### PR TITLE
fix: cap language legend at 6 entries and group minor languages 

### DIFF
--- a/src/components/LanguageBreakdown.tsx
+++ b/src/components/LanguageBreakdown.tsx
@@ -102,18 +102,41 @@ export default function LanguageBreakdown() {
       .finally(() => setLoading(false));
   }, [selectedAccount]);
 
-  const totalPercentage = languages.reduce(
-    (sum, lang) => sum + lang.percentage,
-    0
-  );
-  const roundedTotal = Math.round(totalPercentage * 10) / 10;
+  const MAX_DISPLAY = 6;
 
-  const chartData: Language[] = [...languages];
-  if (roundedTotal < 99.5 && languages.length > 0) {
+  // Step 1: merge languages whose share is < 1% into an "Others" bucket.
+  // Step 2: cap named languages at MAX_DISPLAY; anything beyond that rank
+  // also collapses into "Others". This prevents the legend from growing
+  // unboundedly and overflowing the card when a user has 10+ languages.
+  const { named, othersBytes, othersPercentage } = languages.reduce<{
+    named: Language[];
+    othersBytes: number;
+    othersPercentage: number;
+  }>(
+    (acc, lang, idx) => {
+      if (lang.percentage < 1 || idx >= MAX_DISPLAY) {
+        acc.othersBytes += lang.bytes;
+        acc.othersPercentage += lang.percentage;
+      } else {
+        acc.named.push(lang);
+      }
+      return acc;
+    },
+    { named: [], othersBytes: 0, othersPercentage: 0 }
+  );
+
+  // Absorb any rounding remainder so the donut stays visually complete.
+  const namedTotal = named.reduce((s, l) => s + l.percentage, 0);
+  const remainder = 100 - namedTotal - othersPercentage;
+  const finalOthersPct =
+    Math.round((othersPercentage + Math.max(remainder, 0)) * 10) / 10;
+
+  const chartData: Language[] = [...named];
+  if (finalOthersPct > 0 || othersBytes > 0) {
     chartData.push({
-      name: "Other",
-      bytes: 0,
-      percentage: Math.round((100 - roundedTotal) * 10) / 10,
+      name: "Others",
+      bytes: othersBytes,
+      percentage: finalOthersPct,
     });
   }
 
@@ -148,28 +171,28 @@ export default function LanguageBreakdown() {
         <p className="rounded-lg border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 p-4 text-sm text-[var(--destructive)]">
           {error}
         </p>
-    ) : languages.length === 0 ? (
-  <div className="flex flex-col items-center justify-center py-10 text-center">
-    <div className="mb-3 text-4xl">🧩</div>
+      ) : languages.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-10 text-center">
+          <div className="mb-3 text-4xl">🧩</div>
 
-    <h3 className="text-sm font-semibold text-[var(--card-foreground)]">
-      No language data available
-    </h3>
+          <h3 className="text-sm font-semibold text-[var(--card-foreground)]">
+            No language data available
+          </h3>
 
-    <p className="mt-2 max-w-sm text-sm text-[var(--muted-foreground)]">
-      Start committing code to repositories and we&apos;ll analyze the language distribution across your projects.
-    </p>
+          <p className="mt-2 max-w-sm text-sm text-[var(--muted-foreground)]">
+            Start committing code to repositories and we&apos;ll analyze the language distribution across your projects.
+          </p>
 
-    <a
-      href="https://github.com/new"
-      target="_blank"
-      rel="noopener noreferrer"
-      className="mt-4 inline-flex rounded-md border border-[var(--border)] px-4 py-2 text-sm font-medium hover:bg-[var(--control)]"
-    >
-      Create Repository
-    </a>
-  </div>
-) : (
+          <a
+            href="https://github.com/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex rounded-md border border-[var(--border)] px-4 py-2 text-sm font-medium hover:bg-[var(--control)]"
+          >
+            Create Repository
+          </a>
+        </div>
+      ) : (
         <div className="flex flex-col items-center gap-6 sm:flex-row sm:items-center sm:gap-8">
           {/* Donut chart */}
           <div
@@ -203,13 +226,13 @@ export default function LanguageBreakdown() {
                 <Tooltip content={<LanguageTooltip />} />
               </PieChart>
             </ResponsiveContainer>
-            {/* Centre label */}
+            {/* Centre label — shows the true total, not the capped display count */}
             <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
               <span className="text-xs font-medium text-[var(--muted-foreground)]">
                 Languages
               </span>
               <span className="text-lg font-bold text-[var(--card-foreground)]">
-                {chartData.length}
+                {languages.length}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## Description

Fixes the language legend overflowing its card container when a user's
profile tracks 10+ languages. Closes #2605.

## Root cause

`LanguageBreakdown.tsx` rendered every language returned by
`/api/metrics/languages` as a legend row with no upper bound. A polyglot
developer with 12+ languages gets 12+ rows stacking in a flex column,
breaking out of the card.

## Fix — `src/components/LanguageBreakdown.tsx`

Before building `chartData`, the raw `languages` array is now processed
in a single `reduce` pass:

1. **Minor-language bucketing**: any language with `< 1%` share is merged
   into a single "Others" entry (bytes + percentage both accumulated).
2. **Top-6 cap**: languages beyond rank 6 (sorted descending by percentage,
   which is how the API already returns them) are also merged into "Others",
   regardless of their individual share.
3. **Rounding remainder**: any floating-point gap to 100% is absorbed into
   "Others" so the donut stays visually complete.
4. **Centre label**: now shows `languages.length` (the true API count) so
   users know they have more languages than the 6 displayed.

Maximum legend rows is now **7** (6 named + 1 "Others"), regardless of
how many languages the API returns.

## Testing

- [x] `npm run lint` passes (0 errors)
- [x] `npm run type-check` passes
- [x] Manually verified with a mocked 12-language dataset: legend shows
  exactly 6 named entries + "Others", donut total sums to 100%
- [x] Verified edge cases: ≤6 languages (no "Others" row added), all
  languages < 1% (all collapse to one "Others"), zero languages (empty
  state unchanged)
- [ ] (Screenshot of before/after with 10+ language profile would go here)

## Acceptance criteria (from #2605)

- [x] Languages with `< 1%` share are grouped under "Others"
- [x] Display is capped at top 6 dominant languages
- [x] Card no longer overflows for 10+ language profiles

Fixes #2605