### PR TITLE
feat(prs): add review time histogram buckets to /api/metrics/prs and …

### DIFF
--- a/src/app/api/metrics/prs/route.ts
+++ b/src/app/api/metrics/prs/route.ts
@@ -28,6 +28,36 @@ interface PRMetricsBase {
   avgCycleTime: number;
   weeklyTrend: { week: string; avgHours: number }[];
   slowestRepos: { repo: string; avgHours: number }[];
+  reviewTimeBuckets: { range: string; count: number }[];
+}
+
+function computeReviewTimeBuckets(durationsHours: number[]): { range: string; count: number }[] {
+  const buckets = {
+    "<1h": 0,
+    "1–4h": 0,
+    "4–24h": 0,
+    "1–3d": 0,
+    "3–7d": 0,
+    "7d+": 0,
+  };
+
+  for (const h of durationsHours) {
+    if (h < 1) buckets["<1h"]++;
+    else if (h < 4) buckets["1–4h"]++;
+    else if (h < 24) buckets["4–24h"]++;
+    else if (h < 72) buckets["1–3d"]++;
+    else if (h < 168) buckets["3–7d"]++;
+    else buckets["7d+"]++;
+  }
+
+  return [
+    { range: "<1h", count: buckets["<1h"] },
+    { range: "1–4h", count: buckets["1–4h"] },
+    { range: "4–24h", count: buckets["4–24h"] },
+    { range: "1–3d", count: buckets["1–3d"] },
+    { range: "3–7d", count: buckets["3–7d"] },
+    { range: "7d+", count: buckets["7d+"] },
+  ];
 }
 
 interface ReviewMetrics {
@@ -297,7 +327,14 @@ async function fetchPRMetrics(
   const slowestRepos = Object.entries(repoMap)
     .map(([repo, times]) => ({ repo, avgHours: Math.round(times.reduce((a, b) => a + b, 0) / times.length) }))
     .sort((a, b) => b.avgHours - a.avgHours)
-    .slice(0, 3);
+  const prReviewDurations = mergedPRs
+    .map((pr) => {
+      if (!pr.closed_at || !pr.created_at) return null;
+      return (new Date(pr.closed_at).getTime() - new Date(pr.created_at).getTime()) / 3600000;
+    })
+    .filter((h): h is number => typeof h === "number" && !Number.isNaN(h) && h >= 0);
+
+  const reviewTimeBuckets = computeReviewTimeBuckets(prReviewDurations);
 
   return {
     open,
@@ -312,6 +349,7 @@ async function fetchPRMetrics(
     avgCycleTime,
     weeklyTrend,
     slowestRepos,
+    reviewTimeBuckets,
   };
 }
 
@@ -392,6 +430,9 @@ async function fetchGitLabMRMetrics(token: string): Promise<PRMetricsBase> {
 
   const sampleTotal = items.length;
 
+  const gitlabHours = reviewDurations.map((d) => d / 3600000);
+  const reviewTimeBuckets = computeReviewTimeBuckets(gitlabHours);
+
   return {
     open,
     merged,
@@ -405,6 +446,7 @@ async function fetchGitLabMRMetrics(token: string): Promise<PRMetricsBase> {
     avgCycleTime: 0,
     weeklyTrend: [],
     slowestRepos: [],
+    reviewTimeBuckets,
   };
 }
 
@@ -456,6 +498,7 @@ function formatPRMetrics(metrics: PRMetricsBase) {
     slowestRepos: metrics.slowestRepos,
     totalAdditions: metrics.totalAdditions,
     totalDeletions: metrics.totalDeletions,
+    reviewTimeBuckets: metrics.reviewTimeBuckets,
   };
 }
 
@@ -678,6 +721,28 @@ export async function GET(req: NextRequest) {
         .sort((a, b) => b.avgHours - a.avgHours)
         .slice(0, 3);
 
+      const combinedBucketsMap: Record<string, number> = {
+        "<1h": 0,
+        "1–4h": 0,
+        "4–24h": 0,
+        "1–3d": 0,
+        "3–7d": 0,
+        "7d+": 0,
+      };
+      results.forEach(r => {
+        r.reviewTimeBuckets?.forEach(b => {
+          combinedBucketsMap[b.range] = (combinedBucketsMap[b.range] ?? 0) + b.count;
+        });
+      });
+      const combinedReviewTimeBuckets = [
+        { range: "<1h", count: combinedBucketsMap["<1h"] },
+        { range: "1–4h", count: combinedBucketsMap["1–4h"] },
+        { range: "4–24h", count: combinedBucketsMap["4–24h"] },
+        { range: "1–3d", count: combinedBucketsMap["1–3d"] },
+        { range: "3–7d", count: combinedBucketsMap["3–7d"] },
+        { range: "7d+", count: combinedBucketsMap["7d+"] },
+      ];
+
       const combinedMetrics: PRMetricsBase = {
         totalAdditions: results.reduce(
           (sum, r) => sum + r.totalAdditions,
@@ -697,7 +762,8 @@ export async function GET(req: NextRequest) {
         mergeRate: combinedTotal > 0 ? combinedMerged / combinedTotal : 0,
         avgCycleTime: combinedCycleTime,
         weeklyTrend: combinedWeeklyTrend,
-        slowestRepos: combinedSlowest
+        slowestRepos: combinedSlowest,
+        reviewTimeBuckets: combinedReviewTimeBuckets,
       };
 
       const [gitlab, reviews] = await Promise.all([

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -5,10 +5,19 @@ import { useCallback, useEffect, useState } from "react";
 import { usePersistentState } from "@/hooks/usePersistentState";
 import { useAccount } from "@/components/AccountContext";
 import { useDashboardWidgetA11y } from "@/components/dashboard/DashboardWidgetA11yContext";
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { LineChart, Line, BarChart, Bar, Cell, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import PRStatusDonutChart from "./PRStatusDonutChart";
 import MiniPRTrendChart from "./MiniPRTrendChart";
 import { SkeletonBlock } from "./WidgetSkeleton";
+
+const BUCKET_COLORS: Record<string, string> = {
+  "<1h": "#10b981",
+  "1–4h": "#10b981",
+  "4–24h": "#f59e0b",
+  "1–3d": "#f59e0b",
+  "3–7d": "#ef4444",
+  "7d+": "#ef4444",
+};
 
 interface PRMetricsSummary {
   open: number;
@@ -23,6 +32,7 @@ interface PRMetricsSummary {
   avgCycleTime?: number;
   weeklyTrend?: { week: string; avgHours: number }[];
   slowestRepos?: { repo: string; avgHours: number }[];
+  reviewTimeBuckets?: { range: string; count: number }[];
 }
 
 interface PRData extends PRMetricsSummary {
@@ -308,6 +318,59 @@ export default function PRMetrics() {
                 merged={prFilter === "open" ? 0 : (metrics.merged || 0)}
                 closed={prFilter === "all" ? (metrics.closed || 0) : 0}
               />
+            </div>
+          )}
+
+          {/* Review Time Histogram */}
+          {metrics?.reviewTimeBuckets && metrics.reviewTimeBuckets.length > 0 && (
+            <div className="rounded-lg bg-[var(--control)] p-4 border border-[var(--border)]">
+              <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+                <div>
+                  <h3 className="text-sm font-semibold text-[var(--card-foreground)]">
+                    Review Time Distribution
+                  </h3>
+                  <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
+                    Histogram of PR review turnaround time buckets
+                  </p>
+                </div>
+                <div className="flex items-center gap-3 text-xs">
+                  <span className="flex items-center gap-1 text-[var(--muted-foreground)]">
+                    <span className="w-2.5 h-2.5 rounded-full bg-[#10b981]" /> Fast (&lt;4h)
+                  </span>
+                  <span className="flex items-center gap-1 text-[var(--muted-foreground)]">
+                    <span className="w-2.5 h-2.5 rounded-full bg-[#f59e0b]" /> Moderate (4h–3d)
+                  </span>
+                  <span className="flex items-center gap-1 text-[var(--muted-foreground)]">
+                    <span className="w-2.5 h-2.5 rounded-full bg-[#ef4444]" /> Slow (3d+)
+                  </span>
+                </div>
+              </div>
+
+              <ResponsiveContainer width="100%" height={220}>
+                <BarChart data={metrics.reviewTimeBuckets} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+                  <XAxis dataKey="range" tick={{ fontSize: 11, fill: "var(--muted-foreground)" }} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11, fill: "var(--muted-foreground)" }} />
+                  <Tooltip
+                    formatter={(value: any) => [`${value} PRs`, "Reviewed"]}
+                    labelFormatter={(label) => `Turnaround: ${label}`}
+                    contentStyle={{
+                      backgroundColor: "var(--card)",
+                      borderColor: "var(--border)",
+                      borderRadius: "8px",
+                      color: "var(--card-foreground)",
+                      fontSize: "12px",
+                    }}
+                  />
+                  <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+                    {metrics.reviewTimeBuckets.map((entry) => (
+                      <Cell
+                        key={entry.range}
+                        fill={BUCKET_COLORS[entry.range] || "var(--accent)"}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

Adds a PR Review Time Distribution Histogram to `PRMetrics.tsx` and extends `/api/metrics/prs/route.ts` to return review turnaround time buckets (`<1h`, `1–4h`, `4–24h`, `1–3d`, `3–7d`, `7d+`). This replaces reliance on a single average review time with a color-coded distribution chart.

Closes #3245

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code cleanup (no functional change)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Tests only

---

## What Changed

- **`src/app/api/metrics/prs/route.ts`**:
  - Computed PR review durations and categorized them into 6 standardized time buckets (`<1h`, `1–4h`, `4–24h`, `1–3d`, `3–7d`, `7d+`).
  - Added support for single account, GitLab, and combined account aggregation.
- **`src/components/PRMetrics.tsx`**:
  - Added Recharts `BarChart` histogram displaying review time buckets with custom tooltips (`"X PRs reviewed within this range"`).
  - Applied color coding: Emerald (fast), Amber (moderate), Red (slow).

---

## How to Test

1. Navigate to the DevTrack dashboard and scroll to **PR Analytics**.
2. Verify that the **Review Time Distribution** histogram renders below the stat cards and donut chart.
3. Hover over histogram bars to inspect turnaround count tooltips.
4. Toggle time ranges (`7d`, `30d`, `90d`) and verify that histogram bucket counts update dynamically.

---

## Checklist

- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log` or debug code
- [x] Responsive layout & color legend verified
- [x] Single average skew issue addressed via histogram distribution
