### PR TITLE
Add aria-live region for dashboard sync status

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -365,7 +365,11 @@ export default function DashboardHeader() {
               coding activity at a glance
             </p>
             {minutesAgo !== null && (
-              <p className="mt-1 flex items-center gap-1.5 text-xs text-[var(--muted-foreground)]">
+              <p
+                aria-live="polite"
+                aria-atomic="true"
+                className="mt-1 flex items-center gap-1.5 text-xs text-[var(--muted-foreground)]"
+              >
                 {minutesAgo <= 0 ? "Synced just now" : `Synced ${minutesAgo} min ago`}
                 {isHeaderLive && (
                   <span


### PR DESCRIPTION
## Summary

Adds an `aria-live` region to the dashboard sync status text so screen readers automatically announce sync completion updates such as "Synced just now" or "Synced 5 min ago" without requiring users to manually navigate back to the status message.

Closes #216 

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- Added `aria-live="polite"` to the dashboard sync status message in `src/components/DashboardHeader.tsx`.
- Added `aria-atomic="true"` so the full sync status message is announced when it changes.
- Preserved existing visual appearance and behavior while improving screen reader accessibility.

---

## How to Test

1. Open the dashboard with a screen reader enabled.
2. Trigger a dashboard sync event.
3. Wait for the sync status text to update.

**Expected result:**

The updated sync status (e.g. "Synced just now") is automatically announced by the screen reader without requiring focus to move to the element.

---

## Screenshots / Recordings

Not applicable — no visual changes were introduced.

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [ ] Tested on mobile / responsive layout

---

## Additional Context

This change is intentionally limited to semantic accessibility improvements and introduces no visual or behavioral changes for sighted users.