### PR TITLE
feat(ui): add reusable copy-to-clipboard component with success anima…

### DIFF
--- a/src/app/dashboard/RoastHypeWidget.tsx
+++ b/src/app/dashboard/RoastHypeWidget.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from 'react';
-import { Copy, Sparkles, Flame } from 'lucide-react';
+import { Sparkles, Flame } from 'lucide-react';
+import CopyToClipboardButton from '@/components/CopyToClipboardButton';
 
 interface UserStats {
   commits: number;
@@ -14,12 +15,14 @@ export default function RoastHypeWidget({ stats }: { stats: UserStats }) {
   const [mode, setMode] = useState<'roast' | 'hype'>('hype');
   const [loading, setLoading] = useState(false);
   const [output, setOutput] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+
+  const shareText = output
+    ? `DevTrack ${mode === 'hype' ? 'Hype' : 'Roast'}:\n"${output}"\n\nTrack your stats at devtrack.app! 🚀`
+    : "";
 
   const generateContent = async () => {
     setLoading(true);
     setOutput(null);
-    setCopied(false);
 
     try {
       const response = await fetch('/api/ai/roast', {
@@ -39,14 +42,6 @@ export default function RoastHypeWidget({ stats }: { stats: UserStats }) {
       setOutput('Network error. Check your connection.');
     } finally {
       setLoading(false);
-    }
-  };
-
-  const copyToClipboard = () => {
-    if (output) {
-      navigator.clipboard.writeText(`DevTrack ${mode === 'hype' ? 'Hype' : 'Roast'}:\n"${output}"\n\nTrack your stats at devtrack.app! 🚀`);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     }
   };
 
@@ -93,17 +88,15 @@ export default function RoastHypeWidget({ stats }: { stats: UserStats }) {
       {output && (
         <div className="mt-5 p-4 bg-[var(--background)] border border-[var(--border)] rounded-lg relative group">
           <p className="text-[var(--foreground)] pr-6 text-sm italic">&ldquo;{output}&rdquo;</p>
-          <button
-            onClick={copyToClipboard}
-            className="absolute top-3 right-3 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
-            title="Copy to clipboard"
-          >
-            {copied ? (
-              <span className="text-[10px] text-green-500 font-bold uppercase tracking-wider">Copied!</span>
-            ) : (
-              <Copy size={16} />
-            )}
-          </button>
+          <CopyToClipboardButton
+            value={shareText}
+            iconOnly
+            variant="ghost"
+            size="icon"
+            className="absolute top-2 right-2 h-8 w-8 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            ariaLabel="Copy to clipboard"
+            copiedLabel="Copied!"
+          />
         </div>
       )}
     </div>

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -16,7 +16,6 @@ import WebhookManager from "@/components/webhook/WebhookManager";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import CopyToClipboardButton from "@/components/CopyToClipboardButton";
-import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 import { useLocale, useTranslations } from "next-intl";
 import { localeMetadata, locales, type AppLocale } from "@/i18n/config";
 

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -15,6 +15,8 @@ import { useRouter } from "next/navigation";
 import WebhookManager from "@/components/webhook/WebhookManager";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 import { useLocale, useTranslations } from "next-intl";
 import { localeMetadata, locales, type AppLocale } from "@/i18n/config";
 
@@ -178,7 +180,6 @@ function SettingsPageContent() {
   const [saving, setSaving] = useState(false);
   const [webhookUrl, setWebhookUrl] = useState<string | null>(null);
   const [webhookSaving, setWebhookSaving] = useState(false);
-  const [copied, setCopied] = useState(false);
   const [removeError, setRemoveError] = useState<string | null>(null);
   const [accountsError, setAccountsError] = useState<string | null>(null);
   const [removingAccountId, setRemovingAccountId] = useState<string | null>(
@@ -197,7 +198,6 @@ function SettingsPageContent() {
   const [testingDiscord, setTestingDiscord] = useState(false);
   const [discordMutedUntil, setDiscordMutedUntil] = useState<string | null>(null);
   const [muteDuration, setMuteDuration] = useState<number>(1);
-  const copyResetTimerRef = useRef<number | null>(null);
 
   // GitHub Orgs States
   const [orgAccounts, setOrgAccounts] = useState<any[]>([]);
@@ -789,32 +789,6 @@ function SettingsPageContent() {
     }
   };
 
-  const copyShareLink = () => {
-    if (!profileUrl) return;
-
-    if (copyResetTimerRef.current) {
-      window.clearTimeout(copyResetTimerRef.current);
-      copyResetTimerRef.current = null;
-    }
-
-    if (!navigator.clipboard?.writeText) {
-      toast.error("Clipboard access is not available in this browser.");
-      return;
-    }
-
-    navigator.clipboard.writeText(profileUrl).then(() => {
-      setCopied(true);
-      toast.success("Link copied successfully!");
-      copyResetTimerRef.current = window.setTimeout(() => {
-        setCopied(false);
-        copyResetTimerRef.current = null;
-      }, 2000);
-    }).catch((err) => {
-      console.error("Clipboard copy failed:", err);
-      toast.error("Failed to copy profile URL");
-    });
-  };
-
   const handleRemoveAccount = async (githubId: string) => {
     setRemoveError(null);
     setRemovingAccountId(githubId);
@@ -969,15 +943,18 @@ function SettingsPageContent() {
                 aria-label="Public profile URL"
                 className="min-w-0 flex-1 rounded-xl border border-[var(--border)] bg-[var(--control)] px-4 py-2 text-sm text-[var(--card-foreground)] outline-none transition-colors focus:border-[var(--accent)]"
               />
-              <Button
-                type="button"
-                onClick={copyShareLink}
+              <CopyToClipboardButton
+                value={profileUrl}
+                label="Copy"
+                copiedLabel="Copied!"
                 variant="secondary"
                 className="w-full sm:w-auto"
-                aria-label="Copy public profile URL"
-              >
-                {copied ? "Copied!" : "Copy"}
-              </Button>
+                showToast
+                successMessage="Link copied successfully!"
+                errorMessage="Failed to copy profile URL"
+                ariaLabel="Copy public profile URL"
+                disabled={!profileUrl}
+              />
             </div>
             {!settings.is_public && (
               <p className="mt-3 text-sm text-[var(--muted-foreground)]">

--- a/src/components/BadgeSection.tsx
+++ b/src/components/BadgeSection.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import Image from "next/image";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 
 interface BadgeSectionProps {
   username: string;
@@ -137,30 +138,20 @@ function Toast({ visible }: { visible: boolean }) {
  * Copyable code block component
  */
 function CopyableCodeBlock({ code, onCopySuccess }: { code: string; onCopySuccess?: () => void }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setCopied(true);
-      onCopySuccess?.();
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy:", err);
-    }
-  };
-
   return (
     <div className="flex items-center justify-between rounded-lg bg-[var(--control)] p-3 border border-[var(--border)]">
       <code className="flex-1 text-xs text-[var(--card-foreground)] overflow-auto scrollbar-thin">
         {code}
       </code>
-      <button
-        onClick={handleCopy}
-        className="ml-2 shrink-0 px-2 py-1 text-xs font-medium rounded bg-[var(--accent)] text-[var(--accent-foreground)] hover:opacity-90 transition-opacity"
-      >
-        {copied ? "✓ Copied!" : "Copy"}
-      </button>
+      <CopyToClipboardButton
+        value={code}
+        label="Copy"
+        copiedLabel="Copied!"
+        size="sm"
+        className="ml-2 shrink-0 px-2 py-1 text-xs h-auto"
+        onCopied={onCopySuccess}
+        ariaLabel="Copy badge markdown"
+      />
     </div>
   );
 }

--- a/src/components/CopyLinkButton.tsx
+++ b/src/components/CopyLinkButton.tsx
@@ -1,56 +1,24 @@
 "use client";
 
-import { useState } from "react";
-import { toast } from "sonner";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 
 interface CopyLinkButtonProps {
   url: string;
 }
 
 export default function CopyLinkButton({ url }: CopyLinkButtonProps) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    // Fallback strategy for older browsers
-    if (!navigator.clipboard) {
-      const textArea = document.createElement("textarea");
-      textArea.value = url;
-      document.body.appendChild(textArea);
-      textArea.select();
-      try {
-        document.execCommand("copy");
-        triggerSuccess();
-      } catch (err) {
-        toast.error("Failed to copy link.");
-      }
-      document.body.removeChild(textArea);
-      return;
-    }
-
-    // Modern browser copying execution
-    try {
-      await navigator.clipboard.writeText(url);
-      triggerSuccess();
-    } catch (err) {
-      toast.error("Failed to copy link.");
-    }
-  };
-
-  const triggerSuccess = () => {
-    setCopied(true);
-    toast.success("Link copied!", { duration: 2000 });
-    setTimeout(() => setCopied(false), 2000);
-  };
-
   return (
-    <button
-      onClick={handleCopy}
-      type="button"
-      aria-label="Copy profile link"
-      title="Copy profile link"
-      className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-md border border-gray-300 bg-white text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-700"
-    >
-      <span>{copied ? "Copied!" : "Copy link"}</span>
-    </button>
+    <CopyToClipboardButton
+      value={url}
+      label="Copy link"
+      copiedLabel="Copied!"
+      variant="outline"
+      size="sm"
+      showToast
+      successMessage="Link copied!"
+      errorMessage="Failed to copy link."
+      ariaLabel="Copy profile link"
+      className="text-xs font-medium"
+    />
   );
 }

--- a/src/components/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { cn } from "@/lib/utils";
+
+export interface CopyToClipboardButtonProps
+  extends Omit<ButtonProps, "onClick" | "children"> {
+  value: string;
+  label?: string;
+  copiedLabel?: string;
+  iconOnly?: boolean;
+  showToast?: boolean;
+  resetDelay?: number;
+  successMessage?: string;
+  errorMessage?: string;
+  ariaLabel?: string;
+  onCopied?: () => void;
+}
+
+export default function CopyToClipboardButton({
+  value,
+  label = "Copy",
+  copiedLabel = "Copied!",
+  iconOnly = false,
+  showToast = false,
+  resetDelay = 2500,
+  successMessage,
+  errorMessage,
+  ariaLabel,
+  onCopied,
+  className,
+  variant = "outline",
+  size,
+  disabled,
+  ...buttonProps
+}: CopyToClipboardButtonProps) {
+  const { copy, copied } = useCopyToClipboard({
+    resetDelay,
+    showToast,
+    successMessage,
+    errorMessage,
+    onSuccess: onCopied,
+  });
+
+  const resolvedSize = size ?? (iconOnly ? "icon" : "default");
+  const defaultAriaLabel = ariaLabel ?? label;
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={resolvedSize}
+      disabled={disabled || !value}
+      aria-live="polite"
+      aria-label={copied ? copiedLabel : defaultAriaLabel}
+      title={copied ? copiedLabel : defaultAriaLabel}
+      className={cn(
+        copied && "text-[var(--success)] border-[var(--success)]/30",
+        className,
+      )}
+      onClick={() => {
+        void copy(value);
+      }}
+      {...buttonProps}
+    >
+      {copied ? (
+        <>
+          <Check
+            className={cn(
+              "h-4 w-4 shrink-0 text-[var(--success)] animate-in zoom-in-50 duration-200",
+              iconOnly ? "" : "",
+            )}
+            aria-hidden="true"
+          />
+          {!iconOnly && <span>{copiedLabel}</span>}
+        </>
+      ) : (
+        <>
+          <Copy className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {!iconOnly && <span>{label}</span>}
+        </>
+      )}
+    </Button>
+  );
+}

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -8,6 +8,7 @@ import ConfirmModal from "@/components/ConfirmModal";
 import { buildPublicGoalShareUrl } from "@/lib/goals/share";
 import GoalHistory from "@/components/GoalHistory";
 import EmptyState from "@/components/EmptyState";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 
 
 type Recurrence = "none" | "weekly" | "monthly";
@@ -368,7 +369,6 @@ export default function GoalTracker() {
       ? (session as { githubLogin: string }).githubLogin
       : null;
 
-  const [copiedGoalId, setCopiedGoalId] = useState<string | null>(null);
   const [sharingGoalId, setSharingGoalId] = useState<string | null>(null);
   const [shareError, setShareError] = useState<string | null>(null);
 
@@ -397,31 +397,6 @@ export default function GoalTracker() {
       setShareError("Failed to update goal sharing. Please check your connection.");
     } finally {
       setSharingGoalId(null);
-    }
-  };
-
-  const copyGoalShareLink = async (goalId: string) => {
-    if (!githubLogin) {
-      setShareError("Unable to build share link for this account.");
-      return;
-    }
-
-    const shareUrl = buildPublicGoalShareUrl(
-      window.location.origin,
-      githubLogin,
-      goalId
-    );
-
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      setCopiedGoalId(goalId);
-      window.setTimeout(() => {
-        setCopiedGoalId((currentGoalId) =>
-          currentGoalId === goalId ? null : currentGoalId
-        );
-      }, 2000);
-    } catch {
-      setShareError("Failed to copy share link. Please copy it manually.");
     }
   };
 
@@ -734,14 +709,21 @@ export default function GoalTracker() {
                     </label>
                   </div>
 
-                  {goal.is_public && (
-                    <button
-                      type="button"
-                      onClick={() => copyGoalShareLink(goal.id)}
+                  {goal.is_public && githubLogin && (
+                    <CopyToClipboardButton
+                      value={buildPublicGoalShareUrl(
+                        window.location.origin,
+                        githubLogin,
+                        goal.id,
+                      )}
+                      label="Copy share link"
+                      copiedLabel="Copied!"
+                      variant="secondary"
+                      size="sm"
                       className="secondary-button mt-3 rounded-lg px-3 py-1.5 text-sm"
-                    >
-                      {copiedGoalId === goal.id ? "Copied!" : "Copy share link"}
-                    </button>
+                      ariaLabel={`Copy share link for ${goal.title}`}
+                      errorMessage="Failed to copy share link. Please copy it manually."
+                    />
                   )}
                 </div>
               </li>

--- a/src/components/ShareProfileButton.tsx
+++ b/src/components/ShareProfileButton.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { Link2, Check } from "lucide-react";
-import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 
 interface ShareProfileButtonProps {
   githubLogin: string;
@@ -12,42 +9,19 @@ interface ShareProfileButtonProps {
 export default function ShareProfileButton({
   githubLogin,
 }: ShareProfileButtonProps) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    try {
-      const baseUrl =
-        process.env.NEXT_PUBLIC_APP_URL ||
-        "https://devtrack-delta.vercel.app";
-
-      const profileUrl = `${baseUrl}/u/${githubLogin}`;
-
-      await navigator.clipboard.writeText(profileUrl);
-
-      setCopied(true);
-      toast.success("Link copied!");
-
-      setTimeout(() => {
-        setCopied(false);
-      }, 2000);
-    } catch {
-      toast.error("Failed to copy link");
-    }
-  };
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL || "https://devtrack-delta.vercel.app";
+  const profileUrl = `${baseUrl}/u/${githubLogin}`;
 
   return (
-    <Button onClick={handleCopy}>
-      {copied ? (
-        <>
-          <Check className="mr-2 h-4 w-4" />
-          Copied
-        </>
-      ) : (
-        <>
-          <Link2 className="mr-2 h-4 w-4" />
-          Share Profile
-        </>
-      )}
-    </Button>
+    <CopyToClipboardButton
+      value={profileUrl}
+      label="Share Profile"
+      copiedLabel="Copied"
+      showToast
+      successMessage="Link copied!"
+      errorMessage="Failed to copy link"
+      ariaLabel="Share profile link"
+    />
   );
 }

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -8,9 +8,11 @@ import { useCountUp } from "@/hooks/useCountUp";
 import StreakMilestoneBanner from "@/components/StreakMilestoneBanner";
 import { useHeatmapTheme } from "@/hooks/useHeatmapTheme";
 import { toast } from "sonner";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { toPng } from "html-to-image";
-import { Flame, Trophy, Calendar, Zap, Copy, CheckCircle, Medal, Star, Sparkles } from "lucide-react";
+import { Flame, Trophy, Calendar, Zap, CheckCircle, Medal, Star, Sparkles } from "lucide-react";
 import ConfirmModal from "@/components/ConfirmModal";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 
 const DATA_WINDOW_DAYS = 90;
 const dataWindowLabel = `Last ${DATA_WINDOW_DAYS} days`;
@@ -47,7 +49,11 @@ export function useStreakTracker() {
   const [lastCelebratedMilestone, setLastCelebratedMilestone] = useState<number>(0);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
-  const [copied, setCopied] = useState(false);
+  const { copy, copied } = useCopyToClipboard({
+    showToast: true,
+    successMessage: "Streak stats copied to clipboard!",
+    errorMessage: "Failed to copy streak stats.",
+  });
   const [error, setError] = useState<string | null>(null);
   const [calendarMonth, setCalendarMonth] = useState(new Date());
   const [freeze, setFreeze] = useState<FreezeData | null>(null);
@@ -294,23 +300,7 @@ export function useStreakTracker() {
       `Active days: ${data.totalActiveDays}`,
     ].join("\n");
 
-    if (typeof navigator === "undefined" || !navigator.clipboard) {
-      toast.error("Clipboard is not supported in this browser.");
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(textToCopy);
-
-      setCopied(true);
-
-      toast.success("Streak stats copied to clipboard!");
-
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy streak stats:", err);
-      toast.error("Failed to copy streak stats.");
-    }
+    await copy(textToCopy);
   };
 
   // -------------------------------------------------------------------------
@@ -349,7 +339,6 @@ export function useStreakTracker() {
     lastUpdated,
     minutesAgo,
     copied,
-    setCopied,
     error,
     setError,
     calendarMonth,
@@ -397,8 +386,6 @@ export default function StreakTracker() {
     lastCelebratedMilestone,
     lastUpdated,
     minutesAgo,
-    copied,
-    setCopied,
     error,
     setError,
     calendarMonth,
@@ -424,7 +411,6 @@ export default function StreakTracker() {
     currentMilestone,
     shouldShowBanner,
     handleDismissBanner,
-    handleCopy,
   } = useStreakTracker();
 
   const { setSummary, setIsUpdating } = useDashboardWidgetA11y("streak-tracker");
@@ -577,18 +563,23 @@ export default function StreakTracker() {
       <div className="relative">
         {data && (
           <div className="absolute top-6 right-6 flex items-center gap-2 z-10">
-            <button
-              type="button"
-              onClick={handleCopy}
-              className="cursor-pointer flex h-8 items-center justify-center rounded-md px-2 text-sm text-[var(--muted-foreground)] hover:bg-[var(--control)] hover:text-[var(--card-foreground)] transition-colors"
-              aria-label="Copy streak stats to clipboard"
-            >
-              {copied ? (
-                <span className="text-xs font-medium text-[var(--success)]">Copied!</span>
-              ) : (
-                <Copy size={16} className="opacity-80 hover:opacity-100" />
-              )}
-            </button>
+            <CopyToClipboardButton
+              value={[
+                "🔥 DevTrack Stats",
+                `Current streak: ${data.current} days`,
+                `Longest streak: ${data.longest} days`,
+                `Active days: ${data.totalActiveDays}`,
+              ].join("\n")}
+              iconOnly
+              showToast
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-[var(--muted-foreground)] hover:bg-[var(--control)] hover:text-[var(--card-foreground)]"
+              successMessage="Streak stats copied to clipboard!"
+              errorMessage="Failed to copy streak stats."
+              ariaLabel="Copy streak stats to clipboard"
+              copiedLabel="Copied!"
+            />
             <button
               type="button"
               onClick={handleDownload}

--- a/src/components/WeeklySummaryCard.tsx
+++ b/src/components/WeeklySummaryCard.tsx
@@ -1,9 +1,10 @@
 ﻿"use client";
 
-import { Check, ChevronDown, Copy, Download, Sparkles } from "lucide-react";
+import { ChevronDown, Download, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAccount } from "@/components/AccountContext";
 import { signOut } from "next-auth/react";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 
 interface WeeklySummaryData {
   commits: {
@@ -34,7 +35,6 @@ interface AiSummaryState {
   loading: boolean;
   error: string | null;
   rateLimitReset: Date | null;
-  copied: boolean;
 }
 
 export default function WeeklySummaryCard() {
@@ -50,7 +50,6 @@ export default function WeeklySummaryCard() {
     loading: false,
     error: null,
     rateLimitReset: null,
-    copied: false,
   });
 
   const maxCommits = summary?.commits
@@ -201,14 +200,6 @@ ${ai.text ? `\nAI Summary\n----------\n${ai.text}` : ""}
       });
   }, [summary, ai.loading]);
 
-  const handleCopy = useCallback(() => {
-    if (!ai.text) return;
-    navigator.clipboard.writeText(ai.text).then(() => {
-      setAi((prev) => ({ ...prev, copied: true }));
-      setTimeout(() => setAi((prev) => ({ ...prev, copied: false })), 2000);
-    });
-  }, [ai.text]);
-
   const rateLimitMessage = (() => {
     if (!ai.rateLimitReset) return null;
     const now = Date.now();
@@ -344,25 +335,16 @@ ${ai.text ? `\nAI Summary\n----------\n${ai.text}` : ""}
                     <Sparkles className="h-3.5 w-3.5" />
                     AI Summary
                   </span>
-                  <button
-                    type="button"
-                    onClick={handleCopy}
-                    className="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--border)] hover:text-[var(--card-foreground)]"
-                    aria-label="Copy AI summary to clipboard"
-                    title="Copy to clipboard"
-                  >
-                    {ai.copied ? (
-                      <>
-                        <Check className="h-3 w-3 text-[var(--success)]" />
-                        <span className="text-[var(--success)]">Copied</span>
-                      </>
-                    ) : (
-                      <>
-                        <Copy className="h-3 w-3" />
-                        <span>Copy</span>
-                      </>
-                    )}
-                  </button>
+                  <CopyToClipboardButton
+                    value={ai.text ?? ""}
+                    label="Copy"
+                    copiedLabel="Copied"
+                    iconOnly
+                    variant="ghost"
+                    size="sm"
+                    className="h-auto px-1.5 py-0.5 text-xs text-[var(--muted-foreground)] hover:bg-[var(--border)] hover:text-[var(--card-foreground)]"
+                    ariaLabel="Copy AI summary to clipboard"
+                  />
                 </div>
                 <p className="text-sm leading-relaxed text-[var(--card-foreground)]">
                   {ai.text}

--- a/src/components/career-intelligence/ExportPanel.tsx
+++ b/src/components/career-intelligence/ExportPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { useState } from "react";
-import { FileText, FileCode, Braces, Copy, Check, Download } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { FileText, FileCode, Braces, Download } from "lucide-react";
 import { cn } from "@/lib/utils";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 import type { ResumeContent, ExportFormat } from "@/types/cv-types";
 
 interface ExportPanelProps {
@@ -12,30 +13,20 @@ interface ExportPanelProps {
 
 export default function ExportPanel({ content, onExport }: ExportPanelProps) {
   const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
-  const [copied, setCopied] = useState(false);
 
-  const handleExport = async (format: ExportFormat) => {
-    setExportingFormat(format);
-    try {
-      await onExport(format);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setExportingFormat(null);
-    }
-  };
+  const resumeText = useMemo(() => {
+    const bulletText = content.bulletPoints.map((bp) => `- ${bp.text}`).join("\n");
+    const projectText = content.projectDescriptions
+      .map(
+        (p) =>
+          `### ${p.name}\n${p.description}\n${p.highlights.map((h) => `- ${h}`).join("\n")}`,
+      )
+      .join("\n\n");
+    const skillText = content.skills
+      .map((c) => `**${c.category}**: ${c.skills.join(", ")}`)
+      .join("\n");
 
-  const copyToClipboard = async () => {
-    try {
-      const bulletText = content.bulletPoints.map((bp) => `- ${bp.text}`).join("\n");
-      const projectText = content.projectDescriptions
-        .map((p) => `### ${p.name}\n${p.description}\n${p.highlights.map((h) => `- ${h}`).join("\n")}`)
-        .join("\n\n");
-      const skillText = content.skills
-        .map((c) => `**${c.category}**: ${c.skills.join(", ")}`)
-        .join("\n");
-
-      const textToCopy = `
+    return `
 # Resume: ${content.role}
 
 ## Professional Summary
@@ -50,13 +41,17 @@ ${projectText}
 ## Skills Summary
 ${content.skillSummary}
 ${skillText}
-      `.trim();
+    `.trim();
+  }, [content]);
 
-      await navigator.clipboard.writeText(textToCopy);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+  const handleExport = async (format: ExportFormat) => {
+    setExportingFormat(format);
+    try {
+      await onExport(format);
     } catch (err) {
-      console.error("Failed to copy resume content:", err);
+      console.error(err);
+    } finally {
+      setExportingFormat(null);
     }
   };
 
@@ -138,23 +133,14 @@ ${skillText}
       </div>
 
       <div className="flex justify-center">
-        <button
-          type="button"
-          onClick={copyToClipboard}
-          className="inline-flex items-center gap-2 whitespace-nowrap rounded-md text-sm font-semibold transition-colors border border-[var(--border)] bg-[var(--card)] hover:bg-[var(--card-muted)] text-[var(--foreground)] h-9 px-5 py-2"
-        >
-          {copied ? (
-            <>
-              <Check className="h-4 w-4 text-emerald-500" />
-              Copied to Clipboard!
-            </>
-          ) : (
-            <>
-              <Copy className="h-4 w-4" />
-              Copy Full Resume Text
-            </>
-          )}
-        </button>
+        <CopyToClipboardButton
+          value={resumeText}
+          label="Copy Full Resume Text"
+          copiedLabel="Copied to Clipboard!"
+          variant="outline"
+          className="h-9 px-5"
+          ariaLabel="Copy full resume text"
+        />
       </div>
     </div>
   );

--- a/src/components/career-intelligence/ResumePreview.tsx
+++ b/src/components/career-intelligence/ResumePreview.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { Edit2, Eye, Copy, Check, Info, Trash2, Plus } from "lucide-react";
+import { Edit2, Eye, Info, Trash2, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
+import CopyToClipboardButton from "@/components/CopyToClipboardButton";
 import type { ResumeContent, ResumeBulletPoint, ProjectDescription, SkillCategory } from "@/types/cv-types";
 
 interface ResumePreviewProps {
@@ -14,17 +15,30 @@ interface ResumePreviewProps {
 
 export default function ResumePreview({ content, onContentChange }: ResumePreviewProps) {
   const [isEditMode, setIsEditMode] = useState(false);
-  const [copiedSection, setCopiedSection] = useState<string | null>(null);
 
-  const handleCopySection = async (sectionName: string, text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedSection(sectionName);
-      setTimeout(() => setCopiedSection(null), 2000);
-    } catch (err) {
-      console.error("Failed to copy section:", err);
-    }
-  };
+  const experienceText = useMemo(
+    () => content.bulletPoints.map((bp) => `- ${bp.text}`).join("\n"),
+    [content.bulletPoints],
+  );
+
+  const projectsText = useMemo(
+    () =>
+      content.projectDescriptions
+        .map(
+          (p) =>
+            `### ${p.name}\n${p.description}\n${p.highlights.map((h) => `- ${h}`).join("\n")}`,
+        )
+        .join("\n\n"),
+    [content.projectDescriptions],
+  );
+
+  const skillsText = useMemo(
+    () =>
+      `${content.skillSummary}\n\n${content.skills
+        .map((c) => `${c.category}: ${c.skills.join(", ")}`)
+        .join("\n")}`,
+    [content.skillSummary, content.skills],
+  );
 
   // State update helpers
   const updateSummary = (newSummary: string) => {
@@ -191,14 +205,14 @@ export default function ResumePreview({ content, onContentChange }: ResumePrevie
             <TabsContent value="summary" className="space-y-4">
               <div className="flex justify-between items-center">
                 <h4 className="text-sm font-bold text-[var(--foreground)]">Professional Summary</h4>
-                <button
-                  type="button"
-                  onClick={() => handleCopySection("summary", content.professionalSummary)}
-                  className="p-1 rounded hover:bg-[var(--card-muted)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-                  title="Copy Section"
-                >
-                  {copiedSection === "summary" ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
-                </button>
+                <CopyToClipboardButton
+                  value={content.professionalSummary}
+                  iconOnly
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 p-1 text-[var(--muted-foreground)] hover:bg-[var(--card-muted)] hover:text-[var(--foreground)]"
+                  ariaLabel="Copy professional summary section"
+                />
               </div>
 
               {isEditMode ? (
@@ -220,19 +234,14 @@ export default function ResumePreview({ content, onContentChange }: ResumePrevie
             <TabsContent value="experience" className="space-y-6">
               <div className="flex justify-between items-center">
                 <h4 className="text-sm font-bold text-[var(--foreground)]">Experience Bullet Points</h4>
-                <button
-                  type="button"
-                  onClick={() =>
-                    handleCopySection(
-                      "experience",
-                      content.bulletPoints.map((bp) => `- ${bp.text}`).join("\n")
-                    )
-                  }
-                  className="p-1 rounded hover:bg-[var(--card-muted)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-                  title="Copy All Bullets"
-                >
-                  {copiedSection === "experience" ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
-                </button>
+                <CopyToClipboardButton
+                  value={experienceText}
+                  iconOnly
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 p-1 text-[var(--muted-foreground)] hover:bg-[var(--card-muted)] hover:text-[var(--foreground)]"
+                  ariaLabel="Copy experience bullet points section"
+                />
               </div>
 
               <div className="space-y-4">
@@ -319,24 +328,14 @@ export default function ResumePreview({ content, onContentChange }: ResumePrevie
             <TabsContent value="projects" className="space-y-6">
               <div className="flex justify-between items-center">
                 <h4 className="text-sm font-bold text-[var(--foreground)]">Project Highlights</h4>
-                <button
-                  type="button"
-                  onClick={() =>
-                    handleCopySection(
-                      "projects",
-                      content.projectDescriptions
-                        .map(
-                          (p) =>
-                            `### ${p.name}\n${p.description}\n${p.highlights.map((h) => `- ${h}`).join("\n")}`
-                        )
-                        .join("\n\n")
-                    )
-                  }
-                  className="p-1 rounded hover:bg-[var(--card-muted)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-                  title="Copy All Projects"
-                >
-                  {copiedSection === "projects" ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
-                </button>
+                <CopyToClipboardButton
+                  value={projectsText}
+                  iconOnly
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 p-1 text-[var(--muted-foreground)] hover:bg-[var(--card-muted)] hover:text-[var(--foreground)]"
+                  ariaLabel="Copy project highlights section"
+                />
               </div>
 
               <div className="space-y-6">
@@ -442,22 +441,14 @@ export default function ResumePreview({ content, onContentChange }: ResumePrevie
             <TabsContent value="skills" className="space-y-6">
               <div className="flex justify-between items-center">
                 <h4 className="text-sm font-bold text-[var(--foreground)]">Technical Skills & Categories</h4>
-                <button
-                  type="button"
-                  onClick={() =>
-                    handleCopySection(
-                      "skills",
-                      `${content.skillSummary}\n\n` +
-                        content.skills
-                          .map((c) => `${c.category}: ${c.skills.join(", ")}`)
-                          .join("\n")
-                    )
-                  }
-                  className="p-1 rounded hover:bg-[var(--card-muted)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-                  title="Copy Skills"
-                >
-                  {copiedSection === "skills" ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
-                </button>
+                <CopyToClipboardButton
+                  value={skillsText}
+                  iconOnly
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 p-1 text-[var(--muted-foreground)] hover:bg-[var(--card-muted)] hover:text-[var(--foreground)]"
+                  ariaLabel="Copy skills section"
+                />
               </div>
 
               <div className="space-y-4">

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { copyTextToClipboard } from "@/lib/copy-to-clipboard";
+
+export interface UseCopyToClipboardOptions {
+  resetDelay?: number;
+  showToast?: boolean;
+  successMessage?: string;
+  errorMessage?: string;
+  onSuccess?: () => void;
+}
+
+export function useCopyToClipboard({
+  resetDelay = 2500,
+  showToast = false,
+  successMessage = "Copied to clipboard!",
+  errorMessage = "Failed to copy to clipboard.",
+  onSuccess,
+}: UseCopyToClipboardOptions = {}) {
+  const [copied, setCopied] = useState(false);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const resetTimerRef = useRef<number | null>(null);
+
+  const clearResetTimer = useCallback(() => {
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearResetTimer, [clearResetTimer]);
+
+  const resetCopiedState = useCallback(() => {
+    setCopied(false);
+    setCopiedId(null);
+  }, []);
+
+  const copy = useCallback(
+    async (text: string, id?: string) => {
+      clearResetTimer();
+
+      try {
+        await copyTextToClipboard(text);
+        setCopied(true);
+        setCopiedId(id ?? null);
+
+        if (showToast) {
+          toast.success(successMessage, { duration: resetDelay });
+        }
+
+        onSuccess?.();
+
+        resetTimerRef.current = window.setTimeout(() => {
+          resetCopiedState();
+          resetTimerRef.current = null;
+        }, resetDelay);
+
+        return true;
+      } catch {
+        toast.error(errorMessage);
+        resetCopiedState();
+        return false;
+      }
+    },
+    [
+      clearResetTimer,
+      errorMessage,
+      resetCopiedState,
+      resetDelay,
+      showToast,
+      successMessage,
+      onSuccess,
+    ],
+  );
+
+  const isCopied = useCallback(
+    (id?: string) => {
+      if (!copied) return false;
+      if (id === undefined) return true;
+      return copiedId === id;
+    },
+    [copied, copiedId],
+  );
+
+  return {
+    copy,
+    copied,
+    copiedId,
+    isCopied,
+    resetCopiedState,
+  };
+}

--- a/src/lib/copy-to-clipboard.ts
+++ b/src/lib/copy-to-clipboard.ts
@@ -1,0 +1,39 @@
+export class CopyToClipboardError extends Error {
+  constructor(message = "Failed to copy to clipboard.") {
+    super(message);
+    this.name = "CopyToClipboardError";
+  }
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Fall through to legacy copy when clipboard API is blocked.
+    }
+  }
+
+  if (typeof document === "undefined") {
+    throw new CopyToClipboardError();
+  }
+
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.opacity = "0";
+  textArea.style.pointerEvents = "none";
+  document.body.appendChild(textArea);
+  textArea.select();
+
+  try {
+    const copied = document.execCommand("copy");
+    if (!copied) {
+      throw new CopyToClipboardError();
+    }
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}

--- a/test/copy-to-clipboard.test.ts
+++ b/test/copy-to-clipboard.test.ts
@@ -1,0 +1,112 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import {
+  CopyToClipboardError,
+  copyTextToClipboard,
+} from "@/lib/copy-to-clipboard";
+
+describe("copyTextToClipboard", () => {
+  beforeEach(() => {
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes text with the clipboard API", async () => {
+    const writeText = vi.spyOn(window.navigator.clipboard, "writeText");
+
+    await copyTextToClipboard("hello world");
+
+    expect(writeText).toHaveBeenCalledWith("hello world");
+  });
+
+  it("falls back to execCommand when clipboard API fails", async () => {
+    vi.spyOn(window.navigator.clipboard, "writeText").mockRejectedValue(
+      new Error("blocked"),
+    );
+
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await copyTextToClipboard("fallback text");
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("throws CopyToClipboardError when fallback copy fails", async () => {
+    vi.spyOn(window.navigator.clipboard, "writeText").mockRejectedValue(
+      new Error("blocked"),
+    );
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn().mockReturnValue(false),
+    });
+
+    await expect(copyTextToClipboard("fail")).rejects.toBeInstanceOf(
+      CopyToClipboardError,
+    );
+  });
+});
+
+describe("useCopyToClipboard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("marks copied true after a successful copy", async () => {
+    const { result } = renderHook(() => useCopyToClipboard({ resetDelay: 2500 }));
+
+    await act(async () => {
+      await result.current.copy("profile link");
+    });
+
+    expect(result.current.copied).toBe(true);
+  });
+
+  it("resets copied state after resetDelay", async () => {
+    const { result } = renderHook(() => useCopyToClipboard({ resetDelay: 2500 }));
+
+    await act(async () => {
+      await result.current.copy("profile link");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("tracks copiedId when an id is provided", async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy("goal link", "goal-1");
+    });
+
+    expect(result.current.isCopied("goal-1")).toBe(true);
+    expect(result.current.isCopied("goal-2")).toBe(false);
+  });
+});


### PR DESCRIPTION
Introduce shared clipboard utility, hook, and CopyToClipboardButton with checkmark feedback and a 2.5s Copied state. Migrate existing copy actions across profile sharing, settings, goals, streaks, and career tools.

## Summary

Adds a reusable copy-to-clipboard system with consistent visual feedback (Copy → checkmark animation + temporary "Copied!" state). Replaces 10+ ad-hoc clipboard implementations across the app so profile links, share actions, and content copies behave the same way.

Closes #1937 

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- Added `src/lib/copy-to-clipboard.ts` — shared clipboard API with `execCommand` fallback
- Added `src/hooks/useCopyToClipboard.ts` — copied state (2.5s reset), optional toast, per-id tracking, `onSuccess` callback
- Added `src/components/CopyToClipboardButton.tsx` — reusable button with Copy/Check icons, `aria-live`, and optional `showToast`
- Refactored `src/components/CopyLinkButton.tsx` — thin wrapper preserving existing `url` prop API
- Migrated copy actions in: `ShareProfileButton`, dashboard settings page, `WeeklySummaryCard`, `StreakTracker`, `GoalTracker`, `BadgeSection`, `ExportPanel`, `ResumePreview`, `RoastHypeWidget`
- Added `test/copy-to-clipboard.test.ts` — utility + hook tests

---

## How to Test

1. Run unit tests: `npm test test/copy-to-clipboard.test.ts`
2. Open `/dashboard` → click **Share Profile** in the header — confirm checkmark + "Copied" for ~2.5s (toast optional)
3. Visit **Settings** → public profile URL **Copy**, and a public profile `/u/[username]` **Copy link** — same feedback pattern
4. Test other migrated surfaces: goal share link, streak copy button, AI summary copy, roast/hype output copy, resume export copy

**Expected result:** Every copy action shows a checkmark animation and temporary success state. Optional toasts appear only where `showToast` is enabled (e.g. profile share, settings, streak stats). No duplicate or inconsistent "Copied" UI.

---

## Screenshots / Recordings

Recommended: short screen recording of Share Profile → Copied state, and one icon-only copy (e.g. streak or AI summary).

| Before | After |
|--------|-------|
| Mixed copy feedback (text-only, icons, toasts, inconsistent timing) | Unified Copy → Check animation + 2.5s "Copied!" state |

---

## Checklist

- [ ] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`) — pre-existing failure: missing `@google/generative-ai` in unrelated file
- [x] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly — uses standard `Button` component
- [x] Color contrast meets WCAG AA standard — success state uses `var(--success)`
- [x] ARIA labels / roles added where needed — `aria-live="polite"`, dynamic `aria-label` on copy/copied
- [ ] Tested on mobile / responsive layout

---

## Additional Context

- `CopyLinkButton` API is unchanged for existing consumers (`ShareProfileSection`, public profile page).
- Toast notifications are **optional** (`showToast` prop, default `false`); enabled where they existed before (profile share, settings, streak copy).
- `useCopyToClipboard` supports per-item tracking via `copy(text, id)` for list UIs like goal share links.