### PR TITLE
Fix division by zero in goal progress calculation

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -535,9 +535,12 @@ export default function GoalTracker() {
         <ul className="space-y-4">
 
           {goals.map((goal) => {
-            const pct =
-              goal.current > 0
-                ? Math.max(1, Math.min(Math.round((goal.current / goal.target) * 100), 100))
+            const pct = 
+              goal.current > 0 && goal.target > 0 
+                ? Math.max(
+                  1, 
+                  Math.min(Math.round((goal.current / goal.target) * 100), 100)
+                  )
                 : 0;
             const isDeleting = deletingId === goal.id;
             const completed = goal.current >= goal.target;


### PR DESCRIPTION
## Summary

Prevents division-by-zero errors in `GoalTracker` when rendering goals with `target = 0`. This ensures the progress bar does not produce `Infinity` or `NaN` values and safely falls back to `0%` progress for invalid or legacy goal data.

Closes #165 

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- Added a defensive guard in `src/components/GoalTracker.tsx` to prevent progress calculations when `goal.target <= 0`.
- Ensured goals with invalid or legacy `target = 0` values render as `0%` progress instead of producing `Infinity` or `NaN`.
- Preserved the existing behavior for valid goals, including the minimum `1%` progress indicator and the `100%` cap.

---

## How to Test

1. Create or mock a goal with `target = 0` and `current > 0`.
2. Open the Goals widget in the dashboard.
3. Observe the progress bar rendering for that goal.

**Expected result:**

The progress bar safely renders as `0%` width and the dashboard continues functioning normally without `NaN` or `Infinity` values appearing in the UI or DOM.

---

## Screenshots / Recordings

Not applicable — this is a defensive bug fix with no intended visual changes.

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

Not applicable.

---

## Additional Context

This issue can occur with legacy, imported, or malformed goal data where `target = 0`. The fix is intentionally minimal and only affects the invalid edge case while preserving all existing behavior for valid goals.