### PR TITLE
test : added unit tests for csrf.ts

### DIFF
--- a/test/csrf.test.ts
+++ b/test/csrf.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { isStateChangingMethod, isCsrfExempt } from "../src/lib/csrf";
+
+describe("csrf", () => {
+  describe("isStateChangingMethod", () => {
+    it("returns true for POST", () => {
+      expect(isStateChangingMethod("POST")).toBe(true);
+    });
+
+    it("returns true for PUT", () => {
+      expect(isStateChangingMethod("PUT")).toBe(true);
+    });
+
+    it("returns true for PATCH", () => {
+      expect(isStateChangingMethod("PATCH")).toBe(true);
+    });
+
+    it("returns true for DELETE", () => {
+      expect(isStateChangingMethod("DELETE")).toBe(true);
+    });
+
+    it("returns false for GET", () => {
+      expect(isStateChangingMethod("GET")).toBe(false);
+    });
+
+    it("returns false for HEAD", () => {
+      expect(isStateChangingMethod("HEAD")).toBe(false);
+    });
+
+    it("returns false for OPTIONS", () => {
+      expect(isStateChangingMethod("OPTIONS")).toBe(false);
+    });
+
+    it("is case-sensitive", () => {
+      expect(isStateChangingMethod("post")).toBe(false);
+      expect(isStateChangingMethod("Post")).toBe(false);
+    });
+  });
+
+  describe("isCsrfExempt", () => {
+    it("returns true for webhook routes", () => {
+      expect(isCsrfExempt("/api/webhooks/github")).toBe(true);
+      expect(isCsrfExempt("/api/webhooks/github/push")).toBe(true);
+      expect(isCsrfExempt("/api/webhooks/custom")).toBe(true);
+      expect(isCsrfExempt("/api/webhooks/dispatch/event")).toBe(true);
+    });
+
+    it("returns true for rate-limit API routes", () => {
+      expect(isCsrfExempt("/api/metrics")).toBe(true);
+      expect(isCsrfExempt("/api/metrics/weekly")).toBe(true);
+      expect(isCsrfExempt("/api/auth/signin")).toBe(true);
+      expect(isCsrfExempt("/api/auth/callback")).toBe(true);
+    });
+
+    it("returns false for non-exempt routes", () => {
+      expect(isCsrfExempt("/api/goals")).toBe(false);
+      expect(isCsrfExempt("/api/user")).toBe(false);
+      expect(isCsrfExempt("/api/repos")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2854.

Summary of What Has Been Done:
Added a comprehensive test suite for the csrf.ts utility module covering isStateChangingMethod and isCsrfExempt functions.

Changes Made:
- Created test/csrf.test.ts with 11 test cases
- Tested isStateChangingMethod for POST/PUT/PATCH/DELETE (true) and GET/HEAD/OPTIONS (false)
- Tested case sensitivity of isStateChangingMethod
- Tested isCsrfExempt for webhook routes (/api/webhooks/github, /api/webhooks/custom, /api/webhooks/dispatch)
- Tested isCsrfExempt for rate-limit API routes (/api/metrics, /api/auth/signin, /api/auth/callback)
- Tested isCsrfExempt returning false for non-exempt routes

Impact it Made:
Increases test coverage and ensures CSRF protection correctly handles cross-origin request validation.