### PR TITLE
feat: add floating scroll-to-top button for Agents list (#3149)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -15,6 +15,7 @@ import { redirect } from "next/navigation";
 import DashboardSSEProvider from "@/components/DashboardSSEProvider";
 import { DashboardWidgetA11yProvider } from "@/components/dashboard/DashboardWidgetA11yContext";
 import RoastHypeWidget from "./RoastHypeWidget";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 
 
 export default async function DashboardPage() {
@@ -90,7 +91,7 @@ export default async function DashboardPage() {
 
             {/* Today Focus */}
             <section>
-              <TodayFocusHero userName={session.user?.name ?? null} />
+              <TodayFocusHero userName={session?.user?.name ?? null} />
             </section>
 
             {/* Featured Section */}
@@ -146,6 +147,8 @@ export default async function DashboardPage() {
               <MilestonePlanner />
             </section>
           </div>
+
+          <ScrollToTopButton />
         </main>
       </DashboardWidgetA11yProvider>
     </DashboardSSEProvider>

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { ArrowUp } from "lucide-react";
+
+export default function ScrollToTopButton({ threshold = 400 }: { threshold?: number }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > threshold);
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [threshold]);
+
+  const scrollToTop = useCallback(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      className="fixed bottom-6 right-6 z-50 flex h-11 w-11 items-center justify-center rounded-full bg-[var(--accent)] text-white shadow-lg transition-transform hover:scale-110 hover:shadow-xl active:scale-95"
+    >
+      <ArrowUp className="h-5 w-5" />
+    </button>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -281,6 +281,7 @@ export async function middleware(req: NextRequest) {
     (route) => pathname === route || pathname.startsWith(`${route}/`)
   );
 
+
   if ((isProtectedRoute || isAdminRoute) && !token) {
     const url = req.nextUrl.clone();
     url.pathname = "/";


### PR DESCRIPTION
Adds a floating "Scroll to Top" button on the dashboard that appears after scrolling past 400px and smoothly scrolls back to top when clicked.

Closes #3149