### PR TITLE
fix: guard /api/ai/roast against missing GEMINI_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,11 @@ UPSTASH_REDIS_REST_TOKEN=your_upstash_redis_rest_token
 GROQ_API_KEY=your_groq_api_key
 
 # -------------------------------------------------------
+# Gemini API Key (optional — enables the /api/ai/roast route)
+# aistudio.google.com → Get API key
+GEMINI_API_KEY=your_gemini_api_key
+
+# -------------------------------------------------------
 # Leaderboard Configuration
 # Controls concurrent user fetches during leaderboard builds
 # Safe range: 1-100 (default: 5)

--- a/src/app/api/ai/roast/route.ts
+++ b/src/app/api/ai/roast/route.ts
@@ -1,10 +1,19 @@
 import { NextResponse } from 'next/server';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || '';
+
 // Initialize the Google Generative AI SDK
-const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
 
 export async function POST(req: Request) {
+  if (!GEMINI_API_KEY) {
+    return NextResponse.json(
+      { error: 'Gemini API key is not configured' },
+      { status: 500 }
+    );
+  }
+
   try {
     const body = await req.json();
     const { mode, stats } = body;


### PR DESCRIPTION
## Summary

The /api/ai/roast route created the GoogleGenerativeAI client at module level with an empty key, so calls threw a cryptic Google SDK error as a 500. Guard the key and return a clear error, and document GEMINI_API_KEY in .env.example.

Closes #3109

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## What Changed

- Guard in src/app/api/ai/roast/route.ts returning 500 with a clear message when GEMINI_API_KEY is missing
- GEMINI_API_KEY documented in .env.example
