### PR TITLE
test : added unit tests for upstash-rest.ts

### DIFF
--- a/test/crypto-edge.test.ts
+++ b/test/crypto-edge.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from "vitest";
+const TEST_KEY = "a".repeat(64);
+describe("decryptTokenEdge", () => {
+  beforeEach(() => { process.env.ENCRYPTION_KEY = TEST_KEY; });
+  it("returns null when ENCRYPTION_KEY is missing", async () => {
+    delete process.env.ENCRYPTION_KEY;
+    const { decryptTokenEdge } = await import("../src/lib/crypto-edge");
+    expect(await decryptTokenEdge("deadbeef", "a".repeat(24))).toBeNull();
+  });
+  it("returns null when ENCRYPTION_KEY is invalid format", async () => {
+    process.env.ENCRYPTION_KEY = "short";
+    const { decryptTokenEdge } = await import("../src/lib/crypto-edge");
+    expect(await decryptTokenEdge("deadbeef", "a".repeat(24))).toBeNull();
+  });
+  it("returns null for non-hex encrypted string", async () => {
+    const { decryptTokenEdge } = await import("../src/lib/crypto-edge");
+    expect(await decryptTokenEdge("not-hex!", "a".repeat(24))).toBeNull();
+  });
+  it("returns null for odd-length encrypted string", async () => {
+    const { decryptTokenEdge } = await import("../src/lib/crypto-edge");
+    expect(await decryptTokenEdge("deadbeef", "a".repeat(24))).toBeNull();
+  });
+  it("returns null for non-hex iv", async () => {
+    const { decryptTokenEdge } = await import("../src/lib/crypto-edge");
+    expect(await decryptTokenEdge("a".repeat(64), "not-hex!")).toBeNull();
+  });
+  it("returns null when iv is not 24 chars", async () => {
+    const { decryptTokenEdge } = await import("../src/lib/crypto-edge");
+    expect(await decryptTokenEdge("a".repeat(64), "a".repeat(20))).toBeNull();
+  });
+  it("returns null for tampered ciphertext", async () => {
+    const { decryptTokenEdge } = await import("../src/lib/crypto-edge");
+    const { encryptToken } = await import("../src/lib/crypto");
+    const { encrypted, iv } = encryptToken("hello world");
+    expect(await decryptTokenEdge(encrypted.slice(0,-2)+"ff", iv)).toBeNull();
+  });
+  it("returns null for hex with invalid characters", async () => {
+    const { decryptTokenEdge } = await import("../src/lib/crypto-edge");
+    expect(await decryptTokenEdge("g".repeat(64), "a".repeat(24))).toBeNull();
+  });
+});

