### PR TITLE
[FEAT] : fixed Broken Real-Time SSE Dashboard Updates  

### DIFF
--- a/src/app/api/stream/route.ts
+++ b/src/app/api/stream/route.ts
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase";
 import { resolveAppUser } from "@/lib/resolve-user";
-import { activeStreamConnections } from "@/lib/sse";
+import { activeStreamConnections, sseConnections } from "@/lib/sse";
 
 export const dynamic = "force-dynamic";
 
@@ -82,6 +82,13 @@ export async function GET(req: NextRequest) {
   const stream = new ReadableStream({
     start(controller) {
       let isClosed = false;
+
+      let connectionsSet = sseConnections.get(userId);
+      if (!connectionsSet) {
+        connectionsSet = new Set();
+        sseConnections.set(userId, connectionsSet);
+      }
+      connectionsSet.add(controller);
       let interval: ReturnType<typeof setInterval>;
       let maxDurationTimeout: ReturnType<typeof setTimeout>;
 
@@ -102,6 +109,14 @@ export async function GET(req: NextRequest) {
         isClosed = true;
         clearInterval(interval);
         clearTimeout(maxDurationTimeout);
+
+        const connectionsSet = sseConnections.get(userId);
+        if (connectionsSet) {
+          connectionsSet.delete(controller);
+          if (connectionsSet.size === 0) {
+            sseConnections.delete(userId);
+          }
+        }
 
         try {
           controller.close();

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -158,7 +158,7 @@ export async function POST(req: NextRequest) {
       await invalidateUserMetricsCache(staleResult.githubId);
     }
 
-    sendSSEEvent(githubLogin, "commit", {
+    sendSSEEvent(staleResult.userId, "commit", {
       repo: payload.repository?.full_name,
       timestamp: new Date().toISOString(),
     });

--- a/src/lib/sse.ts
+++ b/src/lib/sse.ts
@@ -1,7 +1,7 @@
 // Per-user registry of SSE push controllers (one entry per user, last writer
 // wins). Used by server-side code (e.g. webhook dispatch) to push events to a
 // connected client without waiting for the next poll cycle.
-export const sseConnections = new Map<string, ReadableStreamDefaultController>();
+export const sseConnections = new Map<string, Set<ReadableStreamDefaultController>>();
 
 // Tracks the number of active /api/stream connections per user so the route
 // can enforce a cap and prevent unbounded database polling.
@@ -12,14 +12,19 @@ export function sendSSEEvent(
   event: string,
   data: object
 ): void {
-  const controller = sseConnections.get(userId);
-  if (controller) {
-    try {
-      controller.enqueue(
-        `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
-      );
-    } catch (e) {
-      sseConnections.delete(userId);
+  const connectionsSet = sseConnections.get(userId);
+  if (connectionsSet) {
+    for (const controller of connectionsSet) {
+      try {
+        controller.enqueue(
+          `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+        );
+      } catch (e) {
+        connectionsSet.delete(controller);
+        if (connectionsSet.size === 0) {
+          sseConnections.delete(userId);
+        }
+      }
     }
   }
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -297,7 +297,6 @@ CREATE TABLE IF NOT EXISTS leaderboard_cache (
   building_until timestamptz,
   updated_at timestamptz default now()
 );
-);
 
 -- -------------------------------------------------------
 -- User Sponsor Metrics: cache for user-specific GitHub Sponsors data

--- a/test/sse-stream-route.test.ts
+++ b/test/sse-stream-route.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
-import { activeStreamConnections } from "@/lib/sse";
+import { activeStreamConnections, sseConnections } from "@/lib/sse";
 
 // ─── hoisted mocks ──────────────────────────────────────────────────────────
 
@@ -86,6 +86,7 @@ describe("GET /api/stream — SSE stream route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     activeStreamConnections.clear();
+    sseConnections.clear();
 
     mocks.getServerSession.mockResolvedValue({
       githubId: "gh-1",
@@ -274,5 +275,50 @@ describe("GET /api/stream — SSE stream route", () => {
     const { GET } = await import("@/app/api/stream/route");
     const res = await GET(makeRequest());
     expect(res.headers.get("Connection")).toBe("keep-alive");
+  });
+
+  // ── sse connections registry ──────────────────────────────────────────
+
+  it("registers controller in sseConnections on connection", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    await GET(makeRequest());
+
+    const userConnections = sseConnections.get("user-1");
+    expect(userConnections).toBeDefined();
+    expect(userConnections instanceof Set).toBe(true);
+    expect(userConnections?.size).toBe(1);
+  });
+
+  it("removes controller from sseConnections on disconnection", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    const { req, abort } = makeAbortableRequest();
+
+    await GET(req);
+    expect(sseConnections.get("user-1")?.size).toBe(1);
+
+    abort();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(sseConnections.has("user-1")).toBe(false);
+  });
+
+  it("supports concurrent tab connections in sseConnections", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+
+    const res1 = await GET(makeRequest());
+    const res2 = await GET(makeRequest());
+    const { req: req3, abort: abort3 } = makeAbortableRequest();
+    await GET(req3);
+
+    const userConnections = sseConnections.get("user-1");
+    expect(userConnections?.size).toBe(3);
+
+    abort3();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(sseConnections.get("user-1")?.size).toBe(2);
+
+    await res1.body?.getReader().cancel();
+    await res2.body?.getReader().cancel();
+    expect(sseConnections.has("user-1")).toBe(false);
   });
 });


### PR DESCRIPTION


## Summary

This PR fixes the Server-Sent Events (SSE) real-time dashboard notification system. It adds connection registration logic to the stream API route, refactors the socket registry to support multi-tab synchronization via Sets, and resolves a database UUID lookup mismatch in the GitHub push webhook handler.

Closes #3129
---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [x] 🧪 Tests only

---

## What Changed

- **SSE Core Registry (`src/lib/sse.ts`)**:
  - Refactored `sseConnections` to map user UUIDs to a `Set<ReadableStreamDefaultController>` instead of a single controller. This supports multi-tab setups and prevents tabs from overriding or clearing active sockets.
  - Updated `sendSSEEvent` to push events to all active controllers in the user's Set and dynamically prune failed connections.
- **Stream API Router (`src/app/api/stream/route.ts`)**:
  - Registered the active stream `controller` in the user's `sseConnections` Set during stream startup.
  - Safely deleted the controller from the user's Set in `closeStream()`, cleaning up empty registry keys.
- **GitHub Webhook Handler (`src/app/api/webhooks/github/route.ts`)**:
  - Changed `sendSSEEvent` to dispatch push notification payloads using the resolved database user UUID (`staleResult.userId`) instead of the mutable `githubLogin` string.
- **SSE Unit Tests (`test/sse-stream-route.test.ts`)**:
  - Added test cases verifying stream controller registration on connection, cleanup on disconnection, and concurrent tab tracking.

---

## How to Test

1. Run the stream route tests:
   ```bash
   node node_modules/vitest/vitest.mjs run test/sse-stream-route.test.ts
   ```
2. Verify that all 21 unit tests (including the 3 new connection lifecycle tests) pass successfully.

**Expected result:**
All tests pass cleanly.

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Additional Context

- The Set-based socket registry solves a key limitation of the original design where closing any browser tab terminated push events for all other active tabs.