### PR TITLE
Optimize API rate limiting handling for third-party integrations

### DIFF
--- a/src/app/api/metrics/contributions/route.ts
+++ b/src/app/api/metrics/contributions/route.ts
@@ -11,7 +11,7 @@ import {
   mergeMetrics,
 } from "@/lib/github-accounts";
 import { orgSearchSegment } from "@/lib/github-orgs";
-import { GITHUB_API, GitHubCommitSearchItem, CommitItem } from "@/lib/github";
+import { GITHUB_API, GitHubCommitSearchItem, CommitItem, githubFetch } from "@/lib/github";
 import {
   isMetricsCacheBypassed,
   METRICS_CACHE_TTL_SECONDS,
@@ -176,7 +176,7 @@ async function fetchContributionsForAccount(
         // Authorization header raises the rate limit from 60 req/hr (unauthenticated,
         // shared per IP) to 5,000 req/hr per user. Without it, shared server IPs
         // would exhaust the unauthenticated quota almost immediately.
-        const searchRes = await fetch(
+        const searchRes = await githubFetch(
           searchUrl.toString(),
           {
             headers: {

--- a/src/app/api/wakatime/sync/route.ts
+++ b/src/app/api/wakatime/sync/route.ts
@@ -1,4 +1,4 @@
-﻿import { NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
 import { decryptToken } from "@/lib/crypto";
 import { validateCronRequest } from "@/lib/cron-auth";
@@ -42,16 +42,35 @@ export async function GET(req: Request) {
           return;
         }
 
-        // Fetch from Wakatime with no-store cache
-        const res = await fetch("https://wakatime.com/api/v1/users/current/summaries?range=Last%207%20Days", {
-          headers: {
-            Authorization: `Basic ${Buffer.from(apiKey + ":").toString("base64")}`,
-          },
-          cache: "no-store"
-        });
+        // Fetch from Wakatime with no-store cache and retry logic
+        let res: Response | null = null;
+        let attempt = 0;
+        const maxRetries = 3;
 
-        if (!res.ok) {
-          console.error(`Wakatime API error for user ${user.id}: ${res.status}`);
+        while (attempt <= maxRetries) {
+          try {
+            res = await fetch("https://wakatime.com/api/v1/users/current/summaries?range=Last%207%20Days", {
+              headers: {
+                Authorization: `Basic ${Buffer.from(apiKey + ":").toString("base64")}`,
+              },
+              cache: "no-store"
+            });
+            
+            if (res.status === 429 && attempt < maxRetries) {
+              attempt++;
+              await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+              continue;
+            }
+            break; // Success or non-retriable error
+          } catch (e) {
+            if (attempt === maxRetries) throw e;
+            attempt++;
+            await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+          }
+        }
+
+        if (!res || !res.ok) {
+          console.error(`Wakatime API error for user ${user.id}: ${res?.status}`);
           failureCount++;
           return;
         }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -11,19 +11,57 @@ export const GITHUB_API = "https://api.github.com";
  * Fetch wrapper with AbortController-based timeout for GitHub API calls.
  * Prevents hanging requests under slow/stalled network conditions.
  */
-async function githubFetch(
+export async function githubFetch(
   url: string,
   options: RequestInit = {},
-  timeoutMs = 30_000
+  timeoutMs = 30_000,
+  maxRetries = 3
 ): Promise<Response> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch(url, { ...options, signal: controller.signal });
+  let attempt = 0;
+  
+  while (attempt <= maxRetries) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let res: Response;
+    
+    try {
+      res = await fetch(url, { ...options, signal: controller.signal });
+    } catch (error) {
+      clearTimeout(timeout);
+      if (attempt === maxRetries) throw error;
+      attempt++;
+      await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+      continue;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const rateLimitDetails = getGitHubRateLimitDetails(res);
+    if (rateLimitDetails && attempt < maxRetries) {
+      const retryAfter = res.headers.get("retry-after");
+      let delayMs = Math.pow(2, attempt + 1) * 1000;
+
+      if (retryAfter) {
+        delayMs = parseInt(retryAfter, 10) * 1000;
+      } else if (rateLimitDetails.resetAtEpoch) {
+        const resetMs = rateLimitDetails.resetAtEpoch * 1000;
+        const waitMs = resetMs - Date.now();
+        if (waitMs > 0 && waitMs <= 60000) {
+          delayMs = waitMs;
+        } else {
+          return res;
+        }
+      }
+
+      attempt++;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      continue;
+    }
+
     return res;
-  } finally {
-    clearTimeout(timeout);
   }
+  
+  throw new Error("githubFetch reached unreachable code");
 }
 
 /**
@@ -203,16 +241,16 @@ export async function fetchIssuesMetrics(
   const avgCloseTimeDays =
     closedItems.length > 0
       ? Math.round(
-          closedItems.reduce((sum, i) => {
-            return (
-              sum +
-              (new Date(i.closed_at!).getTime() -
-                new Date(i.created_at).getTime())
-            );
-          }, 0) /
-            closedItems.length /
-            86400000
-        )
+        closedItems.reduce((sum, i) => {
+          return (
+            sum +
+            (new Date(i.closed_at!).getTime() -
+              new Date(i.created_at).getTime())
+          );
+        }, 0) /
+        closedItems.length /
+        86400000
+      )
       : 0;
 
   const thisMonthRes = await githubFetch(


### PR DESCRIPTION
Resolves #3026. Added exponential backoff and retry logic for GitHub and WakaTime APIs to properly handle 429 Too Many Requests and secondary rate limits.