### PR TITLE
feat(dashboard): add confirmation modal and toast notification for reset layout

### DIFF
--- a/src/components/dashboard/CustomizableDashboard.tsx
+++ b/src/components/dashboard/CustomizableDashboard.tsx
@@ -43,6 +43,8 @@ import DailyNoteWidget from "@/components/DailyNoteWidget";
 import WidgetErrorBoundary from "@/components/WidgetErrorBoundary";
 import DashboardLayoutToolbar from "@/components/dashboard/DashboardLayoutToolbar";
 import { DashboardWidgetA11yProvider } from "@/components/dashboard/DashboardWidgetA11yContext";
+import ConfirmModal from "@/components/ConfirmModal";
+import { toast } from "sonner";
 import SortableDashboardWidget from "@/components/dashboard/SortableDashboardWidget";
 import {
   DASHBOARD_LAYOUT_STORAGE_KEY,
@@ -476,6 +478,7 @@ export default function CustomizableDashboard() {
   const [isEditing, setIsEditing] = useState(false);
   const [isHydrated, setIsHydrated] = useState(false);
   const [hasLoadedRemoteLayout, setHasLoadedRemoteLayout] = useState(false);
+  const [isConfirmResetOpen, setIsConfirmResetOpen] = useState(false);
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 8 },
@@ -622,8 +625,18 @@ export default function CustomizableDashboard() {
     setLayout((currentLayout) => showWidget(currentLayout, widgetId));
   };
 
-  const handleResetLayout = () => {
+  const handleResetClick = () => {
+    setIsConfirmResetOpen(true);
+  };
+
+  const handleResetConfirm = () => {
     setLayout(resetDashboardLayout());
+    setIsConfirmResetOpen(false);
+    toast.success("Dashboard layout has been reset to defaults.");
+  };
+
+  const handleResetCancel = () => {
+    setIsConfirmResetOpen(false);
   };
 
   return (
@@ -632,7 +645,7 @@ export default function CustomizableDashboard() {
         isEditing={isEditing}
         hiddenWidgets={layout.hidden}
         onEditingChange={setIsEditing}
-        onReset={handleResetLayout}
+        onReset={handleResetClick}
         onShowWidget={handleShowWidget}
       />
 
@@ -699,6 +712,16 @@ export default function CustomizableDashboard() {
           })}
         </DndContext>
       </DashboardWidgetA11yProvider>
+
+      <ConfirmModal
+        isOpen={isConfirmResetOpen}
+        title="Reset Dashboard Layout"
+        message="Are you sure you want to reset your dashboard layout? This will restore all default widgets and their original positions."
+        confirmLabel="Reset"
+        cancelLabel="Cancel"
+        onConfirm={handleResetConfirm}
+        onCancel={handleResetCancel}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR adds a confirmation dialog and success toast notification flow for the **Reset Layout** functionality in the Customizable Dashboard. This prevents accidental resets of customized dashboards by prompting the user with a `ConfirmModal` before resetting the layout in local storage and syncing with the database.

Closes #<!-- Replace this comment with the actual issue number -->

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **[CustomizableDashboard.tsx](file:///c:/Users/DEEKSHITHANOWDU/devtrack/src/components/dashboard/CustomizableDashboard.tsx)**:
  - Imported `ConfirmModal` and `toast` from `sonner`.
  - Added `isConfirmResetOpen` boolean state to control modal visibility.
  - Implemented event handlers `handleResetClick`, `handleResetConfirm`, and `handleResetCancel`.
  - Passed `handleResetClick` to `DashboardLayoutToolbar`'s `onReset` prop.
  - Rendered `<ConfirmModal>` at the bottom of the dashboard layout tree.

---

## How to Test

1. Click **Edit Layout** on the dashboard layout customization toolbar.
2. Click the **Reset Layout** button (RotateCcw icon).
3. Verify that the **Reset Dashboard Layout** confirmation modal appears, prompting you to reset or cancel.
4. Click **Reset** in the modal.
5. Verify that the layout is successfully restored to default coordinates, the modal closes, and a success toast notification appears.

**Expected result:**
The layout snaps back to its default configuration, and the user receives a success toast notification: *"Dashboard layout has been reset to defaults."*

---

## Screenshots / Recordings

<!-- For UI changes, attach before/after screenshots or a short screen recording. Delete this section if not applicable. -->

| Before | After |
|--------|-------|
|        |       |

---

## Checklist

- [ ] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [x] Added or updated tests where applicable
- [x] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context

This is a GSSoC Level 1 (`gssoc:level1`) issue. It reuses existing styling and the pre-built `ConfirmModal` and `sonner` components to maintain project visual standards.
