### PR TITLE
security(supabase): add RLS enablement and policies for users, goals,…

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,6 +53,21 @@ The `service_role` key is a **database superkey** — it completely bypasses all
 
 DevTrack uses this key only in server-side API routes. See `.env.example` for detailed security requirements.
 
+### 🔒 Database Security: Row Level Security (RLS) & Verification
+
+All user-owned database tables in DevTrack (`users`, `goals`, `goal_history`, `streak_freezes`, `user_github_achievements`, `user_sponsor_metrics`, `wakatime_stats`, `collaboration_rooms`, etc.) have Row Level Security (RLS) enabled in `supabase/schema.sql`.
+
+#### Why RLS Matters
+Although DevTrack primarily performs server-side database operations using `SUPABASE_SERVICE_ROLE_KEY`, explicit RLS policies provide critical defense-in-depth:
+- If client-side queries or the public `NEXT_PUBLIC_SUPABASE_ANON_KEY` are used directly, users are strictly restricted to reading and writing their own data (`user_id = auth.uid()`).
+- Prevents cross-tenant data leaks and unauthorized modifications.
+
+#### Verifying RLS in the Supabase Dashboard
+1. Log in to your project on [supabase.com](https://supabase.com).
+2. Go to **Authentication** → **Policies** (or **Table Editor**).
+3. Confirm that **RLS Enabled** (green lock badge) is present on all user tables (`users`, `goals`, `streak_freezes`, etc.).
+4. Verify that each table has explicit policies configured (e.g., `"Users can manage own goals"` with expression `user_id = auth.uid()::text`).
+
 ---
 
 ## 3. Create a GitHub OAuth App

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -38,6 +38,11 @@ add column if not exists dashboard_layout jsonb not null default
 CREATE INDEX IF NOT EXISTS users_leaderboard_opt_in_idx
   ON users(leaderboard_opt_in)
   WHERE leaderboard_opt_in = true;
+alter table users enable row level security;
+drop policy if exists "Users can manage own record" on users;
+create policy "Users can manage own record"
+  on users for all
+  using (id = auth.uid()::text);
 
 create table if not exists goals (
   id           text primary key default gen_random_uuid()::text,
@@ -57,6 +62,11 @@ create table if not exists goals (
 );
 create index if not exists goals_user_period on goals(user_id, period_start);
 create index if not exists goals_user_category on goals(user_id, category);
+alter table goals enable row level security;
+drop policy if exists "Users can manage own goals" on goals;
+create policy "Users can manage own goals"
+  on goals for all
+  using (user_id = auth.uid()::text);
 
 create table if not exists goal_history (
   id           text primary key default gen_random_uuid()::text,
@@ -121,6 +131,11 @@ create table if not exists streak_freezes (
 create index if not exists streak_freezes_user on streak_freezes(user_id);
 create unique index if not exists streak_freezes_user_date_uniq
   on streak_freezes(user_id, freeze_date);
+alter table streak_freezes enable row level security;
+drop policy if exists "Users can manage own streak freezes" on streak_freezes;
+create policy "Users can manage own streak freezes"
+  on streak_freezes for all
+  using (user_id = auth.uid()::text);
 
 create table if not exists notifications (
   id         text primary key default gen_random_uuid()::text,


### PR DESCRIPTION
## Summary

Audited database tables and added explicit Supabase Row Level Security (RLS) policies for `users`, `goals`, and `streak_freezes` tables in `supabase/schema.sql`. Also added documentation in `DEVELOPMENT.md` explaining RLS policies and how to verify active policies in the Supabase Dashboard.

Closes #3250 

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **`supabase/schema.sql`**:
  - Enabled RLS on `users`, `goals`, and `streak_freezes` tables.
  - Added policies restricting user access to their own rows (`auth.uid()::text`).
- **`DEVELOPMENT.md`**:
  - Added documentation on RLS defense-in-depth and dashboard verification instructions.

---

## How to Test

1. Execute `supabase/schema.sql` in the Supabase SQL Editor.
2. In the Supabase Dashboard, open **Authentication** → **Policies** or **Table Editor**.
3. Verify that `users`, `goals`, and `streak_freezes` display the **RLS Enabled** badge and list their user-scoped policies (`user_id = auth.uid()::text`).

---

## Checklist

- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log` or debug code
- [x] Updated documentation / comments
