### PR TITLE
fix(metrics): include timezone in cache keys for timezone-sensitive endpoints

### DIFF
--- a/src/app/api/metrics/consistency-score/route.ts
+++ b/src/app/api/metrics/consistency-score/route.ts
@@ -21,10 +21,12 @@ async function fetchActiveDates(
   githubLogin: string,
   token: string,
   cacheContext: { bypass: boolean; userId: string },
-  timeZone = "UTC",
+  timeZone = "UTC"
 ): Promise<Set<string>> {
   const key = metricsCacheKey(cacheContext.userId, "streak", {
     githubLogin,
+    // Timezone affects active-date bucketing, so it must be part
+    // of the cache key to prevent stale results across timezones.
     timeZone,
   });
 
@@ -51,7 +53,7 @@ async function fetchActiveDates(
               Accept: "application/vnd.github+json",
             },
             cache: "no-store",
-          },
+          }
         );
 
         if (!searchRes.ok) {
@@ -83,7 +85,7 @@ async function fetchActiveDates(
       }
 
       return Array.from(activeDates);
-    },
+    }
   );
 
   return new Set(dates);
@@ -92,16 +94,16 @@ async function fetchActiveDates(
 async function getConsistencyScoreForDates(
   activeDates: Set<string>,
   timeZone: string,
-  cacheContext: { bypass: boolean; userId: string; accountKey: string },
+  cacheContext: { bypass: boolean; userId: string; accountKey: string }
 ) {
-const key = `metrics:${cacheContext.userId}:consistency-score:${cacheContext.accountKey}:${timeZone}`;
+  const key = `metrics:${cacheContext.userId}:consistency-score:${cacheContext.accountKey}:${timeZone}`;
   return withMetricsCache(
     {
       bypass: cacheContext.bypass,
       key,
       ttlSeconds: METRICS_CACHE_TTL_SECONDS.streak,
     },
-    async () => calculateConsistencyScore(activeDates, timeZone),
+    async () => calculateConsistencyScore(activeDates, timeZone)
   );
 }
 
@@ -137,7 +139,7 @@ export async function GET(req: NextRequest) {
         session.githubLogin,
         session.accessToken,
         { bypass, userId: session.githubId },
-        timeZone,
+        timeZone
       );
       const result = await getConsistencyScoreForDates(activeDates, timeZone, {
         bypass,
@@ -161,7 +163,7 @@ export async function GET(req: NextRequest) {
         githubId: session.githubId,
         githubLogin: session.githubLogin,
       },
-      appUserId,
+      appUserId
     );
 
     const dateResults = await Promise.allSettled(
@@ -170,9 +172,9 @@ export async function GET(req: NextRequest) {
           account.githubLogin,
           account.token,
           { bypass, userId: account.githubId },
-          timeZone,
-        ),
-      ),
+          timeZone
+        )
+      )
     );
 
     const unifiedDates = new Set<string>();
@@ -182,11 +184,15 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    const scoreData = await getConsistencyScoreForDates(unifiedDates, timeZone, {
-      bypass,
-      userId: appUserId,
-      accountKey: "combined",
-    });
+    const scoreData = await getConsistencyScoreForDates(
+      unifiedDates,
+      timeZone,
+      {
+        bypass,
+        userId: appUserId,
+        accountKey: "combined",
+      }
+    );
 
     return Response.json(scoreData);
   }
@@ -221,7 +227,7 @@ export async function GET(req: NextRequest) {
       resolvedLogin,
       resolvedToken,
       { bypass, userId: accountId },
-      timeZone,
+      timeZone
     );
     const result = await getConsistencyScoreForDates(activeDates, timeZone, {
       bypass,

--- a/src/app/api/metrics/consistency-score/route.ts
+++ b/src/app/api/metrics/consistency-score/route.ts
@@ -23,7 +23,10 @@ async function fetchActiveDates(
   cacheContext: { bypass: boolean; userId: string },
   timeZone = "UTC",
 ): Promise<Set<string>> {
-  const key = metricsCacheKey(cacheContext.userId, "streak", { githubLogin });
+  const key = metricsCacheKey(cacheContext.userId, "streak", {
+    githubLogin,
+    timeZone,
+  });
 
   const dates = await withMetricsCache(
     {
@@ -91,8 +94,7 @@ async function getConsistencyScoreForDates(
   timeZone: string,
   cacheContext: { bypass: boolean; userId: string; accountKey: string },
 ) {
-  const key = `metrics:${cacheContext.userId}:consistency-score:${cacheContext.accountKey}`;
-
+const key = `metrics:${cacheContext.userId}:consistency-score:${cacheContext.accountKey}:${timeZone}`;
   return withMetricsCache(
     {
       bypass: cacheContext.bypass,

--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -128,6 +128,7 @@ async function fetchContributionsForAccount(
   const key = metricsCacheKey(cacheContext.userId, "contributions", {
     days,
     githubLogin,
+    timezone,
     from: fromDate ?? undefined,
     repo,
     orgName: orgName || undefined,

--- a/src/app/api/metrics/streak/route.ts
+++ b/src/app/api/metrics/streak/route.ts
@@ -26,7 +26,10 @@ async function fetchActiveDates(
 ): Promise<Set<string>> {
   // Cache key is scoped per user + githubLogin so multi-account "combined" view
   // stores each account's dates separately and merges them in the GET handler.
-  const key = metricsCacheKey(cacheContext.userId, "streak", { githubLogin });
+  const key = metricsCacheKey(cacheContext.userId, "streak", {
+    githubLogin,
+    timeZone,
+  });
 
   // withMetricsCache returns cached dates if available within the TTL window,
   // skipping all GitHub API calls below. This is the primary protection against


### PR DESCRIPTION
## Summary

Fixes a timezone-related caching bug in metrics endpoints.

Closes #2716

---

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that changes existing behavior)
* [ ] 📝 Documentation update
* [ ] ♻️ Refactor / code cleanup (no functional change)
* [ ] ⚡ Performance improvement
* [ ] 🔒 Security fix
* [ ] 🧪 Tests only

---

## What Changed

* Added `timezone` to the cache key parameters in `src/app/api/metrics/contributions/route.ts`
* Added `timeZone` to the cache key parameters in `src/app/api/metrics/streak/route.ts`
* Added `timeZone` to the cache key parameters in `src/app/api/metrics/consistency-score/route.ts`
* Scoped the consistency score cache by timezone to prevent stale cross-timezone cache hits

---

## How to Test

1. Set the dashboard timezone to one timezone (e.g. `Asia/Kolkata`) and load Contributions, Streak, or Consistency Score metrics.
2. Change the timezone preference to another timezone (e.g. `America/New_York`).
3. Reload the metrics endpoints.

**Expected result:**

Metrics should be recalculated or fetched from a timezone-specific cache entry instead of reusing data generated for a different timezone.

---

## Checklist

* [x] Linked the related issue above
* [x] Self-reviewed my own diff
* [x] No unnecessary `console.log`, debug code, or commented-out blocks
* [ ] `npm run lint` passes locally
* [ ] No TypeScript errors (`npm run type-check`)
* [ ] Added or updated tests where applicable
* [ ] Updated documentation / comments if behavior changed

---

## Additional Context

The cache keys previously omitted timezone information, causing timezone-sensitive metrics to be reused across different timezone settings. This change ensures cache entries are properly scoped per timezone.
