### PR TITLE
ci: broaden assign-bot matching + star-required PR gate

### DIFF
--- a/.github/workflows/issue-assignment.yml
+++ b/.github/workflows/issue-assignment.yml
@@ -20,21 +20,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const comment = context.payload.comment.body.toLowerCase().trim();
-            const KEYWORDS = [
-              "i'd like to work on this",
-              "i would like to work on this",
-              "i want to work on this",
-              "i'll work on this",
-              "i'll take this",
-              "i can work on this",
-              "i will work on this",
-              "assign me",
-              "please assign me",
-              "can i work on this",
-              "can i take this",
+
+            // Broad intent matching. The old exact-string list missed common
+            // phrasings — e.g. "I'd love to work on this feature", "please
+            // assign it to me", "/assign" — leaving contributors unassigned
+            // even though the bot ran. These regexes tolerate those variants.
+            const PATTERNS = [
+              /(^|\s)\/assign\b/,                                          // slash command: /assign, /assign me
+              /\bassign(ed|ing)?\b[\s\S]{0,40}\b(me|this|it|myself|to me)\b/, // "assign me", "assign this to me", "assign it to me"
+              /\b(me|this|it|myself)\b[\s\S]{0,25}\bassign(ed)?\b/,          // "can this be assigned to me"
+              /\bwork(ing)?\s+on\s+(this|it)\b/,                            // "work on this", "working on it"
+              /\b(want|like|love|willing|happy|keen|glad|wish|hoping)\s+to\s+(work|take|tackle|contribute|help|solve|fix|do)\b/,
+              /\b(let me|i can|i'?ll|i will|i'?d|i would|i want|can i|may i|could i)\b[\s\S]{0,30}\b(work|take|tackle|handle|pick|solve|fix|contribute|do this)\b/,
+              /\binterested\s+in\s+(work|contribut|solv|this|tak|fix)/,     // "interested in working/contributing"
+              /\b(take|tackle|handle|pick)\s+(this|it|up)\b/,               // "take this", "pick it up"
             ];
 
-            if (!KEYWORDS.some(kw => comment.includes(kw))) return;
+            if (!PATTERNS.some(re => re.test(comment))) return;
 
             // Skip bots
             if (context.payload.comment.user.type === 'Bot') return;

--- a/.github/workflows/pr-star-required.yml
+++ b/.github/workflows/pr-star-required.yml
@@ -1,0 +1,84 @@
+name: Require star to contribute
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  watch:
+    types: [started] # fires when someone stars the repo
+
+permissions:
+  pull-requests: write
+  statuses: write
+
+jobs:
+  star-gate:
+    name: Star required
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const CONTEXT = 'star-required';
+            const repoUrl = `https://github.com/${owner}/${repo}`;
+
+            async function hasStarred(username) {
+              const login = username.toLowerCase();
+              const stargazers = await github.paginate(
+                github.rest.activity.listStargazersForRepo,
+                { owner, repo, per_page: 100 },
+              );
+              return stargazers.some(u => u.login.toLowerCase() === login);
+            }
+
+            async function setStatus(sha, state, description) {
+              await github.rest.repos.createCommitStatus({
+                owner, repo, sha, context: CONTEXT, state, description,
+                target_url: repoUrl,
+              });
+            }
+
+            // --- Someone starred: clear the gate on all of their open PRs ---
+            if (context.eventName === 'watch') {
+              const starrer = context.payload.sender.login.toLowerCase();
+              const prs = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+              for (const pr of prs) {
+                if (pr.user.login.toLowerCase() !== starrer) continue;
+                await setStatus(pr.head.sha, 'success', 'Repo starred — thank you!');
+              }
+              return;
+            }
+
+            // --- Pull request opened / reopened / synchronized ---
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const sha = pr.head.sha;
+
+            // Bots and maintainers bypass the gate.
+            if (pr.user.type === 'Bot') {
+              await setStatus(sha, 'success', 'Bot PR — exempt');
+              return;
+            }
+            if (['OWNER', 'MEMBER', 'COLLABORATOR'].includes(pr.author_association)) {
+              await setStatus(sha, 'success', 'Maintainer — exempt');
+              return;
+            }
+
+            if (await hasStarred(author)) {
+              await setStatus(sha, 'success', 'Repo starred — thank you!');
+              return;
+            }
+
+            // Not starred → block.
+            await setStatus(sha, 'failure', 'Please star the repo to contribute');
+
+            // Comment only on the first open, to avoid spamming on every push.
+            if (context.payload.action === 'opened') {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number,
+                body: `Hi @${author} — thanks for the PR! 🙌\n\nDevTrack asks contributors to **[⭐ star the repo](${repoUrl})** before a PR can be merged. It takes two seconds and is the easiest way to support the project.\n\nOnce you've starred, the **\`star-required\`** check turns green automatically (give it a moment). Thanks for contributing!`,
+              });
+            }


### PR DESCRIPTION
## What

Two CI workflow changes.

### 1. Fix issue-assignment bot brittle matching
The assign bot ran fine but used an exact-string keyword list that missed common phrasings — e.g. *"I'd love to work on this feature"*, *"please assign it to me"*, `/assign`. Contributors stayed unassigned even though the workflow triggered. Replaced with intent-based regex patterns covering those variants. Verified against real missed comments (e.g. #2647).

### 2. New `star-required` PR gate (hard block)
`pr-star-required.yml`:
- PR from a non-stargazer → failing `star-required` commit status + one comment asking them to star.
- Flips to green automatically when they star (`watch` event scans their open PRs).
- Maintainers (`OWNER`/`MEMBER`/`COLLABORATOR`) and bots exempt.

## Manual step after merge
The status only hard-blocks once made required:
**Settings → Branches → `main` rule → Require status checks → add `star-required`.**
The check name appears in that search box **only after it has run once** — so merge this, let it fire on a PR/star event, then add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)