### PR TITLE
Support localization (i18n) framework setup

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'es'],
+  },
+};


### PR DESCRIPTION
Resolves #3067. Initialized basic i18n configuration to support future translations into Spanish and French.