### PR TITLE
feat: Add "Print Profile / Export to PDF" action on Public Profile Page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -647,13 +647,11 @@ body {
   inset: -1px;
   border-radius: inherit;
   padding: 1px;
-  background: radial-gradient(
-    250px circle at var(--mouse-x, 0px) var(--mouse-y, 0px),
-    rgba(129, 140, 248, 0.5) 0%,
-    transparent 80%
-  );
-  -webkit-mask: 
-    linear-gradient(#fff 0 0) content-box, 
+  background: radial-gradient(250px circle at var(--mouse-x, 0px) var(--mouse-y, 0px),
+      rgba(129, 140, 248, 0.5) 0%,
+      transparent 80%);
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
@@ -727,6 +725,7 @@ body {
 .animate-shimmer {
   animation: shimmer 1.5s infinite;
 }
+
 /* Mouse spotlight enhancement for visibility on all backgrounds */
 .lnd-root .mouse-spotlight {
   pointer-events: none;
@@ -740,4 +739,83 @@ body {
   outline: 3px solid var(--accent);
   outline-offset: 2px;
   border-radius: 4px;
+}
+
+
+
+/* ═══════════════════════════════════════════
+   PRINT / EXPORT PDF — Public Profile Page
+   ═══════════════════════════════════════════ */
+@media print {
+
+  /* Force white background + black text regardless of theme */
+  html,
+  body {
+    background: #ffffff !important;
+    background-image: none !important;
+    color: #111111 !important;
+  }
+
+  /* Override all CSS custom property colors for print */
+  * {
+    --background: #ffffff !important;
+    --foreground: #111111 !important;
+    --card: #ffffff !important;
+    --card-foreground: #111111 !important;
+    --muted-foreground: #555555 !important;
+    --border: #dddddd !important;
+    --control: #f5f5f5 !important;
+    --accent: #2563eb !important;
+    --shadow-soft: none !important;
+    --shadow-medium: none !important;
+  }
+
+  /* Hide everything that shouldn't print */
+  .print\:hidden,
+  nav,
+  footer,
+  button,
+  [role="button"] {
+    display: none !important;
+  }
+
+  /* Remove shadows from cards */
+  [class*="rounded-2xl"],
+  [class*="rounded-xl"],
+  [class*="shadow"] {
+    box-shadow: none !important;
+  }
+
+  /* Keep cards readable with light borders */
+  .rounded-2xl,
+  .rounded-xl {
+    border: 1px solid #dddddd !important;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Accent bars (language/repo bars) should print in a neutral color */
+  [style*="var(--accent)"] {
+    background-color: #2563eb !important;
+  }
+
+  /* Remove background gradients */
+  body,
+  div {
+    background-image: none !important;
+  }
+
+  /* Page setup */
+  @page {
+    size: A4;
+    margin: 1.5cm 1.8cm;
+  }
+
+  /* Prevent orphaned headings */
+  h1,
+  h2,
+  h3 {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
 }

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 export const dynamic = "force-dynamic";
 import QrCodeButton from "@/components/QrCodeButton";
 import ProfileThemeWrapper from "@/components/ProfileThemeWrapper";
@@ -17,6 +18,7 @@ import { Moon, Sun } from "lucide-react";
 import { authOptions } from "@/lib/auth";
 import { getUserByGithubId } from "@/lib/supabase";
 import type { PublicProfileData } from "@/lib/public-profile-data";
+import PrintProfileButton from "@/components/PrintProfileButton";
 
 // Extend tracking structures to forward gamification flags seamlessly downstream
 interface ExtendedPublicProfileData extends PublicProfileData {
@@ -173,32 +175,32 @@ export default async function PublicProfilePage({
   if (!profile) {
     return (
       <ProfileThemeWrapper>
-      <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors flex items-center justify-center">
-        <div className="surface-card max-w-md rounded-2xl p-8 text-center">
-          <h1 className="text-3xl md:text-4xl font-bold mb-2">
-            Profile Not Found
-          </h1>
-          <p className="text-[var(--muted-foreground)] mb-2">
-            This profile is not available or has not been made public.
-          </p>
-          <p className="text-sm text-[var(--muted-foreground)] mb-6">
-            If this is your profile, go to{" "}
+        <div className="min-h-screen bg-[var(--background)] p-4 md:p-8 text-[var(--foreground)] transition-colors flex items-center justify-center">
+          <div className="surface-card max-w-md rounded-2xl p-8 text-center">
+            <h1 className="text-3xl md:text-4xl font-bold mb-2">
+              Profile Not Found
+            </h1>
+            <p className="text-[var(--muted-foreground)] mb-2">
+              This profile is not available or has not been made public.
+            </p>
+            <p className="text-sm text-[var(--muted-foreground)] mb-6">
+              If this is your profile, go to{" "}
+              <Link
+                href="/dashboard/settings"
+                className="text-[var(--accent)] underline hover:opacity-80"
+              >
+                Settings
+              </Link>{" "}
+              and enable <strong>Public Profile</strong>.
+            </p>
             <Link
-              href="/dashboard/settings"
-              className="text-[var(--accent)] underline hover:opacity-80"
+              href="/"
+              className="primary-button inline-block rounded-lg px-6 py-2"
             >
-              Settings
-            </Link>{" "}
-            and enable <strong>Public Profile</strong>.
-          </p>
-          <Link
-            href="/"
-            className="primary-button inline-block rounded-lg px-6 py-2"
-          >
-            Back to Home
-          </Link>
+              Back to Home
+            </Link>
+          </div>
         </div>
-      </div>
       </ProfileThemeWrapper>
     );
   }
@@ -230,218 +232,217 @@ export default async function PublicProfilePage({
 
   const memberSinceFormatted = profile.memberSince
     ? new Date(profile.memberSince).toLocaleDateString("en-US", {
-        month: "long",
-        year: "numeric",
-      })
+      month: "long",
+      year: "numeric",
+    })
     : null;
 
   return (
     <ProfileThemeWrapper>
-    <div className="min-h-screen bg-[var(--background)] p-4 text-[var(--foreground)] transition-colors md:p-8">
+      <div className="min-h-screen bg-[var(--background)] p-4 text-[var(--foreground)] transition-colors md:p-8">
 
-      {/* ── Header: Avatar + Identity ── */}
-      <div className="mb-8 flex flex-wrap items-start gap-5">
-        {/* GitHub avatar */}
-        <div className="shrink-0">
-          <Image
-            src={avatarUrl}
-            alt={`${profile.username}'s GitHub avatar`}
-            width={80}
-            height={80}
-            className="rounded-full border-2 border-[var(--border)] shadow-md"
-            unoptimized
-          />
-        </div>
-
-        {/* Identity block */}
-        <div className="flex-1 min-w-0">
-          <div className="flex flex-wrap items-center gap-3">
-            <h1 className="text-3xl md:text-4xl font-bold text-[var(--foreground)] flex flex-wrap items-center gap-2">
-              <span>@{profile.username}</span>
-              {profile.isSponsor && <SponsorBadge />}
-
-              {/* Night Owl / Early Bird badges */}
-              {profile.isNightOwl && (
-                <span
-                  title="Night Owl Milestone Badge"
-                  className="inline-flex items-center gap-1 rounded-full bg-indigo-500/10 border border-indigo-500/30 px-2.5 py-0.5 text-xs font-bold text-indigo-400"
-                >
-                  <Moon className="h-3 w-3" />
-                  <span>Night Owl</span>
-                </span>
-              )}
-              {profile.isEarlyBird && (
-                <span
-                  title="Early Bird Milestone Badge"
-                  className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 border border-amber-500/30 px-2.5 py-0.5 text-xs font-bold text-amber-400"
-                >
-                  <Sun className="h-3 w-3" />
-                  <span>Early Bird</span>
-                </span>
-              )}
-            </h1>
-            <CopyLinkButton url={profileUrl} />
+        {/* ── Header: Avatar + Identity ── */}
+        <div className="mb-8 flex flex-wrap items-start gap-5">
+          {/* GitHub avatar */}
+          <div className="shrink-0">
+            <Image
+              src={avatarUrl}
+              alt={`${profile.username}'s GitHub avatar`}
+              width={80}
+              height={80}
+              className="rounded-full border-2 border-[var(--border)] shadow-md"
+              unoptimized
+            />
           </div>
 
-          <p className="mt-1 text-[var(--muted-foreground)]">
-            GitHub activity and coding stats
-          </p>
+          {/* Identity block */}
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-3xl md:text-4xl font-bold text-[var(--foreground)] flex flex-wrap items-center gap-2">
+                <span>@{profile.username}</span>
+                {profile.isSponsor && <SponsorBadge />}
+                {profile.isNightOwl && (
+                  <span
+                    title="Night Owl Milestone Badge"
+                    className="inline-flex items-center gap-1 rounded-full bg-indigo-500/10 border border-indigo-500/30 px-2.5 py-0.5 text-xs font-bold text-indigo-400"
+                  >
+                    <Moon className="h-3 w-3" />
+                    <span>Night Owl</span>
+                  </span>
+                )}
+                {profile.isEarlyBird && (
+                  <span
+                    title="Early Bird Milestone Badge"
+                    className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 border border-amber-500/30 px-2.5 py-0.5 text-xs font-bold text-amber-400"
+                  >
+                    <Sun className="h-3 w-3" />
+                    <span>Early Bird</span>
+                  </span>
+                )}
+              </h1>
+              <CopyLinkButton url={profileUrl} />
+              <PrintProfileButton />
+            </div>
 
-          {/* Member since + View on GitHub */}
-          <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-[var(--muted-foreground)]">
-            {memberSinceFormatted && (
-              <span>Member since {memberSinceFormatted}</span>
-            )}
-            <a
-              href={githubUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] bg-[var(--control)] px-3 py-1 text-xs font-medium text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)] hover:border-[var(--accent)]"
-            >
-              <svg viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5" aria-hidden="true">
-                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-              </svg>
-              View on GitHub
-            </a>
-            {profile.publicGists > 0 && (
+            <p className="mt-1 text-[var(--muted-foreground)]">
+              GitHub activity and coding stats
+            </p>
+
+            {/* Member since + View on GitHub */}
+            <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-[var(--muted-foreground)]">
+              {memberSinceFormatted && (
+                <span>Member since {memberSinceFormatted}</span>
+              )}
               <a
-                href={gistsUrl}
+                href={githubUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center rounded-full border border-[var(--border)] bg-[var(--control)] px-3 py-1 text-xs font-medium text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)]"
+                className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border)] bg-[var(--control)] px-3 py-1 text-xs font-medium text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)] hover:border-[var(--accent)]"
               >
-                {profile.publicGists} Gists
+                <svg viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5" aria-hidden="true">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                </svg>
+                View on GitHub
               </a>
-            )}
+              {profile.publicGists > 0 && (
+                <a
+                  href={gistsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center rounded-full border border-[var(--border)] bg-[var(--control)] px-3 py-1 text-xs font-medium text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)]"
+                >
+                  {profile.publicGists} Gists
+                </a>
+              )}
+            </div>
+
+            {/* Compare buttons */}
+            <div className="mt-3 flex flex-wrap gap-2">
+              {compareHref && (
+                <Link
+                  href={compareHref}
+                  className="primary-button inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
+                >
+                  Compare with me
+                </Link>
+              )}
+              {!loggedInUsername && (
+                <Link
+                  href={signInToCompareHref}
+                  className="secondary-button inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
+                >
+                  Log in to compare
+                </Link>
+              )}
+            </div>
           </div>
 
-          {/* Compare buttons */}
-          <div className="mt-3 flex flex-wrap gap-2">
-            {compareHref && (
-              <Link
-                href={compareHref}
-                className="primary-button inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
-              >
-                Compare with me
-              </Link>
-            )}
-            {!loggedInUsername && (
-              <Link
-                href={signInToCompareHref}
-                className="secondary-button inline-flex rounded-lg px-4 py-2 text-sm font-semibold"
-              >
-                Log in to compare
-              </Link>
-            )}
+          {/* Stats card download */}
+          <div className="shrink-0">
+            <StatsCard
+              username={profile.username}
+              avatarUrl={avatarUrl}
+              currentStreak={profile.streak.current}
+              longestStreak={profile.streak.longest}
+              totalCommits={profile.contributions.total}
+              topRepo={topRepo}
+            />
           </div>
         </div>
 
-        {/* Stats card download */}
-        <div className="shrink-0">
-          <StatsCard
+        {/* Share section */}
+        <div className="mb-8">
+          <ShareProfileSection
             username={profile.username}
-            avatarUrl={avatarUrl}
-            currentStreak={profile.streak.current}
-            longestStreak={profile.streak.longest}
-            totalCommits={profile.contributions.total}
-            topRepo={topRepo}
+            streak={profile.streak.current}
+            profileUrl={profileUrl}
           />
-        </div>
-      </div>
-
-      {/* Share section */}
-      <div className="mb-8">
-        <ShareProfileSection
-          username={profile.username}
-          streak={profile.streak.current}
-          profileUrl={profileUrl}
-        />
           <div className="mt-3">
             <QrCodeButton profileUrl={profileUrl} username={profile.username} />
           </div>
 
-      </div>
-
-      {/* Row 1: Contribution graph + Streak (gated by public_widgets) */}
-      {(showContributions || showStreak) && (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {showContributions && (
-            <div className="lg:col-span-2">
-              <PublicContributionGraph data={profile.contributions} />
-            </div>
-          )}
-          {showStreak && (
-            <div className={showContributions ? "" : "lg:col-span-3"}>
-              <PublicStreakTracker streak={profile.streak} />
-            </div>
-          )}
         </div>
-      )}
 
-      {/* Languages (gated) */}
-      {showLanguages && profile.topLanguages.length > 0 && (
+        {/* Row 1: Contribution graph + Streak (gated by public_widgets) */}
+        {(showContributions || showStreak) && (
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {showContributions && (
+              <div className="lg:col-span-2">
+                <PublicContributionGraph data={profile.contributions} />
+              </div>
+            )}
+            {showStreak && (
+              <div className={showContributions ? "" : "lg:col-span-3"}>
+                <PublicStreakTracker streak={profile.streak} />
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Languages (gated) */}
+        {showLanguages && profile.topLanguages.length > 0 && (
+          <div className="mt-6">
+            <PublicLanguageBreakdown languages={profile.topLanguages} />
+          </div>
+        )}
+
+        {/* Pull Requests (gated) */}
+        {showPRs && (
+          <div className="mt-6">
+            <PublicPRCount pullRequests={profile.pullRequests} />
+          </div>
+        )}
+
+        {/* Custom Spotlight Repositories */}
+        {profile.spotlightRepos?.length ? (
+          <div className="mt-6">
+            <PinnedReposWidget
+              initialRepos={profile.spotlightRepos}
+              isPublic={true}
+            />
+          </div>
+        ) : null}
+
+        {/* Weekly Goal Progress */}
+        {profile.weeklyGoalProgress && (
+          <div className="mt-6">
+            <PublicWeeklyGoalProgress progress={profile.weeklyGoalProgress} />
+          </div>
+        )}
+
+        {/* Top repos */}
         <div className="mt-6">
-          <PublicLanguageBreakdown languages={profile.topLanguages} />
+          <PublicTopRepos repos={profile.repos} />
         </div>
-      )}
 
-      {/* Pull Requests (gated) */}
-      {showPRs && (
+        {/* GitHub achievements */}
         <div className="mt-6">
-          <PublicPRCount pullRequests={profile.pullRequests} />
-        </div>
-      )}
-
-      {/* Custom Spotlight Repositories */}
-      {profile.spotlightRepos?.length ? (
-        <div className="mt-6">
-          <PinnedReposWidget
-            initialRepos={profile.spotlightRepos}
-            isPublic={true}
+          <GitHubAchievements
+            achievements={profile.achievements}
+            error={profile.achievementsError}
           />
         </div>
-      ) : null}
 
-      {/* Weekly Goal Progress */}
-      {profile.weeklyGoalProgress && (
+        {/* Get your badge */}
         <div className="mt-6">
-          <PublicWeeklyGoalProgress progress={profile.weeklyGoalProgress} />
+          <BadgeSection username={profile.username} />
         </div>
-      )}
 
-      {/* Top repos */}
-      <div className="mt-6">
-        <PublicTopRepos repos={profile.repos} />
+        {/* Powered by DevTrack footer badge */}
+        <div className="mt-10 flex justify-center">
+          <a
+            href="https://devtrack-delta.vercel.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--card)] px-4 py-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] hover:border-[var(--accent)]"
+          >
+            <svg viewBox="0 0 24 24" fill="currentColor" className="h-3.5 w-3.5 text-[var(--accent)]" aria-hidden="true">
+              <path d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+            Powered by DevTrack
+          </a>
+        </div>
       </div>
-
-      {/* GitHub achievements */}
-      <div className="mt-6">
-        <GitHubAchievements
-          achievements={profile.achievements}
-          error={profile.achievementsError}
-        />
-      </div>
-
-      {/* Get your badge */}
-      <div className="mt-6">
-        <BadgeSection username={profile.username} />
-      </div>
-
-      {/* Powered by DevTrack footer badge */}
-      <div className="mt-10 flex justify-center">
-        <a
-          href="https://devtrack-delta.vercel.app"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--card)] px-4 py-2 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] hover:border-[var(--accent)]"
-        >
-          <svg viewBox="0 0 24 24" fill="currentColor" className="h-3.5 w-3.5 text-[var(--accent)]" aria-hidden="true">
-            <path d="M13 10V3L4 14h7v7l9-11h-7z" />
-          </svg>
-          Powered by DevTrack
-        </a>
-      </div>
-    </div>
     </ProfileThemeWrapper>
   );
 }
