### PR TITLE
feat(Dashboard): Implement client-side workspace layout preferences and persistent state serialization (#2802)

### DIFF
--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -2,6 +2,7 @@
 import SectionHeader from "./SectionHeader";
 
 import { useCallback, useEffect, useState } from "react";
+import { usePersistentState } from "@/hooks/usePersistentState";
 import { useAccount } from "@/components/AccountContext";
 import { useDashboardWidgetA11y } from "@/components/dashboard/DashboardWidgetA11yContext";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
@@ -53,10 +54,10 @@ export default function PRMetrics() {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"authored" | "reviews">("authored");
-  const [prFilter, setPrFilter] = useState<"all" | "merged" | "open">("all");
-  const [range, setRange] = useState<"7d" | "30d" | "90d">("30d");
-  const [staleThresholdDays, setStaleThresholdDays] = useState(14);
+  const [activeTab, setActiveTab] = usePersistentState<"authored" | "reviews">("devtrack:pr-metrics:activeTab", "authored");
+  const [prFilter, setPrFilter] = usePersistentState<"all" | "merged" | "open">("devtrack:pr-metrics:prFilter", "all");
+  const [range, setRange] = usePersistentState<"7d" | "30d" | "90d">("devtrack:pr-metrics:range", "30d");
+  const [staleThresholdDays, setStaleThresholdDays] = usePersistentState("devtrack:pr-metrics:staleThreshold", 14);
 
   const fetchMetrics = useCallback(() => {
     setLoading(true);

--- a/src/components/dashboard/CustomizableDashboard.tsx
+++ b/src/components/dashboard/CustomizableDashboard.tsx
@@ -626,6 +626,21 @@ export default function CustomizableDashboard() {
     setLayout(resetDashboardLayout());
   };
 
+  if (!isHydrated) {
+    return (
+      <div className="mt-10 px-0.5">
+        <div className="h-12 w-full mb-8 bg-[var(--card-muted)] rounded-lg animate-pulse" />
+        <div className="space-y-14">
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="mt-10 px-0.5">
       <DashboardLayoutToolbar

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * A custom hook that behaves like useState but persists the state in localStorage.
+ * It reads synchronously on the first render, preventing FOUC for components
+ * that are strictly rendered on the client side (e.g., dynamic components with ssr: false).
+ */
+export function usePersistentState<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T | ((val: T) => T)) => void] {
+  const [state, setState] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${key}":`, error);
+      return initialValue;
+    }
+  });
+
+  const setValue = useCallback(
+    (value: T | ((val: T) => T)) => {
+      try {
+        setState((prevState) => {
+          const valueToStore =
+            value instanceof Function ? value(prevState) : value;
+          if (typeof window !== "undefined") {
+            window.localStorage.setItem(key, JSON.stringify(valueToStore));
+          }
+          return valueToStore;
+        });
+      } catch (error) {
+        console.warn(`Error setting localStorage key "${key}":`, error);
+      }
+    },
+    [key]
+  );
+
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === key && e.newValue) {
+        try {
+          setState(JSON.parse(e.newValue));
+        } catch {
+          // ignore parsing error
+        }
+      }
+    };
+    window.addEventListener("storage", handleStorageChange);
+    return () => window.removeEventListener("storage", handleStorageChange);
+  }, [key]);
+
+  return [state, setValue];
+}


### PR DESCRIPTION
## Summary

This PR implements a client-side layout serialization manager that persists visual workspace preferences (such as dashboard layout and specific widget tracking scopes) across browser sessions using `localStorage`. It also incorporates a smooth hydration strategy to prevent flash-of-unstyled-content (FOUC) layout shifts.

Closes #2802 

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [x] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **`src/hooks/usePersistentState.ts`**: Implemented a lightweight hook that wraps `useState` and safely serializes UI configuration state to the client's `localStorage` on the first render to avoid hydration mismatches.
- **`src/components/PRMetrics.tsx`**: Updated local widget configurations (such as active filtering scopes and default timeframes) to utilize the new persistent hook.
- **`src/components/dashboard/CustomizableDashboard.tsx`**: Refactored the initial mounting lifecycle to render an aesthetic skeleton layout until the client has hydrated local caching preferences, ensuring zero layout shift or FOUC when standard repository defaults temporarily render.

---

## How to Test

1. Navigate to your DevTrack dashboard and configure the **PR Analytics** widget by changing the range (e.g. from 30d to 90d) and active tabs.
2. In the **Customizable Dashboard** section, drag and drop several widgets to reorder them or hide specific panels.
3. Hard refresh the page in your browser.

**Expected result:** 
A skeleton loader will seamlessly appear for a brief moment, after which your exact dashboard grid and widget configuration states will immediately load without flashing the default configuration.

---

## Screenshots / Recordings

| Before | After |
|--------|-------|
| *(Widgets would flash in their default spots and settings would clear on refresh)* | *(Smooth skeleton loader transitioning instantly into the preserved layout)* |

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [ ] Keyboard navigation works correctly
- [ ] Color contrast meets WCAG AA standard
- [ ] ARIA labels / roles added where needed
- [ ] Tested on mobile / responsive layout

---

## Additional Context

Local client testing confirmed that reading from `localStorage` synchronously during the first client-side pass avoids hydration issues because the complex widget components are dynamically fetched without server-side rendering (`ssr: false`).
