### PR TITLE
fix(security): prevent CSRF bypass via domain boundary check on referer

### DIFF
--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -75,7 +75,7 @@ export function validateCsrf(req: NextRequest): {
   }
 
   if (referer) {
-    const match = allowed.some((a) => referer.startsWith(a));
+    const match = allowed.some((a) => referer === a || referer.startsWith(a + "/"));
     if (!match) {
       return { valid: false, reason: "Forbidden" };
     }


### PR DESCRIPTION
This PR fixes a security vulnerability in the custom CSRF validator (`validateCsrf`). The previous implementation used a naive `referer.startsWith(a)` string match, allowing attackers to bypass CSRF protections by registering subdomains like `https://devtrack.com.attacker.com`. The logic has been updated to strictly enforce the domain boundary by appending a trailing slash to the prefix match, preventing subdomain spoofing attacks. Fixes #3168.