### PR TITLE
fix: use NEXT_PUBLIC_APP_URL env var in sitemap and robots (#2581)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,8 @@
 import { MetadataRoute } from "next";
 
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ?? "https://devtrack-delta.vercel.app";
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
@@ -7,6 +10,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/api/", "/dashboard/"],
     },
-    sitemap: "https://devtrack.vercel.app/sitemap.xml",
+    sitemap: `${BASE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,21 +1,24 @@
 import { MetadataRoute } from "next";
 
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ?? "https://devtrack-delta.vercel.app";
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://devtrack.vercel.app",
+      url: BASE_URL,
       lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 1,
     },
     {
-      url: "https://devtrack.vercel.app/compare",
+      url: `${BASE_URL}/compare`,
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
-      url: "https://devtrack.vercel.app/leaderboard",
+      url: `${BASE_URL}/leaderboard`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.8,


### PR DESCRIPTION
closes #2581

## Problem
`sitemap.ts` and `robots.ts` both hardcoded the production URL as
`https://devtrack.vercel.app`, but the actual deployed app is at
`https://devtrack-delta.vercel.app`. This caused the generated sitemap
and robots.txt to point to a wrong domain, hurting SEO.

## Changes
- Added `BASE_URL` constant in both files that reads from
  `process.env.NEXT_PUBLIC_APP_URL` with a fallback to
  `https://devtrack-delta.vercel.app`
- Replaced all hardcoded URLs in `sitemap.ts` with `BASE_URL`
- Replaced hardcoded sitemap URL in `robots.ts` with `${BASE_URL}/sitemap.xml`

## Testing
- Self-hosters and staging environments will now get correct URLs
  via the `NEXT_PUBLIC_APP_URL` environment variable