### PR TITLE
fix(a11y): respect prefers-reduced-motion in BackToTopButton

### DIFF
--- a/src/components/BackToTopButton.tsx
+++ b/src/components/BackToTopButton.tsx
@@ -17,11 +17,21 @@ export default function BackToTopButton() {
     }
   };
 
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
   const scrollToTop = () => {
     if (typeof window !== "undefined") {
       window.scrollTo({
         top: 0,
-        behavior: "smooth",
+        behavior: prefersReducedMotion ? "auto" : "smooth",
       });
     }
   };
@@ -70,7 +80,7 @@ export default function BackToTopButton() {
                 strokeDasharray={circumference}
                 strokeDashoffset={strokeDashoffset}
                 style={{ filter: "drop-shadow(0 0 6px color-mix(in srgb, var(--accent) 60%, transparent))" }}
-                className="transition-[stroke-dashoffset] duration-100"
+                className={`transition-[stroke-dashoffset] duration-100 ${prefersReducedMotion ? "!transition-none" : ""}`}
               />
             </svg>
             <button


### PR DESCRIPTION
## Summary

Adds `prefers-reduced-motion` support to the existing `BackToTopButton` component so users who prefer reduced animations get instant scroll behavior instead of smooth transitions.

Closes #3149

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- `src/components/BackToTopButton.tsx` — Added `prefersReducedMotion` check using `window.matchMedia("(prefers-reduced-motion: reduce)")`. Scroll behavior uses `"auto"` instead of `"smooth"` when reduced motion is preferred. Progress ring SVG transition is disabled via `!transition-none` Tailwind class for reduced motion users.

---

## How to Test

1. Open DevTrack dashboard and scroll down past 300px to reveal the Back to Top button
2. Click the button — should smooth scroll to top (default behavior)
3. Enable "Reduce motion" in OS accessibility settings (Windows: Settings > Accessibility > Visual effects > Animation effects; macOS: System Settings > Accessibility > Display > Reduce motion)
4. Scroll down again and click the button — should instantly jump to top without animation
5. Verify the progress ring around the button also snaps without transition

**Expected result:** Button scrolls smoothly by default, instantly jumps when reduced motion is preferred. No visual regressions on the button appearance or positioning.

---
## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [x] `npm run lint` passes locally
- [x] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)

- [x] Keyboard navigation works correctly
- [x] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed (existing `aria-label="Back to top"` preserved)
- [x] Tested on mobile / responsive layout

---

## Additional Context

The `BackToTopButton` component already existed globally in `providers.tsx` and met all other acceptance criteria from the issue (300px threshold, smooth scroll, hidden near top, responsive, aria-label). This PR adds the missing `prefers-reduced-motion` a11y support.