### PR TITLE
test: add non-mutation coverage for mergeCommitCounts (#2988)

### DIFF
--- a/test/developer-persona.test.ts
+++ b/test/developer-persona.test.ts
@@ -46,6 +46,18 @@ describe("Developer Persona Utilities", () => {
         "2026-05-03": 1,
       });
     });
+
+    it("should not mutate the original input objects", () => {
+      const a = { "2026-05-01": 5, "2026-05-02": 2 };
+      const b = { "2026-05-02": 3, "2026-05-03": 1 };
+      const aSnapshot = { ...a };
+      const bSnapshot = { ...b };
+
+      mergeCommitCounts(a, b);
+
+      expect(a).toEqual(aSnapshot);
+      expect(b).toEqual(bSnapshot);
+    });
   });
 
   describe("mergeSignals", () => {


### PR DESCRIPTION
## Summary
Adds one missing test case to `test/developer-persona.test.ts`: verifies that `mergeCommitCounts` does not mutate its input objects when merging overlapping dates, as called out in issue #2988.

Closes #2988

---

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [x] 🧪 Tests only

---

## What Changed
- `test/developer-persona.test.ts` — added a new test in the `mergeCommitCounts` describe block: `"should not mutate the original input objects"`. It snapshots both input maps before calling `mergeCommitCounts(a, b)` and asserts they're unchanged afterward.

---

## How to Test
1. Pull this branch.
2. Run `pnpm install` (use `--ignore-scripts` if the optional `tree-sitter` native build fails on your machine — it's unrelated to this change).
3. Run `npx vitest run test/developer-persona.test.ts`.

**Expected result:** All 26 tests in the file pass, including the new non-mutation test for `mergeCommitCounts`.

---

## Screenshots / Recordings
Not applicable — this is a test-only change with no UI impact.

---

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)
Not applicable — no UI changes.

---

## Additional Context
Most of the coverage requested in #2988 — `calculateStreaks`, `formatDurationHours`, `choosePersonaCandidate`, `mergeCommitCounts` (sum behavior), and `mergeSignals` — already exists in `test/developer-persona.test.ts` on `main`. This PR adds the one gap I found while reviewing: an explicit assertion that `mergeCommitCounts` doesn't mutate its inputs, which the issue mentions but wasn't previously tested. Flagging this so reviewers aren't surprised the diff is small relative to the issue's original scope.