### PR TITLE
feat: add Ctrl/Cmd+Shift+T keyboard shortcut to toggle theme (#2602)

### DIFF
--- a/src/components/GlobalKeyboardShortcuts.tsx
+++ b/src/components/GlobalKeyboardShortcuts.tsx
@@ -45,8 +45,10 @@ export default function GlobalKeyboardShortcuts() {
         return;
       }
 
-      // Alt+T / Option+T to toggle theme
-      if (e.altKey && e.key.toLowerCase() === "t") {
+      // Alt+T / Option+T  OR  Ctrl+Shift+T / Cmd+Shift+T  -> toggle theme
+      const isAltT = e.altKey && !e.shiftKey && e.key.toLowerCase() === "t";
+      const isCtrlShiftT = (e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "t";
+      if (isAltT || isCtrlShiftT) {
         keyboardToggleRef.current = true;
         toggleTheme();
         e.preventDefault();

--- a/src/components/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal.tsx
@@ -13,8 +13,12 @@ interface ShortcutItem {
   action: string;
 }
 
+// Use a sentinel value so the renderer can substitute the correct
+// platform-specific label (Mac: Cmd, Windows/Linux: Ctrl).
+const THEME_SHORTCUT_SENTINEL = "__THEME__";
+
 const SHORTCUTS: ShortcutItem[] = [
-  { key: "Alt + T", action: "Toggle theme" },
+  { key: THEME_SHORTCUT_SENTINEL, action: "Toggle theme" },
   { key: "B", action: "Toggle chart" },
   { key: "R", action: "Reload data" },
   { key: "G + D", action: "Go to Dashboard" },
@@ -175,7 +179,11 @@ export default function ShortcutsModal({
               {item.action}
             </span>
             <kbd className="min-w-[28px] rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-center text-xs font-semibold text-[var(--card-foreground)] shadow-sm">
-              {item.key === "T" ? (isMac ? "Option + T" : "Alt + T") : item.key}
+              {item.key === THEME_SHORTCUT_SENTINEL
+                ? isMac
+                  ? "⌘ Shift T / ⌥ T"
+                  : "Ctrl Shift T / Alt T"
+                : item.key}
             </kbd>
           </div>
         ))}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -58,10 +58,12 @@ function CompactThemeToggle() {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [open, setOpen] = useState(false);
+  const [isMac, setIsMac] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setMounted(true);
+    setIsMac(/Mac|iPod|iPhone|iPad/.test(navigator.userAgent));
   }, []);
 
   useEffect(() => {
@@ -104,7 +106,8 @@ function CompactThemeToggle() {
         type="button"
         onClick={() => setOpen((value) => !value)}
         className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--border)] bg-[var(--card)] text-[var(--card-foreground)] transition-all duration-200 hover:bg-[var(--control)] active:scale-95"
-        aria-label="Choose theme"
+        aria-label={`Choose theme (${isMac ? "⌘ Shift T" : "Ctrl Shift T"})`}
+        title={`Choose theme — ${isMac ? "⌘ Shift T" : "Ctrl Shift T"} to cycle`}
         aria-haspopup="menu"
         aria-expanded={open}
       >
@@ -130,16 +133,14 @@ function CompactThemeToggle() {
                     role="menuitemradio"
                     aria-checked={isActive}
                     onClick={() => handleSelect(option.id)}
-                    className={`flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors ${
-                      isActive
+                    className={`flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-left transition-colors ${isActive
                         ? "bg-[var(--accent-soft)] text-[var(--foreground)]"
                         : "text-[var(--card-foreground)] hover:bg-[var(--control)]"
-                    }`}
+                      }`}
                   >
                     <span
-                      className={`h-3 w-3 shrink-0 rounded-full border border-black/10 ${
-                        option.mode === "dark" ? "bg-slate-700" : "bg-sky-200"
-                      }`}
+                      className={`h-3 w-3 shrink-0 rounded-full border border-black/10 ${option.mode === "dark" ? "bg-slate-700" : "bg-sky-200"
+                        }`}
                       aria-hidden="true"
                     />
                     <span className="min-w-0 flex-1">


### PR DESCRIPTION
## Description

Adds `Ctrl+Shift+T` (Windows/Linux) and `Cmd+Shift+T` (Mac) as a global keyboard
shortcut to toggle the theme, alongside the existing `Alt+T` / `Option+T` shortcut.
Closes #2602.

## What already existed

`GlobalKeyboardShortcuts.tsx` (mounted globally in `providers.tsx`) already had
`Alt+T` / `Option+T` for theme toggling, with:
- Input field guards (`input`, `textarea`, `select`, `contenteditable`)
- Proper `removeEventListener` cleanup on unmount
- `aria-live="polite"` announcing the new theme name to screen readers

This PR adds the requested `Ctrl/Cmd+Shift+T` chord and surfaces the shortcut
in the UI so users can discover it.

## Changes

**`GlobalKeyboardShortcuts.tsx`**
- Adds `Ctrl+Shift+T` / `Cmd+Shift+T` detection (`ctrlKey || metaKey + shiftKey + t`)
  alongside the existing `altKey + t` path. Both share the same toggle call,
  announcement ref, and `preventDefault`. No new listeners or effects.

**`ShortcutsModal.tsx`**
- Updates the shortcuts list to show both chords for theme toggling
- Fixes a pre-existing bug: the platform-label substitution checked
  `item.key === "T"` but the stored value was `"Alt + T"`, so Mac users
  always saw `"Alt + T"` instead of `"Option + T"`. Replaced with a
  sentinel constant (`__THEME__`) that the renderer correctly substitutes.

**`ThemeToggle.tsx`** (`CompactThemeToggle`)
- Detects `navigator.userAgent` on mount (same pattern as `ShortcutsModal`)
  to pick the correct platform label
- Adds `title` tooltip and updates `aria-label` on the theme button to
  surface the shortcut hint on hover

## Acceptance criteria (from #2602)

- [x] Shortcut works across all pages (listener is in `GlobalKeyboardShortcuts`,
  rendered inside `ThemeProvider` in `providers.tsx` — global scope)
- [x] Shortcut does not fire when an input, textarea, select, or
  contenteditable element is focused
- [x] Clean event listener cleanup (`removeEventListener` in `useEffect` return)
- [x] Tooltip hint next to the theme toggle button informs users of the shortcut

Closes #2602