### PR TITLE
feat: add favorite repositories section

### DIFF
--- a/src/components/FavoriteReposWidget.tsx
+++ b/src/components/FavoriteReposWidget.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useFavorites } from "@/hooks/useFavorites";
+import RepoCard from "./repo-analytics/RepoCard";
+import RepoAnalyticsSheet from "./repo-analytics/RepoAnalyticsSheet";
+import { ExplorerRepoCardData } from "@/lib/repo-analytics-types";
+import { Star } from "lucide-react";
+
+export default function FavoriteReposWidget() {
+  const { favorites, toggleFavorite } = useFavorites();
+  const [repos, setRepos] = useState<ExplorerRepoCardData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedRepo, setSelectedRepo] = useState<ExplorerRepoCardData | null>(null);
+
+  const fetchRepos = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    fetch("/api/metrics/repo-explorer")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch repositories");
+        return res.json();
+      })
+      .then((json: { repos: ExplorerRepoCardData[] }) => {
+        setRepos(json.repos ?? []);
+      })
+      .catch((err) => {
+        console.error("Failed to fetch favorite repos details:", err);
+        setError("Could not load repository details.");
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetchRepos();
+  }, [fetchRepos]);
+
+  const favoriteRepos = repos.filter((repo) => favorites.includes(repo.fullName));
+
+  if (loading) {
+    return (
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)] flex items-center gap-2">
+          <Star className="w-5 h-5 text-yellow-400 fill-yellow-400" />
+          <span>Favorite Repositories</span>
+        </h2>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-64 animate-pulse rounded-3xl bg-[var(--card-muted)]/50 border border-[var(--border)]" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)] flex items-center gap-2">
+          <Star className="w-5 h-5 text-yellow-400 fill-yellow-400" />
+          <span>Favorite Repositories</span>
+        </h2>
+        <div className="rounded-xl border border-[var(--destructive-muted-border)] bg-[var(--destructive-muted)] p-5 text-sm text-[var(--destructive)] flex flex-col items-center justify-center text-center">
+          <p className="font-medium mb-3">{error}</p>
+          <button onClick={fetchRepos} className="rounded-xl border border-[var(--destructive-muted-border)] bg-transparent px-4 py-2 text-sm font-medium text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)] hover:text-white">Try again</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm transition-all duration-300 hover:shadow-md hover:-translate-y-1">
+      <h2 className="mb-4 text-lg font-semibold text-[var(--card-foreground)] flex items-center justify-between">
+        <span className="flex items-center gap-2">
+          <Star className="w-5 h-5 text-yellow-400 fill-yellow-400" />
+          <span>Favorite Repositories</span>
+          {favoriteRepos.length > 0 && (
+            <span className="px-1.5 py-0.5 text-[10px] rounded-full bg-[var(--card-muted)] text-[var(--card-foreground)] font-normal">
+              {favoriteRepos.length}
+            </span>
+          )}
+        </span>
+      </h2>
+
+      {favoriteRepos.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-3xl border border-dashed border-[var(--border)] bg-[var(--card-muted)]/20 p-8 text-center">
+          <div className="rounded-full bg-[var(--card)] p-4 shadow-sm mb-4 border border-[var(--border)] transition-all duration-300 hover:shadow-md hover:-translate-y-1">
+            <Star className="w-8 h-8 text-[var(--muted-foreground)]" />
+          </div>
+          <h3 className="text-sm font-semibold text-[var(--card-foreground)] mb-1">
+            No favorite repositories yet
+          </h3>
+          <p className="text-xs text-[var(--muted-foreground)] max-w-sm mx-auto">
+            Click the star icon on any repository card in the Repo Analytics section to add it here.
+          </p>
+        </div>
+      ) : (
+        <div className="grid min-w-0 grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3 relative mt-6">
+          {favoriteRepos.map((repo, idx) => (
+            <div
+              key={repo.id}
+              className="fade-up transition-all duration-500 hover:-translate-y-1.5"
+              style={{ animationDelay: `${idx * 75}ms` }}
+            >
+              <RepoCard
+                repo={repo}
+                onViewAnalytics={setSelectedRepo}
+                isFavorite={true}
+                onToggleFavorite={toggleFavorite}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <RepoAnalyticsSheet repoFullName={selectedRepo?.fullName ?? null} open={Boolean(selectedRepo)} onClose={() => setSelectedRepo(null)} />
+    </div>
+  );
+}

--- a/src/components/repo-analytics/RepoCard.tsx
+++ b/src/components/repo-analytics/RepoCard.tsx
@@ -14,15 +14,20 @@ import {
   formatDate,
 } from "@/lib/date-utils";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { Star } from "lucide-react";
 
 interface RepoCardProps {
   repo: ExplorerRepoCardData;
   onViewAnalytics: (repo: ExplorerRepoCardData) => void;
+  isFavorite?: boolean;
+  onToggleFavorite?: (repoFullName: string) => void;
 }
 
 export default function RepoCard({
   repo,
   onViewAnalytics,
+  isFavorite = false,
+  onToggleFavorite,
 }: RepoCardProps) {
   const activityData = Array.isArray(repo.activity7d) ? repo.activity7d : [];
   const activeDays = activityData.filter((day) => day.commits > 0).length;
@@ -40,10 +45,33 @@ export default function RepoCard({
       <div className="relative flex flex-col gap-5">
         {/* Header */}
         <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <h3 className="truncate text-lg font-semibold tracking-tight text-[var(--card-foreground)]">
-              {repo.name}
-            </h3>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h3 className="truncate text-lg font-semibold tracking-tight text-[var(--card-foreground)]">
+                {repo.name}
+              </h3>
+              {onToggleFavorite && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleFavorite(repo.fullName);
+                  }}
+                  className="p-1 hover:bg-[var(--card-muted)] rounded-md transition-all duration-200 shrink-0 active:scale-95"
+                  title={isFavorite ? "Remove from Favorites" : "Add to Favorites"}
+                  aria-label={isFavorite ? `Remove ${repo.name} from favorites` : `Favorite ${repo.name}`}
+                >
+                  <Star
+                    size={16}
+                    className={`transition-colors duration-200 ${
+                      isFavorite
+                        ? "fill-yellow-400 text-yellow-400"
+                        : "text-[var(--muted-foreground)] hover:text-yellow-400"
+                    }`}
+                  />
+                </button>
+              )}
+            </div>
 
             <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[var(--muted-foreground)]">
               <span className="rounded-full border border-[var(--border)] bg-[var(--control)] px-2.5 py-1">

--- a/src/components/repo-analytics/RepoCarousel.tsx
+++ b/src/components/repo-analytics/RepoCarousel.tsx
@@ -4,8 +4,10 @@ import { useMemo, useState } from "react";
 import RepoCard from "./RepoCard";
 import RepoAnalyticsSheet from "./RepoAnalyticsSheet";
 import { ExplorerRepoCardData } from "@/lib/repo-analytics-types";
+import { useFavorites } from "@/hooks/useFavorites";
 
 export default function RepoCarousel({ repos }: { repos: ExplorerRepoCardData[] }) {
+  const { isFavorite, toggleFavorite } = useFavorites();
   const PAGE_SIZE = 3;
   const [page, setPage] = useState(1);
   const [selectedRepo, setSelectedRepo] = useState<ExplorerRepoCardData | null>(null);
@@ -134,7 +136,12 @@ export default function RepoCarousel({ repos }: { repos: ExplorerRepoCardData[] 
               className="fade-up transition-all duration-500 hover:-translate-y-1.5"
               style={{ animationDelay: `${idx * 75}ms` }}
             >
-              <RepoCard repo={repo} onViewAnalytics={setSelectedRepo} />
+              <RepoCard
+                repo={repo}
+                onViewAnalytics={setSelectedRepo}
+                isFavorite={isFavorite(repo.fullName)}
+                onToggleFavorite={toggleFavorite}
+              />
             </div>
           ))}
         </div>

--- a/src/components/repo-analytics/RepoGrid.tsx
+++ b/src/components/repo-analytics/RepoGrid.tsx
@@ -4,8 +4,10 @@ import { useMemo, useState } from "react";
 import RepoCard from "./RepoCard";
 import RepoAnalyticsSheet from "./RepoAnalyticsSheet";
 import { ExplorerRepoCardData } from "@/lib/repo-analytics-types";
+import { useFavorites } from "@/hooks/useFavorites";
 
 export default function RepoGrid({ repos }: { repos: ExplorerRepoCardData[] }) {
+  const { isFavorite, toggleFavorite } = useFavorites();
   const PAGE_SIZE = 3;
   const [query, setQuery] = useState("");
   const [languageFilter, setLanguageFilter] = useState("all");
@@ -48,7 +50,15 @@ export default function RepoGrid({ repos }: { repos: ExplorerRepoCardData[] }) {
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--card-muted)] p-6 text-center text-sm text-[var(--muted-foreground)]">No repositories found for this filter.</div>
       ) : (
         <div className="grid min-w-0 grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {pageRepos.map((repo) => <RepoCard key={repo.id} repo={repo} onViewAnalytics={setSelectedRepo} />)}
+          {pageRepos.map((repo) => (
+            <RepoCard
+              key={repo.id}
+              repo={repo}
+              onViewAnalytics={setSelectedRepo}
+              isFavorite={isFavorite(repo.fullName)}
+              onToggleFavorite={toggleFavorite}
+            />
+          ))}
         </div>
       )}
 

