### PR TITLE
fix: improve accessibility in DailyNoteWidget (#2560)

### DIFF
--- a/src/components/DailyNoteWidget.tsx
+++ b/src/components/DailyNoteWidget.tsx
@@ -2,128 +2,121 @@
 
 import { useCallback, useEffect, useState } from "react";
 
-export default function DailyNoteWidget(){
-
-  const [loading,setLoading] = useState(false);
-  const [note,setNote] = useState("");
+export default function DailyNoteWidget() {
+  const [loading, setLoading] = useState(false);
+  const [note, setNote] = useState("");
   const [yesterdayNote, setYesterdayNote] = useState("");
-  const [showYesterday,setShowYesterday] = useState(false);
+  const [showYesterday, setShowYesterday] = useState(false);
 
-  useEffect(()=>{
-    
-    const fetchNotes = async ()=>{
-
-      try{
+  useEffect(() => {
+    const fetchNotes = async () => {
+      try {
         setLoading(true);
 
         const response = await fetch("/api/daily-note");
 
         const data = await response.json();
-        setNote(data.todayNote||"");
-        setYesterdayNote(data.yesterdayNote ||"" );
-      
-      }catch(error){
+        setNote(data.todayNote || "");
+        setYesterdayNote(data.yesterdayNote || "");
+      } catch (error) {
         console.error("Failed to fetch notes");
-      }finally{
+      } finally {
         setLoading(false);
       }
-      
     };
     fetchNotes();
-  },[]);
+  }, []);
 
+  // auto save with debounce
+  // Wrapped in useCallback so the function reference is stable across renders.
+  // Without this, the auto-save useEffect would capture a stale closure of
+  // debounceFunction on any re-render that isn't caused by `note` changing,
+  // silently saving the wrong value or skipping the save entirely.
+  const debounceFunction = useCallback(async () => {
+    if (!note.trim()) return;
 
-// auto save with debounce
-// Wrapped in useCallback so the function reference is stable across renders.
-// Without this, the auto-save useEffect would capture a stale closure of
-// debounceFunction on any re-render that isn't caused by `note` changing,
-// silently saving the wrong value or skipping the save entirely.
-const debounceFunction = useCallback(async () => {
-  if (!note.trim()) return;
+    try {
+      await fetch("/api/daily-note", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          note,
+        }),
+      });
+    } catch (error) {
+      console.error("Failed to save note");
+    }
+  }, [note]);
 
-  try {
-    await fetch("/api/daily-note", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        note,
-      }),
-    });
-  } catch (error) {
-    console.error("Failed to save note");
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      debounceFunction();
+    }, 500);
+    return () => clearTimeout(timeout);
+  }, [note, debounceFunction]);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
+        <div className="h-5 w-40 bg-[var(--card-muted)] rounded animate-pulse mb-4" />
+        <div className="space-y-2">
+          <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse w-3/4" />
+          <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse w-1/2" />
+        </div>
+      </div>
+    );
   }
-}, [note]);
 
-useEffect(() => {
-  const timeout = setTimeout(() => {
-    debounceFunction();
-  }, 500);
-  return () => clearTimeout(timeout);
-}, [note, debounceFunction]);
-
-
-if (loading) {
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-      <div className="h-5 w-40 bg-[var(--card-muted)] rounded animate-pulse mb-4" />
+      <div className="m-3 w-40  rounded mb-4 ml-0">
+        <h2 className="text-lg font-semibold text-[var(--card-foreground)] ">
+          Today&apos;s Plan
+        </h2>
+
+        <p className="text-sm text-[var(--muted-foreground)]">
+          Plan your coding session.
+        </p>
+      </div>
       <div className="space-y-2">
-        <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse w-3/4" />
-        <div className="h-4 bg-[var(--card-muted)] rounded animate-pulse w-1/2" />
-      </div>
-    </div>
-  );
-} 
-
-  return(
-
-    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm">
-        <div className="m-3 w-40  rounded mb-4 ml-0" >
-          <h2 className="text-lg font-semibold text-[var(--card-foreground)] ">
-            Today&apos;s Plan
-          </h2>
-          
-          <p className="text-sm text-[var(--muted-foreground)]">Plan your coding session.</p>
-      </div>
-        <div className="space-y-2">
-         
-         
-        <textarea value={note}
-        onChange={(e)=>{
-          if(e.target.value.length <= 280){
-            setNote(e.target.value);
-          }
-        }} 
-        onBlur={debounceFunction}
-        placeholder="What will you code today?" 
-        rows={3}
-        className=" w-full resize-none rounded-md border border-gray-300 p-2
-        focus:outline-none transition focus:border-gray-500" 
+        <textarea
+          value={note}
+          onChange={(e) => {
+            if (e.target.value.length <= 280) {
+              setNote(e.target.value);
+            }
+          }}
+          onBlur={debounceFunction}
+          placeholder="What will you code today?"
+          aria-label="Today's coding plan"
+          rows={3}
+          className=" w-full resize-none rounded-md border border-gray-300 p-2
+        focus:outline-none transition focus:border-gray-500"
         />
 
         <div className="mt-2 flex items-center justify-between">
-
-          <p className="text-xs text-gray-400">
-            Auto-saves automatically
-         </p>
-         <p className="text-xs text-gray-500">
-            {note.length}/280
-        </p>
+          <p className="text-xs text-gray-400">Auto-saves automatically</p>
+          <p className="text-xs text-gray-500">{note.length}/280</p>
         </div>
 
         <div className="mt-4 rounded-md bg-gray-50 p-3">
-          <p className="text-xs text-gray-500 cursor-pointer" onClick={()=> setShowYesterday((prev)=> !prev)} aria-expanded={showYesterday} >
+          <button
+            type="button"
+            className="text-xs text-gray-500 cursor-pointer text-left"
+            onClick={() => setShowYesterday((prev) => !prev)}
+            aria-expanded={showYesterday}
+          >
             Yesterday you planned to:
-          </p>
-          {showYesterday && 
+          </button>
+          {showYesterday && (
             <p className="mt-1 text-sm text-gray-700">
-            {yesterdayNote || "No plan from yesterday"}
-          </p>
-          }
-          
-        </div>
+              {yesterdayNote || "No plan from yesterday"}
+            </p>
+          )}
         </div>
       </div>
-  )
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
Replaced a clickable `<p>` tag with a proper `<button>` for the yesterday-note toggle in `DailyNoteWidget`, and added an `aria-label` to the note textarea for screen reader users.

Closes #2560

---
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---
## What Changed
- Changed the "Yesterday you planned to:" toggle from a `<p onClick>` to a semantic `<button type="button">` in `src/components/DailyNoteWidget.tsx`
- Added `aria-label="Today's coding plan"` to the auto-save textarea
- Reviewed the auto-save hook's dependency array — `debounceFunction` is already correctly memoized with `useCallback([note])` and included in the effect's deps; no change needed there

---
## How to Test
1. Open the Daily Note widget on the dashboard
2. Tab through the widget using only the keyboard
3. Confirm the "Yesterday you planned to:" toggle can be focused and activated with Enter/Space, and that a screen reader announces the textarea's purpose

**Expected result:** Toggle is keyboard-focusable and operable as a button (not just clickable), and the textarea has an accessible name.

---
## Screenshots / Recordings
N/A — visual appearance unchanged, only semantics/accessibility improved.

---
## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---
## Accessibility (UI changes only)
- [x] Keyboard navigation works correctly
- [ ] Color contrast meets WCAG AA standard
- [x] ARIA labels / roles added where needed
- [ ] Tested on mobile / responsive layout

---
## Additional Context
None.