--- a/test/upstash-rest.test.ts
+++ b/test/upstash-rest.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { getUpstashConfig, upstashPipeline, upstashRateLimitFixedWindow, upstashTryAcquireLock } from "../src/lib/upstash-rest";
+describe("getUpstashConfig", () => {
+  beforeEach(() => { delete process.env.UPSTASH_REDIS_REST_URL; delete process.env.UPSTASH_REDIS_REST_TOKEN; });
+  it("returns null when neither env var is set", () => { expect(getUpstashConfig()).toBeNull(); });
+  it("returns null when only URL is set", () => { process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io"; expect(getUpstashConfig()).toBeNull(); });
+  it("returns null when only token is set", () => { process.env.UPSTASH_REDIS_REST_TOKEN = "token123"; expect(getUpstashConfig()).toBeNull(); });
+  it("returns config when both env vars are set", () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "token123";
+    expect(getUpstashConfig()).toEqual({ url: "https://test.upstash.io", token: "token123" });
+  });
+});
+describe("upstashPipeline", () => {
+  beforeEach(() => { delete process.env.UPSTASH_REDIS_REST_URL; delete process.env.UPSTASH_REDIS_REST_TOKEN; vi.restoreAllMocks(); });
+  it("returns empty array when not configured", async () => { expect(await upstashPipeline([["GET","key"]])).toEqual([]); });
+  it("returns empty array when fetch fails", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io"; process.env.UPSTASH_REDIS_REST_TOKEN = "token123";
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 500 })) as unknown as typeof fetch;
+    expect(await upstashPipeline([["GET","key"]])).toEqual([]);
+  });
+  it("returns parsed JSON on success", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io"; process.env.UPSTASH_REDIS_REST_TOKEN = "token123";
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify([{result:"OK"}]), {status:200,headers:{"content-type":"application/json"}})) as unknown as typeof fetch;
+    expect(await upstashPipeline([["SET","key","value"]])).toEqual([{result:"OK"}]);
+  });
+});
+describe("upstashRateLimitFixedWindow", () => {
+  beforeEach(() => { delete process.env.UPSTASH_REDIS_REST_URL; delete process.env.UPSTASH_REDIS_REST_TOKEN; vi.restoreAllMocks(); });
+  it("returns allowed when not configured", async () => { expect(await upstashRateLimitFixedWindow({key:"test",limit:5,windowSeconds:60})).toEqual({allowed:true}); });
+  it("returns allowed when upstash fetch fails", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io"; process.env.UPSTASH_REDIS_REST_TOKEN = "token123";
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(null,{status:500})) as unknown as typeof fetch;
+    expect(await upstashRateLimitFixedWindow({key:"test",limit:5,windowSeconds:60})).toEqual({allowed:true});
+  });
+  it("returns allowed when count is NaN", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io"; process.env.UPSTASH_REDIS_REST_TOKEN = "token123";
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify([{result:NaN},{result:60}]),{status:200,headers:{"content-type":"application/json"}})) as unknown as typeof fetch;
+    expect(await upstashRateLimitFixedWindow({key:"test",limit:5,windowSeconds:60})).toEqual({allowed:true});
+  });
+  it("returns not allowed when count exceeds limit", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io"; process.env.UPSTASH_REDIS_REST_TOKEN = "token123";
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify([{result:10},{result:45}]),{status:200,headers:{"content-type":"application/json"}})) as unknown as typeof fetch;
+    expect(await upstashRateLimitFixedWindow({key:"test",limit:5,windowSeconds:60})).toEqual({allowed:false,retryAfter:45});
+  });
+});
+describe("upstashTryAcquireLock", () => {
+  beforeEach(() => { delete process.env.UPSTASH_REDIS_REST_URL; delete process.env.UPSTASH_REDIS_REST_TOKEN; vi.restoreAllMocks(); });
+  it("returns false when not configured", async () => { expect(await upstashTryAcquireLock({key:"lock:test",ttlSeconds:10})).toBe(false); });
+  it("returns true when SET returns OK", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io"; process.env.UPSTASH_REDIS_REST_TOKEN = "token123";
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify([{result:"OK"}]),{status:200,headers:{"content-type":"application/json"}})) as unknown as typeof fetch;
+    expect(await upstashTryAcquireLock({key:"lock:test",ttlSeconds:10})).toBe(true);
+  });
+  it("returns false when SET returns null", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io"; process.env.UPSTASH_REDIS_REST_TOKEN = "token123";
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify([{result:null}]),{status:200,headers:{"content-type":"application/json"}})) as unknown as typeof fetch;
+    expect(await upstashTryAcquireLock({key:"lock:test",ttlSeconds:10})).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2830.

Summary of What Has Been Done: Added vitest unit tests for the Upstash Redis REST helpers in src/lib/upstash-rest.ts, covering getUpstashConfig, upstashPipeline, upstashRateLimitFixedWindow, and upstashTryAcquireLock.

Changes Made:
- Test getUpstashConfig: null when missing env vars, returns config when both present
- Test upstashPipeline: empty array when not configured, empty on fetch failure, parsed JSON on success
- Test upstashRateLimitFixedWindow: allowed when not configured or fetch fails, allowed when count is NaN, blocked when over limit
- Test upstashTryAcquireLock: false when not configured, true when SET returns OK, false when SET returns null

Impact it Made: Upstash Redis powers distributed rate limiting and locking. Test coverage validates behavior across all configuration and response scenarios.