### PR TITLE
test : added unit tests for supabase-admin env validation

### DIFF
--- a/test/supabase-admin.test.ts
+++ b/test/supabase-admin.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.resetModules();
+
+describe("supabase-admin env validation", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it("isSupabaseAdminAvailable returns true when both env vars are valid", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc123.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-signature";
+    const { isSupabaseAdminAvailable } = await import("@/lib/supabase-admin");
+    expect(isSupabaseAdminAvailable).toBe(true);
+  });
+
+  it("isSupabaseAdminAvailable returns false when URL contains placeholder", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://placeholder.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-signature";
+    const { isSupabaseAdminAvailable } = await import("@/lib/supabase-admin");
+    expect(isSupabaseAdminAvailable).toBe(false);
+  });
+
+  it("isSupabaseAdminAvailable returns false when key contains placeholder", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc123.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "placeholder-key";
+    const { isSupabaseAdminAvailable } = await import("@/lib/supabase-admin");
+    expect(isSupabaseAdminAvailable).toBe(false);
+  });
+
+  it("isSupabaseAdminAvailable returns false when URL is missing", async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-signature";
+    const { isSupabaseAdminAvailable } = await import("@/lib/supabase-admin");
+    expect(isSupabaseAdminAvailable).toBe(false);
+  });
+
+  it("isSupabaseAdminAvailable returns false when key is missing", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc123.supabase.co";
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const { isSupabaseAdminAvailable } = await import("@/lib/supabase-admin");
+    expect(isSupabaseAdminAvailable).toBe(false);
+  });
+
+  it("isSupabaseAdminAvailable returns false when URL is empty string", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-signature";
+    const { isSupabaseAdminAvailable } = await import("@/lib/supabase-admin");
+    expect(isSupabaseAdminAvailable).toBe(false);
+  });
+
+  it("isSupabaseAdminAvailable returns false when key is empty string", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc123.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "";
+    const { isSupabaseAdminAvailable } = await import("@/lib/supabase-admin");
+    expect(isSupabaseAdminAvailable).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2813.

Summary of What Has Been Done: Created test/supabase-admin.test.ts with 7 test cases covering isSupabaseAdminAvailable across all env-var combinations: valid config, placeholder URL, placeholder key, missing vars, and empty strings.

Changes Made:
- test/supabase-admin.test.ts: 7 test cases using vi.resetModules() and process.env mocking to test the module-level isSupabaseAdminAvailable boolean.

Impact it Made: isSupabaseAdminAvailable is read at module initialisation to determine whether Supabase admin operations are available. Comprehensive env-combination tests prevent regressions when the availability logic changes.