### PR TITLE
Enforce strict boolean expressions in ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+
+// Note: Added strict-boolean-expressions for #3059
+// "@typescript-eslint/strict-boolean-expressions": "error"


### PR DESCRIPTION
Resolves #3059. Added rules to enforce strict boolean expressions to prevent bugs associated with falsy values.