### PR TITLE
fix(dashboard): isolate widget render failures with error boundaries

### DIFF
--- a/src/components/dashboard/SortableDashboardWidget.tsx
+++ b/src/components/dashboard/SortableDashboardWidget.tsx
@@ -6,6 +6,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { DashboardWidgetId } from "@/lib/dashboard-layout";
 import DashboardWidgetShell from "@/components/dashboard/DashboardWidgetShell";
+import WidgetErrorBoundary from "@/components/WidgetErrorBoundary";
 
 interface SortableDashboardWidgetProps {
   id: DashboardWidgetId;
@@ -88,7 +89,11 @@ export default function SortableDashboardWidget({
           title={title}
           isEditing={isEditing}
         >
-          {children}
+          <WidgetErrorBoundary
+            fallbackMessage={`Could not load ${title}.`}
+          >
+            {children}
+          </WidgetErrorBoundary>
         </DashboardWidgetShell>
       </div>
     </div>


### PR DESCRIPTION
## Summary

This PR improves the dashboard's resilience by isolating widget rendering failures using the existing `WidgetErrorBoundary`.

Previously, if any dashboard widget threw a runtime rendering error (for example due to an unexpected API response), React would unmount the entire dashboard component tree, resulting in a blank page. With this change, only the affected widget displays an inline fallback while the rest of the dashboard continues to function normally.

## Changes Made

- Added `WidgetErrorBoundary` to the shared `SortableDashboardWidget` component.
- Wrapped every dashboard widget with the existing reusable error boundary.
- Passed a widget-specific fallback message using the widget title.
- Reused the existing error boundary implementation instead of introducing a new one.

## Why this approach?

Instead of wrapping each widget individually, the error boundary is applied at the shared `SortableDashboardWidget` layer, which is responsible for rendering dashboard widgets.

This approach:
- Protects all current dashboard widgets.
- Automatically protects future widgets added through the same wrapper.
- Keeps the implementation minimal and avoids repetitive code.
- Preserves the existing dashboard architecture.

## Before

- A rendering error in a single widget could cause the entire dashboard to unmount.
- Users would lose access to all dashboard sections.

## After

- Only the widget that throws an error displays the fallback UI.
- All other dashboard widgets continue rendering normally.
- Users can continue interacting with the rest of the dashboard.

## Testing

- Verified that the shared dashboard widget wrapper now renders all widgets inside `WidgetErrorBoundary`.
- Confirmed the change is isolated to the shared wrapper without modifying individual widget implementations.

Closes #2844