### PR TITLE
feat(heatmap): add shared 365-day contribution calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ These features are live in the current version.
 | RSS feed | Atom feed at `/u/[username]/feed.xml` |
 | Year Wrapped | Animated annual coding journey recap |
 | Real-time dashboard | Live Supabase Realtime sync with polling fallback |
+| Contribution heatmap calendar | GitHub-style 365-day grid on dashboard and public profiles ([#18](https://github.com/Priyanshu-byte-coder/devtrack/issues/18)) |
 
 ### In Progress / Planned
 
@@ -417,7 +418,6 @@ Want to contribute? Pick an item below and open an issue or start a PR.
 
 | Feature | Difficulty | Issue |
 |---|---|---|
-| Contribution heatmap calendar | Intermediate | [#18](https://github.com/Priyanshu-byte-coder/devtrack/issues/18) |
 | Chart type toggle (bar / line) | Intermediate | [#17](https://github.com/Priyanshu-byte-coder/devtrack/issues/17) |
 | Language breakdown widget | Intermediate | [#32](https://github.com/Priyanshu-byte-coder/devtrack/issues/32) |
 | Activity feed | Intermediate | [#33](https://github.com/Priyanshu-byte-coder/devtrack/issues/33) |

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -13,6 +13,7 @@ import ShareProfileSection from "@/components/ShareProfileSection";
 import SponsorBadge from "@/components/SponsorBadge";
 import PinnedReposWidget from "@/components/PinnedReposWidget";
 import CopyLinkButton from "@/components/CopyLinkButton";
+import PublicContributionHeatmap from "@/components/public/PublicContributionHeatmap";
 import { Moon, Sun } from "lucide-react";
 import { authOptions } from "@/lib/auth";
 import { getUserByGithubId } from "@/lib/supabase";
@@ -367,7 +368,7 @@ export default async function PublicProfilePage({
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {showContributions && (
             <div className="lg:col-span-2">
-              <PublicContributionGraph data={profile.contributions} />
+              <PublicContributionHeatmap data={profile.contributions} />
             </div>
           )}
           {showStreak && (
@@ -443,64 +444,6 @@ export default async function PublicProfilePage({
       </div>
     </div>
     </ProfileThemeWrapper>
-  );
-}
-
-function PublicContributionGraph({
-  data: contributionData,
-}: {
-  data: {
-    days: number;
-    total: number;
-    data: Record<string, number>;
-  };
-}) {
-  const data = Object.entries(contributionData.data ?? {})
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([day, commits]) => ({ day, commits }));
-
-  return (
-    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-[var(--shadow-soft)]">
-      <div className="flex flex-wrap items-center justify-between mb-4 gap-2">
-        <div>
-          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
-            Commit Activity ({contributionData.days} days)
-          </h2>
-          <p className="text-sm text-[var(--muted-foreground)] mt-1">
-            Total commits: {contributionData.total}
-          </p>
-        </div>
-      </div>
-
-      {data.length === 0 ? (
-        <p className="text-sm text-[var(--muted-foreground)]">
-          No commit data available.
-        </p>
-      ) : (
-        <div className="space-y-2">
-          <div className="text-sm text-[var(--muted-foreground)]">
-            {data.length} active days
-          </div>
-          <div className="grid grid-cols-7 gap-1">
-            {data.map((day) => (
-              <div
-                key={day.day}
-                className="aspect-square rounded-sm"
-                style={{
-                  backgroundColor:
-                    day.commits > 0 ? "var(--accent)" : "var(--control)",
-                  opacity:
-                    day.commits > 0
-                      ? Math.max(0.2, Math.min(day.commits / 10, 1))
-                      : 1,
-                }}
-                title={`${day.day}: ${day.commits} commits`}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -3,8 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHeatmapTheme } from "@/hooks/useHeatmapTheme";
 import DailyBreakdownSheet from "@/components/DailyBreakdownSheet";
-import { getContributionInsights } from "@/lib/contribution-insights";
-import { Calendar, TrendingUp, Zap, Clock, Award, BarChart2 } from "lucide-react";
+import ContributionHeatmapCalendar from "@/components/ContributionHeatmapCalendar";
+import { formatDateKey, countInRangeCommits, buildHeatmap } from "@/lib/contribution-heatmap";
 
 interface ContributionHeatmapProps {
   days?: number;
@@ -14,20 +14,7 @@ interface ContributionResponse {
   data: Record<string, number>;
 }
 
-interface HeatmapCell {
-  date: Date;
-  dateKey: string;
-  count: number;
-  inRange: boolean;
-}
-
 const DEFAULT_DAYS = 365;
-const CELL_SIZE = 14;
-const CELL_GAP = 3;
-const LABEL_WIDTH = 48;
-const HEADER_HEIGHT = 20;
-
-const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 const PRESET_RANGES = [
   { label: "30d", days: 30 },
@@ -35,64 +22,6 @@ const PRESET_RANGES = [
   { label: "6mo", days: 180 },
   { label: "1yr", days: 365 },
 ] as const;
-
-// Memoized formatting engine to avoid recreation garbage collection cycles inside render loops
-const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "short" });
-
-function formatDateKey(date: Date) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
-function formatCommitCount(count: number) {
-  return `${count} commit${count === 1 ? "" : "s"}`;
-}
-
-function buildHeatmap(days: number, contributions: Record<string, number>, fromDate?: string, toDate?: string) {
-  let endDate: Date;
-  let startDate: Date;
-
-  if (fromDate && toDate) {
-    // Use provided custom date range
-    endDate = new Date(toDate);
-    endDate.setHours(23, 59, 59, 999);
-    startDate = new Date(fromDate);
-    startDate.setHours(0, 0, 0, 0);
-  } else {
-    // Calculate from N days ago until today
-    endDate = new Date();
-    endDate.setHours(23, 59, 59, 999);
-    startDate = new Date(endDate);
-    startDate.setDate(endDate.getDate() - (days - 1));
-    startDate.setHours(0, 0, 0, 0);
-  }
-
-  const firstWeekStart = new Date(startDate);
-  firstWeekStart.setDate(startDate.getDate() - startDate.getDay());
-  firstWeekStart.setHours(0, 0, 0, 0);
-
-  const lastWeekEnd = new Date(endDate);
-  lastWeekEnd.setDate(endDate.getDate() + (6 - endDate.getDay()));
-  lastWeekEnd.setHours(23, 59, 59, 999);
-
-  const cells: HeatmapCell[] = [];
-  const cursor = new Date(firstWeekStart);
-
-  while (cursor <= lastWeekEnd) {
-    const dateKey = formatDateKey(cursor);
-    cells.push({
-      date: new Date(cursor),
-      dateKey,
-      count: contributions[dateKey] ?? 0,
-      inRange: cursor >= startDate && cursor <= endDate,
-    });
-    cursor.setDate(cursor.getDate() + 1);
-  }
-
-  return cells;
-}
 
 export default function ContributionHeatmap({
   days = DEFAULT_DAYS,
@@ -105,7 +34,6 @@ export default function ContributionHeatmap({
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const handleCloseSheet = useCallback(() => setSelectedDate(null), []);
 
-  // Range state
   const [selectedDays, setSelectedDays] = useState(days);
   const [showPopover, setShowPopover] = useState(false);
   const [customFrom, setCustomFrom] = useState("");
@@ -114,7 +42,6 @@ export default function ContributionHeatmap({
   const [customError, setCustomError] = useState<string | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
 
-  // Load persisted range preference
   useEffect(() => {
     if (typeof window !== "undefined") {
       try {
@@ -124,13 +51,12 @@ export default function ContributionHeatmap({
         } else {
           localStorage.setItem("devtrack:heatmap-range", String(days));
         }
-      } catch (e) {
+      } catch {
         setSelectedDays(days);
       }
     }
   }, [days]);
 
-  // Handle popover dismiss
   useEffect(() => {
     if (!showPopover) return;
     const handleKey = (e: KeyboardEvent) => {
@@ -158,7 +84,9 @@ export default function ContributionHeatmap({
     if (typeof window !== "undefined") {
       try {
         localStorage.setItem("devtrack:heatmap-range", String(newDays));
-      } catch (e) {}
+      } catch {
+        /* ignore */
+      }
     }
   };
 
@@ -197,12 +125,14 @@ export default function ContributionHeatmap({
     setShowPopover(false);
   };
 
-  const currentFrom = customLabel ? customFrom : (() => {
-    const endDate = new Date();
-    const startDate = new Date(endDate);
-    startDate.setDate(endDate.getDate() - (selectedDays - 1));
-    return formatDateKey(startDate);
-  })();
+  const currentFrom = customLabel
+    ? customFrom
+    : (() => {
+        const endDate = new Date();
+        const startDate = new Date(endDate);
+        startDate.setDate(endDate.getDate() - (selectedDays - 1));
+        return formatDateKey(startDate);
+      })();
 
   const currentTo = customLabel ? customTo : formatDateKey(new Date());
 
@@ -214,7 +144,7 @@ export default function ContributionHeatmap({
     const params = new URLSearchParams();
     params.set("from", currentFrom);
     params.set("to", currentTo);
-    
+
     fetch(`/api/metrics/contributions?${params.toString()}`)
       .then((response) => {
         if (!response.ok) throw new Error("API error");
@@ -249,121 +179,42 @@ export default function ContributionHeatmap({
   }, [lastUpdated]);
 
   const { themeConfig, theme, setTheme } = useHeatmapTheme();
-  
+
   const displayDays = useMemo(() => {
     if (customLabel && customFrom && customTo) {
       const msPerDay = 1000 * 60 * 60 * 24;
-      return Math.ceil(
-        (new Date(customTo).getTime() - new Date(customFrom).getTime()) / msPerDay
-      ) + 1;
+      return (
+        Math.ceil(
+          (new Date(customTo).getTime() - new Date(customFrom).getTime()) / msPerDay
+        ) + 1
+      );
     }
     return selectedDays;
   }, [customLabel, customFrom, customTo, selectedDays]);
-  
-  const cells = useMemo(
-    () => buildHeatmap(
-      displayDays, 
+
+  const totalCommits = useMemo(() => {
+    const cells = buildHeatmap(
+      displayDays,
       data,
       customLabel ? customFrom : undefined,
       customLabel ? customTo : undefined
-    ),
-    [displayDays, data, customLabel, customFrom, customTo]
-  );
-  const weekCount = Math.ceil(cells.length / 7);
-  const maxCommits = Math.max(
-    ...cells.map((cell) => cell.count),
-    1
-  );
-  // 100% MATHEMATICALLY PRECISE MONTH TRACKING SYSTEM
-  const monthMarkers = useMemo(() => {
-    const markers: Array<{ label: string; weekIndex: number }> = [];
-    const seenMonths = new Set<string>();
-
-    for (let w = 0; w < weekCount; w++) {
-      const weekCells = cells.slice(w * 7, (w + 1) * 7);
-
-      for (const cell of weekCells) {
-        if (!cell.inRange) continue;
-
-        const currentMonth = cell.date.getMonth();
-        const currentYear = cell.date.getFullYear();
-        const monthKey = `${currentYear}-${currentMonth}`;
-
-        if (!seenMonths.has(monthKey)) {
-          seenMonths.add(monthKey);
-
-          markers.push({
-            label: monthFormatter.format(cell.date),
-            weekIndex: w,
-          });
-          break; // Move immediately to scanning the next column track block
-        }
-      }
-    }
-    return markers;
-  }, [cells, weekCount]);
-
-  // Shared matrix geometries matching baseline canvas dimensions
-  const totalGridWidth = LABEL_WIDTH + (weekCount * CELL_SIZE) + ((weekCount - 1) * CELL_GAP);
-
-  const gridStyle = {
-    gridTemplateColumns: `${LABEL_WIDTH}px repeat(${weekCount}, ${CELL_SIZE}px)`,
-    gridTemplateRows: `repeat(7, ${CELL_SIZE}px)`,
-    columnGap: `${CELL_GAP}px`,
-    rowGap: `${CELL_GAP}px`,
-  } as const;
-
-  const today = new Date();
-  const getHeatmapColor = (count: number) => {
-    if (count === 0) return themeConfig.missed;
-
-    const normalized = count / maxCommits;
-
-    if (normalized <= 0.25) {
-      return themeConfig.levelOne;
-    }
-
-    if (normalized <= 0.5) {
-      return themeConfig.levelTwo;
-    }
-
-    if (normalized <= 0.75) {
-      return themeConfig.levelThree;
-    }
-
-    return themeConfig.levelFour;
-  };
-  const totalCommits = cells
-    .filter((cell) => cell.inRange)
-    .reduce((total, cell) => total + cell.count, 0);
-  const { inRangeDays, insights } = useMemo(() => {
-    const days = cells
-      .filter((cell) => cell.inRange)
-      .map((cell) => ({
-        date: cell.date,
-        dateKey: cell.dateKey,
-        count: cell.count,
-      }));
-    return {
-      inRangeDays: days,
-      insights: getContributionInsights(days),
-    };
-  }, [cells]);
-
-  const heatmapSummary = `Contribution heatmap showing ${formatCommitCount(totalCommits)} across ${displayDays} days.`;
+    );
+    return countInRangeCommits(cells);
+  }, [displayDays, data, customLabel, customFrom, customTo]);
 
   return (
     <div className="w-full overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-6 shadow-sm">
-      <div className="mb-4 flex flex-col items-start justify-between gap-3">
-        <div className="w-full">
-          <h2 className="text-base font-semibold text-[var(--card-foreground)] dark:text-white">Contribution Heatmap</h2>          
-          <p className="text-xs text-[var(--muted-foreground)] dark:text-gray-300">
+      <div className="mb-4 flex flex-col sm:flex-row sm:flex-wrap items-start sm:items-center justify-between gap-4 sm:gap-2">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)] dark:text-white">
+            Contribution Heatmap
+          </h2>
+          <p className="text-sm text-[var(--muted-foreground)] dark:text-gray-300">
             {customLabel ? `${customLabel}` : `Last ${selectedDays} days of commit activity.`}
           </p>
         </div>
 
-        <div className="flex w-full flex-wrap items-center gap-2">
-          {/* Range buttons */}
+        <div className="flex flex-col sm:flex-row flex-wrap items-start sm:items-center gap-2">
           <div className="flex flex-wrap gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)] p-1">
             {PRESET_RANGES.map((r) => (
               <button
@@ -382,11 +233,12 @@ export default function ContributionHeatmap({
             ))}
           </div>
 
-          {/* Custom date range popover */}
           <div className="relative" ref={popoverRef}>
             <button
               onClick={() => setShowPopover((v) => !v)}
-              aria-label={customLabel ? `Custom date range: ${customLabel}` : "Select custom date range"}
+              aria-label={
+                customLabel ? `Custom date range: ${customLabel}` : "Select custom date range"
+              }
               aria-expanded={showPopover}
               className={`px-3 py-1 rounded-md text-xs font-medium transition-colors border border-[var(--border)] ${
                 customLabel
@@ -399,9 +251,7 @@ export default function ContributionHeatmap({
 
             {showPopover && (
               <div className="absolute right-0 top-10 z-50 w-72 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 shadow-lg">
-                <p className="text-sm font-medium text-[var(--foreground)] mb-3">
-                  Custom range
-                </p>
+                <p className="text-sm font-medium text-[var(--foreground)] mb-3">Custom range</p>
                 <div className="flex flex-col gap-2">
                   <label className="text-xs text-[var(--muted-foreground)]">
                     Start date
@@ -445,7 +295,11 @@ export default function ContributionHeatmap({
           <button
             type="button"
             onClick={() => setTheme("default")}
-            style={theme === "default" ? { backgroundColor: themeConfig.accent, color: "#fff" } : undefined}
+            style={
+              theme === "default"
+                ? { backgroundColor: themeConfig.accent, color: "#fff" }
+                : undefined
+            }
             className="rounded px-2 py-1 text-xs dark:text-gray-300"
           >
             Default
@@ -453,153 +307,34 @@ export default function ContributionHeatmap({
           <button
             type="button"
             onClick={() => setTheme("colour-blind-friendly")}
-            style={theme === "colour-blind-friendly" ? { backgroundColor: themeConfig.accent, color: "#fff" } : undefined}
+            style={
+              theme === "colour-blind-friendly"
+                ? { backgroundColor: themeConfig.accent, color: "#fff" }
+                : undefined
+            }
             className="rounded px-2 py-1 text-xs dark:text-gray-300"
           >
             Colour-blind
           </button>
         </div>
-
-        {/* Legend - Less / More */}
-        <div className="flex items-center gap-2 text-xs text-[var(--muted-foreground)]">
-          <span className="dark:text-gray-300">Less</span>
-          <div className="flex items-center gap-1">
-            {[
-              0,
-              Math.ceil(maxCommits * 0.25),
-              Math.ceil(maxCommits * 0.5),
-              Math.ceil(maxCommits * 0.75),
-              maxCommits,
-            ].map((count, index) => {
-              const swatch = getHeatmapColor(count);
-              return (
-                <span
-                  key={index} // <-- Changed from count to index
-                  className="h-3 w-3 rounded-sm border"
-                  style={{ backgroundColor: swatch, borderColor: themeConfig.border }}
-                />
-              );
-            })}
-          </div>
-          <span className="dark:text-gray-300">More</span>
-        </div>
       </div>
 
-      {loading ? (
-        <div className="h-[300px] animate-pulse rounded-lg bg-[var(--card-muted)]" />
-      ) : error ? (
+      {error ? (
         <div className="flex h-[180px] items-center rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-4">
           <p className="text-sm text-[var(--destructive)]">{error} Please try refreshing.</p>
         </div>
       ) : (
         <>
-          <div
-            className="overflow-x-auto pb-2 scrollbar-thin"
-            role="img"
-            aria-label={heatmapSummary}
-          >
-            <div className="mx-auto flex flex-col gap-1" style={{ width: `${totalGridWidth}px` }}>
-              
-              {/* MATHEMATICAL COORDINATE TIMELINE HEADER BANNER CONTAINER */}
-              <div 
-                className="relative w-full text-[11px] font-semibold text-[var(--foreground)] dark:text-gray-200" 
-                style={{ height: `${HEADER_HEIGHT}px` }}
-              >
-                {monthMarkers.map((marker, idx) => {
-                  const absoluteLeftOffset = LABEL_WIDTH + (marker.weekIndex * (CELL_SIZE + CELL_GAP));
-                  const nextMarker = monthMarkers[idx + 1];
-                  const nextOffset = nextMarker ? LABEL_WIDTH + (nextMarker.weekIndex * (CELL_SIZE + CELL_GAP)) : totalGridWidth;
-                  const availableWidth = nextOffset - absoluteLeftOffset - 8;
+          <ContributionHeatmapCalendar
+            data={data}
+            days={displayDays}
+            fromDate={customLabel ? customFrom : undefined}
+            toDate={customLabel ? customTo : undefined}
+            themeConfig={themeConfig}
+            onCellClick={setSelectedDate}
+            loading={loading}
+          />
 
-                  return (
-                    <div
-                      key={`${marker.label}-${marker.weekIndex}`}
-                      className="absolute top-0 truncate font-semibold"
-                      style={{
-                        left: `${absoluteLeftOffset}px`,
-                        width: `${Math.max(0, availableWidth)}px`,
-                        paddingRight: "4px",
-                      }}
-                      title={marker.label}
-                    >
-                      {marker.label}
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* Grid System Area mapping identical columns */}
-              <div className="grid items-center" style={gridStyle}>
-                {DAY_LABELS.map((label, rowIndex) => (
-                  <div
-                    key={label}
-                    className="flex items-center justify-end pr-2 text-[10px] text-[var(--muted-foreground)] dark:text-gray-500"
-                    style={{
-                      gridRow: rowIndex + 1,
-                      gridColumn: 1,
-                      opacity: rowIndex % 2 === 0 ? 1 : 0,
-                    }}
-                  >
-                    {rowIndex % 2 === 0 ? label : ""}
-                  </div>
-                ))}
-
-                {cells.map((cell, index) => {
-                  const weekIndex = Math.floor(index / 7);
-                  const dayIndex = index % 7;
-                  const isFuture = cell.date > today;
-                  const showTooltipBelow = dayIndex < 2;
-                  const isNearRightEdge = weekIndex >= weekCount - 3;
-                  const formattedDate = cell.date.toLocaleDateString("en-US", {
-                    weekday: "short",
-                    month: "short",
-                    day: "numeric",
-                  });
-                  const accessibleLabel = `${formatCommitCount(cell.count)} on ${cell.dateKey}`;
-                  const tooltip = `${formatCommitCount(cell.count)} on ${formattedDate}`;
-
-                  return (
-                    <button
-                      key={cell.dateKey}
-                      type="button"
-                      title={isFuture ? "" : tooltip}
-                      aria-label={isFuture ? `Future date on ${cell.dateKey}` : accessibleLabel}
-                      disabled={isFuture}
-                      onClick={() => !isFuture && setSelectedDate(cell.dateKey)}
-                      className={`group relative z-0 h-4 w-4 rounded-[3px] border transition-transform hover:z-20 hover:scale-110 focus:z-20 focus-visible:ring-2 focus-visible:ring-[var(--heatmap-focus-ring)] disabled:cursor-default disabled:opacity-20 ${
-                        cell.inRange ? "opacity-100" : "opacity-40"
-                      }`}
-                      style={{
-                        gridRow: dayIndex + 1,
-                        gridColumn: weekIndex + 2,
-                        backgroundColor: isFuture
-                          ? "transparent"
-                          : getHeatmapColor(cell.count),
-                        borderColor: themeConfig.border,
-                        ["--heatmap-focus-ring" as any]: themeConfig.accent,
-                      }}
-                    >
-                      {!isFuture && (
-                        <span
-                          className={`pointer-events-none absolute z-50 hidden whitespace-nowrap rounded-md bg-[var(--foreground)] px-2 py-1 text-[11px] text-[var(--background)] shadow-lg group-hover:block group-focus:block ${
-                            showTooltipBelow ? "top-full mt-2" : "bottom-full mb-2"
-                          } ${
-                            isNearRightEdge
-                              ? "right-0 translate-x-0"
-                              : "left-1/2 -translate-x-1/2"
-                          }`}
-                        >
-                          {tooltip}
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-
-          {/* Commits shown + Updated timestamp */}
           <div className="mt-4 flex items-center justify-between gap-4 text-xs text-[var(--muted-foreground)] dark:text-gray-400">
             <p>
               {totalCommits} commits shown across {displayDays} days.
@@ -608,135 +343,9 @@ export default function ContributionHeatmap({
               <p>{minutesAgo === 0 ? "Updated just now" : `Updated ${minutesAgo} min ago`}</p>
             )}
           </div>
-
-          {/* Contribution Insights section */}
-          <div className="mt-6 border-t border-[var(--border)] pt-6">
-            <h3 className="text-sm font-semibold text-[var(--card-foreground)] dark:text-white mb-4">
-              Contribution Insights
-            </h3>
-            
-            {inRangeDays.length === 0 ? (
-              <p className="text-xs text-[var(--muted-foreground)]">No contribution data available for this range.</p>
-            ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4" role="region" aria-label="Contribution Insights Panel">
-                {/* Most Productive Weekday */}
-                <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-4 shadow-sm flex flex-col justify-between">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Calendar className="h-4 w-4 text-blue-500" aria-hidden="true" />
-                    <span className="text-xs font-medium text-[var(--muted-foreground)] uppercase tracking-wide">
-                      Most Productive Day
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-lg font-semibold text-[var(--card-foreground)] dark:text-white">
-                      {insights.mostProductiveWeekday}
-                    </span>
-                    <p className="text-[11px] text-[var(--muted-foreground)] mt-1">
-                      Day with highest average commits
-                    </p>
-                  </div>
-                </div>
-
-                {/* Average Weekly Contributions */}
-                <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-4 shadow-sm flex flex-col justify-between">
-                  <div className="flex items-center gap-2 mb-2">
-                    <BarChart2 className="h-4 w-4 text-green-500" aria-hidden="true" />
-                    <span className="text-xs font-medium text-[var(--muted-foreground)] uppercase tracking-wide">
-                      Avg Weekly Contributions
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-lg font-semibold text-[var(--card-foreground)] dark:text-white">
-                      {insights.averageWeeklyContributions.toFixed(1)}
-                    </span>
-                    <p className="text-[11px] text-[var(--muted-foreground)] mt-1">
-                      Commits per 7 calendar days
-                    </p>
-                  </div>
-                </div>
-
-                {/* Longest Contribution Streak */}
-                <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-4 shadow-sm flex flex-col justify-between">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Zap className="h-4 w-4 text-amber-500" aria-hidden="true" />
-                    <span className="text-xs font-medium text-[var(--muted-foreground)] uppercase tracking-wide">
-                      Longest Streak
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-lg font-semibold text-[var(--card-foreground)] dark:text-white">
-                      {insights.longestStreak} {insights.longestStreak === 1 ? 'day' : 'days'}
-                    </span>
-                    <p className="text-[11px] text-[var(--muted-foreground)] mt-1">
-                      Max consecutive active days
-                    </p>
-                  </div>
-                </div>
-
-                {/* Longest Inactive Period */}
-                <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-4 shadow-sm flex flex-col justify-between">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Clock className="h-4 w-4 text-red-500" aria-hidden="true" />
-                    <span className="text-xs font-medium text-[var(--muted-foreground)] uppercase tracking-wide">
-                      Longest Inactive Period
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-lg font-semibold text-[var(--card-foreground)] dark:text-white">
-                      {insights.longestInactivePeriod} {insights.longestInactivePeriod === 1 ? 'day' : 'days'}
-                    </span>
-                    <p className="text-[11px] text-[var(--muted-foreground)] mt-1">
-                      Max consecutive days with zero commits
-                    </p>
-                  </div>
-                </div>
-
-                {/* Monthly Contribution Trends */}
-                <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-4 shadow-sm flex flex-col justify-between">
-                  <div className="flex items-center gap-2 mb-2">
-                    <TrendingUp className="h-4 w-4 text-purple-500" aria-hidden="true" />
-                    <span className="text-xs font-medium text-[var(--muted-foreground)] uppercase tracking-wide">
-                      Monthly Trend
-                    </span>
-                  </div>
-                  <div>
-                    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium border ${
-                      insights.monthlyTrend === 'Increasing'
-                        ? 'bg-green-500/10 text-green-400 border-green-500/20'
-                        : insights.monthlyTrend === 'Decreasing'
-                        ? 'bg-red-500/10 text-red-400 border-red-500/20'
-                        : 'bg-blue-500/10 text-blue-400 border-blue-500/20'
-                    }`}>
-                      {insights.monthlyTrend}
-                    </span>
-                    <p className="text-[11px] text-[var(--muted-foreground)] mt-2">
-                      Recent month vs preceding month
-                    </p>
-                  </div>
-                </div>
-
-                {/* Best Contribution Month */}
-                <div className="rounded-xl border border-[var(--border)] bg-[var(--control)] p-4 shadow-sm flex flex-col justify-between">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Award className="h-4 w-4 text-indigo-500" aria-hidden="true" />
-                    <span className="text-xs font-medium text-[var(--muted-foreground)] uppercase tracking-wide">
-                      Best Month
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-lg font-semibold text-[var(--card-foreground)] dark:text-white truncate block">
-                      {insights.bestMonth}
-                    </span>
-                    <p className="text-[11px] text-[var(--muted-foreground)] mt-1">
-                      Highest total ({insights.bestMonthTotal} commits)
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
         </>
       )}
+
       <DailyBreakdownSheet
         date={selectedDate}
         onClose={handleCloseSheet}

--- a/src/components/ContributionHeatmapCalendar.tsx
+++ b/src/components/ContributionHeatmapCalendar.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  buildHeatmap,
+  buildMonthMarkers,
+  countInRangeCommits,
+  formatCellTooltip,
+  formatCommitCount,
+  HEATMAP_CELL_GAP,
+  HEATMAP_CELL_SIZE,
+  HEATMAP_DAY_LABELS,
+  HEATMAP_HEADER_HEIGHT,
+  HEATMAP_LABEL_WIDTH,
+  HEATMAP_LEGEND_COUNTS,
+} from "@/lib/contribution-heatmap";
+import {
+  getHeatmapCellStyle,
+  type HeatmapThemeConfig,
+} from "@/hooks/useHeatmapTheme";
+
+export interface ContributionHeatmapCalendarProps {
+  data: Record<string, number>;
+  days?: number;
+  fromDate?: string;
+  toDate?: string;
+  themeConfig: HeatmapThemeConfig;
+  onCellClick?: (dateKey: string) => void;
+  loading?: boolean;
+  className?: string;
+  showLegend?: boolean;
+}
+
+export default function ContributionHeatmapCalendar({
+  data,
+  days = 365,
+  fromDate,
+  toDate,
+  themeConfig,
+  onCellClick,
+  loading = false,
+  className = "",
+  showLegend = true,
+}: ContributionHeatmapCalendarProps) {
+  const displayDays = useMemo(() => {
+    if (fromDate && toDate) {
+      const msPerDay = 1000 * 60 * 60 * 24;
+      return (
+        Math.ceil(
+          (new Date(toDate).getTime() - new Date(fromDate).getTime()) / msPerDay
+        ) + 1
+      );
+    }
+    return days;
+  }, [days, fromDate, toDate]);
+
+  const cells = useMemo(
+    () => buildHeatmap(displayDays, data, fromDate, toDate),
+    [displayDays, data, fromDate, toDate]
+  );
+
+  const weekCount = Math.ceil(cells.length / 7);
+  const monthMarkers = useMemo(
+    () => buildMonthMarkers(cells, weekCount),
+    [cells, weekCount]
+  );
+
+  const totalGridWidth =
+    HEATMAP_LABEL_WIDTH + weekCount * HEATMAP_CELL_SIZE + (weekCount - 1) * HEATMAP_CELL_GAP;
+
+  const gridStyle = {
+    gridTemplateColumns: `${HEATMAP_LABEL_WIDTH}px repeat(${weekCount}, ${HEATMAP_CELL_SIZE}px)`,
+    gridTemplateRows: `repeat(7, ${HEATMAP_CELL_SIZE}px)`,
+    columnGap: `${HEATMAP_CELL_GAP}px`,
+    rowGap: `${HEATMAP_CELL_GAP}px`,
+  } as const;
+
+  const today = new Date();
+  today.setHours(23, 59, 59, 999);
+
+  const totalCommits = countInRangeCommits(cells);
+  const heatmapSummary = `Contribution heatmap showing ${formatCommitCount(totalCommits)} across ${displayDays} days.`;
+
+  if (loading) {
+    return (
+      <div
+        className={`h-[300px] animate-pulse rounded-lg bg-[var(--card-muted)] ${className}`}
+        aria-busy="true"
+        aria-label="Loading contribution heatmap"
+      />
+    );
+  }
+
+  return (
+    <div className={className}>
+      <div
+        className="overflow-x-auto pb-2 scrollbar-thin"
+        role="img"
+        aria-label={heatmapSummary}
+      >
+        <div
+          className="mx-auto flex flex-col gap-1"
+          style={{ width: `${totalGridWidth}px` }}
+        >
+          <div
+            className="relative w-full text-[11px] font-semibold text-[var(--foreground)] dark:text-gray-200"
+            style={{ height: `${HEATMAP_HEADER_HEIGHT}px` }}
+          >
+            {monthMarkers.map((marker, idx) => {
+              const absoluteLeftOffset =
+                HEATMAP_LABEL_WIDTH + marker.weekIndex * (HEATMAP_CELL_SIZE + HEATMAP_CELL_GAP);
+              const nextMarker = monthMarkers[idx + 1];
+              const nextOffset = nextMarker
+                ? HEATMAP_LABEL_WIDTH +
+                  nextMarker.weekIndex * (HEATMAP_CELL_SIZE + HEATMAP_CELL_GAP)
+                : totalGridWidth;
+              const availableWidth = nextOffset - absoluteLeftOffset - 8;
+
+              return (
+                <div
+                  key={`${marker.label}-${marker.weekIndex}`}
+                  className="absolute top-0 truncate font-semibold"
+                  style={{
+                    left: `${absoluteLeftOffset}px`,
+                    width: `${Math.max(0, availableWidth)}px`,
+                    paddingRight: "4px",
+                  }}
+                  title={marker.label}
+                >
+                  {marker.label}
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="grid items-center" style={gridStyle}>
+            {HEATMAP_DAY_LABELS.map((label, rowIndex) => (
+              <div
+                key={label}
+                className="flex items-center justify-end pr-2 text-[10px] text-[var(--muted-foreground)] dark:text-gray-500"
+                style={{
+                  gridRow: rowIndex + 1,
+                  gridColumn: 1,
+                  opacity: rowIndex % 2 === 0 ? 1 : 0,
+                }}
+              >
+                {rowIndex % 2 === 0 ? label : ""}
+              </div>
+            ))}
+
+            {cells.map((cell, index) => {
+              const weekIndex = Math.floor(index / 7);
+              const dayIndex = index % 7;
+              const isFuture = cell.date > today;
+              const showTooltipBelow = dayIndex < 2;
+              const isNearRightEdge = weekIndex >= weekCount - 3;
+              const cellStyle = getHeatmapCellStyle(cell.count, themeConfig);
+              const tooltip = formatCellTooltip(cell.count, cell.date);
+              const accessibleLabel = `${formatCommitCount(cell.count)} on ${cell.dateKey}`;
+              const isInteractive = !isFuture && Boolean(onCellClick);
+
+              return (
+                <button
+                  key={cell.dateKey}
+                  type="button"
+                  title={isFuture ? "" : tooltip}
+                  aria-label={isFuture ? `Future date on ${cell.dateKey}` : accessibleLabel}
+                  disabled={isFuture}
+                  onClick={() => {
+                    if (!isFuture && onCellClick) onCellClick(cell.dateKey);
+                  }}
+                  className={`group relative z-0 h-4 w-4 rounded-[3px] border transition-transform hover:z-20 hover:scale-110 focus:z-20 focus-visible:ring-2 focus-visible:ring-[var(--heatmap-focus-ring)] disabled:cursor-default disabled:opacity-20 ${
+                    cell.inRange ? "opacity-100" : "opacity-40"
+                  } ${isInteractive ? "cursor-pointer" : "cursor-default"}`}
+                  style={{
+                    gridRow: dayIndex + 1,
+                    gridColumn: weekIndex + 2,
+                    backgroundColor: isFuture ? "transparent" : cellStyle.backgroundColor,
+                    borderColor: themeConfig.border,
+                    ["--heatmap-focus-ring" as string]: themeConfig.accent,
+                  }}
+                >
+                  {!isFuture && (
+                    <span
+                      className={`pointer-events-none absolute z-50 hidden whitespace-nowrap rounded-md bg-[var(--foreground)] px-2 py-1 text-[11px] text-[var(--background)] shadow-lg group-hover:block group-focus:block ${
+                        showTooltipBelow ? "top-full mt-2" : "bottom-full mb-2"
+                      } ${
+                        isNearRightEdge
+                          ? "right-0 translate-x-0"
+                          : "left-1/2 -translate-x-1/2"
+                      }`}
+                    >
+                      {tooltip}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {showLegend && (
+        <div className="mt-3 flex items-center justify-end gap-2 text-xs text-[var(--muted-foreground)]">
+          <span className="dark:text-gray-300">Less</span>
+          <div className="flex items-center gap-1">
+            {HEATMAP_LEGEND_COUNTS.map((count) => {
+              const swatch = getHeatmapCellStyle(count, themeConfig);
+              return (
+                <span
+                  key={count}
+                  className="h-3 w-3 rounded-sm border"
+                  style={{
+                    backgroundColor: swatch.backgroundColor,
+                    borderColor: themeConfig.border,
+                  }}
+                />
+              );
+            })}
+          </div>
+          <span className="dark:text-gray-300">More</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/public/PublicContributionHeatmap.tsx
+++ b/src/components/public/PublicContributionHeatmap.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import ContributionHeatmapCalendar from "@/components/ContributionHeatmapCalendar";
+import { useHeatmapTheme } from "@/hooks/useHeatmapTheme";
+import type { ContributionData } from "@/lib/public-profile-data";
+
+interface PublicContributionHeatmapProps {
+  data: ContributionData;
+}
+
+export default function PublicContributionHeatmap({ data: contributionData }: PublicContributionHeatmapProps) {
+  const { themeConfig } = useHeatmapTheme();
+
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-[var(--shadow-soft)]">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--card-foreground)]">
+            Contribution Heatmap
+          </h2>
+          <p className="text-sm text-[var(--muted-foreground)] mt-1">
+            {contributionData.total} contributions in the last {contributionData.days} days
+          </p>
+        </div>
+      </div>
+
+      {Object.keys(contributionData.data ?? {}).length === 0 ? (
+        <p className="text-sm text-[var(--muted-foreground)]">No commit data available.</p>
+      ) : (
+        <ContributionHeatmapCalendar
+          data={contributionData.data}
+          days={contributionData.days}
+          themeConfig={themeConfig}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/lib/contribution-heatmap.ts
+++ b/src/lib/contribution-heatmap.ts
@@ -1,0 +1,118 @@
+export interface HeatmapCell {
+  date: Date;
+  dateKey: string;
+  count: number;
+  inRange: boolean;
+}
+
+export const HEATMAP_CELL_SIZE = 14;
+export const HEATMAP_CELL_GAP = 3;
+export const HEATMAP_LABEL_WIDTH = 48;
+export const HEATMAP_HEADER_HEIGHT = 20;
+export const HEATMAP_DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+/** Absolute commit counts matching getHeatmapCellStyle thresholds. */
+export const HEATMAP_LEGEND_COUNTS = [0, 1, 3, 6, 10] as const;
+
+const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "short" });
+
+export function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function formatCommitCount(count: number): string {
+  return `${count} contribution${count === 1 ? "" : "s"}`;
+}
+
+export function formatCellTooltip(count: number, date: Date): string {
+  const formattedDate = date.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return `${formatCommitCount(count)} on ${formattedDate}`;
+}
+
+export function buildHeatmap(
+  days: number,
+  contributions: Record<string, number>,
+  fromDate?: string,
+  toDate?: string
+): HeatmapCell[] {
+  let endDate: Date;
+  let startDate: Date;
+
+  if (fromDate && toDate) {
+    endDate = new Date(toDate);
+    endDate.setHours(23, 59, 59, 999);
+    startDate = new Date(fromDate);
+    startDate.setHours(0, 0, 0, 0);
+  } else {
+    endDate = new Date();
+    endDate.setHours(23, 59, 59, 999);
+    startDate = new Date(endDate);
+    startDate.setDate(endDate.getDate() - (days - 1));
+    startDate.setHours(0, 0, 0, 0);
+  }
+
+  const firstWeekStart = new Date(startDate);
+  firstWeekStart.setDate(startDate.getDate() - startDate.getDay());
+  firstWeekStart.setHours(0, 0, 0, 0);
+
+  const lastWeekEnd = new Date(endDate);
+  lastWeekEnd.setDate(endDate.getDate() + (6 - endDate.getDay()));
+  lastWeekEnd.setHours(23, 59, 59, 999);
+
+  const cells: HeatmapCell[] = [];
+  const cursor = new Date(firstWeekStart);
+
+  while (cursor <= lastWeekEnd) {
+    const dateKey = formatDateKey(cursor);
+    cells.push({
+      date: new Date(cursor),
+      dateKey,
+      count: contributions[dateKey] ?? 0,
+      inRange: cursor >= startDate && cursor <= endDate,
+    });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return cells;
+}
+
+export function buildMonthMarkers(
+  cells: HeatmapCell[],
+  weekCount: number
+): Array<{ label: string; weekIndex: number }> {
+  const markers: Array<{ label: string; weekIndex: number }> = [];
+  const seenMonths = new Set<string>();
+
+  for (let w = 0; w < weekCount; w++) {
+    const weekCells = cells.slice(w * 7, (w + 1) * 7);
+
+    for (const cell of weekCells) {
+      if (!cell.inRange) continue;
+
+      const monthKey = `${cell.date.getFullYear()}-${cell.date.getMonth()}`;
+
+      if (!seenMonths.has(monthKey)) {
+        seenMonths.add(monthKey);
+        markers.push({
+          label: monthFormatter.format(cell.date),
+          weekIndex: w,
+        });
+        break;
+      }
+    }
+  }
+
+  return markers;
+}
+
+export function countInRangeCommits(cells: HeatmapCell[]): number {
+  return cells.filter((cell) => cell.inRange).reduce((total, cell) => total + cell.count, 0);
+}

--- a/src/lib/public-profile-data.ts
+++ b/src/lib/public-profile-data.ts
@@ -129,37 +129,69 @@ export async function fetchPublicTopRepos(
  * Fetches the user's public contribution data over a specified number of days.
  * @param username - The GitHub username.
  * @param token - Optional GitHub personal access token.
- * @param days - The number of days to look back for activity (default: 30).
+ * @param days - The number of days to look back for activity (default: 365).
  * @returns Contribution data including daily counts and total.
  */
 export async function fetchPublicContributions(
   username: string,
   token?: string,
-  days = 30
+  days = 365
 ): Promise<ContributionData> {
   const since = new Date();
   since.setDate(since.getDate() - days);
   const sinceStr = since.toISOString().slice(0, 10);
 
-  const res = await ghFetch(
-    `${GITHUB_API}/search/commits?q=author:${username}+author-date:>=${sinceStr}&per_page=100&sort=author-date&order=desc`,
-    token
-  );
+  const q = `author:${username}+author-date:>=${sinceStr}`;
+  let allItems: Array<{ commit: { author: { date: string } } }> = [];
+  let totalCount = 0;
+  let page = 1;
 
-  if (!res.ok) return { days, total: 0, data: {} };
+  while (page <= 10) {
+    const url = new URL(`${GITHUB_API}/search/commits`);
+    url.searchParams.set("q", q);
+    url.searchParams.set("per_page", "100");
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("sort", "author-date");
+    url.searchParams.set("order", "desc");
 
-  const data = (await res.json()) as {
-    total_count: number;
-    items: Array<{ commit: { author: { date: string } } }>;
-  };
+    const res = await ghFetch(url.toString(), token);
+
+    if (!res.ok) {
+      if (allItems.length === 0) {
+        return { days, total: 0, data: {} };
+      }
+      break;
+    }
+
+    const data = (await res.json()) as {
+      total_count: number;
+      items: Array<{ commit: { author: { date: string } } }>;
+    };
+
+    if (page === 1) {
+      totalCount = data.total_count;
+    }
+
+    allItems = allItems.concat(data.items);
+
+    if (data.items.length < 100) {
+      break;
+    }
+
+    if (allItems.length >= 1000 || allItems.length >= totalCount) {
+      break;
+    }
+
+    page += 1;
+  }
 
   const commitsByDay: Record<string, number> = {};
-  for (const item of data.items) {
+  for (const item of allItems) {
     const date = item.commit.author.date.slice(0, 10);
     commitsByDay[date] = (commitsByDay[date] ?? 0) + 1;
   }
 
-  return { days, total: data.total_count, data: commitsByDay };
+  return { days, total: totalCount, data: commitsByDay };
 }
 
 /**
@@ -387,7 +419,7 @@ export async function fetchPublicProfile(
   ] = await Promise.all([
     fetchPublicGists(user.github_login, githubToken),
     fetchPublicTopRepos(user.github_login, githubToken, 30),
-    fetchPublicContributions(user.github_login, githubToken, 30),
+    fetchPublicContributions(user.github_login, githubToken, 365),
     fetchPublicStreak(user.github_login, githubToken, user.timezone),
     fetchPublicTopLanguages(user.github_login, githubToken),
     fetchPublicPullRequests(user.github_login, githubToken),

--- a/test/contribution-heatmap-calendar.test.ts
+++ b/test/contribution-heatmap-calendar.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildHeatmap,
+  buildMonthMarkers,
+  countInRangeCommits,
+  formatCellTooltip,
+  formatCommitCount,
+  formatDateKey,
+} from "@/lib/contribution-heatmap";
+
+describe("contribution-heatmap lib", () => {
+  it("formatDateKey returns YYYY-MM-DD", () => {
+    const date = new Date(2026, 2, 14);
+    expect(formatDateKey(date)).toBe("2026-03-14");
+  });
+
+  it("formatCommitCount uses singular and plural", () => {
+    expect(formatCommitCount(1)).toBe("1 contribution");
+    expect(formatCommitCount(3)).toBe("3 contributions");
+  });
+
+  it("formatCellTooltip includes count and formatted date", () => {
+    const date = new Date(2026, 2, 14);
+    const tooltip = formatCellTooltip(3, date);
+    expect(tooltip).toContain("3 contributions");
+    expect(tooltip).toContain("Mar");
+    expect(tooltip).toContain("14");
+    expect(tooltip).toContain("2026");
+  });
+
+  it("buildHeatmap fills missing days with zero and marks inRange", () => {
+    const today = new Date();
+    const todayKey = formatDateKey(today);
+    const contributions = { [todayKey]: 2 };
+    const cells = buildHeatmap(7, contributions);
+    expect(cells.length % 7).toBe(0);
+    const inRange = cells.filter((c) => c.inRange);
+    expect(inRange.length).toBe(7);
+    const match = cells.find((c) => c.dateKey === todayKey);
+    expect(match?.count).toBe(2);
+    const empty = inRange.find((c) => c.count === 0);
+    expect(empty).toBeDefined();
+  });
+
+  it("buildHeatmap uses custom from/to range", () => {
+    const cells = buildHeatmap(365, {}, "2026-01-01", "2026-01-07");
+    const inRange = cells.filter((c) => c.inRange);
+    expect(inRange.length).toBe(7);
+    expect(inRange[0].dateKey).toBe("2026-01-01");
+    expect(inRange[6].dateKey).toBe("2026-01-07");
+  });
+
+  it("buildMonthMarkers returns one marker per month in range", () => {
+    const cells = buildHeatmap(60, {}, "2026-01-15", "2026-03-15");
+    const weekCount = Math.ceil(cells.length / 7);
+    const markers = buildMonthMarkers(cells, weekCount);
+    expect(markers.length).toBeGreaterThanOrEqual(2);
+    expect(markers[0].label).toBeTruthy();
+  });
+
+  it("countInRangeCommits sums only in-range cells", () => {
+    const cells = buildHeatmap(7, {
+      [formatDateKey(new Date())]: 4,
+    });
+    expect(countInRangeCommits(cells)).toBe(4);
+  });
+});

--- a/test/public-profile-data.test.ts
+++ b/test/public-profile-data.test.ts
@@ -84,9 +84,37 @@ describe("public-profile-data", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       const contributions = await fetchPublicContributions("user123");
+      expect(contributions.days).toBe(365);
       expect(contributions.total).toBe(3);
       expect(contributions.data["2026-05-10"]).toBe(2);
       expect(contributions.data["2026-05-11"]).toBe(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should paginate through multiple GitHub search pages", async () => {
+      const page1Items = Array.from({ length: 100 }, (_, i) => ({
+        commit: { author: { date: `2026-05-${String((i % 28) + 1).padStart(2, "0")}T12:00:00Z` } },
+      }));
+      const page2Items = [
+        { commit: { author: { date: "2026-05-01T12:00:00Z" } } },
+      ];
+
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ total_count: 101, items: page1Items }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ total_count: 101, items: page2Items }),
+        });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const contributions = await fetchPublicContributions("user123");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(contributions.total).toBe(101);
+      expect(Object.values(contributions.data).reduce((a, b) => a + b, 0)).toBe(101);
     });
   });
 


### PR DESCRIPTION
Extract ContributionHeatmapCalendar for dashboard and public profiles, paginate public contribution fetch for a full year, and align cell colors to absolute commit thresholds.

## Summary

Adds a shared GitHub-style 365-day contribution heatmap calendar used on both the authenticated dashboard and public profiles. The dashboard widget is refactored to use the shared component, public profiles now show the full-year grid (with paginated data fetch), and cell colors use absolute commit thresholds with theme support.

Closes #2809 

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [x] 📝 Documentation update
- [x] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **`src/lib/contribution-heatmap.ts`** — Shared helpers: `buildHeatmap`, `buildMonthMarkers`, date/tooltip formatters, and legend constants.
- **`src/components/ContributionHeatmapCalendar.tsx`** — Reusable 7×53 grid with month labels, hover/focus tooltips, horizontal scroll, legend, and `getHeatmapCellStyle()` absolute color levels.
- **`src/components/ContributionHeatmap.tsx`** — Refactored into a thin wrapper (fetch, range controls, theme toggle, drill-down) that renders the shared calendar.
- **`src/lib/public-profile-data.ts`** — `fetchPublicContributions` now defaults to 365 days and paginates GitHub Search (up to 1000 commits).
- **`src/components/public/PublicContributionHeatmap.tsx`** — New public profile heatmap using `useHeatmapTheme()` and server-provided data.
- **`src/app/u/[username]/page.tsx`** — Replaced inline `PublicContributionGraph` with `PublicContributionHeatmap`.
- **`test/contribution-heatmap-calendar.test.ts`** — Unit tests for heatmap grid helpers.
- **`test/public-profile-data.test.ts`** — Tests for 365-day default and pagination.
- **`README.md`** — Moved contribution heatmap calendar (#18) from Planned to Completed.

---

## How to Test

1. Check out `feat/contribution-heatmap-calendar` and run `npm install` if needed.
2. Start the app with `npm run dev`, sign in, and open the dashboard **Contribution Heatmap** widget.
3. Confirm the 365-day grid renders, tooltips show date + contribution count on hover, and **Default / Colour-blind** theme toggle updates colors instantly.
4. Visit a public profile at `/u/{username}` and confirm the full-year heatmap renders with horizontal scroll on a narrow viewport.

**Expected result:** Dashboard and public profile both show the same GitHub-style calendar grid with theme-aware absolute color levels and accurate year-long data.

Automated checks:

```bash
npm run lint
npm test -- test/contribution-heatmap-calendar.test.ts test/useHeatmapTheme.test.ts test/public-profile-data.test.ts