### PR TITLE
fix: respect prefers-reduced-motion accessibility preference

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -716,6 +716,26 @@ body {
   .hover\:-translate-y-1:hover {
     transform: none !important;
   }
+
+  .primary-button:hover,
+  .secondary-button:hover {
+    transform: none !important;
+  }
+
+  .lnd-cta-primary:hover,
+  .lnd-cta-primary:active,
+  .lnd-cta-secondary:hover {
+    transform: none !important;
+  }
+
+  .lnd-ticker {
+    transform: none !important;
+  }
+
+  .skeleton-shimmer,
+  .animate-shimmer {
+    animation: none !important;
+  }
 }
 
 @keyframes shimmer {

--- a/src/components/ProfileCard.css
+++ b/src/components/ProfileCard.css
@@ -212,3 +212,21 @@
 @media (min-width: 920px){
   .profile-card__social-text{ display:inline-block; }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .profile-card {
+    transition: none !important;
+  }
+
+  .profile-card:hover {
+    transform: none !important;
+  }
+
+  .profile-card__social a {
+    transition: none !important;
+  }
+
+  .profile-card__social a:hover {
+    transform: none !important;
+  }
+}

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -99,8 +99,12 @@ const ABOUT_HIGHLIGHTS: Array<{
    ═══════════════════════════════════════════════════════════ */
 function useScrollReveal(threshold = 0.15) {
   const ref = useRef<HTMLDivElement>(null);
-  const [vis, setVis] = useState(false);
+  const prefersReducedMotion =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const [vis, setVis] = useState(prefersReducedMotion);
   useEffect(() => {
+    if (prefersReducedMotion) return;
     const el = ref.current;
     if (!el) return;
     const io = new IntersectionObserver(
@@ -111,7 +115,7 @@ function useScrollReveal(threshold = 0.15) {
     );
     io.observe(el);
     return () => io.disconnect();
-  }, [threshold]);
+  }, [threshold, prefersReducedMotion]);
   return [ref, vis] as const;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1078. Ensures the app fully respects `prefers-reduced-motion: reduce` by stopping scroll-reveal animations from hiding content, removing hover transforms, and explicitly disabling looping effects.

---
Closes : #1078 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---

## What Changed

- `LandingPage.tsx` — `useScrollReveal` now initialises `vis = true` immediately when reduced motion is preferred, so elements are never rendered hidden
- `globals.css` — expanded reduced-motion block: adds `transform: none` for `.primary-button`, `.secondary-button`, `.lnd-cta-primary/secondary` hover/active states, `lnd-ticker` position reset, and `animation: none` for shimmer loaders
- `ProfileCard.css` — added `prefers-reduced-motion` block to suppress card lift (`translateY(-6px)`) and social link hover transforms

---

## How to Test

1. Open Chrome DevTools → Rendering → enable **Emulate CSS media feature `prefers-reduced-motion: reduce`**
2. Navigate to the landing page (`/`)
3. Scroll through all sections

**Expected result:** Hero text, bento cells, about cards, heatmap, and stat counters appear immediately without fade/slide-in; ticker is stationary; button hovers have no transform motion; profile card does not lift on hover; shimmer loaders are static.

---

## Screenshots / Recordings

| Before | After |
|--------|-------|
| Elements start hidden (`opacity: 0`) and animate in on scroll | Elements are visible immediately, no motion |

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context

The global `* { animation-duration: 0.01ms }` override was already in place but was insufficient on its own — elements controlled by JS state (`vis`) still started invisible. The `useScrollReveal` fix is the most impactful change. No layout or visual regressions for users without reduced motion preference.
