### PR TITLE
fix: preserve CI test failures

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Run Automated Unit Testing Framework Suites
         run: pnpm test
 
-      - name: Execute Security & Code Quality Monitoring Audits
-        run: echo "Code coverage thresholds verified at 80%+. Monitoring data packages fully initialized."
+      - name: Log Security & Code Quality Audit Placeholder
+        run: echo "Security/code-quality audits are not currently executed in this workflow."

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -28,8 +28,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run Automated Unit Testing Framework Suites
-        run: pnpm test || echo "Baseline mock unit test execution passes completed successfully."
+        run: pnpm test
 
       - name: Execute Security & Code Quality Monitoring Audits
         run: echo "Code coverage thresholds verified at 80%+. Monitoring data packages fully initialized."
-


### PR DESCRIPTION
## Summary
Make the automated test step return Vitest's actual exit status instead of replacing a failure with a successful echo command.

Closes #3349

## Type of Change
- [x] Bug fix

## What Changed
- Updated .github/workflows/automated-tests.yml.
- Removed the fallback that masked failed test runs.

## How to Test
1. Run pnpm test.
2. Confirm its exit code is preserved by the workflow.

Expected result: a failing test suite fails the CI job.

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary debug code
- [ ] pnpm test passes locally
- [x] Added or updated tests where applicable

## Additional Context
The current full suite has unrelated existing failures (86 failed, 2271 passed). This change intentionally ensures CI reports them rather than masking them.