### PR TITLE
Add tooltip for average review time metric

### DIFF
--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -112,7 +112,11 @@ export default function PRMetrics() {
         label: "Lines Changed",
         value: `+${(source.totalAdditions ?? 0).toLocaleString()} / -${(source.totalDeletions ?? 0).toLocaleString()}`
       },
-      { label: labels.avgReview, value: `${source.avgReviewHours}h` },
+      {
+        label: `${labels.avgReview} ⓘ`,
+        value: `${source.avgReviewHours}h`,
+        title: "Average time from PR creation to close, based on your last 30 closed PRs",
+      },
       {
         label: labels.avgFirstReview,
         value: formatReviewCycle(source.avgFirstReviewHours),


### PR DESCRIPTION
## Summary

Adds an explanatory tooltip for the "Avg Review Time" metric in `PRMetrics.tsx` to clarify that it represents the average time from PR creation to close across recent PRs. Also adds a visible ⓘ indicator next to the metric label to improve discoverability of the tooltip.

Closes #43 

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [x] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- Added a tooltip description for the `Avg Review Time` metric using the existing `title` property support in `PRMetrics.tsx`.
- Added a visible `ⓘ` indicator next to the metric label to signal the presence of additional information.
- Reused the existing tooltip rendering pattern already used for `Avg First Review`, avoiding additional dependencies or UI components.

---

## How to Test

1. Navigate to the PR Analytics section.
2. Locate the `Avg Review Time ⓘ` metric card.
3. Hover over the card (or focus it via keyboard navigation).

**Expected result:**

A tooltip appears with the text:

> Average time from PR creation to close, based on your last 30 closed PRs

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context

This implementation reuses the existing `title`-based tooltip mechanism already used by the `Avg First Review` metric to maintain consistency and avoid introducing additional dependencies.