### PR TITLE
feat(dashboard): add loading skeletons for widgets

### DIFF
--- a/src/components/ContributionGraph.tsx
+++ b/src/components/ContributionGraph.tsx
@@ -129,10 +129,11 @@ function mergeContributionSources(
   return merged;
 }
 
-export default function ContributionGraph() {
+export default function ContributionGraph({ isLoading }: { isLoading?: boolean } = {}) {
   const { selectedAccount } = useAccount();
   const [data, setData] = useState<DayData[]>([]);
   const [loading, setLoading] = useState(true);
+  const showSkeleton = isLoading !== undefined ? isLoading : loading;
   const [days, setDays] = useState<number>(() => {
     if (typeof window !== "undefined") {
       try {
@@ -486,7 +487,7 @@ export default function ContributionGraph() {
           {compareMode && compareLoading && (
             <p className="text-xs text-[var(--muted-foreground)] mt-1">Loading friend data...</p>
           )}
-          {!compareMode && !loading && !error && (
+          {!compareMode && !showSkeleton && !error && (
             <p className="mt-1 text-xs text-[var(--muted-foreground)]">
               {totalCommits} commit{totalCommits === 1 ? "" : "s"}
             </p>
@@ -643,17 +644,22 @@ export default function ContributionGraph() {
         </div>
       </div>
 
-      {loading ? (
+      {showSkeleton ? (
         <div
           role="status"
           aria-live="polite"
           aria-busy="true"
+          className="flex h-[220px] items-end justify-between gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)] p-4"
         >
           <span className="sr-only">Loading contribution graph</span>
-          <div
-            aria-hidden="true"
-            className="h-[220px] rounded border border-[var(--border)] bg-[var(--background)] animate-pulse"
-          />
+          {[2, 4, 3, 6, 5, 8, 6, 4, 7, 5, 3, 6, 4, 2, 5, 3].map((h, i) => (
+            <div
+              key={i}
+              aria-hidden="true"
+              className="w-full rounded-sm bg-muted animate-pulse"
+              style={{ height: `${(h / 8) * 100}%` }}
+            />
+          ))}
         </div>
       ) : error ? (
         <div className="flex h-[220px] items-center rounded-lg border border-[var(--border)] bg-[var(--background)] px-4">

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -430,16 +430,22 @@ export default function GoalTracker() {
   if (loading) {
     return (
       <div className="h-full rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-6 shadow-sm">
-        <div role="status" aria-live="polite" aria-busy="true">
-          <span className="sr-only">Loading weekly goals</span>
-          <div
-            aria-hidden="true"
-            className="mb-4 h-5 w-32 rounded bg-[var(--card-muted)] animate-pulse"
-          />
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-6 w-16 bg-muted rounded animate-pulse" />
+          <div className="h-7 w-24 bg-muted rounded animate-pulse" />
+        </div>
+        <div role="status" aria-live="polite" aria-busy="true" className="space-y-4">
+          <span className="sr-only">Loading goals</span>
           {[1, 2, 3].map((i) => (
-            <div key={i} aria-hidden="true" className="mb-4">
-              <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse mb-2" />
-              <div className="h-2 bg-[var(--card-muted)] rounded animate-pulse" />
+            <div key={i} aria-hidden="true" className="animate-pulse">
+              <div className="flex justify-between items-center mb-1">
+                <div className="h-4 w-32 bg-muted rounded" />
+                <div className="flex items-center gap-2">
+                  <div className="h-4 w-16 bg-muted rounded" />
+                  <div className="h-6 w-6 bg-muted rounded" />
+                </div>
+              </div>
+              <div className="h-2 w-full bg-muted rounded-full" />
             </div>
           ))}
         </div>

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -46,10 +46,11 @@ function formatReviewCycle(hours: number | null): string {
   return `${Math.round((hours / 24) * 10) / 10}d`;
 }
 
-export default function PRMetrics() {
+export default function PRMetrics({ isLoading }: { isLoading?: boolean } = {}) {
   const { selectedAccount } = useAccount();
   const [metrics, setMetrics] = useState<PRData | null>(null);
   const [loading, setLoading] = useState(true);
+  const showSkeleton = isLoading !== undefined ? isLoading : loading;
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -179,64 +180,80 @@ export default function PRMetrics() {
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between mb-4">
         <SectionHeader title="PR Analytics" />
         <div className="flex flex-wrap items-center gap-2">
-          <div className="flex gap-2">
-            {(["7d", "30d", "90d"] as const).map((option) => (
-              <button
-                key={option}
-                onClick={() => setRange(option)}
-                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${range === option
-                  ? "bg-[var(--accent)] text-white"
-                  : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
-                  }`}
-              >
-                {option}
-              </button>
-            ))}
-          </div>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setActiveTab("authored")}
-              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${activeTab === "authored" ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
-                }`}
-            >
-              PRs Authored
-            </button>
-            <button
-              onClick={() => setActiveTab("reviews")}
-              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${activeTab === "reviews" ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
-                }`}
-            >
-              Reviews Given
-            </button>
-          </div>
-          <label className="flex items-center gap-2 text-xs font-medium text-[var(--muted-foreground)]">
-            Range
-            <select
-              value={range}
-              onChange={(event) => setRange(event.target.value as "7d" | "30d" | "90d")}
-              className="rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--foreground)] transition-colors"
-            >
-              <option value="7d">7d</option>
-              <option value="30d">30d</option>
-              <option value="90d">90d</option>
-            </select>
-          </label>
-          <label className="flex items-center gap-2 text-xs font-medium text-[var(--muted-foreground)]">
-            Stale after
-            <select
-              value={staleThresholdDays}
-              onChange={(event) => setStaleThresholdDays(Number(event.target.value))}
-              className="rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--foreground)] transition-colors"
-            >
-              {[7, 14, 30].map((days) => (
-                <option key={days} value={days}>{days} days</option>
-              ))}
-            </select>
-          </label>
+          {showSkeleton ? (
+            <>
+              <div className="flex gap-2">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="h-8 w-14 rounded-md bg-muted animate-pulse" aria-hidden="true" />
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <div className="h-8 w-28 rounded-md bg-muted animate-pulse" aria-hidden="true" />
+                <div className="h-8 w-28 rounded-md bg-muted animate-pulse" aria-hidden="true" />
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="flex gap-2">
+                {(["7d", "30d", "90d"] as const).map((option) => (
+                  <button
+                    key={option}
+                    onClick={() => setRange(option)}
+                    className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${range === option
+                      ? "bg-[var(--accent)] text-white"
+                      : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+                      }`}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setActiveTab("authored")}
+                  className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${activeTab === "authored" ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+                    }`}
+                >
+                  PRs Authored
+                </button>
+                <button
+                  onClick={() => setActiveTab("reviews")}
+                  className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${activeTab === "reviews" ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+                    }`}
+                >
+                  Reviews Given
+                </button>
+              </div>
+              <label className="flex items-center gap-2 text-xs font-medium text-[var(--muted-foreground)]">
+                Range
+                <select
+                  value={range}
+                  onChange={(event) => setRange(event.target.value as "7d" | "30d" | "90d")}
+                  className="rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--foreground)] transition-colors"
+                >
+                  <option value="7d">7d</option>
+                  <option value="30d">30d</option>
+                  <option value="90d">90d</option>
+                </select>
+              </label>
+              <label className="flex items-center gap-2 text-xs font-medium text-[var(--muted-foreground)]">
+                Stale after
+                <select
+                  value={staleThresholdDays}
+                  onChange={(event) => setStaleThresholdDays(Number(event.target.value))}
+                  className="rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--foreground)] transition-colors"
+                >
+                  {[7, 14, 30].map((days) => (
+                    <option key={days} value={days}>{days} days</option>
+                  ))}
+                </select>
+              </label>
+            </>
+          )}
         </div>
       </div>
 
-      {loading ? (
+      {showSkeleton ? (
         <div
           role="status"
           aria-live="polite"
@@ -244,21 +261,18 @@ export default function PRMetrics() {
           className="space-y-4"
         >
           <span className="sr-only">Loading PR analytics</span>
-
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {[1, 2, 3, 4, 5, 6, 7].map((i) => (
+            {[1, 2, 3, 4].map((i) => (
               <div
                 key={i}
                 aria-hidden="true"
-                className="bg-[var(--card-muted)] rounded-lg p-4 h-24 animate-pulse"
-              />
+                className="rounded-lg border border-[var(--border)] bg-[var(--control)] p-4 h-24 flex flex-col justify-center space-y-2 animate-pulse"
+              >
+                <div className="h-6 w-14 rounded bg-muted" />
+                <div className="h-4 w-20 rounded bg-muted" />
+              </div>
             ))}
           </div>
-          <div className="h-[270px] rounded-lg bg-[var(--card-muted)] animate-pulse" aria-hidden="true" />
-          <div
-            className="h-[220px] rounded-lg bg-[var(--card-muted)] animate-pulse"
-            aria-hidden="true"
-          />
         </div>
       ) : error ? (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -382,7 +382,7 @@ export function useStreakTracker() {
   };
 }
 
-export default function StreakTracker() {
+export default function StreakTracker({ isLoading }: { isLoading?: boolean } = {}) {
   const {
     selectedAccount,
     isStreakLive,
@@ -428,10 +428,11 @@ export default function StreakTracker() {
   } = useStreakTracker();
 
   const { setSummary, setIsUpdating } = useDashboardWidgetA11y("streak-tracker");
+  const showSkeleton = isLoading !== undefined ? isLoading : loading;
 
   useEffect(() => {
-    setIsUpdating(loading);
-  }, [loading, setIsUpdating]);
+    setIsUpdating(showSkeleton);
+  }, [showSkeleton, setIsUpdating]);
 
   useEffect(() => {
     if (!data) {
@@ -443,18 +444,22 @@ export default function StreakTracker() {
     );
   }, [data, setSummary]);
 
-  if (loading) {
+  if (showSkeleton) {
     return (
-      <div className="bg-[var(--card)] rounded-xl p-6 min-h-[700px]">
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
         <div role="status" aria-live="polite" aria-busy="true">
           <span className="sr-only">Loading streak tracker</span>
-          <div
-            aria-hidden="true"
-            className="h-6 w-36 bg-[var(--card-muted)] rounded animate-pulse mb-4"
-          />
-          <div aria-hidden="true" className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div aria-hidden="true" className="h-6 w-36 bg-muted rounded animate-pulse mb-6" />
+          <div aria-hidden="true" className="grid grid-cols-2 gap-3">
             {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="bg-[var(--card-muted)] rounded-lg h-28 animate-pulse" />
+              <div
+                key={i}
+                className="rounded-lg border border-[var(--border)] bg-[var(--control)] p-4 h-[108px] flex flex-col items-center justify-center space-y-2 animate-pulse"
+              >
+                <div className="h-5 w-5 rounded-full bg-muted" />
+                <div className="h-6 w-12 rounded bg-muted" />
+                <div className="h-3.5 w-20 rounded bg-muted" />
+              </div>
             ))}
           </div>
         </div>

--- a/src/components/TopRepos.tsx
+++ b/src/components/TopRepos.tsx
@@ -259,10 +259,11 @@ function getVisibleLanguages(languages: RepoLanguage[]): RepoLanguage[] {
   ];
 }
 
-export default function TopRepos() {
+export default function TopRepos({ isLoading }: { isLoading?: boolean } = {}) {
   const { selectedAccount } = useAccount();
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(true);
+  const showSkeleton = isLoading !== undefined ? isLoading : loading;
   const [error, setError] = useState<string | null>(null);
   const [days, setDays] = useState(30);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -456,7 +457,7 @@ export default function TopRepos() {
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
           <SectionHeader
-            title={`Top Repositories${!loading && repos.length > 0 ? ` (${repos.length})` : ""}`}
+            title={`Top Repositories${!showSkeleton && repos.length > 0 ? ` (${repos.length})` : ""}`}
           />
 
           {pinError && (
@@ -503,23 +504,33 @@ export default function TopRepos() {
         </button>
       </div>
 
-      {loading ? (
+      {showSkeleton ? (
         <div
           role="status"
           aria-live="polite"
           aria-busy="true"
-          className="space-y-5 mt-4"
+          className="space-y-5 mt-4 animate-pulse"
         >
           <span className="sr-only">Loading top repositories</span>
           <div aria-hidden="true" className="space-y-5">
             {[1, 2, 3, 4, 5].map((i) => (
-              <div key={i}>
-                <div className="flex items-center justify-between mb-2">
-                  <div className="h-4 w-1/3 bg-[var(--card-muted)] rounded animate-pulse" />
-                  <div className="h-4 w-16 bg-[var(--card-muted)] rounded animate-pulse" />
+              <div key={i} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="h-4 w-4 rounded bg-muted" />
+                    <div className="h-4 w-32 rounded bg-muted" />
+                  </div>
+                  <div className="h-4 w-16 rounded bg-muted" />
                 </div>
                 <div className="h-1.5 w-full bg-[var(--control)] rounded-full overflow-hidden">
-                  <div className="h-full bg-[var(--card-muted)] animate-pulse w-1/2" />
+                  <div
+                    className="h-full bg-muted rounded-full"
+                    style={{ width: `${30 + (i * 13) % 55}%` }}
+                  />
+                </div>
+                <div className="flex gap-1.5">
+                  <div className="h-5 w-16 rounded-full bg-muted" />
+                  <div className="h-5 w-12 rounded-full bg-muted" />
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## Summary

Adds loading skeleton states for dashboard widgets to improve perceived performance and reduce layout shifts while dashboard data is loading.

Closes #1774

---

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that changes existing behavior)
* [ ] 📝 Documentation update
* [ ] ♻️ Refactor / code cleanup (no functional change)
* [x] ⚡ Performance improvement
* [ ] 🔒 Security fix
* [ ] 🧪 Tests only

---

## What Changed

* Added loading skeleton UI for `ContributionGraph.tsx`
* Added skeleton states for `PRMetrics.tsx`, `TopRepos.tsx`, `StreakTracker.tsx`, and `GoalTracker.tsx`
* Improved dashboard loading UX by reducing layout shifts and visual flicker

---

## How to Test

1. Start the application locally using `pnpm dev`
2. Open the dashboard page and throttle network speed (optional: Slow 3G in browser dev tools)
3. Refresh the page and observe skeleton loaders before actual data loads

**Expected result:**

Dashboard widgets should display skeleton placeholders during loading and smoothly transition to actual content once data is fetched.

---

## Screenshots / Recordings

| Before       
<img width="1918" height="777" alt="Screenshot 2026-06-21 220105" src="https://github.com/user-attachments/assets/d01ed20a-a38e-40bd-acf0-53de68aec1aa" />
| After      
<img width="1918" height="782" alt="Screenshot 2026-06-21 220639" src="https://github.com/user-attachments/assets/2700755a-e810-438e-9fb6-2d3da0f79d74" />

---

## Checklist

* [x] Linked the related issue above
* [x] Self-reviewed my own diff
* [x] No unnecessary `console.log`, debug code, or commented-out blocks
* [x] `npm run lint` passes locally
* [ ] No TypeScript errors (`npm run type-check`)
* [ ] Added or updated tests where applicable
* [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

* [x] Keyboard navigation works correctly
* [x] Color contrast meets WCAG AA standard
* [x] ARIA labels / roles added where needed
* [x] Tested on mobile / responsive layout

---

## Additional Context

This PR was recreated from a clean branch based on the latest upstream `main` because the previous branch accumulated merge conflicts during rebase. The functionality remains unchanged.
