### PR TITLE
fix: readable feature card descriptions by default

### DIFF
--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -744,7 +744,7 @@ function AboutHighlightCard({
         }}>
           {item.title}
         </h3>
-        <p style={{ color: MUTED, fontSize: 14, lineHeight: 1.65, margin: 0 }}>
+        <p style={{ color: 'var(--foreground)', opacity: 0.85, fontSize: 14, lineHeight: 1.65, margin: 0 }}>
           {item.desc}
         </p>
       </div>


### PR DESCRIPTION
## Fix: Feature card descriptions now readable without hover

Closes #2317

### Problem
Description text in About DevTrack feature cards used `var(--muted-foreground)` which has very low contrast against dark card backgrounds. Text only became legible on hover.

### Fix
Changed from `color: MUTED` to `color: var(--foreground), opacity: 0.85` — readable by default, hover state unchanged.

### Ponytail
One-line style swap. Root cause: MUTED token too dim on dark cards.