### PR TITLE
[FEAT] : Interactive Activity Heatmap Filters (UX & Interaction

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -4,14 +4,44 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHeatmapTheme } from "@/hooks/useHeatmapTheme";
 import DailyBreakdownSheet from "@/components/DailyBreakdownSheet";
 import { getContributionInsights } from "@/lib/contribution-insights";
-import { Calendar, TrendingUp, Zap, Clock, Award, BarChart2 } from "lucide-react";
+import { Calendar, TrendingUp, Zap, Clock, Award, BarChart2, Filter } from "lucide-react";
+import { useAccount } from "@/components/AccountContext";
 
 interface ContributionHeatmapProps {
   days?: number;
 }
 
+interface CommitItem {
+  sha: string;
+  message: string;
+  date: string;
+  repo: string;
+  url: string;
+}
+
 interface ContributionResponse {
+  days: number;
+  total: number;
   data: Record<string, number>;
+  commits: CommitItem[];
+}
+
+interface RepoLanguage {
+  name: string;
+  bytes: number;
+  percentage: number;
+}
+
+interface RepoSummary {
+  name: string;
+  commits: number;
+  description: string | null;
+  url: string;
+  languages?: RepoLanguage[];
+}
+
+interface ReposApiResponse {
+  repos: RepoSummary[];
 }
 
 interface HeatmapCell {
@@ -97,7 +127,13 @@ function buildHeatmap(days: number, contributions: Record<string, number>, fromD
 export default function ContributionHeatmap({
   days = DEFAULT_DAYS,
 }: ContributionHeatmapProps) {
+  const { selectedAccount } = useAccount();
   const [data, setData] = useState<Record<string, number>>({});
+  const [commits, setCommits] = useState<CommitItem[]>([]);
+  const [reposData, setReposData] = useState<RepoSummary[]>([]);
+  const [selectedRepo, setSelectedRepo] = useState<string>("all");
+  const [selectedLanguage, setSelectedLanguage] = useState<string>("all");
+
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -214,21 +250,36 @@ export default function ContributionHeatmap({
     const params = new URLSearchParams();
     params.set("from", currentFrom);
     params.set("to", currentTo);
+    if (selectedAccount) {
+      params.set("accountId", selectedAccount);
+    }
     
-    fetch(`/api/metrics/contributions?${params.toString()}`)
-      .then((response) => {
+    // Reset filters when range/account changes
+    setSelectedRepo("all");
+    setSelectedLanguage("all");
+
+    Promise.all([
+      fetch(`/api/metrics/contributions?${params.toString()}`).then((response) => {
         if (!response.ok) throw new Error("API error");
-        return response.json();
+        return response.json() as Promise<ContributionResponse>;
+      }),
+      fetch(`/api/metrics/repos?days=${selectedDays}${selectedAccount ? `&accountId=${encodeURIComponent(selectedAccount)}` : ""}`).then((response) => {
+        if (!response.ok) throw new Error("API error");
+        return response.json() as Promise<ReposApiResponse>;
       })
-      .then((result: ContributionResponse) => {
+    ])
+      .then(([contribResult, reposResult]) => {
         if (!active) return;
-        setData(result.data ?? {});
+        setData(contribResult.data ?? {});
+        setCommits(contribResult.commits ?? []);
+        setReposData(reposResult.repos ?? []);
         setLastUpdated(new Date());
         setMinutesAgo(0);
       })
-      .catch(() => {
+      .catch((err) => {
         if (!active) return;
         setError("Failed to load contribution heatmap.");
+        console.error("Error loading heatmap data:", err);
       })
       .finally(() => {
         if (!active) return;
@@ -238,7 +289,7 @@ export default function ContributionHeatmap({
     return () => {
       active = false;
     };
-  }, [currentFrom, currentTo]);
+  }, [currentFrom, currentTo, selectedDays, selectedAccount]);
 
   useEffect(() => {
     if (!lastUpdated) return;
@@ -259,15 +310,71 @@ export default function ContributionHeatmap({
     }
     return selectedDays;
   }, [customLabel, customFrom, customTo, selectedDays]);
+
+  // Extract unique repositories
+  const uniqueRepos = useMemo(() => {
+    const reposSet = new Set<string>();
+    commits.forEach((c) => {
+      if (c.repo) reposSet.add(c.repo);
+    });
+    return Array.from(reposSet).sort();
+  }, [commits]);
+
+  // Extract unique languages
+  const uniqueLanguages = useMemo(() => {
+    const langsSet = new Set<string>();
+    reposData.forEach((repo) => {
+      repo.languages?.forEach((l) => {
+        if (l.name) langsSet.add(l.name);
+      });
+    });
+    return Array.from(langsSet).sort();
+  }, [reposData]);
+
+  // Map each repo to its languages for quick lookup
+  const repoLanguagesMap = useMemo(() => {
+    const map = new Map<string, string[]>();
+    reposData.forEach((repo) => {
+      const langs = repo.languages?.map((l) => l.name) ?? [];
+      map.set(repo.name, langs);
+    });
+    return map;
+  }, [reposData]);
+
+  // Compute filtered dataset
+  const filteredData = useMemo(() => {
+    if (selectedRepo === "all" && selectedLanguage === "all") {
+      return data;
+    }
+
+    const counts: Record<string, number> = {};
+    commits.forEach((commit) => {
+      // 1. Filter by repo
+      if (selectedRepo !== "all" && commit.repo !== selectedRepo) {
+        return;
+      }
+      // 2. Filter by language
+      if (selectedLanguage !== "all") {
+        const repoLangs = repoLanguagesMap.get(commit.repo) ?? [];
+        if (!repoLangs.includes(selectedLanguage)) {
+          return;
+        }
+      }
+
+      counts[commit.date] = (counts[commit.date] ?? 0) + 1;
+    });
+
+    return counts;
+  }, [data, commits, repoLanguagesMap, selectedRepo, selectedLanguage]);
   
   const cells = useMemo(
     () => buildHeatmap(
       displayDays, 
-      data,
+      filteredData,
       customLabel ? customFrom : undefined,
       customLabel ? customTo : undefined
     ),
-    [displayDays, data, customLabel, customFrom, customTo]
+    [displayDays, filteredData, customLabel, customFrom, customTo]
   );
   const weekCount = Math.ceil(cells.length / 7);
   const maxCommits = Math.max(
@@ -458,6 +565,42 @@ export default function ContributionHeatmap({
           >
             Colour-blind
           </button>
+
+          {/* Repository and Language Filters */}
+          <div className="flex flex-wrap items-center gap-2 border-t border-[var(--border)] pt-2 mt-1 w-full sm:border-t-0 sm:border-l sm:pt-0 sm:mt-0 sm:pl-2 sm:w-auto">
+            <div className="flex items-center gap-1 text-[11px] text-[var(--muted-foreground)] dark:text-gray-300">
+              <Filter className="h-3 w-3" />
+              <span>Filter:</span>
+            </div>
+            
+            <select
+              value={selectedRepo}
+              onChange={(e) => setSelectedRepo(e.target.value)}
+              className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-0.5 text-xs text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--accent)] hover:border-gray-400 dark:hover:border-gray-600 transition-colors max-w-[150px] truncate"
+              aria-label="Filter by repository"
+            >
+              <option value="all">All Repositories</option>
+              {uniqueRepos.map((repo) => (
+                <option key={repo} value={repo}>
+                  {repo.split("/")[1] ?? repo}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={selectedLanguage}
+              onChange={(e) => setSelectedLanguage(e.target.value)}
+              className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-0.5 text-xs text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--accent)] hover:border-gray-400 dark:hover:border-gray-600 transition-colors"
+              aria-label="Filter by language"
+            >
+              <option value="all">All Languages</option>
+              {uniqueLanguages.map((lang) => (
+                <option key={lang} value={lang}>
+                  {lang}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {/* Legend - Less / More */}
@@ -740,7 +883,10 @@ export default function ContributionHeatmap({
       <DailyBreakdownSheet
         date={selectedDate}
         onClose={handleCloseSheet}
-        heatmapData={data}
+        heatmapData={filteredData}
+        selectedRepo={selectedRepo}
+        selectedLanguage={selectedLanguage}
+        reposData={reposData}
       />
     </div>
   );

--- a/src/components/DailyBreakdownSheet.tsx
+++ b/src/components/DailyBreakdownSheet.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface DailyBreakdownSheetProps {
   date: string | null;
   onClose: () => void;
   heatmapData?: Record<string, number>;
+  selectedRepo?: string;
+  selectedLanguage?: string;
+  reposData?: any[];
 }
 
 interface RepoCommit {
@@ -18,8 +21,11 @@ export default function DailyBreakdownSheet({
   date,
   onClose,
   heatmapData,
+  selectedRepo = "all",
+  selectedLanguage = "all",
+  reposData = [],
 }: DailyBreakdownSheetProps) {
-  const [commits, setCommits] = useState<RepoCommit[]>([]);
+  const [rawCommits, setRawCommits] = useState<RepoCommit[]>([]);
   const [loading, setLoading] = useState(false);
   const isOpen = date !== null;
 
@@ -27,7 +33,7 @@ export default function DailyBreakdownSheet({
     if (!date) return;
     const totalForDay = heatmapData?.[date] ?? 0;
     if (totalForDay === 0) {
-      setCommits([]);
+      setRawCommits([]);
       setLoading(false);
       return;
     }
@@ -35,11 +41,32 @@ export default function DailyBreakdownSheet({
     fetch(`/api/metrics/contributions/daily?date=${date}`)
     .then((res) => res.json())
     .then((result) => {
-        setCommits(result.repos ?? []);
+        setRawCommits(result.repos ?? []);
     })
-      .catch(() => setCommits([]))
+      .catch(() => setRawCommits([]))
       .finally(() => setLoading(false));
   }, [date, heatmapData]);
+
+  const commits = useMemo(() => {
+    const repoLangsMap = new Map<string, string[]>();
+    reposData.forEach(repo => {
+      const langs = repo.languages?.map((l: any) => l.name) ?? [];
+      repoLangsMap.set(repo.name, langs);
+    });
+
+    return rawCommits.filter(item => {
+      if (selectedRepo !== "all" && item.repo !== selectedRepo) {
+        return false;
+      }
+      if (selectedLanguage !== "all") {
+        const repoLangs = repoLangsMap.get(item.repo) ?? [];
+        if (!repoLangs.includes(selectedLanguage)) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [rawCommits, selectedRepo, selectedLanguage, reposData]);
 
   const onCloseRef = useRef(onClose);
   useEffect(() => {


### PR DESCRIPTION


## Summary

Adds interactive dropdown filters for **Repository** and **Language** to the Contribution Heatmap on the developer dashboard. This allows users to isolate and analyze specific coding efforts (e.g., side projects, client work, or language-specific patterns) with zero-latency client-side transitions. 

Closes #2985
---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **[ContributionHeatmap.tsx]**:
  * Integrated `useAccount` from `AccountContext` to dynamically fetch and sync data when the active user account is changed.
  * Updated initial data loading to fetch `/api/metrics/contributions` and `/api/metrics/repos` in parallel using `Promise.all` to resolve repository language profiles.
  * Added React state, drop-down controls, and client-side filter computations for Repository and Language.
  * Connected cells calculation to the filtered output, automatically updating all heatmap cells, total commit counts, streak metrics, and productivity insights.
  * Passed the active filter options and repositories language metadata to `DailyBreakdownSheet`.
- **[DailyBreakdownSheet.tsx]**:
  * Added new filtering properties (`selectedRepo`, `selectedLanguage`, `reposData`) to the component interface.
  * Implemented client-side filtering on the daily commits array so that the breakdown drawer reflects active heatmap filters when a cell is clicked.

---

## How to Test

1. Start the local DevTrack application dev server.
2. Log in and navigate to the main dashboard.
3. Observe the top right corner of the **Contribution Heatmap** widget; locate the new **Filter** control bar next to the color theme selectors.
4. Select a specific repository in the dropdown: the heatmap grid, total count, streak days, and productivity insights should instantaneously adjust.
5. Select a specific language in the dropdown: the heatmap grid should display only commits made in repositories matching that language profile.
6. Click any cell on the heatmap while filters are active: the sliding **Daily Breakdown** sheet should only list commits matching your active repository or language filters.

**Expected result:** The heatmap grid, metrics, insights panel, and clicked breakdown drawer update instantly client-side with no loading delay or extra network calls when filters are adjusted.

---

## Checklist

- [ ] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly (drop-downs are focusable and keyboard selectable)
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout (filters wrap cleanly on small screens)

---

## Additional Context

Filtering is handled client-side using the full `commits` payload and repositories mapping. This guarantees zero-latency, high-performance transitions for a premium UX, avoiding slow, repeated network queries.