### PR TITLE
test: add mocked crypto.subtle coverage for decryptTokenEdge (#2990)

### DIFF
--- a/test/crypto-edge.test.ts
+++ b/test/crypto-edge.test.ts
@@ -127,4 +127,66 @@ describe("decryptTokenEdge", () => {
     const result = await decryptTokenEdge(longCipher.encrypted, longCipher.iv);
     expect(result).toBe(longPlaintext);
   });
+
+  it("returns null when crypto.subtle.decrypt throws", async () => {
+    const importKeySpy = vi.fn().mockResolvedValue("mock-crypto-key");
+    const decryptSpy = vi.fn().mockRejectedValue(new Error("decrypt failed"));
+
+    vi.stubGlobal("crypto", {
+      ...globalThis.crypto,
+      subtle: {
+        ...globalThis.crypto.subtle,
+        importKey: importKeySpy,
+        decrypt: decryptSpy,
+      },
+    });
+
+    const result = await decryptTokenEdge(validCipher.encrypted, validCipher.iv);
+
+    expect(result).toBeNull();
+    expect(decryptSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls crypto.subtle.importKey and crypto.subtle.decrypt with the correct parameters", async () => {
+    const importKeySpy = vi.fn().mockResolvedValue("mock-crypto-key");
+    const decryptSpy = vi.fn().mockResolvedValue(new TextEncoder().encode("decrypted-value").buffer);
+
+    vi.stubGlobal("crypto", {
+      ...globalThis.crypto,
+      subtle: {
+        ...globalThis.crypto.subtle,
+        importKey: importKeySpy,
+        decrypt: decryptSpy,
+      },
+    });
+
+    const result = await decryptTokenEdge(validCipher.encrypted, validCipher.iv);
+
+    expect(result).toBe("decrypted-value");
+
+    expect(importKeySpy).toHaveBeenCalledTimes(1);
+    expect(importKeySpy).toHaveBeenCalledWith(
+      "raw",
+      expect.any(Uint8Array),
+      { name: "AES-GCM" },
+      false,
+      ["decrypt"]
+    );
+    const [, importedKeyBytes] = importKeySpy.mock.calls[0];
+    expect(importedKeyBytes).toHaveLength(32);
+
+    expect(decryptSpy).toHaveBeenCalledTimes(1);
+    expect(decryptSpy).toHaveBeenCalledWith(
+      {
+        name: "AES-GCM",
+        iv: expect.any(Uint8Array),
+        tagLength: 128,
+      },
+      "mock-crypto-key",
+      expect.any(Uint8Array)
+    );
+    const [decryptOptions, , decryptedEncryptedBytes] = decryptSpy.mock.calls[0];
+    expect(decryptOptions.iv).toHaveLength(12);
+    expect(decryptedEncryptedBytes).toHaveLength(validCipher.encrypted.length / 2);
+  });
 });


### PR DESCRIPTION
## Summary
Adds two missing test cases to `test/crypto-edge.test.ts`: mocking `globalThis.crypto.subtle` via `vi.stubGlobal` to verify `decryptTokenEdge` returns `null` when `crypto.subtle.decrypt` throws, and to assert the exact parameters passed to `crypto.subtle.importKey` and `crypto.subtle.decrypt`, per issue #2990.

Closes #2990

---

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [x] 🧪 Tests only

---

## What Changed
- `test/crypto-edge.test.ts` — added two tests to the `decryptTokenEdge` describe block:
  - `"returns null when crypto.subtle.decrypt throws"` — stubs `globalThis.crypto.subtle` with `vi.stubGlobal` so `decrypt` rejects, and asserts the function catches it and returns `null`.
  - `"calls crypto.subtle.importKey and crypto.subtle.decrypt with the correct parameters"` — stubs `crypto.subtle` with spies and asserts `importKey` is called with `"raw"`, a 32-byte key, `{ name: "AES-GCM" }`, `false`, `["decrypt"]`, and `decrypt` is called with `{ name: "AES-GCM", iv: <12-byte Uint8Array>, tagLength: 128 }` and the correctly-sized encrypted byte array.

---

## How to Test
1. Pull this branch.
2. Run `pnpm install` (use `--ignore-scripts` if the optional `tree-sitter` native build fails locally — unrelated to this change).
3. Run `npx vitest run test/crypto-edge.test.ts`.

**Expected result:** All 15 tests in the file pass, including the two new mocked-`crypto.subtle` tests.

---

## Screenshots / Recordings
Not applicable — test-only change, no UI impact.

---

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)
Not applicable — no UI changes.

---

## Additional Context
Most of the coverage requested in #2990 (missing/invalid key, invalid hex/odd-length ciphertext, invalid IV length, successful decryption) already existed in `test/crypto-edge.test.ts` on `main`, using the real Web Crypto API end-to-end. This PR adds the two pieces the issue specifically asked for that weren't covered: mocking `globalThis.crypto.subtle` with `vi.stubGlobal`, and verifying the exact call parameters to `importKey`/`decrypt`. Flagging this so the diff's scope relative to the issue is clear.