### PR TITLE
fix(repos): paginate repo-explorer to fetch all repos beyond 100 limit (#2843)

### DIFF
--- a/src/app/api/metrics/repo-explorer/route.ts
+++ b/src/app/api/metrics/repo-explorer/route.ts
@@ -1,4 +1,5 @@
 import { getSessionWithToken } from "@/lib/get-session-token";
+import { fetchUserRepos } from "@/lib/github";
 import { NextRequest } from "next/server";
 import { isMetricsCacheBypassed, metricsCacheKey, withMetricsCache } from "@/lib/metrics-cache";
 import { ExplorerRepoCardData } from "@/lib/repo-analytics-types";
@@ -20,14 +21,9 @@ export async function GET(req: NextRequest) {
 
   try {
     const data = await withMetricsCache({ bypass, key, ttlSeconds: 30 * 60 }, async () => {
-      const reposRes = await fetch(`${GITHUB_API}/user/repos?sort=pushed&per_page=100`, {
-        headers: { Authorization: `Bearer ${accessToken}`, Accept: "application/vnd.github+json" },
-        cache: "no-store",
-      });
-
-      if (!reposRes.ok) throw new Error("API error fetching repos");
-      const repos = await reposRes.json();
-
+	// Paginate through all pages (up to 1000 repos) so users with more
+	// than 100 repositories see their complete list — fixes #2843.
+	const repos = await fetchUserRepos(accessToken, { perPage: 100, maxPages: 10 });
       const since = new Date();
       since.setDate(since.getDate() - 30);
       const sinceStr = since.toISOString().slice(0, 10);
@@ -84,8 +80,8 @@ export async function GET(req: NextRequest) {
           commitCount,
           createdAt: repo.created_at,
           updatedAt: repo.updated_at,
-          primaryLanguage: repo.language,
-          htmlUrl: repo.html_url,
+	  primaryLanguage: repo.language ?? undefined,
+	  htmlUrl: repo.html_url,
           activity7d,
         });
       }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -111,6 +111,8 @@ export interface GitHubRepo {
   stargazers_count: number;
   pushed_at: string | null;
   updated_at: string;
+  created_at: string;
+  language: string | null;
   archived?: boolean;
 }
 

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -35,6 +35,9 @@ describe("github types and interfaces", () => {
         stargazers_count: 100,
         pushed_at: "2024-01-15T10:00:00Z",
         updated_at: "2024-01-15T10:00:00Z",
+	created_at: "2024-01-01T00:00:00Z",
+        language: "TypeScript",
+
       };
       expect(repo.full_name).toBe("owner/repo");
       expect(repo.visibility).toBe("public");
@@ -50,6 +53,8 @@ describe("github types and interfaces", () => {
         open_issues_count: 0,
         stargazers_count: 0,
         pushed_at: null,
+	created_at: "2024-01-01T00:00:00Z",
+        language: null,
         updated_at: "2024-01-15T10:00:00Z",
         archived: true,
       };


### PR DESCRIPTION
Closes #2843

## Problem
The repo-explorer endpoint called `/user/repos?per_page=100` once,
returning at most 100 repositories. Users with more than 100 repos
saw an incomplete list on the dashboard, and metrics derived from
that list (PR counts, streak) were also incomplete.

## Fix
- Replaced the single `fetch()` call in `repo-explorer/route.ts` with
  the existing `fetchUserRepos()` helper from `src/lib/github.ts`, which
  already paginates up to 10 pages (1000 repos maximum).
- Added missing `created_at` and `language` fields to the `GitHubRepo`
  interface so the type accurately reflects the GitHub API response.
- Updated test mock objects to include the new required fields.

## Testing
- `npm run type-check` — 0 errors
- `npm run lint` — 0 errors