@@ -531,9 +532,9 @@ function PublicStreakTracker({ streak }: { streak: any }) {
       label: "Last Commit",
       value: streak.lastCommitDate
         ? new Date(streak.lastCommitDate).toLocaleDateString("en-US", {
-            month: "short",
-            day: "numeric",
-          })
+          month: "short",
+          day: "numeric",
+        })
         : "—",
       unit: "",
       highlight: false,
@@ -550,11 +551,10 @@ function PublicStreakTracker({ streak }: { streak: any }) {
         {stats.map((stat) => (
           <div
             key={stat.label}
-            className={`rounded-lg border p-3 ${
-              stat.highlight
-                ? "border-[var(--accent)] bg-[var(--accent)]/10"
-                : "border-[var(--border)] bg-[var(--control)]"
-            }`}
+            className={`rounded-lg border p-3 ${stat.highlight
+              ? "border-[var(--accent)] bg-[var(--accent)]/10"
+              : "border-[var(--border)] bg-[var(--control)]"
+              }`}
           >
             <div className="text-xs font-medium text-[var(--muted-foreground)]">
               {stat.icon} {stat.label}

--- a/src/components/PrintProfileButton.tsx
+++ b/src/components/PrintProfileButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+export default function PrintProfileButton() {
+    return (
+        <button
+            onClick={() => window.print()}
+            className="print:hidden inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--control)] px-3 py-1.5 text-xs font-medium text-[var(--card-foreground)] transition-colors hover:text-[var(--accent)] hover:border-[var(--accent)]"
+            aria-label="Export profile as PDF"
+        >
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+            >
+                <polyline points="6 9 6 2 18 2 18 9" />
+                <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+                <rect x="6" y="14" width="12" height="8" />
+            </svg>
+            Export / Print PDF
+        </button>
+    );
+}


### PR DESCRIPTION
Closes #2604

## What changed
- Added a `Print Profile / Export to PDF` button to the `/u/[username]` public profile header
- Button calls `window.print()` — zero external dependencies
- Button carries `print:hidden` so it never appears in the printed PDF
- Added `@media print` CSS rules in `globals.css` to:
  - Hide nav, footer, and all interactive elements
  - Remove card shadows for a clean paper layout
  - Prevent cards from splitting across pages
  - Set 1.5cm page margins

## Acceptance criteria checklist
- [x] No external dependencies — uses native browser `window.print()`
- [x] Printed output is free from buttons and navigation
- [x] Works in Chrome, Firefox, and Safari print dialogs