### PR TITLE
test : added unit tests for supabase-browser env validation

### DIFF
--- a/test/supabase-browser.test.ts
+++ b/test/supabase-browser.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.resetModules();
+
+describe("supabase-browser env validation", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it("isBrowserClientAvailable returns true when both env vars are valid", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc123.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-anon-key";
+    const { isBrowserClientAvailable } = await import("@/lib/supabase-browser");
+    expect(isBrowserClientAvailable).toBe(true);
+  });
+
+  it("isBrowserClientAvailable returns false when URL contains placeholder", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://placeholder.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-anon-key";
+    const { isBrowserClientAvailable } = await import("@/lib/supabase-browser");
+    expect(isBrowserClientAvailable).toBe(false);
+  });
+
+  it("isBrowserClientAvailable returns false when anon key contains placeholder", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc123.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "placeholder-key";
+    const { isBrowserClientAvailable } = await import("@/lib/supabase-browser");
+    expect(isBrowserClientAvailable).toBe(false);
+  });
+
+  it("isBrowserClientAvailable returns false when URL is missing", async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-anon-key";
+    const { isBrowserClientAvailable } = await import("@/lib/supabase-browser");
+    expect(isBrowserClientAvailable).toBe(false);
+  });
+
+  it("isBrowserClientAvailable returns false when anon key is missing", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc123.supabase.co";
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    const { isBrowserClientAvailable } = await import("@/lib/supabase-browser");
+    expect(isBrowserClientAvailable).toBe(false);
+  });
+
+  it("isBrowserClientAvailable returns false when URL is empty string", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real-anon-key";
+    const { isBrowserClientAvailable } = await import("@/lib/supabase-browser");
+    expect(isBrowserClientAvailable).toBe(false);
+  });
+
+  it("isBrowserClientAvailable returns false when anon key is empty string", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc123.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "";
+    const { isBrowserClientAvailable } = await import("@/lib/supabase-browser");
+    expect(isBrowserClientAvailable).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2814.

Summary of What Has Been Done: Created test/supabase-browser.test.ts with 7 test cases covering isBrowserClientAvailable across all env-var combinations: valid config, placeholder URL, placeholder key, missing vars, and empty strings.

Changes Made:
- test/supabase-browser.test.ts: 7 test cases using vi.resetModules() and process.env mocking to test the module-level isBrowserClientAvailable boolean.

Impact it Made: isBrowserClientAvailable determines whether the browser-safe Supabase client is usable in the current environment. Tests protect against regressions when the env validation logic changes.