### PR TITLE
fix : added null guard to parseRepoParam and unit tests

### DIFF
--- a/src/lib/repo-analytics-utils.ts
+++ b/src/lib/repo-analytics-utils.ts
@@ -12,6 +12,7 @@ export interface ParsedRepo {
  * Returns the split components on success, or null if the value is invalid.
  */
 export function parseRepoParam(raw: string): ParsedRepo | null {
+  if (!raw || typeof raw !== "string") return null;
   const trimmed = raw.trim();
   const match = REPO_IDENTIFIER_RE.exec(trimmed);
   if (!match) return null;

--- a/test/repo-analytics-utils.test.ts
+++ b/test/repo-analytics-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { parseRepoParam, type ParsedRepo } from "@/lib/repo-analytics-utils";
+
+describe("parseRepoParam", () => {
+  it("parses a simple owner/repo", () => {
+    expect(parseRepoParam("facebook/react")).toEqual({ owner: "facebook", repo: "react" });
+  });
+
+  it("parses owner with hyphen", () => {
+    expect(parseRepoParam("my-org/my-repo")).toEqual({ owner: "my-org", repo: "my-repo" });
+  });
+
+  it("parses owner with numbers", () => {
+    expect(parseRepoParam("org123/repo456")).toEqual({ owner: "org123", repo: "repo456" });
+  });
+
+  it("parses repo with dots", () => {
+    expect(parseRepoParam("owner/repo.name")).toEqual({ owner: "owner", repo: "repo.name" });
+  });
+
+  it("parses repo with underscores", () => {
+    expect(parseRepoParam("owner/repo_name")).toEqual({ owner: "owner", repo: "repo_name" });
+  });
+
+  it("parses repo with hyphens", () => {
+    expect(parseRepoParam("owner/repo-name-v2")).toEqual({ owner: "owner", repo: "repo-name-v2" });
+  });
+
+  it("trims leading whitespace", () => {
+    expect(parseRepoParam("  owner/repo")).toEqual({ owner: "owner", repo: "repo" });
+  });
+
+  it("trims trailing whitespace", () => {
+    expect(parseRepoParam("owner/repo  ")).toEqual({ owner: "owner", repo: "repo" });
+  });
+
+  it("trims both leading and trailing whitespace", () => {
+    expect(parseRepoParam("  owner/repo  ")).toEqual({ owner: "owner", repo: "repo" });
+  });
+
+  it("returns null for null input", () => {
+    expect(parseRepoParam(null as any)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseRepoParam(undefined as any)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseRepoParam("")).toBeNull();
+  });
+
+  it("returns null for string with only whitespace", () => {
+    expect(parseRepoParam("   ")).toBeNull();
+  });
+
+  it("returns null for no slash", () => {
+    expect(parseRepoParam("just-a-repo")).toBeNull();
+  });
+
+  it("returns null for extra path segments", () => {
+    expect(parseRepoParam("owner/repo/extra")).toBeNull();
+  });
+
+  it("returns null for extra path segments after slash", () => {
+    expect(parseRepoParam("owner/repo/foo/bar")).toBeNull();
+  });
+
+  it("returns null when repo part is \".\"", () => {
+    expect(parseRepoParam("owner/.")).toBeNull();
+  });
+
+  it("returns null when repo part is \"..\"", () => {
+    expect(parseRepoParam("owner/..")).toBeNull();
+  });
+
+  it("accepts maximum-length owner (39 chars alphanumeric)", () => {
+    const owner = "a".repeat(38) + "a";
+    expect(parseRepoParam(`${owner}/repo`)).toEqual({ owner, repo: "repo" });
+  });
+
+  it("accepts maximum-length repo (100 chars)", () => {
+    const repo = "a".repeat(100);
+    expect(parseRepoParam(`owner/${repo}`)).toEqual({ owner: "owner", repo });
+  });
+
+  it("returns null for owner starting with hyphen", () => {
+    expect(parseRepoParam("-owner/repo")).toBeNull();
+  });
+
+  it("returns null for owner ending with hyphen", () => {
+    expect(parseRepoParam("owner-/repo")).toBeNull();
+  });
+
+  it("accepts single-char owner", () => {
+    expect(parseRepoParam("a/repo")).toEqual({ owner: "a", repo: "repo" });
+  });
+
+  it("accepts single-char repo", () => {
+    expect(parseRepoParam("owner/r")).toEqual({ owner: "owner", repo: "r" });
+  });
+
+  it("returns null for missing owner", () => {
+    expect(parseRepoParam("/repo")).toBeNull();
+  });
+
+  it("returns null for missing repo", () => {
+    expect(parseRepoParam("owner/")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #2811.

Summary of What Has Been Done: Created test/repo-analytics-utils.test.ts with 26 test cases covering parseRepoParam. Also fixed parseRepoParam to handle null/undefined/empty input safely instead of crashing.

Changes Made:
- src/lib/repo-analytics-utils.ts: Added null/undefined guard at function entry (typeof check).
- test/repo-analytics-utils.test.ts: 26 test cases covering valid inputs, whitespace trimming, invalid formats, dot segments, max-length boundaries, and null/undefined inputs.

Impact it Made: parseRepoParam is the entry-point validator for the repo-analytics API. The null guard prevents TypeError crashes when the parameter is falsy, making the function defensive-by-default.