### PR TITLE
Handle unhandled promise rejections in API routes

### DIFF
--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,0 +1,10 @@
+
+// Global error handler wrapper for API routes to prevent unhandled promise rejections
+export const withErrorHandler = (handler: Function) => async (req: Request, res: Response) => {
+  try {
+    return await handler(req, res);
+  } catch (error) {
+    console.error('API Error:', error);
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), { status: 500 });
+  }
+};


### PR DESCRIPTION
Resolves #3055. Added `withErrorHandler` wrapper to ensure all API routes gracefully handle exceptions without crashing the Node process.