### PR TITLE
fix: resolve AI CV generator internal server errors

### DIFF
--- a/src/app/api/cv/analyze/route.ts
+++ b/src/app/api/cv/analyze/route.ts
@@ -13,7 +13,35 @@ const analyzeRateLimit = new Map<
 >();
 
 const WINDOW_MS = 60 * 60 * 1000; // 1 hour
-const MAX_REQUESTS = 3;
+const MAX_REQUESTS = process.env.NODE_ENV === "development" ? 100 : 3;
+
+/**
+ * Resolves the GitHub login string for the current session.
+ * Falls back to calling GET /user if the session's githubLogin is absent
+ * or looks like a stale/numeric value (e.g. "219068160").
+ */
+async function resolveGitHubLogin(
+  sessionLogin: string | undefined | null,
+  accessToken: string
+): Promise<string> {
+  // Valid login: non-empty and not purely numeric
+  if (sessionLogin && !/^\d+$/.test(sessionLogin)) {
+    return sessionLogin;
+  }
+  // Fallback: resolve via GitHub REST API
+  const res = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/vnd.github+json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to resolve GitHub login: ${res.status}`);
+  }
+  const data = (await res.json()) as { login: string };
+  return data.login;
+}
 
 /**
  * POST /api/cv/analyze
@@ -74,7 +102,13 @@ export async function POST() {
       return NextResponse.json(response);
     }
 
-    /* ── 4. Fetch & classify ─────────────────────────────────── */
+    /* ── 4. Resolve login & fetch contributions ───────────────── */
+    const accessToken = session.accessToken as string;
+    const githubLogin = await resolveGitHubLogin(
+      session.githubLogin as string | undefined,
+      accessToken
+    );
+
     const { fetchContributionData } = await import(
       "@/lib/cv/cv-github-fetcher"
     );
@@ -82,18 +116,14 @@ export async function POST() {
       "@/lib/cv/cv-classifier"
     );
 
-    const contributionData = await fetchContributionData(
-      session.accessToken as string,
-      session.githubId
-    );
-
+    const contributionData = await fetchContributionData(accessToken, githubLogin);
     const analysis = classifyContributions(contributionData);
 
-    /* ── 5. Cache in Supabase (24 h TTL) ─────────────────────── */
+    /* ── 5. Cache in Supabase (24 h TTL) — non-fatal ─────────── */
     const now = new Date();
     const expiresAt = new Date(now.getTime() + 24 * 60 * 60 * 1000);
 
-    await supabaseAdmin.from("cv_analyses").upsert(
+    const { error: upsertError } = await supabaseAdmin.from("cv_analyses").upsert(
       {
         user_id: userId,
         analysis_data: analysis,
@@ -102,6 +132,14 @@ export async function POST() {
       },
       { onConflict: "user_id" }
     );
+
+    if (upsertError) {
+      // Log but don't fail — analysis is computed, just not cached.
+      console.warn(
+        "CV analyze: Supabase cache upsert failed (non-fatal):",
+        upsertError.message
+      );
+    }
 
     /* ── 6. Respond ──────────────────────────────────────────── */
     const response: CVAnalyzeResponse = { analysis, cached: false };

--- a/src/app/api/cv/generate/route.ts
+++ b/src/app/api/cv/generate/route.ts
@@ -18,7 +18,7 @@ const generateRateLimit = new Map<
 >();
 
 const WINDOW_MS = 60 * 60 * 1000; // 1 hour
-const MAX_REQUESTS = 5;
+const MAX_REQUESTS = process.env.NODE_ENV === "development" ? 100 : 5;
 
 /**
  * POST /api/cv/generate

--- a/supabase/migrations/cv_intelligence.sql
+++ b/supabase/migrations/cv_intelligence.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS cv_analyses (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id TEXT NOT NULL,
   analysis_data JSONB NOT NULL,
+  generated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   expires_at TIMESTAMPTZ NOT NULL,
   CONSTRAINT cv_analyses_user_id_unique UNIQUE (user_id)
@@ -52,7 +53,9 @@ CREATE TABLE IF NOT EXISTS cv_generated_content (
   user_id TEXT NOT NULL,
   role TEXT NOT NULL,
   content JSONB NOT NULL,
+  generated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '24 hours'),
   CONSTRAINT cv_generated_content_user_role_unique UNIQUE (user_id, role)
 );
 


### PR DESCRIPTION
## Summary

This PR resolves multiple 500 Internal Server Errors in the AI Resume & CV Generator flow. It fixes missing database columns in the Supabase migrations, corrects the GitHub session identifier passed to the GraphQL API, and makes Supabase caching non-fatal so that database errors don't prevent users from seeing their analysis.

Fixes #3125 

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **`supabase/migrations/cv_intelligence.sql`**: Added the missing `generated_at` and `expires_at` columns required by the API routes to both the `cv_analyses` and `cv_generated_content` tables.
- **`src/app/api/cv/analyze/route.ts`**:
  - Changed `session.githubId` to `session.githubLogin` when querying the GitHub GraphQL API, as the API requires a string username, not a numeric ID.
  - Added a `resolveGitHubLogin` fallback to query `https://api.github.com/user` for the correct username if the JWT session holds a stale or numeric login ID.
  - Wrapped the Supabase cache `upsert` so that database errors (like a missing table) log a warning rather than throwing a 500 status and breaking the request.
  - Relaxed development rate limits from 3 requests/hour to 100 requests/hour for easier local testing.
- **`src/app/api/cv/generate/route.ts`**:
  - Relaxed development rate limits from 5 requests/hour to 100 requests/hour.

---

## How to Test

1. Ensure the `cv_intelligence.sql` migration has been run in your Supabase instance.
2. Sign into DevTrack locally or on staging.
3. Navigate to the AI Resume Generator page and click "Analyze My GitHub Footprint".
4. Verify that the analysis completes 100% without throwing a 500 error.

**Expected result:** The application successfully fetches your GitHub data, classifies it, caches it in Supabase, and proceeds to the Resume Generation step without crashing.

---

## Screenshots / Recordings

Before :
<img width="2557" height="1396" alt="image" src="https://github.com/user-attachments/assets/32318346-0620-4fd9-812c-fe18f75cf65f" />

After:

https://github.com/user-attachments/assets/e2f6a50b-ddec-4292-95cf-6ec21c38d6ea


---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

<!-- Skip this section if your PR has no UI impact. -->

- [ ] Keyboard navigation works correctly
- [ ] Color contrast meets WCAG AA standard
- [ ] ARIA labels / roles added where needed
- [ ] Tested on mobile / responsive layout

---

## Additional Context

Development rate limits were artificially restricting local testing, making debugging the API errors difficult. Production rate limits (`3/hr` and `5/hr`) have been strictly preserved.
