### PR TITLE
docs: add missing API Documentation link to Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 - [Tech Stack](#tech-stack)
 - [Project Structure](#project-structure)
 - [Architecture](#architecture)
+- [API Documentation](#api-documentation)
 - [Getting Started](#getting-started)
 - [Docker Development Setup](#docker-development-setup)
 - [Roadmap](#roadmap)


### PR DESCRIPTION
## Summary

This PR resolves a structural issue in the README's Table of Contents by adding a missing link to the "API Documentation" section, ensuring developers can easily discover and navigate to the API guidelines.

Closes #None (just a documentation fix)

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [x] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- Updated `README.md` to include `- [API Documentation](#api-documentation)` in the Table of Contents.
- Placed the new anchor link in its proper sequential order (between "Architecture" and "Getting Started").

---

## How to Test

No tests required (Documentation only).

---

## Screenshots / Recordings

None

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

None

---

## Additional Context

None