### PR TITLE
feat: add SWR local storage cache layer for offline dashboard resiliency (#2801)

### DIFF
--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -9,6 +9,7 @@ import { buildPublicGoalShareUrl } from "@/lib/goals/share";
 import GoalHistory from "@/components/GoalHistory";
 import EmptyState from "@/components/EmptyState";
 import WidgetSkeleton, { SkeletonBlock } from "./WidgetSkeleton";
+import { saveSnapshot, getSnapshot } from "@/lib/localCache";
 
 
 type Recurrence = "none" | "weekly" | "monthly";
@@ -90,9 +91,12 @@ export function useGoalTracker() {
     const data: { goals: Goal[] } = await response.json();
     const fetchedGoals = data.goals ?? [];
     setGoals(fetchedGoals);
+
+    // SWR: persist fresh snapshot for offline / instant-hydration use
+    saveSnapshot("goals", fetchedGoals);
+
     return fetchedGoals;
   }, []);
-
   const handleSync = useCallback(async () => {
     setSyncing(true);
     setSyncError(null);
@@ -131,6 +135,15 @@ export function useGoalTracker() {
     }
   }, [loadGoals]);
 
+ // SWR Step 1: instant hydration from localStorage before network resolves
+  useEffect(() => {
+    const cached = getSnapshot<Goal[]>("goals");
+    if (cached) {
+      setGoals(cached.data);
+      setLoading(false); // show stale goals immediately, no spinner
+    }
+  }, []);
+
   useEffect(() => {
     loadGoals()
       .then(async (fetchedGoals) => {
@@ -145,7 +158,14 @@ export function useGoalTracker() {
         }
       })
       .catch(() => {
-        setSyncError("Failed to load goals. Please try again.");
+        // SWR fallback: agar live fetch fail ho, cached snapshot dikhta rahe
+        const cached = getSnapshot<Goal[]>("goals");
+        if (cached) {
+          setGoals(cached.data);
+          setSyncError(null);
+        } else {
+          setSyncError("Failed to load goals. Please try again.");
+        }
       })
       .finally(() => {
         setLoading(false);

--- a/src/components/GoalTracker.tsx
+++ b/src/components/GoalTracker.tsx
@@ -158,7 +158,7 @@ export function useGoalTracker() {
         }
       })
       .catch(() => {
-        // SWR fallback: agar live fetch fail ho, cached snapshot dikhta rahe
+        // SWR fallback: if the live fetch fails, keep showing the cached snapshot
         const cached = getSnapshot<Goal[]>("goals");
         if (cached) {
           setGoals(cached.data);

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -120,7 +120,7 @@ export function useStreakTracker() {
     } catch (err) {
       console.error("Failed to fetch streak data:", err);
 
-      // SWR fallback: agar live fetch fail ho, cached snapshot dikhado
+     // SWR fallback: if the live fetch fails, fall back to the cached snapshot
       const cached = getSnapshot<{ streak: StreakData; contribution: ContributionData }>(cacheKey);
       if (cached) {
         setData(cached.data.streak);

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -135,7 +135,7 @@ export function useStreakTracker() {
       setLastUpdated(new Date());
       setMinutesAgo(0);
     }
-  }, [selectedAccount]);
+  }, [selectedAccount, cacheKey]);
 
   const fetchFreeze = useCallback(() => {
     setFreezeLoading(true);

--- a/src/components/StreakTracker.tsx
+++ b/src/components/StreakTracker.tsx
@@ -1,5 +1,6 @@
 "use client";
 import SectionHeader from "./SectionHeader";
+import { saveSnapshot, getSnapshot } from "@/lib/localCache";
 import { useCallback, useEffect, useState, useRef } from "react";
 import { useAccount } from "@/components/AccountContext";
 import { useDashboardWidgetA11y } from "@/components/dashboard/DashboardWidgetA11yContext";
@@ -40,6 +41,7 @@ interface FreezeData {
 
 export function useStreakTracker() {
   const { selectedAccount } = useAccount();
+  const cacheKey = selectedAccount ? `streak-${selectedAccount}` : "streak-default";
   const [data, setData] = useState<StreakData | null>(null);
   const [contributionData, setContributionData] = useState<ContributionData | null>(null);
   const [freezeDates, setFreezeDates] = useState<string[]>([]);
@@ -112,9 +114,22 @@ export function useStreakTracker() {
       setData(streakData);
       setContributionData(contribData);
       setFreezeDates(streakData.freezeDates || []);
+
+      // SWR: persist fresh snapshot for offline / instant-hydration use
+      saveSnapshot(cacheKey, { streak: streakData, contribution: contribData });
     } catch (err) {
       console.error("Failed to fetch streak data:", err);
-      setError("We couldn't load your streak data right now. Please try again in a moment.");
+
+      // SWR fallback: agar live fetch fail ho, cached snapshot dikhado
+      const cached = getSnapshot<{ streak: StreakData; contribution: ContributionData }>(cacheKey);
+      if (cached) {
+        setData(cached.data.streak);
+        setContributionData(cached.data.contribution);
+        setFreezeDates(cached.data.streak.freezeDates || []);
+        setError(null);
+      } else {
+        setError("We couldn't load your streak data right now. Please try again in a moment.");
+      }
     } finally {
       setLoading(false);
       setLastUpdated(new Date());
@@ -133,6 +148,17 @@ export function useStreakTracker() {
       })
       .finally(() => setFreezeLoading(false));
   }, []);
+
+  // SWR Step 1: instant hydration from localStorage before network resolves
+  useEffect(() => {
+    const cached = getSnapshot<{ streak: StreakData; contribution: ContributionData }>(cacheKey);
+    if (cached) {
+      setData(cached.data.streak);
+      setContributionData(cached.data.contribution);
+      setFreezeDates(cached.data.streak.freezeDates || []);
+      setLoading(false); // show stale data immediately, no spinner
+    }
+  }, [cacheKey]);
 
   useEffect(() => {
     fetchStreak();

--- a/src/lib/localCache.ts
+++ b/src/lib/localCache.ts
@@ -1,0 +1,36 @@
+const CACHE_PREFIX = "devtrack_cache_";
+
+interface CachedSnapshot<T> {
+  data: T;
+  timestamp: number;
+}
+
+export function saveSnapshot<T>(key: string, data: T): void {
+  try {
+    const payload: CachedSnapshot<T> = { data, timestamp: Date.now() };
+    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(payload));
+  } catch (err) {
+    // localStorage full, disabled, or unavailable (SSR) — fail silently
+    console.warn(`[localCache] Could not save snapshot for "${key}"`, err);
+  }
+}
+
+export function getSnapshot<T>(key: string): CachedSnapshot<T> | null {
+  try {
+    if (typeof window === "undefined") return null; // SSR guard
+    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    if (!raw) return null;
+    return JSON.parse(raw) as CachedSnapshot<T>;
+  } catch (err) {
+    console.warn(`[localCache] Could not read snapshot for "${key}"`, err);
+    return null;
+  }
+}
+
+export function clearSnapshot(key: string): void {
+  try {
+    localStorage.removeItem(CACHE_PREFIX + key);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary

Implements a Stale-While-Revalidate (SWR) local storage cache layer for the dashboard's Streak Tracker and Goal Tracker widgets, so users see their last-known data instantly on load instead of a blank/loading state — even on spotty networks, during GitHub API rate-limiting, or fully offline.

Closes #2801

## Changes

- **`src/lib/localCache.ts`** (new) — lightweight `saveSnapshot` / `getSnapshot` / `clearSnapshot` helpers backed by `localStorage`, with `try/catch` guards so a full, disabled, or missing `localStorage` never throws at runtime.
- **`src/components/StreakTracker.tsx`** — on mount, hydrates instantly from the last cached streak/contribution snapshot before the network call resolves. On successful fetch, persists the new snapshot. On fetch failure, falls back to the cached snapshot instead of showing an error.
- **`src/components/GoalTracker.tsx`** — same pattern applied to the goals list: instant hydration from cache, snapshot saved on successful load, cached goals shown if the live fetch fails.

## How it works

1. **Instant hydration** — a `useEffect` on mount reads the cached snapshot from `localStorage` and populates state immediately, skipping the loading spinner if data is available.
2. **Background sync** — the existing fetch logic runs unchanged in parallel; on success it silently overwrites both the UI state and the cached snapshot.
3. **Graceful fallback** — if the live request fails (offline, rate-limited, etc.), the cached snapshot is shown instead of an error message, whenever one exists.

## Notes

- Scoped to the two widgets driven by `/api/metrics` and `/api/goals` (streaks + goals), matching the issue's acceptance criteria. Other widgets are untouched and can adopt the same `localCache.ts` utility in future PRs if desired.