### PR TITLE
fix: show repository subscriber counts

### DIFF
--- a/src/app/dashboard/repo-comparison/page.tsx
+++ b/src/app/dashboard/repo-comparison/page.tsx
@@ -99,7 +99,7 @@ export default function RepoComparisonPage() {
             name: data.full_name,
             stars: data.stargazers_count,
             forks: data.forks_count,
-            watchers: data.watchers_count,
+            watchers: data.subscribers_count,
             issues: data.open_issues_count,
           };
         })


### PR DESCRIPTION
## Summary
Map the repository comparison Watchers metric to GitHub's subscribers_count field instead of the legacy watchers_count field that mirrors stars.

Closes #3350

## Type of Change
- [x] Bug fix

## What Changed
- Updated the repository comparison API response mapping.

## How to Test
1. Compare repositories with different star and subscriber totals.
2. Verify the Watchers value matches GitHub subscriber counts.

Expected result: Stars and Watchers can display different values.

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary debug code
- [x] Focused lint passes locally
- [x] TypeScript check passes locally

## Additional Context
