### PR TITLE
fix(a11y): add skip-to-main-content link for keyboard navigation

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -104,7 +104,7 @@ export default async function DashboardPage() {
   return (
     <DashboardSSEProvider>
       <DashboardWidgetA11yProvider>
-        <div className="min-h-screen bg-[var(--background)] px-4 py-8 text-[var(--foreground)] transition-colors sm:px-6 lg:px-8 max-w-[1600px] mx-auto">
+        <main className="min-h-screen bg-[var(--background)] px-4 py-8 text-[var(--foreground)] transition-colors sm:px-6 lg:px-8 max-w-[1600px] mx-auto">
           <DashboardHeader />
 
           <div className="mt-6 space-y-8">
@@ -238,7 +238,7 @@ export default async function DashboardPage() {
 
             <CustomizableDashboard />
           </div>
-        </div>
+        </main>
       </DashboardWidgetA11yProvider>
     </DashboardSSEProvider>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -98,6 +98,12 @@ export default async function RootLayout({
       <body
         className={`${inter.className} min-h-screen bg-[var(--background)] text-[var(--foreground)]`}
       >
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-[var(--accent)] focus:px-4 focus:py-2 focus:text-[var(--accent-foreground)] focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+        >
+          Skip to main content
+        </a>
         <CustomCursor />
         <OfflineBanner />
 
@@ -106,7 +112,9 @@ export default async function RootLayout({
             <NextIntlClientProvider locale={locale} messages={messages}>
               <Providers>
                 <AppNavbar />
-                {children}
+                <div id="main-content" tabIndex={-1} className="outline-none">
+                  {children}
+                </div>
                 <Footer />
               </Providers>
             </NextIntlClientProvider>


### PR DESCRIPTION
feat(a11y): add skip-to-main-content link for keyboard and screen reader users

Adds a visually-hidden skip navigation link as the first focusable element
in the root layout, targeting #main-content so keyboard-only users can bypass
the navbar. Wraps page children with the skip target div and promotes the
dashboard's top-level container to a semantic <main> element.

## Summary

Implements a skip navigation link to improve keyboard and screen reader accessibility. Keyboard-only users can now press Tab on page load to reveal a "Skip to main content" link, then Enter to jump past the navbar directly to the page content.

Closes #1891

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- `src/app/layout.tsx` — added a visually-hidden `<a href="#main-content">` as the first focusable element in `<body>`; wrapped `{children}` in `<div id="main-content" tabIndex={-1}>` as the skip target
- `src/app/dashboard/page.tsx` — promoted the top-level `<div>` container to a semantic `<main>` element

---

## How to Test

1. Open any page (e.g. `/dashboard`) in a browser
2. Press `Tab` — the "Skip to main content" link should appear in the top-left corner
3. Press `Enter` — focus should move to the main content area, bypassing the navbar

**Expected result:** Tab order skips the entire navbar; focus lands on the page content. All existing navigation, sidebar, and layout behaviour is unchanged.

---

## Screenshots / Recordings

| Before | After |
|--------|-------|
| No skip link; Tab enters the navbar first | "Skip to main content" link appears on first Tab press |

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context

A `<div>` (not `<main>`) is used as the skip target wrapper in the root layout because several child pages (privacy-policy, guidelines, auth/signin, leaderboard) already render their own `<main>` landmark — nesting `<main>` inside `<main>` would be invalid HTML. The dashboard page was the only major route missing a semantic landmark and was updated to use `<main>` directly.
