### PR TITLE
test : added unit tests for repo-analytics-utils.ts parseRepoParam

### DIFF
--- a/test/repo-analytics-utils.test.ts
+++ b/test/repo-analytics-utils.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { parseRepoParam } from "@/lib/repo-analytics-utils";
+
+describe("repo-analytics-utils", () => {
+  describe("parseRepoParam", () => {
+    it("returns { owner, repo } for a valid owner/repo identifier", () => {
+      expect(parseRepoParam("owner/repo")).toEqual({ owner: "owner", repo: "repo" });
+    });
+
+    it("trims leading and trailing whitespace", () => {
+      expect(parseRepoParam("  owner/repo  ")).toEqual({ owner: "owner", repo: "repo" });
+    });
+
+    it("throws for null input (type signature is string, not string | null)", () => {
+      expect(() => parseRepoParam(null as any)).toThrow();
+    });
+
+    it("throws for undefined input (type signature is string, not string | null)", () => {
+      expect(() => parseRepoParam(undefined as any)).toThrow();
+    });
+
+    it("returns null for empty string", () => {
+      expect(parseRepoParam("")).toBeNull();
+    });
+
+    it("returns null for whitespace-only string", () => {
+      expect(parseRepoParam("   ")).toBeNull();
+    });
+
+    it("returns null for single-word identifier (no slash)", () => {
+      expect(parseRepoParam("justareponame")).toBeNull();
+    });
+
+    it("returns null for identifier with extra path segments", () => {
+      expect(parseRepoParam("owner/repo/extra")).toBeNull();
+    });
+
+    it("returns null for owner starting with hyphen", () => {
+      expect(parseRepoParam("-owner/repo")).toBeNull();
+    });
+
+    it("returns null for owner ending with hyphen", () => {
+      expect(parseRepoParam("owner-/repo")).toBeNull();
+    });
+
+    it("accepts repo name containing dots", () => {
+      expect(parseRepoParam("owner/repo.name")).toEqual({ owner: "owner", repo: "repo.name" });
+    });
+
+    it("accepts repo name containing hyphens", () => {
+      expect(parseRepoParam("owner/repo-name")).toEqual({ owner: "owner", repo: "repo-name" });
+    });
+
+    it("accepts repo name containing underscores", () => {
+      expect(parseRepoParam("owner/repo_name")).toEqual({ owner: "owner", repo: "repo_name" });
+    });
+
+    it("returns null when repo is '.'", () => {
+      expect(parseRepoParam("owner/.")).toBeNull();
+    });
+
+    it("returns null when repo is '..'", () => {
+      expect(parseRepoParam("owner/..")).toBeNull();
+    });
+
+    it("accepts owner with hyphens in the middle", () => {
+      expect(parseRepoParam("my-org/my-repo")).toEqual({ owner: "my-org", repo: "my-repo" });
+    });
+
+    it("returns null when owner exceeds 39 characters", () => {
+      const longOwner = "a".repeat(40) + "/repo";
+      expect(parseRepoParam(longOwner)).toBeNull();
+    });
+
+    it("accepts owner with exactly 39 characters", () => {
+      const maxOwner = "a".repeat(39) + "/repo";
+      expect(parseRepoParam(maxOwner)).toEqual({ owner: "a".repeat(39), repo: "repo" });
+    });
+
+    it("returns null when repo exceeds 100 characters", () => {
+      const longRepo = "owner/" + "r".repeat(101);
+      expect(parseRepoParam(longRepo)).toBeNull();
+    });
+
+    it("accepts repo with exactly 100 characters", () => {
+      const maxRepo = "owner/" + "r".repeat(100);
+      expect(parseRepoParam(maxRepo)).toEqual({ owner: "owner", repo: "r".repeat(100) });
+    });
+
+    it("accepts single-character owner and repo", () => {
+      expect(parseRepoParam("a/b")).toEqual({ owner: "a", repo: "b" });
+    });
+  });
+});


### PR DESCRIPTION
Closes #2938.

Summary of What Has Been Done:
Added comprehensive vitest unit tests for the pure repository identifier parser parseRepoParam() exported from src/lib/repo-analytics-utils.ts.

Changes Made:
- Created test/repo-analytics-utils.test.ts with 21 test cases.
- Tests verify: valid owner/repo returns { owner, repo }; leading and trailing whitespace is trimmed; null/undefined inputs throw (per the string type signature); empty string and whitespace-only strings return null; single-word identifiers (no slash) return null; identifiers with extra path segments return null; owner starting or ending with hyphen returns null; repo names containing dots, hyphens, and underscores are accepted; "." and ".." repo names return null; owner exceeding 39 characters returns null; owner with exactly 39 characters is accepted; repo exceeding 100 characters returns null; repo with exactly 100 characters is accepted; single-character owner and repo are accepted.

Impact it Made:
parseRepoParam is the first validation gate for all repository-identifier inputs in the repo analytics feature. Comprehensive tests ensure the regex-based parser correctly handles the full range of valid GitHub identifiers while rejecting malformed inputs at the boundary.