### PR TITLE
feat: Add SWR local storage cache layer for offline dashboard resiliency

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -41,7 +41,14 @@ const RECURRENCE_LABELS: Record<Recurrence, string> = {
 
 export function useGoalTracker() {
   const [goals, setGoals] = useState<Goal[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(() => {
+    if (typeof window !== "undefined") {
+      try {
+        return !window.localStorage.getItem("devtrack:swr:goals");
+      } catch (e) {}
+    }
+    return true;
+  });
   const [syncing, setSyncing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -62,6 +69,26 @@ export function useGoalTracker() {
   const initialLoadDoneRef = useRef<boolean>(false);
 
   const loadGoals = useCallback(async () => {
+    const cacheKey = "devtrack:swr:goals";
+
+    if (typeof window !== "undefined") {
+      try {
+        const cached = window.localStorage.getItem(cacheKey);
+        if (cached) {
+          const parsed = JSON.parse(cached);
+          if (parsed && parsed.data) {
+            setGoals(parsed.data);
+            if (parsed.timestamp) {
+              setLastUpdated(new Date(parsed.timestamp));
+              setMinutesAgo(Math.floor((Date.now() - parsed.timestamp) / 60000));
+            }
+          }
+        }
+      } catch (e) {
+        // ignore
+      }
+    }
+
     const response = await fetch("/api/goals");
     if (!response.ok) {
       throw new Error(`Failed to load goals (HTTP ${response.status})`);
@@ -69,6 +96,13 @@ export function useGoalTracker() {
     const data: { goals: Goal[] } = await response.json();
     const fetchedGoals = data.goals ?? [];
     setGoals(fetchedGoals);
+    
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.setItem(cacheKey, JSON.stringify({ data: fetchedGoals, timestamp: Date.now() }));
+      } catch (e) {}
+    }
+    
     return fetchedGoals;
   }, []);
 

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -59,13 +59,38 @@ export default function PRMetrics() {
   const [staleThresholdDays, setStaleThresholdDays] = useState(14);
 
   const fetchMetrics = useCallback(() => {
-    setLoading(true);
-    setError(null);
-
     const url =
       selectedAccount !== null
         ? `/api/metrics/prs?accountId=${encodeURIComponent(selectedAccount)}&range=${range}`
         : `/api/metrics/prs?range=${range}`;
+
+    const cacheKey = `devtrack:swr:prs:${selectedAccount || 'default'}:${range}`;
+    let hasStale = false;
+
+    if (typeof window !== "undefined") {
+      try {
+        const cached = window.localStorage.getItem(cacheKey);
+        if (cached) {
+          const parsed = JSON.parse(cached);
+          if (parsed && parsed.data) {
+            setMetrics(parsed.data);
+            if (parsed.timestamp) {
+              setLastUpdated(new Date(parsed.timestamp));
+              setMinutesAgo(Math.floor((Date.now() - parsed.timestamp) / 60000));
+            }
+            setLoading(false);
+            hasStale = true;
+          }
+        }
+      } catch (e) {
+        // Ignore parsing errors or local storage disabled
+      }
+    }
+
+    if (!hasStale) {
+      setLoading(true);
+    }
+    setError(null);
 
     fetch(url)
       .then((r) => {
@@ -76,9 +101,23 @@ export default function PRMetrics() {
         setMetrics(data);
         setLastUpdated(new Date());
         setMinutesAgo(0);
+        
+        if (typeof window !== "undefined") {
+          try {
+            window.localStorage.setItem(cacheKey, JSON.stringify({ data, timestamp: Date.now() }));
+          } catch (e) {
+            // Ignore quota exceeded or storage disabled
+          }
+        }
       })
-      .catch(() => setError("We couldn't load your PR analytics right now. Please try again in a moment."))
-      .finally(() => setLoading(false));
+      .catch(() => {
+        if (!hasStale) {
+          setError("We couldn't load your PR analytics right now. Please try again in a moment.");
+        }
+      })
+      .finally(() => {
+        if (!hasStale) setLoading(false);
+      });
   }, [selectedAccount, range]);
 
   useEffect(() => {

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -83,7 +83,37 @@ export function useStreakTracker() {
   }, []);
 
   const fetchStreak = useCallback(async () => {
-    setLoading(true);
+    const cacheKeyStreak = `devtrack:swr:streak:${selectedAccount || 'default'}`;
+    const cacheKeyContrib = `devtrack:swr:contrib:${selectedAccount || 'default'}`;
+    let hasStale = false;
+
+    if (typeof window !== "undefined") {
+      try {
+        const cachedStreak = window.localStorage.getItem(cacheKeyStreak);
+        const cachedContrib = window.localStorage.getItem(cacheKeyContrib);
+        if (cachedStreak && cachedContrib) {
+          const parsedStreak = JSON.parse(cachedStreak);
+          const parsedContrib = JSON.parse(cachedContrib);
+          if (parsedStreak && parsedStreak.data && parsedContrib && parsedContrib.data) {
+            setData(parsedStreak.data);
+            setContributionData(parsedContrib.data);
+            setFreezeDates(parsedStreak.data.freezeDates || []);
+            if (parsedStreak.timestamp) {
+              setLastUpdated(new Date(parsedStreak.timestamp));
+              setMinutesAgo(Math.floor((Date.now() - parsedStreak.timestamp) / 60000));
+            }
+            setLoading(false);
+            hasStale = true;
+          }
+        }
+      } catch (e) {
+        // Ignore parsing errors or local storage disabled
+      }
+    }
+
+    if (!hasStale) {
+      setLoading(true);
+    }
     setError(null);
 
     try {
@@ -111,13 +141,25 @@ export function useStreakTracker() {
       setData(streakData);
       setContributionData(contribData);
       setFreezeDates(streakData.freezeDates || []);
-    } catch (err) {
-      console.error("Failed to fetch streak data:", err);
-      setError("We couldn't load your streak data right now. Please try again in a moment.");
-    } finally {
-      setLoading(false);
+      
       setLastUpdated(new Date());
       setMinutesAgo(0);
+
+      if (typeof window !== "undefined") {
+        try {
+          window.localStorage.setItem(cacheKeyStreak, JSON.stringify({ data: streakData, timestamp: Date.now() }));
+          window.localStorage.setItem(cacheKeyContrib, JSON.stringify({ data: contribData, timestamp: Date.now() }));
+        } catch (e) {
+          // Ignore quota exceeded or storage disabled
+        }
+      }
+    } catch (err) {
+      console.error("Failed to fetch streak data:", err);
+      if (!hasStale) {
+        setError("We couldn't load your streak data right now. Please try again in a moment.");
+      }
+    } finally {
+      if (!hasStale) setLoading(false);
     }
   }, [selectedAccount]);
 


### PR DESCRIPTION
Fixes #2801 

### Description
Implemented a lightweight client-side data resiliency layer using a Stale-While-Revalidate (SWR) model for the core dashboard widgets. 

This ensures that if a developer works on a spotty local network or encounters GitHub API rate-limits, the dashboard avoids crashing or showing endless loading spinners by instantly hydrating from a local snapshot while syncing live data in the background.

### Changes Made
- **PRMetrics, StreakTracker, and GoalTracker**: Intercepted incoming API dashboard metrics payloads.
- Added `localStorage` caching with timestamps.
- Implemented immediate UI hydration on load using the saved snapshot.
- Added silent background fetching to fetch live data and overwrite the stale snapshot without disrupting the user layout.
- Handled errors gracefully so the dashboard doesn't crash if `localStorage` is completely empty or disabled.

### Testing
- Tested locally by simulating an "Offline" network in Chrome DevTools.
- Verified that widgets instantly display cached data on hard refresh.
- Confirmed that failed background requests are quietly swallowed, preventing UI crashes.
