### PR TITLE
test: fix unit tests for csv.ts (csvCell and toCsv)

### DIFF
--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -54,8 +54,8 @@ describe("toCsv", () => {
     expect(toCsv([])).toBe("");
   });
 
-  it("returns header row only for single row", () => {
-    expect(toCsv([{ name: "Alice", age: 30 }])).toBe("name,age");
+  it("returns header and data row for single row", () => {
+  expect(toCsv([{ name: "Alice", age: 30 }])).toBe("name,age\nAlice,30");
   });
 
   it("serialises multiple rows with correct values", () => {


### PR DESCRIPTION
## Summary

Fixes the existing unit tests in `test/csv.test.ts` for CSV serialisation 
utilities exported from `src/lib/csv.ts`.

Closes #2941 

## Changes Made

- Fixed incorrect expectation in `toCsv` single-row test case
  - Previous: expected header row only (`"name,age"`)
  - Fixed: expects header + data row (`"name,age\nAlice,30"`) which matches 
    actual implementation behaviour

## Why

The existing test assumed `toCsv` with a single row returns only headers. 
But the implementation always appends data rows — even for a single row. 
The wrong expectation would have caused CI to fail.

## Test Coverage (already present, now correct)

All requirements from issue #2804 are covered:
- `csvCell`: null/undefined, plain text, comma, double-quote, newline, carriage return
- `toCsv`: empty array, single row, multiple rows, missing keys, numbers/booleans