### PR TITLE
docs: Add FAQ section for contributors and users (Closes #2906)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [API Documentation](#api-documentation)
 - [Getting Started](#getting-started)
 - [Docker Development Setup](#docker-development-setup)
+- [FAQ](#faq)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [Community](#community)
@@ -377,6 +378,114 @@ View container logs:
 ```bash
 docker compose logs -f
 ```
+
+---
+
+## FAQ
+
+Answers to questions new contributors and self-hosters ask most often. For deeper setup detail, see [DEVELOPMENT.md](./DEVELOPMENT.md) and the [Self-Hosting Guide](./docs/self-hosting.md).
+
+<details>
+<summary><strong>How do I configure GitHub OAuth?</strong></summary>
+
+1. Go to [GitHub → Settings → Developer Settings → OAuth Apps](https://github.com/settings/applications/new) and create a new OAuth App.
+2. Set the **Authorization callback URL** to:
+   - Local dev: `http://localhost:3000/api/auth/callback/github`
+   - Production: `https://<your-domain>/api/auth/callback/github`
+3. Copy the generated **Client ID** and **Client Secret** into `GITHUB_ID` and `GITHUB_SECRET` in `.env.local`.
+4. Make sure `NEXTAUTH_URL` matches the base URL you're running on, and `NEXTAUTH_SECRET` is set (generate one with `openssl rand -base64 32`).
+
+</details>
+
+<details>
+<summary><strong>Why is login not working?</strong></summary>
+
+This is almost always one of the following:
+
+- **Callback URL mismatch** — the URL registered on your GitHub OAuth App must exactly match `NEXTAUTH_URL` + `/api/auth/callback/github`, including protocol and trailing slashes.
+- **Missing/incorrect `NEXTAUTH_SECRET`** — sessions will silently fail without it.
+- **Stale `.env.local`** — restart `pnpm dev` after changing any auth-related env vars; Next.js doesn't hot-reload env files.
+- **Supabase RLS blocking the user row** — check that the relevant migrations from `supabase/migrations/` have been applied in order.
+
+If the issue persists, check your browser console and terminal logs for the specific NextAuth error code, then search/open a [Discussion](https://github.com/Priyanshu-byte-coder/devtrack/discussions).
+
+</details>
+
+<details>
+<summary><strong>How do I obtain Supabase credentials?</strong></summary>
+
+1. Create a free project at [supabase.com](https://supabase.com).
+2. Open **Project Settings → API**.
+3. Copy:
+   - **Project URL** → `NEXT_PUBLIC_SUPABASE_URL`
+   - **anon public key** → `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - **service_role key** → `SUPABASE_SERVICE_ROLE_KEY` (server-side only — never expose this in client code or commit it)
+4. Run all SQL files in `supabase/migrations/` via the Supabase SQL editor, in order, before starting the app.
+
+</details>
+
+<details>
+<summary><strong>Why are GitHub metrics not loading?</strong></summary>
+
+- You're likely hitting **GitHub's unauthenticated API rate limit**. Set the optional `GITHUB_TOKEN` (a personal access token) in `.env.local` to raise the limit significantly.
+- Check that your GitHub OAuth scopes were granted during sign-in — if you denied a permission, re-authenticate by signing out and back in.
+- If you're self-hosting behind a proxy or firewall, confirm outbound requests to `api.github.com` aren't being blocked.
+- Look at the server logs/terminal for the specific API error (403 usually means rate-limited; 401 means a token problem).
+
+</details>
+
+<details>
+<summary><strong>How do I run tests?</strong></summary>
+
+```bash
+# Unit tests
+pnpm test
+
+# End-to-end tests (Playwright, first-time setup)
+npx playwright install --with-deps chromium
+pnpm run test:e2e
+
+# Run a single e2e spec
+npx playwright test e2e/goals.spec.ts
+
+# Visual regression tests
+npx playwright test -c playwright.visual.config.mjs
+```
+
+E2E tests use mocked external calls (no real GitHub/Supabase credentials needed) and also run automatically on every PR via `.github/workflows/e2e.yml`.
+
+</details>
+
+<details>
+<summary><strong>How can I contribute?</strong></summary>
+
+1. Browse [open issues](https://github.com/Priyanshu-byte-coder/devtrack/issues) and start with one labeled `good first issue`.
+2. Comment on the issue to get assigned before starting work.
+3. Fork the repo, branch off `main` (e.g. `feat/issue-42-description`), and open a PR.
+4. Before pushing, make sure CI passes locally:
+   ```bash
+   pnpm run lint && pnpm run type-check
+   ```
+5. See [CONTRIBUTING.md](./CONTRIBUTING.md) for commit message style, branch naming conventions, and the review process.
+
+Questions are welcome anytime in [Discussions](https://github.com/Priyanshu-byte-coder/devtrack/discussions).
+
+</details>
+
+<details>
+<summary><strong>Which Node.js and pnpm versions are supported?</strong></summary>
+
+| Tool | Version | Check |
+|------|---------|-------|
+| Node.js | >= 20 | `node -v` |
+| pnpm | >= 9 | `pnpm -v` |
+| Git | any | `git --version` |
+
+Install pnpm via `corepack enable` or `npm install -g pnpm` if you don't already have it.
+
+If your local versions differ and you hit install/build errors, aligning your Node.js/pnpm version with the table above is the first thing to check.
+
+</details>
 
 ---
 


### PR DESCRIPTION
## What this PR does

New contributors keep asking the same questions about setup, auth, deployment, and testing — this PR adds a dedicated **FAQ** section to the README so those answers live in one place instead of being repeated across issues and discussions.

Closes #2906

## Changes

- Added a new **FAQ** section in `README.md`, placed after *Docker Development Setup* and before *Roadmap*.
- Linked it in the Table of Contents.
- Used collapsible `<details>` blocks for each question so the README stays scannable instead of getting longer.
- Covered all the questions requested in the issue:
  - How do I configure GitHub OAuth?
  - Why is login not working?
  - How do I obtain Supabase credentials?
  - Why are GitHub metrics not loading?
  - How do I run tests?
  - How can I contribute?
  - Which Node.js and pnpm versions are supported?
- All answers are based on what's already documented in the README/DEVELOPMENT.md (env vars, OAuth steps, test commands, contributing flow) — nothing new was invented.
- Version table for Node.js/pnpm/Git matches current project requirements.

## Why this approach

A separate `docs/FAQ.md` was considered, but since most contributors land on the README first, keeping the FAQ there (collapsed by default) makes it more discoverable without cluttering the page.

## Testing

- Verified Markdown renders correctly in preview.
- Checked all internal links/anchors work.
- Confirmed no secrets, tokens, or sensitive info were added.

## Checklist

- [x] Follows existing README tone and formatting
- [x] No breaking changes
- [x] Ready for review