### PR TITLE
feat: add colored Lines Changed stat tile to PR Analytics widget (#2450)

### DIFF
--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -1,11 +1,18 @@
 "use client";
 import SectionHeader from "./SectionHeader";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { usePersistentState } from "@/hooks/usePersistentState";
 import { useAccount } from "@/components/AccountContext";
 import { useDashboardWidgetA11y } from "@/components/dashboard/DashboardWidgetA11yContext";
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
 import PRStatusDonutChart from "./PRStatusDonutChart";
 import MiniPRTrendChart from "./MiniPRTrendChart";
 import { SkeletonBlock } from "./WidgetSkeleton";
@@ -36,7 +43,7 @@ interface PRData extends PRMetricsSummary {
 
 interface PRStat {
   label: string;
-  value: string | number;
+  value: string | number | ReactNode;
   title?: string;
   warning?: boolean;
   href?: string;
@@ -55,10 +62,22 @@ export default function PRMetrics() {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [minutesAgo, setMinutesAgo] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = usePersistentState<"authored" | "reviews">("devtrack:pr-metrics:activeTab", "authored");
-  const [prFilter, setPrFilter] = usePersistentState<"all" | "merged" | "open">("devtrack:pr-metrics:prFilter", "all");
-  const [range, setRange] = usePersistentState<"7d" | "30d" | "90d">("devtrack:pr-metrics:range", "30d");
-  const [staleThresholdDays, setStaleThresholdDays] = usePersistentState("devtrack:pr-metrics:staleThreshold", 14);
+  const [activeTab, setActiveTab] = usePersistentState<"authored" | "reviews">(
+    "devtrack:pr-metrics:activeTab",
+    "authored"
+  );
+  const [prFilter, setPrFilter] = usePersistentState<"all" | "merged" | "open">(
+    "devtrack:pr-metrics:prFilter",
+    "all"
+  );
+  const [range, setRange] = usePersistentState<"7d" | "30d" | "90d">(
+    "devtrack:pr-metrics:range",
+    "30d"
+  );
+  const [staleThresholdDays, setStaleThresholdDays] = usePersistentState(
+    "devtrack:pr-metrics:staleThreshold",
+    14
+  );
 
   const fetchMetrics = useCallback(() => {
     setLoading(true);
@@ -79,7 +98,11 @@ export default function PRMetrics() {
         setLastUpdated(new Date());
         setMinutesAgo(0);
       })
-      .catch(() => setError("We couldn't load your PR analytics right now. Please try again in a moment."))
+      .catch(() =>
+        setError(
+          "We couldn't load your PR analytics right now. Please try again in a moment."
+        )
+      )
       .finally(() => setLoading(false));
   }, [selectedAccount, range]);
 
@@ -112,12 +135,23 @@ export default function PRMetrics() {
       { label: labels.merged, value: source.merged },
       {
         label: "Lines Changed",
-        value: `+${(source.totalAdditions ?? 0).toLocaleString()} / -${(source.totalDeletions ?? 0).toLocaleString()}`
+        value: (
+          <span>
+            <span className="text-green-500">
+              +{(source.totalAdditions ?? 0).toLocaleString()}
+            </span>
+            {" / "}
+            <span className="text-red-500">
+              -{(source.totalDeletions ?? 0).toLocaleString()}
+            </span>
+          </span>
+        ),
       },
       {
         label: `${labels.avgReview} ⓘ`,
         value: `${source.avgReviewHours}h`,
-        title: "Average time from PR creation to close, based on your last 30 closed PRs",
+        title:
+          "Average time from PR creation to close, based on your last 30 closed PRs",
       },
       {
         label: labels.avgFirstReview,
@@ -128,49 +162,64 @@ export default function PRMetrics() {
     ];
 
     if (labels.avgCycleTime && source.avgCycleTime !== undefined) {
-      baseStats.push({ label: labels.avgCycleTime, value: `${source.avgCycleTime}h` });
+      baseStats.push({
+        label: labels.avgCycleTime,
+        value: `${source.avgCycleTime}h`,
+      });
     }
     return baseStats;
   };
 
   const githubStats = metrics
     ? buildStats(metrics, {
-      open: "Open PRs",
-      merged: `Merged (${range}d)`,
-      avgReview: "Avg Review Time",
-      avgFirstReview: "Avg First Review",
-      mergeRate: "Merge Rate",
-      avgCycleTime: "Avg Cycle Time",
-    })
+        open: "Open PRs",
+        merged: `Merged (${range}d)`,
+        avgReview: "Avg Review Time",
+        avgFirstReview: "Avg First Review",
+        mergeRate: "Merge Rate",
+        avgCycleTime: "Avg Cycle Time",
+      })
     : [];
 
   const gitlabStats = metrics?.gitlab
     ? buildStats(metrics.gitlab, {
-      open: "Open MRs",
-      merged: `Merged (${range}d)`,
-      avgReview: "Avg Review Time",
-      avgFirstReview: "Avg First Review",
-      mergeRate: "Merge Rate",
-    })
+        open: "Open MRs",
+        merged: `Merged (${range}d)`,
+        avgReview: "Avg Review Time",
+        avgFirstReview: "Avg First Review",
+        mergeRate: "Merge Rate",
+      })
     : [];
 
   const renderStat = (stat: PRStat) => {
     const content = (
       <>
-        <div className={`truncate text-xl font-bold ${stat.warning ? "text-orange-300" : "text-[var(--accent)]"}`}>
+        <div
+          className={`truncate text-xl font-bold ${stat.warning ? "text-orange-300" : "text-[var(--accent)]"}`}
+        >
           {stat.value}
         </div>
-        <div className="truncate mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
+        <div className="truncate mt-1 text-sm text-[var(--muted-foreground)]">
+          {stat.label}
+        </div>
       </>
     );
 
-    const className = `rounded-lg p-4 text-center min-w-0 border border-transparent transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-md ${stat.warning
-      ? "border-orange-400/30 bg-orange-500/10 hover:bg-orange-500/15 hover:border-orange-400/50"
-      : "bg-[var(--control)] hover:bg-[var(--control-hover)] hover:border-[var(--border)]"
-      }`;
+    const className = `rounded-lg p-4 text-center min-w-0 border border-transparent transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-md ${
+      stat.warning
+        ? "border-orange-400/30 bg-orange-500/10 hover:bg-orange-500/15 hover:border-orange-400/50"
+        : "bg-[var(--control)] hover:bg-[var(--control-hover)] hover:border-[var(--border)]"
+    }`;
 
     return stat.href ? (
-      <a key={stat.label} href={stat.href} target="_blank" rel="noopener noreferrer" className={className} title={stat.title}>
+      <a
+        key={stat.label}
+        href={stat.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+        title={stat.title}
+      >
         {content}
       </a>
     ) : (
@@ -190,10 +239,11 @@ export default function PRMetrics() {
               <button
                 key={option}
                 onClick={() => setRange(option)}
-                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${range === option
-                  ? "bg-[var(--accent)] text-white"
-                  : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
-                  }`}
+                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                  range === option
+                    ? "bg-[var(--accent)] text-white"
+                    : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+                }`}
               >
                 {option}
               </button>
@@ -202,15 +252,21 @@ export default function PRMetrics() {
           <div className="flex gap-2">
             <button
               onClick={() => setActiveTab("authored")}
-              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${activeTab === "authored" ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
-                }`}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                activeTab === "authored"
+                  ? "bg-[var(--accent)] text-white"
+                  : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+              }`}
             >
               PRs Authored
             </button>
             <button
               onClick={() => setActiveTab("reviews")}
-              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${activeTab === "reviews" ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
-                }`}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                activeTab === "reviews"
+                  ? "bg-[var(--accent)] text-white"
+                  : "bg-[var(--control)] text-[var(--muted-foreground)] hover:bg-[var(--card-muted)]"
+              }`}
             >
               Reviews Given
             </button>
@@ -219,7 +275,9 @@ export default function PRMetrics() {
             Range
             <select
               value={range}
-              onChange={(event) => setRange(event.target.value as "7d" | "30d" | "90d")}
+              onChange={(event) =>
+                setRange(event.target.value as "7d" | "30d" | "90d")
+              }
               className="rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--foreground)] transition-colors"
             >
               <option value="7d">7d</option>
@@ -231,11 +289,15 @@ export default function PRMetrics() {
             Stale after
             <select
               value={staleThresholdDays}
-              onChange={(event) => setStaleThresholdDays(Number(event.target.value))}
+              onChange={(event) =>
+                setStaleThresholdDays(Number(event.target.value))
+              }
               className="rounded-md border border-[var(--border)] bg-[var(--control)] px-2 py-1 text-sm text-[var(--foreground)] transition-colors"
             >
               {[7, 14, 30].map((days) => (
-                <option key={days} value={days}>{days} days</option>
+                <option key={days} value={days}>
+                  {days} days
+                </option>
               ))}
             </select>
           </label>
@@ -262,7 +324,10 @@ export default function PRMetrics() {
       ) : error ? (
         <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-400">
           <p>{error}</p>
-          <button onClick={fetchMetrics} className="mt-3 rounded-md px-3 py-1.5 text-xs text-red-300 hover:bg-red-500/10 border border-red-500/30">
+          <button
+            onClick={fetchMetrics}
+            className="mt-3 rounded-md px-3 py-1.5 text-xs text-red-300 hover:bg-red-500/10 border border-red-500/30"
+          >
             Try again
           </button>
         </div>
@@ -271,14 +336,19 @@ export default function PRMetrics() {
           {/* GitHub Stats */}
           <div>
             <div className="flex flex-wrap items-center justify-between mb-4">
-              <p className="text-sm font-medium text-[var(--muted-foreground)]">GitHub PRs</p>
+              <p className="text-sm font-medium text-[var(--muted-foreground)]">
+                GitHub PRs
+              </p>
               <div className="flex items-center gap-2">
                 {(["all", "merged", "open"] as const).map((filter) => (
                   <button
                     key={filter}
                     onClick={() => setPrFilter(filter)}
-                    className={`rounded-full px-4 py-1.5 text-xs font-semibold capitalize transition-colors ${prFilter === filter ? "bg-[var(--accent)] text-white" : "bg-[var(--control)] text-[var(--muted-foreground)]"
-                      }`}
+                    className={`rounded-full px-4 py-1.5 text-xs font-semibold capitalize transition-colors ${
+                      prFilter === filter
+                        ? "bg-[var(--accent)] text-white"
+                        : "bg-[var(--control)] text-[var(--muted-foreground)]"
+                    }`}
                   >
                     {filter}
                   </button>
@@ -290,8 +360,14 @@ export default function PRMetrics() {
                 .filter((stat) => {
                   if (prFilter === "all") return true;
                   const lbl = stat.label.toLowerCase();
-                  if (prFilter === "open") return lbl.includes("open") || lbl.includes("stale");
-                  if (prFilter === "merged") return lbl.includes("merged") || lbl.includes("review") || lbl.includes("merge rate");
+                  if (prFilter === "open")
+                    return lbl.includes("open") || lbl.includes("stale");
+                  if (prFilter === "merged")
+                    return (
+                      lbl.includes("merged") ||
+                      lbl.includes("review") ||
+                      lbl.includes("merge rate")
+                    );
                   return true;
                 })
                 .map(renderStat)}
@@ -302,11 +378,13 @@ export default function PRMetrics() {
           {/* PR Status Donut Chart */}
           {metrics && (
             <div>
-              <p className="mb-2 text-sm font-medium text-[var(--muted-foreground)]">PR Status Distribution</p>
+              <p className="mb-2 text-sm font-medium text-[var(--muted-foreground)]">
+                PR Status Distribution
+              </p>
               <PRStatusDonutChart
-                open={prFilter === "merged" ? 0 : (metrics.open || 0)}
-                merged={prFilter === "open" ? 0 : (metrics.merged || 0)}
-                closed={prFilter === "all" ? (metrics.closed || 0) : 0}
+                open={prFilter === "merged" ? 0 : metrics.open || 0}
+                merged={prFilter === "open" ? 0 : metrics.merged || 0}
+                closed={prFilter === "all" ? metrics.closed || 0 : 0}
               />
             </div>
           )}
@@ -315,13 +393,23 @@ export default function PRMetrics() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {metrics?.weeklyTrend && metrics.weeklyTrend.length > 0 && (
               <div className="rounded-lg bg-[var(--control)] p-4">
-                <h3 className="text-sm font-semibold text-[var(--card-foreground)] mb-3">Review Cycle Trend</h3>
+                <h3 className="text-sm font-semibold text-[var(--card-foreground)] mb-3">
+                  Review Cycle Trend
+                </h3>
                 <ResponsiveContainer width="100%" height={200}>
                   <LineChart data={metrics.weeklyTrend}>
                     <XAxis dataKey="week" tick={{ fontSize: 11 }} />
                     <YAxis tick={{ fontSize: 11 }} unit="h" />
-                    <Tooltip formatter={(val) => [`${val}h`, "Avg Cycle Time"]} />
-                    <Line type="monotone" dataKey="avgHours" stroke="var(--accent)" strokeWidth={2} dot={{ r: 4 }} />
+                    <Tooltip
+                      formatter={(val) => [`${val}h`, "Avg Cycle Time"]}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="avgHours"
+                      stroke="var(--accent)"
+                      strokeWidth={2}
+                      dot={{ r: 4 }}
+                    />
                   </LineChart>
                 </ResponsiveContainer>
               </div>
@@ -329,12 +417,21 @@ export default function PRMetrics() {
 
             {metrics?.slowestRepos && metrics.slowestRepos.length > 0 && (
               <div className="rounded-lg bg-[var(--control)] p-4">
-                <h3 className="text-sm font-semibold text-[var(--card-foreground)] mb-3">Slowest Review Repos</h3>
+                <h3 className="text-sm font-semibold text-[var(--card-foreground)] mb-3">
+                  Slowest Review Repos
+                </h3>
                 <div className="space-y-2">
                   {metrics.slowestRepos.map((r) => (
-                    <div key={r.repo} className="flex justify-between items-center bg-[var(--card)] p-2 rounded">
-                      <span className="text-sm text-[var(--muted-foreground)] truncate">{r.repo}</span>
-                      <span className="text-sm font-bold text-[var(--accent)]">{r.avgHours}h</span>
+                    <div
+                      key={r.repo}
+                      className="flex justify-between items-center bg-[var(--card)] p-2 rounded"
+                    >
+                      <span className="text-sm text-[var(--muted-foreground)] truncate">
+                        {r.repo}
+                      </span>
+                      <span className="text-sm font-bold text-[var(--accent)]">
+                        {r.avgHours}h
+                      </span>
                     </div>
                   ))}
                 </div>
@@ -345,14 +442,22 @@ export default function PRMetrics() {
           {/* GitLab MRs Section */}
           {metrics?.gitlab && (
             <div className="space-y-4 border-t border-[var(--border)] pt-4">
-              <p className="text-sm font-medium text-[var(--muted-foreground)]">GitLab MRs</p>
+              <p className="text-sm font-medium text-[var(--muted-foreground)]">
+                GitLab MRs
+              </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 {gitlabStats
                   .filter((stat) => {
                     if (prFilter === "all") return true;
                     const lbl = stat.label.toLowerCase();
-                    if (prFilter === "open") return lbl.includes("open") || lbl.includes("stale");
-                    if (prFilter === "merged") return lbl.includes("merged") || lbl.includes("review") || lbl.includes("merge rate");
+                    if (prFilter === "open")
+                      return lbl.includes("open") || lbl.includes("stale");
+                    if (prFilter === "merged")
+                      return (
+                        lbl.includes("merged") ||
+                        lbl.includes("review") ||
+                        lbl.includes("merge rate")
+                      );
                     return true;
                   })
                   .map(renderStat)}
@@ -364,12 +469,25 @@ export default function PRMetrics() {
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             {[
-              { label: "Total Reviews Given", value: metrics?.reviews?.totalReviews ?? 0 },
-              { label: "Approval Rate", value: metrics?.reviews?.approvalRate ?? "0%" },
+              {
+                label: "Total Reviews Given",
+                value: metrics?.reviews?.totalReviews ?? 0,
+              },
+              {
+                label: "Approval Rate",
+                value: metrics?.reviews?.approvalRate ?? "0%",
+              },
             ].map((stat) => (
-              <div key={stat.label} className="rounded-lg bg-[var(--control)] p-4 text-center">
-                <div className="text-2xl font-bold text-[var(--accent)]">{stat.value}</div>
-                <div className="mt-1 text-sm text-[var(--muted-foreground)]">{stat.label}</div>
+              <div
+                key={stat.label}
+                className="rounded-lg bg-[var(--control)] p-4 text-center"
+              >
+                <div className="text-2xl font-bold text-[var(--accent)]">
+                  {stat.value}
+                </div>
+                <div className="mt-1 text-sm text-[var(--muted-foreground)]">
+                  {stat.label}
+                </div>
               </div>
             ))}
           </div>
@@ -378,7 +496,9 @@ export default function PRMetrics() {
 
       {lastUpdated && (
         <p className="text-xs text-[var(--muted-foreground)] mt-2 text-right">
-          {minutesAgo === 0 ? "Updated just now" : `Updated ${minutesAgo} min ago`}
+          {minutesAgo === 0
+            ? "Updated just now"
+            : `Updated ${minutesAgo} min ago`}
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary
Adds a "Lines Changed" stat tile to the PR Analytics widget showing total additions/deletions across PRs in the selected time range, styled with green/red coloring to match GitHub's diff style.

Closes #2450

---

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)

---

## What Changed
- Backend (`src/app/api/metrics/prs/route.ts`) already fetched and returned `totalAdditions`/`totalDeletions` via GitHub GraphQL — fixed a latent `typeof value` typo bug found while reviewing this path
- Widened `PRStat.value` type in `src/components/PRMetrics.tsx` to accept `ReactNode` so tiles can render styled content, not just strings/numbers
- Replaced the plain-text Lines Changed value with colored spans: green `+{additions}` and red `-{deletions}`, matching GitHub's diff coloring

---

## How to Test
1. Open the dashboard and view the PR Analytics widget
2. Confirm the "Lines Changed" tile shows `+X` in green and `-Y` in red
3. Switch between 7d / 30d / 90d ranges and confirm numbers update
4. Switch between PRs Authored / Reviews Given tabs to confirm no crashes

**Expected result:** Lines Changed tile renders with correct green/red coloring and accurate numbers across all ranges.

---

## Checklist
- [x] Linked the related issue above
- [x] Self-reviewed my own diff
- [x] No unnecessary `console.log`, debug code, or commented-out blocks
- [ ] `npm run lint` passes locally
- [ ] No TypeScript errors (`npm run type-check`)
- [ ] Added or updated tests where applicable
- [ ] Updated documentation / comments if behavior changed

---

## Accessibility (UI changes only)
- [x] Keyboard navigation works correctly
- [ ] Color contrast meets WCAG AA standard
- [ ] ARIA labels / roles added where needed
- [x] Tested on mobile / responsive layout

---

## Additional Context
Backend GraphQL fetching for additions/deletions was already implemented; this PR focuses on the frontend tile rendering and a small bugfix in the review-time calculation.