### PR TITLE
[FEAT] : fixed Canonical Schema Syntax Error

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -297,7 +297,6 @@ CREATE TABLE IF NOT EXISTS leaderboard_cache (
   building_until timestamptz,
   updated_at timestamptz default now()
 );
-);
 
 -- -------------------------------------------------------
 -- User Sponsor Metrics: cache for user-specific GitHub Sponsors data


### PR DESCRIPTION

## Summary

This PR fixes a minor syntax error in the primary database initialization script (`supabase/schema.sql`). A duplicate closing bracket and semicolon statement on line 300 was causing SQL execution to fail during bootstrapping.

Closes #3130

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **Database Schema (`supabase/schema.sql`)**: Removed a duplicate closing parenthesis and semicolon `);` on line 300 that followed the `leaderboard_cache` table definition.

---

## How to Test

1. Connect to a fresh, empty PostgreSQL/Supabase database instance.
2. Run the entire SQL query content of the `supabase/schema.sql` file.

**Expected result:**
The script compiles and executes successfully from start to finish with no syntax or database structure errors.

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Additional Context

None.