### PR TITLE
fix: respect public widget privacy settings

### DIFF
--- a/src/app/api/public/[username]/route.ts
+++ b/src/app/api/public/[username]/route.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { NextRequest, NextResponse } from "next/server";
-import { fetchPublicProfile } from "@/lib/public-profile-data";
+import { fetchPublicProfile, filterPublicProfileData } from "@/lib/public-profile-data";
 import { getUpstashConfig, upstashRateLimitFixedWindow } from "@/lib/upstash-rest";
 import { createMemoryFixedWindowRateLimiter, getClientIp } from "@/lib/rate-limit";
 
@@ -89,5 +89,5 @@ export async function GET(
     );
   }
 
-  return NextResponse.json(profile);
+  return NextResponse.json(filterPublicProfileData(profile));
 }

--- a/src/lib/public-profile-data.ts
+++ b/src/lib/public-profile-data.ts
@@ -59,6 +59,21 @@ export interface PublicProfileData {
   publicWidgets: PublicWidgetKey[];
 }
 
+/** Remove disabled widget data before a public profile leaves the server. */
+export function filterPublicProfileData(
+  profile: PublicProfileData
+): Partial<PublicProfileData> {
+  const visibleProfile: Partial<PublicProfileData> = { ...profile };
+  const publicWidgets = profile.publicWidgets ?? ["streak", "contributions"];
+
+  if (!publicWidgets.includes("streak")) delete visibleProfile.streak;
+  if (!publicWidgets.includes("contributions")) delete visibleProfile.contributions;
+  if (!publicWidgets.includes("languages")) delete visibleProfile.topLanguages;
+  if (!publicWidgets.includes("prs")) delete visibleProfile.pullRequests;
+
+  return visibleProfile;
+}
+
 async function ghFetch(url: string, token?: string): Promise<Response> {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",

--- a/test/public-profile-data.test.ts
+++ b/test/public-profile-data.test.ts
@@ -5,6 +5,8 @@ import {
   fetchPublicStreak,
   fetchTopLanguage,
   fetchPublicGists,
+  filterPublicProfileData,
+  type PublicProfileData,
 } from "../src/lib/public-profile-data";
 
 describe("public-profile-data", () => {
@@ -44,6 +46,25 @@ describe("public-profile-data", () => {
 
       const repos = await fetchPublicTopRepos("user123");
       expect(repos).toEqual([]);
+    });
+  });
+
+  describe("filterPublicProfileData", () => {
+    it("removes disabled widget data from the public response", () => {
+      const profile = {
+        publicWidgets: ["contributions"],
+        streak: { current: 4 },
+        contributions: { days: 30, total: 12, data: {} },
+        topLanguages: [{ name: "TypeScript", count: 1, percentage: 100 }],
+        pullRequests: 8,
+      } as unknown as PublicProfileData;
+
+      const filtered = filterPublicProfileData(profile);
+
+      expect(filtered.contributions).toEqual(profile.contributions);
+      expect(filtered).not.toHaveProperty("streak");
+      expect(filtered).not.toHaveProperty("topLanguages");
+      expect(filtered).not.toHaveProperty("pullRequests");
     });
   });
 


### PR DESCRIPTION
## Summary
- remove disabled widget data from the public profile API response
- preserve enabled profile data while honoring saved widget preferences
- add regression coverage for hidden streak, language, and PR fields

Closes #3175

## Validation
- npx vitest run test/public-profile-data.test.ts --environment node
- npm run type-check
- npx eslint src/lib/public-profile-data.ts "src/app/api/public/[username]/route.ts" test/public-profile-data.test.ts
- git diff --check