### PR TITLE
chore: trigger star-required check (throwaway)

### DIFF
--- a/.star-check-trigger.md
+++ b/.star-check-trigger.md
@@ -1,0 +1,3 @@
+# star-check trigger
+
+Throwaway PR to make the star-required status post once so it can be added as a required check. Safe to close without merging.


### PR DESCRIPTION
Throwaway PR to make the `star-required` status post once so GitHub lists it in branch-protection required checks. Close without merging after the check appears.