### PR TITLE
fix: sanitize URL path before database lookup

### DIFF
--- a/src/lib/repo-analytics-utils.ts
+++ b/src/lib/repo-analytics-utils.ts
@@ -9,15 +9,21 @@ export interface ParsedRepo {
 
 /**
  * Validates and parses a raw "owner/repo" string.
+ * Strips a single leading slash and collapses consecutive slashes before
+ * validating, so inputs like "/owner/repo" or "owner//repo" (e.g. from
+ * referrer headers or query params) normalise to "owner/repo" instead of
+ * silently failing to match.
  * Returns the split components on success, or null if the value is invalid.
  */
 export function parseRepoParam(raw: string): ParsedRepo | null {
   const trimmed = raw.trim();
-  const match = REPO_IDENTIFIER_RE.exec(trimmed);
+  const withoutLeadingSlash = trimmed.startsWith("/")
+    ? trimmed.slice(1)
+    : trimmed;
+  const normalised = withoutLeadingSlash.replace(/\/{2,}/g, "/");
+  const match = REPO_IDENTIFIER_RE.exec(normalised);
   if (!match) return null;
-
   const [, owner, repo] = match;
   if (repo === "." || repo === "..") return null;
-
   return { owner, repo };
 }

--- a/test/repo-analytics-utils-sanitize.test.ts
+++ b/test/repo-analytics-utils-sanitize.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { parseRepoParam } from "@/lib/repo-analytics-utils";
+
+describe("parseRepoParam — input sanitisation", () => {
+  it("strips a single leading slash before validating", () => {
+    expect(parseRepoParam("/owner/repo")).toEqual({
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("collapses consecutive slashes before validating", () => {
+    expect(parseRepoParam("owner//repo")).toEqual({
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("handles mixed leading slash, double slashes, and surrounding spaces", () => {
+    expect(parseRepoParam("  /owner//repo  ")).toEqual({
+      owner: "owner",
+      repo: "repo",
+    });
+  });
+
+  it("leaves normal input unchanged", () => {
+    expect(parseRepoParam("facebook/react")).toEqual({
+      owner: "facebook",
+      repo: "react",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes `parseRepoParam` in `repo-analytics-utils.ts` to normalise leading and consecutive slashes in "owner/repo" input before validating, instead of silently returning `null` for inputs like `/owner/repo` or `owner//repo`.

Closes #3032

---

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed
- `src/lib/repo-analytics-utils.ts`: `parseRepoParam` now strips a single leading slash and collapses consecutive slashes via regex before running the existing `owner/repo` validation regex
- `test/repo-analytics-utils-sanitize.test.ts` (new): covers leading slash, double slashes, mixed slashes + surrounding spaces, and unchanged normal input

---

## How to Test
1. Checkout this branch
2. Run `npx vitest run test/repo-analytics-utils-sanitize.test.ts test/repo-analytics-utils.test.ts`
3. Confirm all 23 tests pass (19 pre-existing + 4 new)

**Expected result:** `parseRepoParam("/owner/repo")` and `parseRepoParam("owner//repo")` both return `{ owner: "owner", repo: "repo" }` instead of `null`, while all pre-existing valid/invalid cases still behave the same.

---

## Screenshots / Recordings
Not applicable — no UI impact, logic-only change.

---

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)
Not applicable — no UI impact.

---

## Additional Context
None.