### PR TITLE
 Fix: Timezone Mismatch Bug in Streak Freeze

### DIFF
--- a/src/app/api/streak/freeze/route.ts
+++ b/src/app/api/streak/freeze/route.ts
@@ -12,8 +12,45 @@ import {
 
 export const dynamic = "force-dynamic";
 
-function todayStr(): string {
-  return new Date().toISOString().slice(0, 10);
+// Returns "YYYY-MM-DD" for "now", computed in the given IANA timezone
+// (not UTC). This must match the timezone-bucketing logic used in
+// /api/metrics/streak, otherwise a freeze can land on a different
+// calendar day than the streak calculator expects (issue #2952).
+function todayStr(timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+
+  const year = parts.find((p) => p.type === "year")?.value;
+  const month = parts.find((p) => p.type === "month")?.value;
+  const day = parts.find((p) => p.type === "day")?.value;
+
+  return `${year}-${month}-${day}`;
+}
+
+// Fetches the user's stored timezone (Supabase `users.timezone`), falling
+// back to UTC if unset. Wrapped in try/catch because Intl.DateTimeFormat
+// throws on an invalid/garbage IANA timezone string, and we'd rather
+// degrade to UTC than 500 the request.
+async function getUserTimeZone(userId: string): Promise<string> {
+  const { data: userRow } = await supabaseAdmin
+    .from("users")
+    .select("timezone")
+    .eq("id", userId)
+    .single();
+
+  const timeZone = userRow?.timezone || "UTC";
+
+  try {
+    // Cheap validity check: throws RangeError on bad IANA names.
+    new Intl.DateTimeFormat("en", { timeZone });
+    return timeZone;
+  } catch {
+    return "UTC";
+  }
 }
 
 // GET /api/streak/freeze
@@ -27,7 +64,12 @@ export async function GET(req: NextRequest) {
   const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
-  const cacheKey = metricsCacheKey(user.id, "streak_freeze", {});
+  const timeZone = await getUserTimeZone(user.id);
+
+  // timeZone is included in the cache key so users in different timezones
+  // (or a user whose timezone setting changes) don't read a stale
+  // "hasFreeze" computed against the wrong calendar day.
+  const cacheKey = metricsCacheKey(user.id, "streak_freeze", { timeZone });
   const bypass = isMetricsCacheBypassed(req);
 
   const status = await withMetricsCache(
@@ -36,14 +78,14 @@ export async function GET(req: NextRequest) {
       key: cacheKey,
       ttlSeconds: METRICS_CACHE_TTL_SECONDS.streak,
     },
-    async () => getFreezeStatus(user.id)
+    async () => getFreezeStatus(user.id, timeZone)
   );
 
   return Response.json(status);
 }
 
-async function getFreezeStatus(userId: string) {
-  const today = todayStr();
+async function getFreezeStatus(userId: string, timeZone: string) {
+  const today = todayStr(timeZone);
 
   const { data: pending } = await supabaseAdmin
     .from("streak_freezes")
@@ -58,7 +100,8 @@ async function getFreezeStatus(userId: string) {
 }
 
 // POST /api/streak/freeze
-// Inserts a freeze for today. Fails if the user already holds an unused freeze.
+// Inserts a freeze for today (in the user's local timezone). Fails if the
+// user already holds an unused freeze.
 export async function POST() {
   const session = await getServerSession(authOptions);
   if (!session?.githubId) {
@@ -68,7 +111,8 @@ export async function POST() {
   const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
-  const today = todayStr();
+  const timeZone = await getUserTimeZone(user.id);
+  const today = todayStr(timeZone);
 
   // Prevent users from stockpiling unused freezes
   const { count } = await supabaseAdmin
@@ -116,7 +160,7 @@ export async function POST() {
 }
 
 // DELETE /api/streak/freeze
-// Removes today's active freeze for the authenticated user.
+// Removes today's (local-timezone) active freeze for the authenticated user.
 export async function DELETE() {
   const session = await getServerSession(authOptions);
   if (!session?.githubId) {
@@ -126,11 +170,13 @@ export async function DELETE() {
   const user = await resolveAppUser(session.githubId, session.githubLogin);
   if (!user) return Response.json({ error: "User not found" }, { status: 404 });
 
+  const timeZone = await getUserTimeZone(user.id);
+
   const { error } = await supabaseAdmin
     .from("streak_freezes")
     .delete()
     .eq("user_id", user.id)
-    .eq("freeze_date", todayStr());
+    .eq("freeze_date", todayStr(timeZone));
 
   if (error)
     return Response.json({ error: "Failed to cancel freeze" }, { status: 500 });


### PR DESCRIPTION
### Problem
`freeze/route.ts` computed "today" using `new Date().toISOString().slice(0, 10)`,
which is always UTC. `metrics/streak/route.ts`, however, buckets commits and
computes streaks using the user's stored `timezone` (via `Intl.DateTimeFormat`).

When a user's local date and the UTC date differ (e.g. after 6:30 PM IST, which
is already the next day in UTC — or more precisely, whenever local time crosses
midnight before UTC does), a freeze created "today" in local time was stored
against a different UTC date. The streak calculator, checking the local date,
wouldn't find the freeze and the streak would reset to 0 despite the freeze
being active.

### Fix
- `todayStr()` now accepts a `timeZone` and computes the date string using
  `Intl.DateTimeFormat`, the same approach already used in
  `metrics/streak/route.ts`.
- Added `getUserTimeZone()` to fetch the user's timezone from Supabase
  (`users.timezone`), defaulting to `UTC` when unset or invalid.
- `GET`, `POST`, and `DELETE` handlers all resolve the timezone before
  computing `today`, so freeze creation, lookup, and deletion are all
  consistent with the streak calculator's day boundaries.
- Added `timeZone` to the `GET` cache key to avoid serving a stale
  `hasFreeze` result computed under a different timezone.

### Testing
- Set a test user's `timezone` to `Asia/Kolkata`.
- Simulated server time such that UTC date and IST date differ (late IST
  evening / early IST morning).
- Confirmed `POST /api/streak/freeze` now stores `freeze_date` matching the
  IST calendar day.
- Confirmed `GET /api/metrics/streak` correctly finds the freeze and does
  not reset the streak.

### Related
Fixes #2952