--- a/src/hooks/useFavorites.ts
+++ b/src/hooks/useFavorites.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const STORAGE_KEY = "devtrack_favorite_repos";
+const EVENT_NAME = "devtrack-favorites-changed";
+
+export function useFavorites() {
+  const [favorites, setFavorites] = useState<string[]>([]);
+
+  // Load initial favorites
+  const loadFavorites = useCallback(() => {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        setFavorites(stored ? JSON.parse(stored) : []);
+      } catch (err) {
+        console.error("Failed to load favorite repos", err);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    loadFavorites();
+
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) {
+        loadFavorites();
+      }
+    };
+
+    const handleCustomChange = () => {
+      loadFavorites();
+    };
+
+    window.addEventListener("storage", handleStorageChange);
+    window.addEventListener(EVENT_NAME, handleCustomChange);
+
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+      window.removeEventListener(EVENT_NAME, handleCustomChange);
+    };
+  }, [loadFavorites]);
+
+  const toggleFavorite = useCallback((repoFullName: string) => {
+    if (typeof window === "undefined") return;
+
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      const current: string[] = stored ? JSON.parse(stored) : [];
+      const updated = current.includes(repoFullName)
+        ? current.filter((name) => name !== repoFullName)
+        : [...current, repoFullName];
+
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      setFavorites(updated);
+
+      // Dispatch custom event to notify other instances/components
+      window.dispatchEvent(new Event(EVENT_NAME));
+    } catch (err) {
+      console.error("Failed to toggle favorite repo", err);
+    }
+  }, []);
+
+  const isFavorite = useCallback((repoFullName: string) => {
+    return favorites.includes(repoFullName);
+  }, [favorites]);
+
+  return { favorites, toggleFavorite, isFavorite };
+}


### PR DESCRIPTION
## Summary

Added Favorite Repositories section for quick access.
Users can now mark repositories as favorites, remove them, and view all favorite repositories separately on dashboard.

Closes #2677

---

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

---

## What Changed

- Added star button on repository cards for favorite/unfavorite actions
- Added reusable useFavorites hook with persistent localStorage support
- Added FavoriteReposWidget to display saved repositories
- Integrated favorites support with RepoGrid and RepoCarousel

---

## How to Test

1. Open repository dashboard
2. Click star icon on any repository card
3. Check Favorite Repositories section
4. Refresh page and verify favorites remain saved

**Expected result:**

Favorite repositories persist and can be added or removed successfully.

---

## Screenshots / Recordings

UI feature added for repository favorite management.

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary console.log, debug code, or commented-out blocks
- [ ] npm run lint passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly
- [x] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout