### PR TITLE
fix: repair the red test suite and the six product bugs it was hiding

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   validate-and-test:
     name: Continuous Integration Security & Audit Suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+# Default to read-only; jobs that need more raise it themselves.
+permissions:
+  contents: read
+
 # Cancel outdated runs on the same PR/branch to save CI minutes.
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 3 * * 1'
 
+# Default to read-only; the analyze job raises what it needs.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,12 @@
 name: PR Labeler
 on:
   pull_request_target:
+
+# pull_request_target runs with a privileged token, so default it to read-only
+# and let the label job raise only what it needs.
+permissions:
+  contents: read
+
 jobs:
   label:
     permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,11 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,6 +5,8 @@ name: Type Check (DEPRECATED - see ci.yml)
 on:
   pull_request:
     branches: []
+permissions:
+  contents: read
 jobs:
   typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -16,6 +16,9 @@ on:
       - ".github/workflows/visual-regression.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: visual-regression-${{ github.ref }}
   cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ screenshot.png
 
 # Prevent npm lockfile conflicts
 package-lock.json
+
+# code-analysis output
+.jscpd-report/

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,9 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
+# Probe with node rather than curl/wget - neither ships in node:20-alpine, and
+# /api/debug/health is auth-gated, so hit the landing page instead.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "require('http').get({host:'127.0.0.1',port:process.env.PORT||3000,path:'/'},r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"
+
 CMD ["node", "server.js"]

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -140,4 +140,4 @@ DevTrack includes a `render.yaml` Blueprint for easy deployment on Render's free
 - **AI features not available**:
   AI routes (personality, project tutor, roast, weekly summary) require `GROQ_API_KEY` or `ANTHROPIC_API_KEY`. Without them, AI buttons are hidden or the endpoints return a graceful error. The rest of the app functions normally.
 - **Leaderboard rebuild endpoint returns 401**:
-  Set `LEADERBOARD_REBUILD_TOKEN` in your environment and pass it as `Authorization: Bearer <token>` when calling `/api/leaderboard/rebuild`.
+  Set `LEADERBOARD_REBUILD_TOKEN` in your environment and pass it in the `x-devtrack-rebuild-token` header when calling `/api/leaderboard/rebuild`. The token is only read from that header — passing it as a `?token=` query parameter is not supported, because query strings end up in access and proxy logs.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.13",
     "driver.js": "^1.6.0",
     "fflate": "^0.8.3",
     "groq-sdk": "^1.3.0",
@@ -42,8 +42,8 @@
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.7",
     "lucide-react": "^0.577.0",
-    "next": "^16.2.7",
-    "next-auth": "^4.24.14",
+    "next": "~16.2.11",
+    "next-auth": "^4.24.15",
     "next-intl": "^4.13.0",
     "next-pwa": "^5.6.0",
     "qrcode.react": "^4.2.0",
@@ -86,11 +86,11 @@
     "@vitest/coverage-v8": "^4.1.8",
     "autoprefixer": "^10.5.2",
     "eslint": "^9.39.4",
-    "eslint-config-next": "16.2.9",
+    "eslint-config-next": "16.2.11",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "lint-staged": "^17.2.0",
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.23",
     "prettier": "^3.9.6",
     "tailwind-scrollbar": "^3.1.0",
     "tailwindcss": "^3.4.1",
@@ -99,19 +99,6 @@
     "typescript": "^6",
     "vitest": "^4.1.8",
     "web-tree-sitter": "^0.26.10"
-  },
-  "overrides": {
-    "glob": ">=10.5.0",
-    "serialize-javascript": ">=7.0.3",
-    "esbuild": ">=0.25.0",
-    "uuid": ">=9.0.1",
-    "swagger-client": "3.36.2",
-    "undici": ">=7.28.0",
-    "form-data": ">=4.0.6",
-    "@opentelemetry/core": ">=2.8.0",
-    "@opentelemetry/sdk-trace-base": ">=2.8.0",
-    "@opentelemetry/resources": ">=2.8.0",
-    "js-yaml": ">=4.1.0"
   },
   "engines": {
     "node": "20.x"
@@ -124,21 +111,5 @@
     "@parcel/watcher-linux-x64-glibc": "^2.5.6",
     "@parcel/watcher-linux-x64-musl": "^2.5.6",
     "@swc/core-linux-x64-gnu": "^1.15.43"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "@scarf/scarf",
-      "@sentry/cli",
-      "@swc/core",
-      "@tree-sitter-grammars/tree-sitter-yaml",
-      "core-js-pure",
-      "core-js",
-      "esbuild",
-      "sharp",
-      "tree-sitter-json",
-      "tree-sitter",
-      "unrs-resolver"
-    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,19 @@ settings:
 
 overrides:
   serialize-javascript: '>=7.0.3'
-  postcss: '>=8.4.31'
   uuid: '>=9.0.1'
-  js-yaml: 4.1.0
+  esbuild: '>=0.25.0'
+  form-data: '>=4.0.6'
+  postcss: ^8.5.23
+  js-yaml: ^4.3.1
+  fast-uri: ^3.1.5
+  nanoid: ^3.3.18
+  sharp: ^0.35.0
+  undici: ^7.29.0
+  immutable: ^4.3.9
+  brace-expansion@1: ^1.1.18
+  brace-expansion@2: ^2.1.4
+  brace-expansion@5: ^5.0.9
 
 importers:
 
@@ -28,13 +38,13 @@ importers:
         version: 3.2.2(react@18.3.1)
       '@ducanh2912/next-pwa':
         specifier: ^10.2.9
-        version: 10.2.9(@types/babel__core@7.20.5)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.107.2(postcss@8.5.16))
+        version: 10.2.9(@types/babel__core@7.20.5)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.107.2(postcss@8.5.26))
       '@google/generative-ai':
         specifier: ^0.24.1
         version: 0.24.1
       '@sentry/nextjs':
         specifier: ^10
-        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.107.2(postcss@8.5.16))
+        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.107.2(postcss@8.5.26))
       '@supabase/ssr':
         specifier: ^0.12.0
         version: 0.12.0(@supabase/supabase-js@2.108.2)
@@ -49,10 +59,10 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.0.1(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.0.0(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
@@ -66,8 +76,8 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
       dompurify:
-        specifier: ^3.4.11
-        version: 3.4.11
+        specifier: ^3.4.13
+        version: 3.4.13
       driver.js:
         specifier: ^1.6.0
         version: 1.6.0
@@ -93,17 +103,17 @@ importers:
         specifier: ^0.577.0
         version: 0.577.0(react@18.3.1)
       next:
-        specifier: ^16.2.7
-        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ~16.2.11
+        version: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
-        specifier: ^4.24.14
-        version: 4.24.14(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^4.24.15
+        version: 4.24.15(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl:
         specifier: ^4.13.0
-        version: 4.13.0(@swc/helpers@0.5.23)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
+        version: 4.13.0(@swc/helpers@0.5.23)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       next-pwa:
         specifier: ^5.6.0
-        version: 5.6.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(postcss@8.5.16)(webpack@5.107.2(postcss@8.5.16))
+        version: 5.6.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(postcss@8.5.26)(webpack@5.107.2(postcss@8.5.26))
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@18.3.1)
@@ -126,7 +136,7 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       sharp:
-        specifier: ^0.35.1
+        specifier: ^0.35.0
         version: 0.35.2
       sonner:
         specifier: ^2.0.7
@@ -188,13 +198,13 @@ importers:
         version: 4.1.9(vitest@4.1.9)
       autoprefixer:
         specifier: ^10.5.2
-        version: 10.5.2(postcss@8.5.16)
+        version: 10.5.2(postcss@8.5.26)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@1.21.7)
       eslint-config-next:
-        specifier: 16.2.9
-        version: 16.2.9(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+        specifier: 16.2.11
+        version: 16.2.11(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -205,8 +215,8 @@ importers:
         specifier: ^17.2.0
         version: 17.2.0
       postcss:
-        specifier: '>=8.4.31'
-        version: 8.5.16
+        specifier: ^8.5.23
+        version: 8.5.26
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
@@ -1236,22 +1246,10 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-darwin-arm64@0.35.2':
     resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.35.2':
@@ -1265,19 +1263,9 @@ packages:
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-libvips-darwin-arm64@1.3.1':
     resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.3.1':
@@ -1285,21 +1273,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-arm64@1.3.1':
     resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
     cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -1309,21 +1285,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-ppc64@1.3.1':
     resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
-    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -1333,21 +1297,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-s390x@1.3.1':
     resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1357,21 +1309,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
     resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
     cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -1381,24 +1321,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-arm64@0.35.2':
     resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -1409,24 +1335,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-ppc64@0.35.2':
     resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -1437,24 +1349,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-s390x@0.35.2':
     resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -1465,24 +1363,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-linuxmusl-arm64@0.35.2':
     resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -1493,11 +1377,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
-
   '@img/sharp-wasm32@0.35.2':
     resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
     engines: {node: '>=20.9.0'}
@@ -1507,34 +1386,16 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
   '@img/sharp-win32-arm64@0.35.2':
     resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@img/sharp-win32-ia32@0.35.2':
     resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
     engines: {node: ^20.9.0}
     cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.35.2':
@@ -1662,60 +1523,63 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@next/env@16.2.12':
+    resolution: {integrity: sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==}
+
   '@next/env@16.2.9':
     resolution: {integrity: sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==}
 
-  '@next/eslint-plugin-next@16.2.9':
-    resolution: {integrity: sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==}
+  '@next/eslint-plugin-next@16.2.11':
+    resolution: {integrity: sha512-vMEf/aXOpzFFdtIvFYOnIDPKb0xBbrXONsz83CcKdRrekfxNdL8PNkq5qHqAHSXVlIifnX68LOMaxr3z5PkeLQ==}
 
-  '@next/swc-darwin-arm64@16.2.9':
-    resolution: {integrity: sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==}
+  '@next/swc-darwin-arm64@16.2.12':
+    resolution: {integrity: sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.9':
-    resolution: {integrity: sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==}
+  '@next/swc-darwin-x64@16.2.12':
+    resolution: {integrity: sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.9':
-    resolution: {integrity: sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==}
+  '@next/swc-linux-arm64-gnu@16.2.12':
+    resolution: {integrity: sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.9':
-    resolution: {integrity: sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==}
+  '@next/swc-linux-arm64-musl@16.2.12':
+    resolution: {integrity: sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.9':
-    resolution: {integrity: sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==}
+  '@next/swc-linux-x64-gnu@16.2.12':
+    resolution: {integrity: sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.9':
-    resolution: {integrity: sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==}
+  '@next/swc-linux-x64-musl@16.2.12':
+    resolution: {integrity: sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.9':
-    resolution: {integrity: sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==}
+  '@next/swc-win32-arm64-msvc@16.2.12':
+    resolution: {integrity: sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.9':
-    resolution: {integrity: sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==}
+  '@next/swc-win32-x64-msvc@16.2.12':
+    resolution: {integrity: sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3261,7 +3125,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.5.23
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -3342,11 +3206,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.38:
-    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.10.40:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
@@ -3362,15 +3221,15 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3753,8 +3612,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3866,8 +3725,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@16.2.9:
-    resolution: {integrity: sha512-olGtBrs07bQchpaJWeqbk9GaMoU0oGmN/pYNEBXSbfgKngb5uHnPe37X6tVeh6DJfaWFQildvinGEOrolo5fmw==}
+  eslint-config-next@16.2.11:
+    resolution: {integrity: sha512-FIpbK/dUyxUExchDB7eBg3k+VU8R2iR/Cx9/kqTBUTFv2bOIR9aRrpno4rvAQ9VhiPQAyFKNA2NlZwouGWtclA==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -4066,8 +3925,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4381,9 +4240,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  immutable@3.8.3:
-    resolution: {integrity: sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==}
-    engines: {node: '>=0.10.0'}
+  immutable@4.3.9:
+    resolution: {integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -4794,8 +4652,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5140,8 +4998,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5164,8 +5022,8 @@ packages:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
-  next-auth@4.24.14:
-    resolution: {integrity: sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==}
+  next-auth@4.24.15:
+    resolution: {integrity: sha512-NnjYtjrSOAx/TIVFGTX4IfI/9yHnNpi4B7FuLUwuV20v2Zxgr2OGP/YN0ynJuI7y8QOnTBPitfOdEXZrVvhIuA==}
     peerDependencies:
       '@auth/core': 0.34.3
       next: ^12.2.5 || ^13 || ^14 || ^15 || ^16
@@ -5196,8 +5054,8 @@ packages:
     peerDependencies:
       next: '>=9.0.0'
 
-  next@16.2.9:
-    resolution: {integrity: sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==}
+  next@16.2.12:
+    resolution: {integrity: sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5480,20 +5338,20 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.5.23
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.5.23
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.4.31'
+      postcss: ^8.5.23
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -5510,7 +5368,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: '>=8.4.31'
+      postcss: ^8.5.23
 
   postcss-selector-parser@6.1.4:
     resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
@@ -5519,8 +5377,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact-render-to-string@5.2.6:
@@ -5631,12 +5489,12 @@ packages:
   react-immutable-proptypes@2.2.0:
     resolution: {integrity: sha512-Vf4gBsePlwdGvSZoLSBfd4HAP93HDauMY4fDjXhreg/vg6F3Fj/MXDNyTbltPC/xZKmZc+cjLu3598DdYK6sgQ==}
     peerDependencies:
-      immutable: '>=3.6.2'
+      immutable: ^4.3.9
 
   react-immutable-pure-component@2.2.2:
     resolution: {integrity: sha512-vkgoMJUDqHZfXXnjVlG3keCxSO/U6WeDQ5/Sl0GK2cH8TOxEzQ5jXqDXHEL/jqk6fsNxV05oH5kD7VNMUE2k+A==}
     peerDependencies:
-      immutable: '>= 2 || >= 4.0.0-rc'
+      immutable: ^4.3.9
       react: '>= 16.6'
       react-dom: '>= 16.6'
 
@@ -5722,7 +5580,7 @@ packages:
   redux-immutable@4.0.0:
     resolution: {integrity: sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==}
     peerDependencies:
-      immutable: ^3.8.1 || ^4.0.0-rc.1
+      immutable: ^4.3.9
 
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
@@ -5930,10 +5788,6 @@ packages:
     resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
     engines: {node: '>= 0.10'}
     hasBin: true
-
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   sharp@0.35.2:
     resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
@@ -6475,8 +6329,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -7801,15 +7655,15 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@ducanh2912/next-pwa@10.2.9(@types/babel__core@7.20.5)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.107.2(postcss@8.5.16))':
+  '@ducanh2912/next-pwa@10.2.9(@types/babel__core@7.20.5)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.107.2(postcss@8.5.26))':
     dependencies:
       fast-glob: 3.3.2
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       semver: 7.6.3
-      webpack: 5.107.2(postcss@8.5.16)
+      webpack: 5.107.2(postcss@8.5.26)
       workbox-build: 7.1.1(@types/babel__core@7.20.5)
       workbox-core: 7.1.0
-      workbox-webpack-plugin: 7.1.0(@types/babel__core@7.20.5)(webpack@5.107.2(postcss@8.5.16))
+      workbox-webpack-plugin: 7.1.0(@types/babel__core@7.20.5)(webpack@5.107.2(postcss@8.5.26))
       workbox-window: 7.1.0
     transitivePeerDependencies:
       - '@types/babel__core'
@@ -7956,7 +7810,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8005,19 +7859,9 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
   '@img/sharp-darwin-arm64@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.3.1
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
   '@img/sharp-darwin-x64@0.35.2':
@@ -8030,69 +7874,34 @@ snapshots:
       '@img/sharp-wasm32': 0.35.2
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-darwin-arm64@1.3.1':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.3.1':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linux-arm64@1.3.1':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.3.1':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linux-ppc64@1.3.1':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.3.1':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linux-s390x@1.3.1':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.3.1':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-x64@1.3.1':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
   '@img/sharp-linux-arm64@0.35.2':
@@ -8100,19 +7909,9 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.3.1
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
   '@img/sharp-linux-arm@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.3.1
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
   '@img/sharp-linux-ppc64@0.35.2':
@@ -8120,19 +7919,9 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.3.1
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
   '@img/sharp-linux-riscv64@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.3.1
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
   '@img/sharp-linux-s390x@0.35.2':
@@ -8140,19 +7929,9 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.3.1
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
   '@img/sharp-linux-x64@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.3.1
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.35.2':
@@ -8160,19 +7939,9 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
   '@img/sharp-linuxmusl-x64@0.35.2':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.3.1
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
-    dependencies:
-      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-wasm32@0.35.2':
@@ -8185,19 +7954,10 @@ snapshots:
       '@img/sharp-wasm32': 0.35.2
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
   '@img/sharp-win32-arm64@0.35.2':
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
   '@img/sharp-win32-ia32@0.35.2':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@img/sharp-win32-x64@0.35.2':
@@ -8217,7 +7977,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.1.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -8431,34 +8191,36 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@next/env@16.2.12': {}
+
   '@next/env@16.2.9': {}
 
-  '@next/eslint-plugin-next@16.2.9':
+  '@next/eslint-plugin-next@16.2.11':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.9':
+  '@next/swc-darwin-arm64@16.2.12':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.9':
+  '@next/swc-darwin-x64@16.2.12':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.9':
+  '@next/swc-linux-arm64-gnu@16.2.12':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.9':
+  '@next/swc-linux-arm64-musl@16.2.12':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.9':
+  '@next/swc-linux-x64-gnu@16.2.12':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.9':
+  '@next/swc-linux-x64-musl@16.2.12':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.9':
+  '@next/swc-win32-arm64-msvc@16.2.12':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.9':
+  '@next/swc-win32-x64-msvc@16.2.12':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -8821,7 +8583,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.62.0
 
-  '@sentry/nextjs@10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.107.2(postcss@8.5.16))':
+  '@sentry/nextjs@10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.107.2(postcss@8.5.26))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -8833,8 +8595,8 @@ snapshots:
       '@sentry/opentelemetry': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       '@sentry/react': 10.62.0(react@18.3.1)
       '@sentry/vercel-edge': 10.62.0
-      '@sentry/webpack-plugin': 5.3.0(webpack@5.107.2(postcss@8.5.16))
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@sentry/webpack-plugin': 5.3.0(webpack@5.107.2(postcss@8.5.26))
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -8914,10 +8676,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.62.0
 
-  '@sentry/webpack-plugin@5.3.0(webpack@5.107.2(postcss@8.5.16))':
+  '@sentry/webpack-plugin@5.3.0(webpack@5.107.2(postcss@8.5.26))':
     dependencies:
       '@sentry/bundler-plugin-core': 5.3.0
-      webpack: 5.107.2(postcss@8.5.16)
+      webpack: 5.107.2(postcss@8.5.26)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9590,7 +9352,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.4.11
+      dompurify: 3.4.13
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -9740,8 +9502,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.61.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.62.1
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -9942,14 +9704,14 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@2.0.1(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
-  '@vercel/speed-insights@2.0.0(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/speed-insights@2.0.0(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
@@ -10130,7 +9892,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10272,13 +10034,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  autoprefixer@10.5.2(postcss@8.5.16):
+  autoprefixer@10.5.2(postcss@8.5.26):
     dependencies:
       browserslist: 4.28.4
       caniuse-lite: 1.0.30001799
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -10312,14 +10074,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@8.4.1(@babel/core@7.29.7)(webpack@5.107.2(postcss@8.5.16)):
+  babel-loader@8.4.1(@babel/core@7.29.7)(webpack@5.107.2(postcss@8.5.26)):
     dependencies:
       '@babel/core': 7.29.7
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.107.2(postcss@8.5.16)
+      webpack: 5.107.2(postcss@8.5.26)
 
   babel-plugin-istanbul@7.0.1:
     dependencies:
@@ -10395,8 +10157,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.38: {}
-
   baseline-browser-mapping@2.10.40: {}
 
   bidi-js@1.0.3:
@@ -10407,16 +10167,16 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10533,10 +10293,10 @@ snapshots:
 
   classnames@2.5.1: {}
 
-  clean-webpack-plugin@4.0.0(webpack@5.107.2(postcss@8.5.16)):
+  clean-webpack-plugin@4.0.0(webpack@5.107.2(postcss@8.5.26)):
     dependencies:
       del: 4.1.1
-      webpack: 5.107.2(postcss@8.5.16)
+      webpack: 5.107.2(postcss@8.5.26)
 
   client-only@0.0.1: {}
 
@@ -10763,7 +10523,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.11:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10955,9 +10715,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.9(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3):
+  eslint-config-next@16.2.11(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.2.9
+      '@next/eslint-plugin-next': 16.2.11
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
@@ -11250,7 +11010,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -11597,7 +11357,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immutable@3.8.3: {}
+  immutable@4.3.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -12200,7 +11960,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -12221,7 +11981,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -12273,7 +12033,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0
-      dompurify: 3.4.11
+      dompurify: 3.4.13
       html2canvas: 1.4.1
 
   jsx-ast-utils@3.3.5:
@@ -12650,19 +12410,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -12678,7 +12438,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -12690,13 +12450,13 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next-auth@4.24.14(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.15(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.7
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.29.2
@@ -12707,14 +12467,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
-  next-intl@4.13.0(@swc/helpers@0.5.23)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
+  next-intl@4.13.0(@swc/helpers@0.5.23)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.10
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 18.3.1
@@ -12724,14 +12484,14 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-pwa@5.6.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(postcss@8.5.16)(webpack@5.107.2(postcss@8.5.16)):
+  next-pwa@5.6.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(postcss@8.5.26)(webpack@5.107.2(postcss@8.5.26)):
     dependencies:
-      babel-loader: 8.4.1(@babel/core@7.29.7)(webpack@5.107.2(postcss@8.5.16))
-      clean-webpack-plugin: 4.0.0(webpack@5.107.2(postcss@8.5.16))
+      babel-loader: 8.4.1(@babel/core@7.29.7)(webpack@5.107.2(postcss@8.5.26))
+      clean-webpack-plugin: 4.0.0(webpack@5.107.2(postcss@8.5.26))
       globby: 11.1.0
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      terser-webpack-plugin: 5.6.1(postcss@8.5.16)(webpack@5.107.2(postcss@8.5.16))
-      workbox-webpack-plugin: 6.6.0(@types/babel__core@7.20.5)(webpack@5.107.2(postcss@8.5.16))
+      next: 16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      terser-webpack-plugin: 5.6.1(postcss@8.5.26)(webpack@5.107.2(postcss@8.5.26))
+      workbox-webpack-plugin: 6.6.0(@types/babel__core@7.20.5)(webpack@5.107.2(postcss@8.5.26))
       workbox-window: 6.6.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -12751,28 +12511,28 @@ snapshots:
       - uglify-js
       - webpack
 
-  next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 16.2.9
+      '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.38
+      baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
-      postcss: 8.5.16
+      postcss: 8.5.26
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.9
-      '@next/swc-darwin-x64': 16.2.9
-      '@next/swc-linux-arm64-gnu': 16.2.9
-      '@next/swc-linux-arm64-musl': 16.2.9
-      '@next/swc-linux-x64-gnu': 16.2.9
-      '@next/swc-linux-x64-musl': 16.2.9
-      '@next/swc-win32-arm64-msvc': 16.2.9
-      '@next/swc-win32-x64-msvc': 16.2.9
+      '@next/swc-darwin-arm64': 16.2.12
+      '@next/swc-darwin-x64': 16.2.12
+      '@next/swc-linux-arm64-gnu': 16.2.12
+      '@next/swc-linux-arm64-musl': 16.2.12
+      '@next/swc-linux-x64-gnu': 16.2.12
+      '@next/swc-linux-x64-musl': 16.2.12
+      '@next/swc-win32-arm64-msvc': 16.2.12
+      '@next/swc-win32-x64-msvc': 16.2.12
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
-      sharp: 0.34.5
+      sharp: 0.35.2
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -13011,29 +12771,29 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.16):
+  postcss-import@15.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.5.16):
+  postcss-js@4.1.0(postcss@8.5.26):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.16)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.16
+      postcss: 8.5.26
       yaml: 2.9.0
 
-  postcss-nested@6.2.0(postcss@8.5.16):
+  postcss-nested@6.2.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
   postcss-selector-parser@6.1.4:
@@ -13043,9 +12803,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.16:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -13143,14 +12903,14 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-immutable-proptypes@2.2.0(immutable@3.8.3):
+  react-immutable-proptypes@2.2.0(immutable@4.3.9):
     dependencies:
-      immutable: 3.8.3
+      immutable: 4.3.9
       invariant: 2.2.4
 
-  react-immutable-pure-component@2.2.2(immutable@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-immutable-pure-component@2.2.2(immutable@4.3.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      immutable: 3.8.3
+      immutable: 4.3.9
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -13254,9 +13014,9 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  redux-immutable@4.0.0(immutable@3.8.3):
+  redux-immutable@4.0.0(immutable@4.3.9):
     dependencies:
-      immutable: 3.8.3
+      immutable: 4.3.9
 
   redux@5.0.1: {}
 
@@ -13524,38 +13284,6 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
-
-  sharp@0.34.5:
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   sharp@0.35.2:
     dependencies:
@@ -13847,7 +13575,7 @@ snapshots:
       '@swaggerexpert/cookie': 2.0.2
       deepmerge: 4.3.1
       fast-json-patch: 3.1.1
-      js-yaml: 4.1.0
+      js-yaml: 4.3.1
       neotraverse: 0.6.18
       node-abort-controller: 3.1.1
       openapi-path-templating: 2.2.1
@@ -13867,11 +13595,11 @@ snapshots:
       classnames: 2.5.1
       css.escape: 1.5.1
       deep-extend: 0.6.0
-      dompurify: 3.4.11
+      dompurify: 3.4.13
       ieee754: 1.2.1
-      immutable: 3.8.3
+      immutable: 4.3.9
       js-file-download: 0.4.12
-      js-yaml: 4.1.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       prop-types: 15.8.1
       randexp: 0.5.3
@@ -13880,13 +13608,13 @@ snapshots:
       react-copy-to-clipboard: 5.1.0(react@18.3.1)
       react-debounce-input: 3.3.0(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
-      react-immutable-proptypes: 2.2.0(immutable@3.8.3)
-      react-immutable-pure-component: 2.2.2(immutable@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-immutable-proptypes: 2.2.0(immutable@4.3.9)
+      react-immutable-pure-component: 2.2.2(immutable@4.3.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-inspector: 6.0.2(react@18.3.1)
       react-redux: 9.3.0(@types/react@19.2.17)(react@18.3.1)(redux@5.0.1)
       react-syntax-highlighter: 16.1.1(react@18.3.1)
       redux: 5.0.1
-      redux-immutable: 4.0.0(immutable@3.8.3)
+      redux-immutable: 4.0.0(immutable@4.3.9)
       remarkable: 2.0.1
       reselect: 5.2.0
       serialize-error: 8.1.0
@@ -13929,11 +13657,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.16
-      postcss-import: 15.1.0(postcss@8.5.16)
-      postcss-js: 4.1.0(postcss@8.5.16)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.16)(yaml@2.9.0)
-      postcss-nested: 6.2.0(postcss@8.5.16)
+      postcss: 8.5.26
+      postcss-import: 15.1.0(postcss@8.5.26)
+      postcss-js: 4.1.0(postcss@8.5.26)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.26)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.4
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -13952,15 +13680,15 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.6.1(postcss@8.5.16)(webpack@5.107.2(postcss@8.5.16)):
+  terser-webpack-plugin@5.6.1(postcss@8.5.26)(webpack@5.107.2(postcss@8.5.26)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2(postcss@8.5.16)
+      webpack: 5.107.2(postcss@8.5.26)
     optionalDependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
   terser@5.48.0:
     dependencies:
@@ -14185,7 +13913,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -14342,7 +14070,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.26
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -14412,7 +14140,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.107.2(postcss@8.5.16):
+  webpack@5.107.2(postcss@8.5.26):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -14434,7 +14162,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(postcss@8.5.16)(webpack@5.107.2(postcss@8.5.16))
+      terser-webpack-plugin: 5.6.1(postcss@8.5.26)(webpack@5.107.2(postcss@8.5.26))
       watchpack: 2.5.2
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -14785,24 +14513,24 @@ snapshots:
 
   workbox-sw@7.1.0: {}
 
-  workbox-webpack-plugin@6.6.0(@types/babel__core@7.20.5)(webpack@5.107.2(postcss@8.5.16)):
+  workbox-webpack-plugin@6.6.0(@types/babel__core@7.20.5)(webpack@5.107.2(postcss@8.5.26)):
     dependencies:
       fast-json-stable-stringify: 2.1.0
       pretty-bytes: 5.6.0
       upath: 1.2.0
-      webpack: 5.107.2(postcss@8.5.16)
+      webpack: 5.107.2(postcss@8.5.26)
       webpack-sources: 1.4.3
       workbox-build: 6.6.0(@types/babel__core@7.20.5)
     transitivePeerDependencies:
       - '@types/babel__core'
       - supports-color
 
-  workbox-webpack-plugin@7.1.0(@types/babel__core@7.20.5)(webpack@5.107.2(postcss@8.5.16)):
+  workbox-webpack-plugin@7.1.0(@types/babel__core@7.20.5)(webpack@5.107.2(postcss@8.5.26)):
     dependencies:
       fast-json-stable-stringify: 2.1.0
       pretty-bytes: 5.6.0
       upath: 1.2.0
-      webpack: 5.107.2(postcss@8.5.16)
+      webpack: 5.107.2(postcss@8.5.26)
       webpack-sources: 1.4.3
       workbox-build: 7.1.0(@types/babel__core@7.20.5)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,28 @@
 packages:
   - '.'
+# pnpm >=10 reads overrides from this file, not from package.json.
+# Keep every override here — a duplicate block in package.json is silently ignored.
 overrides:
   serialize-javascript: ">=7.0.3"
-  postcss: ">=8.4.31"
   uuid: ">=9.0.1"
-  js-yaml: "4.1.0"
+  esbuild: ">=0.25.0"
+  form-data: ">=4.0.6"
+  # Transitive advisories (see `pnpm audit --prod`). Ranges are caret-bounded on
+  # purpose: an open ">=" here drags every dependent onto the newest major
+  # (js-yaml 5, nanoid 6, undici 8), which is a far bigger change than the fix.
+  postcss: "^8.5.23"
+  js-yaml: "^4.3.1"
+  fast-uri: "^3.1.5"
+  nanoid: "^3.3.18"
+  sharp: "^0.35.0"
+  undici: "^7.29.0"
+  # immutable 3.8.3 has no patched 3.x line; the advisory's fix is 4.3.9.
+  immutable: "^4.3.9"
+  # brace-expansion ships three parallel majors; a single range would let the
+  # vulnerable 2.x satisfy a "^1.1.18" constraint, so bound each line separately.
+  brace-expansion@1: "^1.1.18"
+  brace-expansion@2: "^2.1.4"
+  brace-expansion@5: "^5.0.9"
 allowBuilds:
   '@parcel/watcher': true
   '@scarf/scarf': true

--- a/src/app/api/cron/weekly-digest/route.ts
+++ b/src/app/api/cron/weekly-digest/route.ts
@@ -86,8 +86,9 @@ function currentWeekLabel(): string {
 /**
  * Send one digest email via Resend.
  * Returns { ok: true } on success, { ok: false, error } on failure.
- * When RESEND_API_KEY is absent the call is skipped and treated as sent,
- * so self-hosted deployments using an external mailer are not penalised.
+ * When RESEND_API_KEY is absent the call is skipped rather than failed, so a
+ * self-hosted deployment using an external mailer is not reported as broken.
+ * Those users are counted under skippedUnconfigured in the response.
  */
 async function sendEmail(params: {
   to: string;
@@ -245,6 +246,7 @@ export async function GET(request: Request) {
     let emailsSent = 0;
     let emailsFailed = 0;
     let skippedCount = 0;
+    let skippedUnconfigured = 0;
     const errors: SendError[] = [];
 
     // 2. Page through opted-in users so no single query loads the full table.
@@ -304,6 +306,10 @@ export async function GET(request: Request) {
               });
             } else if (status === "skipped_cooldown") {
               skippedCount++;
+            } else if (status === "skipped_unconfigured") {
+              // No mailer configured. Not a success and not a failure, but it
+              // must be counted or the outcome vanishes from the response.
+              skippedUnconfigured++;
             }
           }
         }
@@ -319,7 +325,7 @@ export async function GET(request: Request) {
     }
 
     console.log(
-      `[weekly-digest] done — processed:${totalUsersProcessed} sent:${emailsSent} failed:${emailsFailed} skipped:${skippedCount}`
+      `[weekly-digest] done — processed:${totalUsersProcessed} sent:${emailsSent} failed:${emailsFailed} skipped:${skippedCount} unconfigured:${skippedUnconfigured}`
     );
 
     return NextResponse.json({
@@ -328,6 +334,7 @@ export async function GET(request: Request) {
       emailsSent,
       emailsFailed,
       skippedCount,
+      skippedUnconfigured,
       errors,
     });
   } catch (err) {

--- a/src/app/api/leaderboard/rebuild/route.ts
+++ b/src/app/api/leaderboard/rebuild/route.ts
@@ -5,7 +5,9 @@ import { cacheSet } from "@/lib/metrics-cache";
 import { supabaseAdmin, isSupabaseAdminAvailable } from "@/lib/supabase";
 
 export async function POST(req: NextRequest) {
-  const token = req.headers.get("x-devtrack-rebuild-token") ?? req.nextUrl.searchParams.get("token");
+  // Header only. A `?token=` fallback would write the secret into access logs,
+  // proxy logs and Referer headers.
+  const token = req.headers.get("x-devtrack-rebuild-token");
   const expected = process.env.LEADERBOARD_REBUILD_TOKEN;
   if (!expected || token !== expected) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/user/settings/route.ts
+++ b/src/app/api/user/settings/route.ts
@@ -308,11 +308,50 @@ export async function PATCH(req: NextRequest) {
     updates.public_widgets = sanitizePublicWidgets(public_widgets);
   }
 
-  if (hasPreferredLocale && preferred_locale !== undefined) {
+  if (hasPreferredLocale && preferred_locale !== undefined && preferred_locale !== null) {
+    // Reject rather than store: an unsupported value is persisted and then used
+    // to pick a message bundle on every later render.
+    if (!isValidLocale(preferred_locale)) {
+      return NextResponse.json({ error: "Unsupported locale" }, { status: 400 });
+    }
     updates.preferred_locale = preferred_locale;
   }
 
-  await supabaseAdmin.from("users").update(updates).eq("id", user.id);
+  // A PATCH whose fields were all absent, null, or unsupported by this schema
+  // leaves nothing to write; skip the round-trip rather than issuing an empty
+  // UPDATE.
+  const hasUpdates = Object.keys(updates).length > 0;
+
+  const { error: updateError } = hasUpdates
+    ? await supabaseAdmin.from("users").update(updates).eq("id", user.id)
+    : { error: null };
+
+  if (updateError) {
+    console.error("[settings] Failed to persist settings update:", updateError);
+    return NextResponse.json({ error: "Failed to update settings" }, { status: 500 });
+  }
+
+  // GET caches the settings payload for 5 minutes, so a write that does not
+  // evict it leaves the settings page showing the old values.
+  if (hasUpdates) {
+    try {
+      await cacheDelete(`settings:${user.id}`);
+    } catch (err) {
+      console.error("[settings] Failed to invalidate settings cache:", err);
+    }
+  }
+
+  // #1779: a change to leaderboard visibility must invalidate the leaderboard
+  // cache, or an opted-out user stays listed for up to an hour (and an opted-in
+  // user stays missing for the same window).
+  if (updates.is_public !== undefined || updates.leaderboard_opt_in !== undefined) {
+    try {
+      await clearLeaderboardCache();
+    } catch (err) {
+      // The settings write already succeeded; a cache miss is not worth a 500.
+      console.error("[settings] Failed to clear leaderboard cache:", err);
+    }
+  }
 
   return settingsResponse({
     id: user.id,

--- a/src/app/dashboard/repo-comparison/page.tsx
+++ b/src/app/dashboard/repo-comparison/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   BarChart,
   Bar,
@@ -29,26 +30,26 @@ export default function RepoComparisonPage() {
     const parts = trimmed.split("/");
 
     if (parts.length !== 2) {
-      alert("Invalid format! Use owner/repo (e.g. facebook/react)");
+      toast.error("Use the owner/repo format, for example facebook/react.");
       return;
     }
 
     const [owner, repo] = parts;
 
     if (!owner || !repo) {
-      alert("Invalid repository");
+      toast.error("Enter both an owner and a repository name.");
       return;
     }
 
     if (trimmed.includes(" ")) {
-      alert("No spaces allowed in repository name");
+      toast.error("Repository names cannot contain spaces.");
       return;
     }
 
     if (repos.includes(trimmed)) return;
 
     if (repos.length >= 5) {
-      alert("You can compare max 5 repositories only");
+      toast.error("You can compare up to 5 repositories at a time.");
       return;
     }
 
@@ -58,7 +59,7 @@ export default function RepoComparisonPage() {
       );
 
       if (!res.ok) {
-        alert("Repository does not exist on GitHub");
+        toast.error("That repository does not exist on GitHub.");
         return;
       }
 
@@ -67,7 +68,7 @@ export default function RepoComparisonPage() {
       setRepos([...repos, data.full_name]);
       setInput("");
     } catch {
-      alert("Error validating repository");
+      toast.error("Could not reach GitHub to check that repository. Try again.");
     }
   };
 
@@ -77,7 +78,7 @@ export default function RepoComparisonPage() {
 
   const fetchRepoData = async () => {
     if (repos.length < 2) {
-      alert("Add at least 2 repositories to compare");
+      toast.error("Add at least 2 repositories to compare.");
       return;
     }
 
@@ -107,7 +108,7 @@ export default function RepoComparisonPage() {
 
       setRepoData(results.filter((r): r is NonNullable<typeof r> => r !== null));
     } catch {
-      alert("Failed to fetch repo data");
+      toast.error("Could not load repository data. Try again.");
     }
 
     setLoading(false);

--- a/src/app/rooms/[roomId]/RoomClient.tsx
+++ b/src/app/rooms/[roomId]/RoomClient.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { toast } from 'sonner';
 import type { CollaborationRoom, RoomMember, RoomMessage } from '@/types/rooms';
 import MessageFeed from '@/components/rooms/MessageFeed';
 import MessageInput from '@/components/rooms/MessageInput';
@@ -69,11 +70,11 @@ export default function RoomClient({
         router.push('/rooms');
       } else {
         const data = await res.json();
-        alert(data.error ?? 'Failed to delete room');
+        toast.error(data.error ?? 'Could not delete this room. Try again.');
       }
     } catch (e) {
       console.error(e);
-      alert('Failed to delete room. Please check your connection.');
+      toast.error('Could not reach the server. Check your connection and try again.');
     } finally {
       setDeleting(false);
     }
@@ -88,7 +89,7 @@ export default function RoomClient({
       router.push('/rooms');
     } else {
       const data = await res.json();
-      alert(data.error ?? 'Failed to leave room');
+      toast.error(data.error ?? 'Could not leave this room. Try again.');
     }
   }
 

--- a/src/components/PRMetrics.tsx
+++ b/src/components/PRMetrics.tsx
@@ -9,6 +9,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "rec
 import PRStatusDonutChart from "./PRStatusDonutChart";
 import MiniPRTrendChart from "./MiniPRTrendChart";
 import { SkeletonBlock } from "./WidgetSkeleton";
+import { safeExternalHref } from "@/lib/safe-url";
 
 interface PRMetricsSummary {
   open: number;
@@ -170,7 +171,7 @@ export default function PRMetrics() {
       }`;
 
     return stat.href ? (
-      <a key={stat.label} href={stat.href} target="_blank" rel="noopener noreferrer" className={className} title={stat.title}>
+      <a key={stat.label} href={safeExternalHref(stat.href)} target="_blank" rel="noopener noreferrer" className={className} title={stat.title}>
         {content}
       </a>
     ) : (

--- a/src/components/ProfileQrModal.tsx
+++ b/src/components/ProfileQrModal.tsx
@@ -68,39 +68,29 @@ export function ProfileQrModal({
   );
 
   const handleDownload = useCallback(() => {
-    const svg = qrContainerRef.current?.querySelector("svg");
-    if (!svg) return;
+    // QRCodeCanvas renders a <canvas>, so the pixels are already there — read
+    // them straight off it. A previous version looked for a <svg> here, which
+    // this component has never rendered, so the button silently did nothing.
+    const source = qrContainerRef.current?.querySelector("canvas");
+    if (!source) return;
 
-    const svgData = new XMLSerializer().serializeToString(svg);
-    const canvas = document.createElement("canvas");
     const padding = 24; // px of white border around the QR code
-    const qrSize = 256;
-    canvas.width = qrSize + padding * 2;
-    canvas.height = qrSize + padding * 2;
+    const canvas = document.createElement("canvas");
+    canvas.width = source.width + padding * 2;
+    canvas.height = source.height + padding * 2;
 
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    // White background
+    // White background so the code still scans when saved on a dark theme.
     ctx.fillStyle = "#ffffff";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(source, padding, padding);
 
-    const img = new Image();
-    const blob = new Blob([svgData], { type: "image/svg+xml;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-
-    img.onload = () => {
-      ctx.drawImage(img, padding, padding, qrSize, qrSize);
-      URL.revokeObjectURL(url);
-
-      const pngUrl = canvas.toDataURL("image/png");
-      const link = document.createElement("a");
-      link.href = pngUrl;
-      link.download = `devtrack-${username}-qr.png`;
-      link.click();
-    };
-
-    img.src = url;
+    const link = document.createElement("a");
+    link.href = canvas.toDataURL("image/png");
+    link.download = `devtrack-${username}-qr.png`;
+    link.click();
   }, [username]);
 
   return (

--- a/src/components/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal.tsx
@@ -72,6 +72,11 @@ export default function ShortcutsModal({
       return;
     }
 
+    // The modal renders null until `mounted` flips true, so on the first pass
+    // closeBtnRef is still empty. Wait for the DOM to exist, otherwise focus
+    // never enters the dialog and a keyboard user is left outside it.
+    if (!mounted) return;
+
     // Save previous active element to restore later, only on initial open
     if (!previousFocusRef.current) {
       previousFocusRef.current = document.activeElement as HTMLElement | null;
@@ -130,7 +135,7 @@ export default function ShortcutsModal({
       document.removeEventListener("touchstart", handleClickOutside);
       document.removeEventListener("focusin", handleFocusIn);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, mounted]);
 
   if (!isOpen || !mounted) return null;
 

--- a/src/components/SponsorAnalytics.tsx
+++ b/src/components/SponsorAnalytics.tsx
@@ -5,6 +5,7 @@ import { Heart, Users, DollarSign, RefreshCw, Trophy, Info, ExternalLink } from 
 import { ResponsiveContainer, LineChart, Line, YAxis, Tooltip, XAxis } from "recharts";
 import { toast } from "sonner";
 import Image from "next/image";
+import { safeExternalHref } from "@/lib/safe-url";
 
 
 interface ActiveSponsor {
@@ -378,7 +379,7 @@ function SponsorAvatar({ sponsor, tierType }: { sponsor: ActiveSponsor; tierType
 
   const innerElement = sponsor.url ? (
     <a
-      href={sponsor.url}
+      href={safeExternalHref(sponsor.url)}
       target="_blank"
       rel="noopener noreferrer"
       className={`relative h-10 w-10 overflow-hidden rounded-full block cursor-pointer transition-transform duration-200 ${borderClass}`}

--- a/src/components/repo-analytics/RepoCard.tsx
+++ b/src/components/repo-analytics/RepoCard.tsx
@@ -13,6 +13,7 @@ import {
   formatRelativeDate,
   formatDate,
 } from "@/lib/date-utils";
+import { safeExternalHref } from "@/lib/safe-url";
 import { Button, buttonVariants } from "@/components/ui/button";
 
 interface RepoCardProps {
@@ -138,7 +139,7 @@ export default function RepoCard({
         {/* Buttons */}
         <div className="grid grid-cols-2 gap-3">
           <a
-            href={repo.htmlUrl}
+            href={safeExternalHref(repo.htmlUrl)}
             target="_blank"
             rel="noopener noreferrer"
             className={buttonVariants({ variant: "outline" })}

--- a/src/components/rooms/MembersPanel.tsx
+++ b/src/components/rooms/MembersPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { RoomMember } from "@/types/rooms";
 import InviteModal from "./InviteModal";
+import { toast } from "sonner";
 
 interface Props {
   roomId: string;
@@ -34,10 +35,10 @@ export default function MembersPanel({
         onMemberRemoved(username);
       } else {
         const data = await res.json().catch(() => ({}));
-        alert((data as { error?: string }).error ?? "Failed to remove member");
+        toast.error((data as { error?: string }).error ?? "Could not remove that member. Try again.");
       }
     } catch {
-      alert("Network error. Please try again.");
+      toast.error("Could not reach the server. Check your connection and try again.");
     } finally {
       setRemovingUsername(null);
     }

--- a/src/lib/safe-url.ts
+++ b/src/lib/safe-url.ts
@@ -1,0 +1,44 @@
+/**
+ * Client-safe URL scheme allowlist for values rendered into an `href`.
+ *
+ * Distinct from `ssrf-protection.ts`, which resolves DNS and is server-only.
+ * This runs in the browser and answers one narrower question: is it safe to put
+ * this string in an anchor a user can click?
+ *
+ * The risk is `javascript:` (and `data:`, `vbscript:`) URIs. Every URL DevTrack
+ * renders comes from the GitHub API today, so nothing here is known to be
+ * attacker-controlled — but a link is one API response away from being so, and
+ * the check costs nothing.
+ */
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+/**
+ * Returns the URL when its scheme is safe to render, otherwise `undefined`.
+ *
+ * Passing `undefined` to an `href` omits the attribute entirely, so the element
+ * renders as plain text rather than a link that goes nowhere.
+ *
+ * Relative and protocol-relative URLs resolve against the current page and are
+ * allowed; they cannot carry a scheme of their own.
+ */
+export function safeExternalHref(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+
+  // Relative ("/repo", "./x") and protocol-relative ("//host/x") URLs have no
+  // scheme to smuggle, so they need no allowlist check.
+  if (trimmed.startsWith("/")) return trimmed;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    // Not an absolute URL and not relative — refuse rather than guess.
+    return undefined;
+  }
+
+  return ALLOWED_PROTOCOLS.has(parsed.protocol) ? trimmed : undefined;
+}

--- a/src/lib/upstash-rest.ts
+++ b/src/lib/upstash-rest.ts
@@ -77,7 +77,10 @@ export async function upstashTryAcquireLock(options: {
   ttlSeconds: number;
   value?: string;
 }): Promise<boolean> {
-  const value = options.value ?? `${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  // The lock value is an ownership token — whoever holds it may release the
+  // lock, so it must not be guessable from the clock. Math.random() is not.
+  // Web Crypto rather than node:crypto so this stays usable from the edge runtime.
+  const value = options.value ?? `${Date.now()}:${globalThis.crypto.randomUUID()}`;
   const results = await upstashPipeline([
     ["SET", options.key, value, "NX", "EX", options.ttlSeconds],
   ]);

--- a/test/GoalTracker.test.ts
+++ b/test/GoalTracker.test.ts
@@ -143,7 +143,9 @@ describe('GoalTracker - useGoalTracker Hook', () => {
     });
 
     expect(result.current.syncing).toBe(false);
-    expect(result.current.syncError).toBe('Failed to sync goals. Please try again.');
+    // handleSync's generic non-429/401/502 branch. The "Failed to sync goals"
+    // wording belongs to the devtrack:sync event listener, a different path.
+    expect(result.current.syncError).toBe('Sync failed. Please try again.');
   });
 
   it('handles creating a non-auto-synced goal successfully', async () => {

--- a/test/anthropic-service.test.ts
+++ b/test/anthropic-service.test.ts
@@ -58,9 +58,12 @@ vi.mock("@anthropic-ai/sdk", () => {
     }
   }
 
-  const MockAnthropic = vi.fn(
-    () => ({ messages: { create: messagesCreate } })
-  ) as unknown as (new () => object) & { APIError: typeof FakeAPIError };
+  // Must be a `function`, not an arrow: production code calls
+  // `new Anthropic({...})`, and an arrow function has no [[Construct]] slot,
+  // so vi.fn() wrapping one throws "is not a constructor".
+  const MockAnthropic = vi.fn(function MockAnthropicClient() {
+    return { messages: { create: messagesCreate } };
+  }) as unknown as (new () => object) & { APIError: typeof FakeAPIError };
   MockAnthropic.APIError = FakeAPIError;
 
   return { default: MockAnthropic, APIError: FakeAPIError };

--- a/test/badge-rate-limit.test.ts
+++ b/test/badge-rate-limit.test.ts
@@ -162,15 +162,29 @@ describe('badge-rate-limit', () => {
     });
   });
 
+  // getBadgeClientIp deliberately ignores x-forwarded-for: any client can set
+  // it on a direct request, which would let an attacker pick their own rate
+  // limit bucket. It reads x-vercel-forwarded-for, then x-real-ip, then req.ip.
   describe('getBadgeClientIp', () => {
-    it('verify x-forwarded-for header parsing', () => {
+    it('prefers x-vercel-forwarded-for, which the edge sets', () => {
+      const req = {
+        headers: new Headers({
+          'x-vercel-forwarded-for': '192.168.1.1',
+          'x-real-ip': '10.0.0.1'
+        })
+      } as unknown as NextRequest;
+
+      expect(getBadgeClientIp(req)).toBe('192.168.1.1');
+    });
+
+    it('ignores x-forwarded-for, because a client can forge it', () => {
       const req = {
         headers: new Headers({
           'x-forwarded-for': '192.168.1.1, 10.0.0.1'
         })
       } as unknown as NextRequest;
 
-      expect(getBadgeClientIp(req)).toBe('192.168.1.1');
+      expect(getBadgeClientIp(req)).toBe('unknown');
     });
 
     it('verify x-real-ip header handling', () => {
@@ -200,11 +214,22 @@ describe('badge-rate-limit', () => {
       expect(getBadgeClientIp(req)).toBe('172.16.0.1');
     });
 
-    it('x-forwarded-for takes precedence over req.ip', () => {
+    it('falls back to req.ip rather than trusting a forged x-forwarded-for', () => {
       const req = {
         ip: '10.0.0.99',
         headers: new Headers({
           'x-forwarded-for': '203.0.113.5'
+        })
+      } as unknown as NextRequest;
+
+      expect(getBadgeClientIp(req)).toBe('10.0.0.99');
+    });
+
+    it('x-real-ip takes precedence over req.ip', () => {
+      const req = {
+        ip: '10.0.0.99',
+        headers: new Headers({
+          'x-real-ip': '203.0.113.5'
         })
       } as unknown as NextRequest;
 

--- a/test/components/DashboardHeader.test.tsx
+++ b/test/components/DashboardHeader.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom/vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import DashboardHeader from "../../src/components/DashboardHeader";
 import { useSession } from "next-auth/react";
@@ -198,16 +198,25 @@ describe("DashboardHeader", () => {
       }),
     });
 
-    renderDashboardHeader();
-
-    const link = await screen.findByRole("link", {
-      name: /share profile/i,
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
     });
 
-    expect(link).toHaveAttribute(
-      "href",
-      "/u/testuser"
-    );
+    renderDashboardHeader();
+
+    // Share Profile is a copy-to-clipboard button, not an anchor: it puts the
+    // absolute profile URL on the clipboard so it can be pasted anywhere.
+    const shareButton = await screen.findByRole("button", {
+      name: /share profile/i,
+    });
+    fireEvent.click(shareButton);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1);
+    });
+    expect(writeText.mock.calls[0][0]).toMatch(/\/u\/testuser$/);
   });
 
   it("handles fetch failure gracefully", async () => {

--- a/test/components/ProfileQrModal.test.tsx
+++ b/test/components/ProfileQrModal.test.tsx
@@ -4,126 +4,120 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ProfileQrModal } from "../../src/components/ProfileQrModal";
 
+/**
+ * ProfileQrModal has no `isOpen` prop — the parent mounts it conditionally, as
+ * its usage docblock shows. These tests therefore cover the mounted component.
+ */
 describe("ProfileQrModal", () => {
+  const onClose = vi.fn();
   const defaultProps = {
-    isOpen: true,
-    onClose: vi.fn(),
+    onClose,
     username: "john_doe",
     profileUrl: "https://devtrack.mock/u/john_doe",
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset document.body style
-    document.body.style.overflow = "unset";
+    document.body.style.overflow = "";
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("does not render when isOpen is false", () => {
-    const { container } = render(<ProfileQrModal {...defaultProps}/>);
-    expect(container.firstChild).toBeNull();
-  });
-
-  it("renders modal content when isOpen is true", () => {
+  it("renders the heading, description, profile URL and QR canvas", () => {
     const { container } = render(<ProfileQrModal {...defaultProps} />);
 
-    // Check heading
-    expect(screen.getByRole("heading", { name: /Share Profile QR/i })).toBeInTheDocument();
-    
-    // Check helper description
     expect(
-      screen.getByText(/Scan with a phone camera to quickly view @john_doe's profile on DevTrack/i)
+      screen.getByRole("heading", { name: /Share Profile/i })
     ).toBeInTheDocument();
-
-    // Check close button
-    expect(screen.getByRole("button", { name: /Close modal/i })).toBeInTheDocument();
-
-    // Check QR code canvas is rendered
-    const canvas = container.querySelector("canvas");
-    expect(canvas).toBeInTheDocument();
+    expect(screen.getByText(/@john_doe/)).toBeInTheDocument();
+    expect(
+      screen.getByText("https://devtrack.mock/u/john_doe")
+    ).toBeInTheDocument();
+    expect(container.querySelector("canvas")).toBeInTheDocument();
   });
 
-  it("calls onClose when Close button is clicked", () => {
+  it("exposes the panel as a labelled modal dialog", () => {
     render(<ProfileQrModal {...defaultProps} />);
 
-    const closeButton = screen.getByRole("button", { name: /Close modal/i });
-    fireEvent.click(closeButton);
-
-    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "qr-modal-title");
   });
 
-  it("calls onClose when backdrop is clicked", () => {
+  it("calls onClose when the close button is clicked", () => {
     render(<ProfileQrModal {...defaultProps} />);
 
-    // Click backdrop using stable testid
-    const backdrop = screen.getByTestId("qr-modal-backdrop");
-    fireEvent.click(backdrop);
+    fireEvent.click(screen.getByRole("button", { name: /Close QR code modal/i }));
 
-    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onClose when Escape key is pressed", () => {
+  it("calls onClose when the backdrop itself is clicked", () => {
+    render(<ProfileQrModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("dialog"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when a click lands inside the panel", () => {
+    render(<ProfileQrModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("heading", { name: /Share Profile/i }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
     render(<ProfileQrModal {...defaultProps} />);
 
     fireEvent.keyDown(document, { key: "Escape" });
 
-    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("locks and unlocks body scroll appropriately", () => {
+  it("locks body scroll while mounted and releases it on unmount", () => {
     const { unmount } = render(<ProfileQrModal {...defaultProps} />);
 
-    // When modal is open, overflow should be hidden
     expect(document.body.style.overflow).toBe("hidden");
 
     unmount();
 
-    // When unmounted/closed, overflow should be restored
-    expect(document.body.style.overflow).toBe("unset");
+    // Cleanup clears the inline style rather than writing a keyword, so the
+    // stylesheet takes over again.
+    expect(document.body.style.overflow).toBe("");
   });
 
-  it("triggers download of QR code when download button is clicked", () => {
-    render(<ProfileQrModal {...defaultProps} />);
-
-    // Mock HTMLCanvasElement.prototype.toDataURL cleanly via spyOn
-    const toDataURLSpy = vi.spyOn(HTMLCanvasElement.prototype, "toDataURL")
+  it("downloads the QR code as a PNG named after the user", () => {
+    const toDataURLSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, "toDataURL")
       .mockReturnValue("data:image/png;base64,mocked_image_data");
 
-    // Spy on document.createElement capturing original implementation to avoid infinite recursion
     const originalCreateElement = document.createElement.bind(document);
     const linkClickSpy = vi.fn();
-    const linkMock = {
-      href: "",
-      download: "",
-      click: linkClickSpy,
-    };
-    const createElementSpy = vi.spyOn(document, "createElement").mockImplementation((tagName) => {
-      if (tagName === "a") {
-        return linkMock as any;
-      }
-      return originalCreateElement(tagName);
-    });
+    const linkMock = { href: "", download: "", click: linkClickSpy };
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) =>
+      tagName === "a" ? (linkMock as never) : originalCreateElement(tagName)
+    );
 
-    const appendChildSpy = vi.spyOn(document.body, "appendChild").mockImplementation(() => ({} as any));
-    const removeChildSpy = vi.spyOn(document.body, "removeChild").mockImplementation(() => ({} as any));
+    render(<ProfileQrModal {...defaultProps} />);
 
-    const downloadButton = screen.getByRole("button", { name: /Download QR Code/i });
-    fireEvent.click(downloadButton);
+    // jsdom has no 2D context, so getContext returns null and the handler bails
+    // before drawing. Stub it only after the QR canvas has painted, so
+    // qrcode.react still gets the real (null-guarded) context during render.
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      fillStyle: "",
+      fillRect: vi.fn(),
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
 
-    // Verify canvas toDataURL was called
+    fireEvent.click(screen.getByRole("button", { name: /Download QR Code/i }));
+
     expect(toDataURLSpy).toHaveBeenCalledWith("image/png");
-
-    // Verify link properties and interaction
-    expect(createElementSpy).toHaveBeenCalledWith("a");
-    expect(appendChildSpy).toHaveBeenCalled();
-    expect(linkClickSpy).toHaveBeenCalled();
-    expect(removeChildSpy).toHaveBeenCalled();
-
-    // Verify filename and href URL properties are assigned correctly
-    expect(linkMock.download).toBe("john_doe-devtrack-qr.png");
+    expect(linkClickSpy).toHaveBeenCalledTimes(1);
     expect(linkMock.href).toBe("data:image/png;base64,mocked_image_data");
+    expect(linkMock.download).toBe("devtrack-john_doe-qr.png");
   });
 });

--- a/test/cron-auth.test.ts
+++ b/test/cron-auth.test.ts
@@ -155,6 +155,32 @@ describe("validateCronRequest", () => {
 
 // ─── discord-sync route — auth regression tests (#1657) ──────────────────────
 
+/**
+ * A stand-in for a PostgREST query builder.
+ *
+ * Every filter method returns the same object, and the object is thenable, so
+ * `await`ing it anywhere in the chain resolves to `result`. This means a route
+ * can add, drop or reorder `.not()` / `.or()` / `.order()` / `.range()` calls
+ * without the test having to mirror the exact chain — which is what broke this
+ * mock when discord-sync gained pagination.
+ */
+function supabaseQueryStub<T>(result: T) {
+  const stub: Record<string, unknown> = {
+    then: (resolve: (value: T) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject),
+  };
+  for (const method of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "is", "in",
+    "not", "or", "filter", "match", "order", "range", "limit",
+  ]) {
+    stub[method] = vi.fn(() => stub);
+  }
+  stub.single = vi.fn(() => Promise.resolve(result));
+  stub.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return stub;
+}
+
 const discordMocks = vi.hoisted(() => ({
   supabaseFrom: vi.fn(),
   fetchPublicStreak: vi.fn(),
@@ -254,12 +280,12 @@ describe("GET /api/notifications/discord-sync — authentication (#1657)", () =>
   it("proceeds past auth when the correct Bearer token is supplied", async () => {
     vi.stubEnv("CRON_SECRET", "s3cr3t");
 
-    // Supabase returns no users — the job completes immediately
-    discordMocks.supabaseFrom.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        not: vi.fn().mockResolvedValue({ data: [], error: null }),
-      }),
-    });
+    // Supabase returns no users — the job completes immediately.
+    // The query builder is chainable and thenable, so the route can add or
+    // reorder filters without this mock needing to mirror the exact chain.
+    discordMocks.supabaseFrom.mockReturnValue(
+      supabaseQueryStub({ data: [], error: null })
+    );
 
     const { GET } = await import("@/app/api/notifications/discord-sync/route");
     const res = await GET(makeDiscordRequest("Bearer s3cr3t"));

--- a/test/cron-auth.test.ts
+++ b/test/cron-auth.test.ts
@@ -21,6 +21,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateCronRequest } from "@/lib/cron-auth";
+import { supabaseQueryStub } from "./supabase-query-stub";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -154,32 +155,6 @@ describe("validateCronRequest", () => {
 });
 
 // ─── discord-sync route — auth regression tests (#1657) ──────────────────────
-
-/**
- * A stand-in for a PostgREST query builder.
- *
- * Every filter method returns the same object, and the object is thenable, so
- * `await`ing it anywhere in the chain resolves to `result`. This means a route
- * can add, drop or reorder `.not()` / `.or()` / `.order()` / `.range()` calls
- * without the test having to mirror the exact chain — which is what broke this
- * mock when discord-sync gained pagination.
- */
-function supabaseQueryStub<T>(result: T) {
-  const stub: Record<string, unknown> = {
-    then: (resolve: (value: T) => unknown, reject?: (reason: unknown) => unknown) =>
-      Promise.resolve(result).then(resolve, reject),
-  };
-  for (const method of [
-    "select", "insert", "update", "upsert", "delete",
-    "eq", "neq", "gt", "gte", "lt", "lte", "like", "ilike", "is", "in",
-    "not", "or", "filter", "match", "order", "range", "limit",
-  ]) {
-    stub[method] = vi.fn(() => stub);
-  }
-  stub.single = vi.fn(() => Promise.resolve(result));
-  stub.maybeSingle = vi.fn(() => Promise.resolve(result));
-  return stub;
-}
 
 const discordMocks = vi.hoisted(() => ({
   supabaseFrom: vi.fn(),

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -91,11 +91,19 @@ describe("toCsv", () => {
       { value: "multi\nline" },
     ];
     const result = toCsv(rows);
-    const lines = result.split("\n");
-    expect(lines[1]).toBe("simple");
-    expect(lines[2]).toBe('"has, comma"');
-    expect(lines[3]).toBe('"has ""quote"""');
-    expect(lines[4]).toBe('"multi\nline"');
+
+    // A quoted cell may itself contain a newline, so splitting the whole
+    // document on "\n" would break that cell in two. Compare the serialised
+    // output as a whole instead.
+    expect(result).toBe(
+      [
+        "value",
+        "simple",
+        '"has, comma"',
+        '"has ""quote"""',
+        '"multi\nline"',
+      ].join("\n")
+    );
   });
 
   it("handles null and undefined in cells", () => {

--- a/test/github-accounts-api.test.ts
+++ b/test/github-accounts-api.test.ts
@@ -83,20 +83,22 @@ describe("GitHub Accounts API Endpoints", () => {
       expect(await res.json()).toEqual({ error: "Unauthorized" });
     });
 
-    it("returns 401 when authenticated session user is not found in database", async () => {
+    it("returns an empty account list when the session user has no database row", async () => {
       (resolveAppUser as any).mockResolvedValue(null);
 
+      // Deliberate graceful fallback: the linked-accounts widget renders empty
+      // rather than taking down the settings page.
       const res = await GET();
-      expect(res.status).toBe(401);
-      expect(await res.json()).toEqual({ error: "Unauthorized" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ accounts: [] });
     });
 
-    it("returns 500 when database fetch fails", async () => {
+    it("falls back to an empty account list when the database fetch fails", async () => {
       mockOrder.mockResolvedValue({ data: null, error: { message: "Database Error" } });
 
       const res = await GET();
-      expect(res.status).toBe(500);
-      expect(await res.json()).toEqual({ error: "Failed to fetch accounts" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ accounts: [] });
     });
 
     it("successfully fetches linked accounts", async () => {

--- a/test/github-auth-metrics.test.ts
+++ b/test/github-auth-metrics.test.ts
@@ -39,8 +39,11 @@ vi.mock("@/lib/metrics-cache", () => ({
   withMetricsCache: vi.fn().mockImplementation((_opts: unknown, fn: () => unknown) => fn()),
 }));
 
+// Routes that go through getSessionWithToken() require a resolved app row;
+// returning null here would 401 before the request ever reaches GitHub, which
+// is not the code path these tests are exercising.
 vi.mock("@/lib/resolve-user", () => ({
-  resolveAppUser: vi.fn().mockResolvedValue(null),
+  resolveAppUser: vi.fn().mockResolvedValue({ id: "user-uuid-1" }),
 }));
 
 vi.mock("@/lib/github-accounts", () => ({

--- a/test/github-rate-limit.test.ts
+++ b/test/github-rate-limit.test.ts
@@ -28,9 +28,14 @@ describe("getGitHubRateLimitDetails", () => {
     expect(getGitHubRateLimitDetails(res)).toBeNull();
   });
 
-  it("returns null for 429 with remaining > 0", () => {
+  it("treats 429 as a rate limit even when remaining > 0", () => {
+    // GitHub returns 429 for *secondary* rate limits (too many concurrent or
+    // rapid requests), where the primary quota in x-ratelimit-remaining has
+    // not been spent. The status is authoritative, the header is not.
     const res = makeResponse(429, { "x-ratelimit-remaining": "5" });
-    expect(getGitHubRateLimitDetails(res)).toBeNull();
+    expect(getGitHubRateLimitDetails(res)).toMatchObject({
+      code: "GITHUB_RATE_LIMITED",
+    });
   });
 
   it("returns null for 403 when remaining header is missing", () => {

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -14,6 +14,13 @@ vi.mock("../src/lib/auth-rate-limit", () => ({
   AUTH_SENSITIVE_PREFIXES: ["/api/auth/signin"],
 }));
 
+/**
+ * The middleware raises its own auth limit under NODE_ENV=test so unrelated
+ * suites are not throttled by it, and reports that effective limit in the
+ * X-RateLimit-Limit header. Assert against it rather than the production 5.
+ */
+const EFFECTIVE_AUTH_LIMIT = "1000";
+
 describe("Middleware - Auth Rate Limiting Redirection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -43,7 +50,7 @@ describe("Middleware - Auth Rate Limiting Redirection", () => {
     // Redirect location points to the signin page with error=RateLimit
     expect(res?.headers.get("Location")).toContain("/auth/signin?error=RateLimit");
     // Rate limit headers are present
-    expect(res?.headers.get("X-RateLimit-Limit")).toBe("5");
+    expect(res?.headers.get("X-RateLimit-Limit")).toBe(EFFECTIVE_AUTH_LIMIT);
     expect(res?.headers.get("X-RateLimit-Remaining")).toBe("0");
     expect(res?.headers.get("X-RateLimit-Reset")).toBe("1234567890");
   });
@@ -75,7 +82,7 @@ describe("Middleware - Auth Rate Limiting Redirection", () => {
       error: "Too many authentication attempts. Please try again later.",
     });
     // Rate limit headers are present
-    expect(res?.headers.get("X-RateLimit-Limit")).toBe("5");
+    expect(res?.headers.get("X-RateLimit-Limit")).toBe(EFFECTIVE_AUTH_LIMIT);
     expect(res?.headers.get("X-RateLimit-Remaining")).toBe("0");
     expect(res?.headers.get("X-RateLimit-Reset")).toBe("1234567890");
   });

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -1,72 +1,115 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { getClientIp, createMemoryFixedWindowRateLimiter } from '../src/lib/rate-limit';
 
+/**
+ * getClientIp only reads forwarding headers when the deployment declares which
+ * proxy sits in front of it. Any client can set x-forwarded-for, x-real-ip or
+ * cf-connecting-ip on a direct request, so trusting them unconditionally would
+ * let an attacker pick their own rate-limit bucket. These tests therefore pin
+ * behaviour per TRUSTED_PROXY mode rather than asserting a single header order.
+ */
 describe('getClientIp', () => {
-  it('gives priority to cf-connecting-ip', () => {
-    const req = {
-      headers: new Headers({
+  const ORIGINAL_TRUSTED_PROXY = process.env.TRUSTED_PROXY;
+  const ORIGINAL_VERCEL = process.env.VERCEL;
+
+  afterEach(() => {
+    process.env.TRUSTED_PROXY = ORIGINAL_TRUSTED_PROXY;
+    process.env.VERCEL = ORIGINAL_VERCEL;
+    if (ORIGINAL_TRUSTED_PROXY === undefined) delete process.env.TRUSTED_PROXY;
+    if (ORIGINAL_VERCEL === undefined) delete process.env.VERCEL;
+  });
+
+  const reqWith = (headers: Record<string, string>) => ({ headers: new Headers(headers) });
+
+  describe('TRUSTED_PROXY=vercel', () => {
+    beforeEach(() => {
+      process.env.TRUSTED_PROXY = 'vercel';
+    });
+
+    it('prefers x-real-ip, which Vercel sets at the edge', () => {
+      const req = reqWith({ 'x-real-ip': '2.2.2.2', 'x-forwarded-for': '3.3.3.3' });
+      expect(getClientIp(req as any)).toBe('2.2.2.2');
+    });
+
+    it('falls back to the first hop of x-forwarded-for', () => {
+      const req = reqWith({ 'x-forwarded-for': '3.3.3.3, 4.4.4.4' });
+      expect(getClientIp(req as any)).toBe('3.3.3.3');
+    });
+
+    it('ignores cf-connecting-ip, which no Vercel proxy sets', () => {
+      const req = reqWith({ 'cf-connecting-ip': '1.1.1.1' });
+      expect(getClientIp(req as any)).toBe('unknown');
+    });
+
+    it('trims whitespace and skips blank header values', () => {
+      const req = reqWith({ 'x-real-ip': '   ', 'x-forwarded-for': '  6.6.6.6  ' });
+      expect(getClientIp(req as any)).toBe('6.6.6.6');
+    });
+
+    it('returns unknown when no forwarding header is present', () => {
+      expect(getClientIp(reqWith({ host: 'example.com' }) as any)).toBe('unknown');
+    });
+  });
+
+  describe('TRUSTED_PROXY=cloudflare', () => {
+    beforeEach(() => {
+      process.env.TRUSTED_PROXY = 'cloudflare';
+    });
+
+    it('prefers cf-connecting-ip', () => {
+      const req = reqWith({ 'cf-connecting-ip': '1.1.1.1', 'x-real-ip': '2.2.2.2' });
+      expect(getClientIp(req as any)).toBe('1.1.1.1');
+    });
+
+    it('falls back to x-real-ip when cf-connecting-ip is blank', () => {
+      const req = reqWith({ 'cf-connecting-ip': '   ', 'x-real-ip': '2.2.2.2' });
+      expect(getClientIp(req as any)).toBe('2.2.2.2');
+    });
+
+    it('ignores x-forwarded-for, which Cloudflare does not vouch for', () => {
+      const req = reqWith({ 'x-forwarded-for': '3.3.3.3' });
+      expect(getClientIp(req as any)).toBe('unknown');
+    });
+  });
+
+  describe('TRUSTED_PROXY=none', () => {
+    beforeEach(() => {
+      process.env.TRUSTED_PROXY = 'none';
+    });
+
+    it('ignores every forwarding header, because a client can forge them all', () => {
+      const req = reqWith({
         'cf-connecting-ip': '1.1.1.1',
         'x-real-ip': '2.2.2.2',
         'x-forwarded-for': '3.3.3.3',
-      }),
-    };
-    expect(getClientIp(req as any)).toBe('1.1.1.1');
+      });
+      expect(getClientIp(req as any)).toBe('unknown');
+    });
   });
 
-  it('falls back to x-real-ip if cf-connecting-ip is missing', () => {
-    const req = {
-      headers: new Headers({
-        'x-real-ip': '2.2.2.2',
-        'x-forwarded-for': '3.3.3.3',
-      }),
-    };
-    expect(getClientIp(req as any)).toBe('2.2.2.2');
+  describe('auto-detection', () => {
+    it('trusts Vercel headers when VERCEL=1 and TRUSTED_PROXY is unset', () => {
+      delete process.env.TRUSTED_PROXY;
+      process.env.VERCEL = '1';
+      expect(getClientIp(reqWith({ 'x-real-ip': '2.2.2.2' }) as any)).toBe('2.2.2.2');
+    });
+
+    it('trusts nothing when neither TRUSTED_PROXY nor VERCEL is set', () => {
+      delete process.env.TRUSTED_PROXY;
+      delete process.env.VERCEL;
+      expect(getClientIp(reqWith({ 'x-real-ip': '2.2.2.2' }) as any)).toBe('unknown');
+    });
+
+    it('falls back to no-trust for an unrecognised TRUSTED_PROXY value', () => {
+      process.env.TRUSTED_PROXY = 'nginx';
+      delete process.env.VERCEL;
+      expect(getClientIp(reqWith({ 'x-real-ip': '2.2.2.2' }) as any)).toBe('unknown');
+    });
   });
 
-  it('falls back to x-forwarded-for (first IP) if others are missing', () => {
-    const req = {
-      headers: new Headers({
-        'x-forwarded-for': '3.3.3.3, 4.4.4.4',
-      }),
-    };
-    expect(getClientIp(req as any)).toBe('3.3.3.3');
-  });
-
-  it('returns unknown when no relevant headers exist', () => {
-    const req = {
-      headers: new Headers({
-        'host': 'example.com',
-      }),
-    };
-    expect(getClientIp(req as any)).toBe('unknown');
-  });
-
-  it('trims whitespace from header values', () => {
-    const req = {
-      headers: new Headers({
-        'cf-connecting-ip': '  5.5.5.5  ',
-      }),
-    };
-    expect(getClientIp(req as any)).toBe('5.5.5.5');
-  });
-
-  it('handles empty string headers gracefully', () => {
-    const req = {
-      headers: new Headers({
-        'cf-connecting-ip': '   ',
-        'x-real-ip': '',
-        'x-forwarded-for': '6.6.6.6',
-      }),
-    };
-    expect(getClientIp(req as any)).toBe('6.6.6.6');
-  });
-
-  it('handles missing headers map completely', () => {
-    const req = {
-      headers: {
-        get: () => null,
-      },
-    };
+  it('handles a request whose headers map returns null for everything', () => {
+    process.env.TRUSTED_PROXY = 'vercel';
+    const req = { headers: { get: () => null } };
     expect(getClientIp(req as any)).toBe('unknown');
   });
 });

--- a/test/safe-url.test.ts
+++ b/test/safe-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { safeExternalHref } from "../src/lib/safe-url";
+
+describe("safeExternalHref", () => {
+  it("allows http and https URLs", () => {
+    expect(safeExternalHref("https://github.com/vercel/next.js")).toBe(
+      "https://github.com/vercel/next.js"
+    );
+    expect(safeExternalHref("http://example.com")).toBe("http://example.com");
+  });
+
+  it("allows mailto links", () => {
+    expect(safeExternalHref("mailto:hello@example.com")).toBe("mailto:hello@example.com");
+  });
+
+  it("rejects javascript: URIs", () => {
+    expect(safeExternalHref("javascript:alert(1)")).toBeUndefined();
+  });
+
+  it("rejects javascript: URIs regardless of casing or padding", () => {
+    expect(safeExternalHref("  JavaScript:alert(1)  ")).toBeUndefined();
+    expect(safeExternalHref("JAVASCRIPT:alert(1)")).toBeUndefined();
+  });
+
+  it("rejects data: and vbscript: URIs", () => {
+    expect(safeExternalHref("data:text/html,<script>alert(1)</script>")).toBeUndefined();
+    expect(safeExternalHref("vbscript:msgbox(1)")).toBeUndefined();
+  });
+
+  it("allows relative and protocol-relative URLs", () => {
+    expect(safeExternalHref("/dashboard")).toBe("/dashboard");
+    expect(safeExternalHref("//cdn.example.com/a.png")).toBe("//cdn.example.com/a.png");
+  });
+
+  it("returns undefined for empty, blank and nullish input", () => {
+    expect(safeExternalHref("")).toBeUndefined();
+    expect(safeExternalHref("   ")).toBeUndefined();
+    expect(safeExternalHref(null)).toBeUndefined();
+    expect(safeExternalHref(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for strings that are not URLs at all", () => {
+    expect(safeExternalHref("not a url")).toBeUndefined();
+  });
+});

--- a/test/sse.test.ts
+++ b/test/sse.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { sseConnections, sendSSEEvent } from "../src/lib/sse";
 
+/**
+ * sseConnections maps a user id to a *Set* of stream controllers, not a single
+ * one, so a user with the dashboard open in several tabs receives each event in
+ * all of them. Tests must register controllers as a Set.
+ */
+function connect(userId: string, ...controllers: Array<{ enqueue: unknown }>) {
+  sseConnections.set(userId, new Set(controllers as never[]));
+}
+
 describe("sse module", () => {
   beforeEach(() => {
     sseConnections.clear();
@@ -12,10 +21,7 @@ describe("sse module", () => {
     });
 
     it("can store a controller", () => {
-      const mockController = {
-        enqueue: vi.fn(),
-      } as any;
-      sseConnections.set("user123", mockController);
+      connect("user123", { enqueue: vi.fn() });
       expect(sseConnections.size).toBe(1);
     });
   });
@@ -27,10 +33,8 @@ describe("sse module", () => {
     });
 
     it("sends event to connected user", () => {
-      const mockController = {
-        enqueue: vi.fn(),
-      } as any;
-      sseConnections.set("user123", mockController);
+      const mockController = { enqueue: vi.fn() };
+      connect("user123", mockController);
 
       sendSSEEvent("user123", "test-event", { message: "hello" });
 
@@ -39,24 +43,49 @@ describe("sse module", () => {
       );
     });
 
+    it("delivers to every open tab for the same user", () => {
+      const tabA = { enqueue: vi.fn() };
+      const tabB = { enqueue: vi.fn() };
+      connect("user123", tabA, tabB);
+
+      sendSSEEvent("user123", "test-event", { message: "hello" });
+
+      expect(tabA.enqueue).toHaveBeenCalledTimes(1);
+      expect(tabB.enqueue).toHaveBeenCalledTimes(1);
+    });
+
     it("removes controller on enqueue error", () => {
       const mockController = {
         enqueue: vi.fn().mockImplementation(() => {
           throw new Error("Connection closed");
         }),
-      } as any;
-      sseConnections.set("user123", mockController);
+      };
+      connect("user123", mockController);
 
       sendSSEEvent("user123", "test-event", { data: "test" });
 
+      // Last controller for the user is gone, so the user entry goes too.
       expect(sseConnections.has("user123")).toBe(false);
     });
 
+    it("drops only the broken tab and keeps the healthy one", () => {
+      const broken = {
+        enqueue: vi.fn().mockImplementation(() => {
+          throw new Error("Connection closed");
+        }),
+      };
+      const healthy = { enqueue: vi.fn() };
+      connect("user123", broken, healthy);
+
+      sendSSEEvent("user123", "test-event", { data: "test" });
+
+      expect(healthy.enqueue).toHaveBeenCalledTimes(1);
+      expect(sseConnections.get("user123")?.size).toBe(1);
+    });
+
     it("handles multiple events for same user", () => {
-      const mockController = {
-        enqueue: vi.fn(),
-      } as any;
-      sseConnections.set("user123", mockController);
+      const mockController = { enqueue: vi.fn() };
+      connect("user123", mockController);
 
       sendSSEEvent("user123", "event1", { data: "1" });
       sendSSEEvent("user123", "event2", { data: "2" });
@@ -65,10 +94,10 @@ describe("sse module", () => {
     });
 
     it("handles different users independently", () => {
-      const mockController1 = { enqueue: vi.fn() } as any;
-      const mockController2 = { enqueue: vi.fn() } as any;
-      sseConnections.set("user1", mockController1);
-      sseConnections.set("user2", mockController2);
+      const mockController1 = { enqueue: vi.fn() };
+      const mockController2 = { enqueue: vi.fn() };
+      connect("user1", mockController1);
+      connect("user2", mockController2);
 
       sendSSEEvent("user1", "event", { data: "user1" });
       sendSSEEvent("user2", "event", { data: "user2" });

--- a/test/supabase-query-stub.ts
+++ b/test/supabase-query-stub.ts
@@ -1,0 +1,47 @@
+import { vi } from "vitest";
+
+/**
+ * A stand-in for a Supabase (PostgREST) query builder.
+ *
+ * Every filter method returns the same object, and the object is thenable, so
+ * `await`ing it at any point in the chain resolves to `result`.
+ *
+ * Why this exists: mocks written as literal nestings —
+ *
+ *     from.mockReturnValue({ select: () => ({ not: () => result }) })
+ *
+ * encode the exact call chain a route used on the day the test was written.
+ * Adding pagination or another filter to the route then breaks the test with
+ * `.range is not a function`, even though nothing about the behaviour under
+ * test changed. Several suites broke exactly that way when the digest and sync
+ * routes gained `.order()` / `.range()`.
+ *
+ * Pass `result` as the resolved `{ data, error }` shape the route expects.
+ */
+export function supabaseQueryStub<T>(result: T) {
+  const stub: Record<string, unknown> = {
+    then: (
+      resolve: (value: T) => unknown,
+      reject?: (reason: unknown) => unknown
+    ) => Promise.resolve(result).then(resolve, reject),
+  };
+
+  const chainable = [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte",
+    "like", "ilike", "is", "in", "contains", "overlaps",
+    "not", "or", "filter", "match",
+    "order", "range", "limit", "abortSignal",
+  ];
+
+  for (const method of chainable) {
+    stub[method] = vi.fn(() => stub);
+  }
+
+  // Terminal methods resolve directly rather than continuing the chain.
+  stub.single = vi.fn(() => Promise.resolve(result));
+  stub.maybeSingle = vi.fn(() => Promise.resolve(result));
+  stub.csv = vi.fn(() => Promise.resolve(result));
+
+  return stub;
+}

--- a/test/token-expired.test.ts
+++ b/test/token-expired.test.ts
@@ -286,8 +286,11 @@ describe("/api/metrics/pinned-repos — token expiry handling", () => {
   });
 
   it("returns token_expired when GitHub GraphQL returns 401", async () => {
+    // githubId is required: the route derives its cache key from it and 401s
+    // with a plain "Unauthorized" before reaching GitHub when it is missing.
     mockGetServerSession.mockResolvedValueOnce({
       accessToken: "revoked-token",
+      githubId: "123",
     } as any);
 
     mockFetch.mockResolvedValueOnce({

--- a/test/user-settings-api.test.ts
+++ b/test/user-settings-api.test.ts
@@ -3,6 +3,7 @@ import { GET, PATCH } from "@/app/api/user/settings/route";
 import { NextRequest } from "next/server";
 import { getServerSession } from "next-auth";
 import { resolveAppUser } from "@/lib/resolve-user";
+import { encryptToken } from "@/lib/crypto";
 
 // Mock next-auth
 vi.mock("next-auth", () => ({
@@ -37,9 +38,34 @@ vi.mock("@/lib/supabase", () => ({
   },
 }));
 
+// GET caches its response for 5 minutes in a module-level store. Left real, the
+// first test to run would populate it and every later test would be served that
+// payload instead of hitting the mocked database.
+const mockCacheGet = vi.fn();
+const mockCacheSet = vi.fn();
+const mockCacheDelete = vi.fn();
+vi.mock("@/lib/metrics-cache", () => ({
+  cacheGet: (...args: unknown[]) => mockCacheGet(...args),
+  cacheSet: (...args: unknown[]) => mockCacheSet(...args),
+  cacheDelete: (...args: unknown[]) => mockCacheDelete(...args),
+}));
+
 describe("User Settings API Endpoints", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks, not clearAllMocks: clearAllMocks only wipes call history,
+    // so a mockResolvedValue set inside one test leaks into the next and the
+    // defaults configured below never take effect. Every mock therefore has to
+    // be (re)wired here rather than once at module scope.
+    vi.resetAllMocks();
+
+    mockFrom.mockImplementation(() => ({
+      select: mockSelect,
+      update: mockUpdate,
+    }));
+    mockCacheGet.mockResolvedValue(null);
+    mockCacheSet.mockResolvedValue(undefined);
+    mockCacheDelete.mockResolvedValue(undefined);
+    (encryptToken as any).mockReturnValue({ encrypted: "encrypted-val", iv: "iv-val" });
 
     // Default mock data returned from database select
     mockSingle.mockResolvedValue({
@@ -128,13 +154,26 @@ describe("User Settings API Endpoints", () => {
       expect(await res.json()).toEqual({ error: "Failed to fetch user settings" });
     });
 
-    it("returns 500 when fetching user settings from database fails", async () => {
-      mockSingle.mockResolvedValue({ data: null, error: { message: "DB Error" } });
+    it("degrades to safe defaults when every settings column query fails", async () => {
+      // fetchUserSettings tries three progressively smaller column sets so a
+      // self-hosted deployment on an older migration still works. When all
+      // three fail it returns defaults rather than an error.
+      // Once per column-set attempt, so the override cannot leak into the next
+      // test the way a plain mockResolvedValue would.
+      const dbError = { data: null, error: { message: "DB Error" } };
+      mockSingle
+        .mockResolvedValueOnce(dbError)
+        .mockResolvedValueOnce(dbError)
+        .mockResolvedValueOnce(dbError);
 
       const req = new NextRequest("http://localhost/api/user/settings");
       const res = await GET(req);
-      expect(res.status).toBe(500);
-      expect(await res.json()).toEqual({ error: "Failed to fetch user settings" });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.is_public).toBe(false);
+      expect(body.leaderboard_opt_in).toBe(false);
+      expect(body.pinned_repos).toEqual([]);
     });
 
     it("successfully retrieves user settings", async () => {
@@ -197,14 +236,17 @@ describe("User Settings API Endpoints", () => {
       expect(await res.json()).toEqual({ error: "Invalid request body" });
     });
 
-    it("returns 500 when fetching user settings fails before update", async () => {
-      mockSingle.mockResolvedValue({ data: null, error: { message: "DB Error" } });
+    it("returns 500 when persisting the settings update fails", async () => {
+      mockUpdate.mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: { message: "DB Error" } }),
+      });
 
       const req = new NextRequest("http://localhost/api/user/settings", {
         method: "PATCH",
         body: JSON.stringify({ is_public: false }),
       });
       const res = await PATCH(req);
+
       expect(res.status).toBe(500);
       expect(await res.json()).toEqual({ error: "Failed to update settings" });
     });

--- a/test/wakatime-sync-auth.test.ts
+++ b/test/wakatime-sync-auth.test.ts
@@ -1,5 +1,6 @@
 ﻿import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/api/wakatime/sync/route";
+import { supabaseQueryStub } from "./supabase-query-stub";
 
 // --- hoisted mocks ---
 
@@ -29,13 +30,9 @@ function makeRequest(authHeader?: string): Request {
 
 /** Sets up Supabase to return zero users (no-op sync). */
 function stubEmptySync() {
-  mocks.supabaseFrom.mockReturnValue({
-    select: vi.fn().mockReturnValue({
-      not: vi.fn().mockReturnValue({
-        not: vi.fn().mockResolvedValue({ data: [], error: null }),
-      }),
-    }),
-  });
+  mocks.supabaseFrom.mockReturnValue(
+    supabaseQueryStub({ data: [], error: null })
+  );
 }
 
 // --- tests ---
@@ -173,18 +170,12 @@ describe("GET /api/wakatime/sync - authentication hardening (#1746 #1657)", () =
     const upsertMock = vi.fn().mockResolvedValue({ error: null });
     mocks.supabaseFrom.mockImplementation((table: string) => {
       if (table === "users") {
-        return {
-          select: vi.fn().mockReturnValue({
-            not: vi.fn().mockReturnValue({
-              not: vi.fn().mockResolvedValue({
-                data: [
-                  { id: "user-1", wakatime_api_key_encrypted: "enc", wakatime_api_key_iv: "iv" },
-                ],
-                error: null,
-              }),
-            }),
-          }),
-        };
+        return supabaseQueryStub({
+          data: [
+            { id: "user-1", wakatime_api_key_encrypted: "enc", wakatime_api_key_iv: "iv" },
+          ],
+          error: null,
+        });
       }
       if (table === "wakatime_stats") {
         return { upsert: upsertMock };
@@ -213,16 +204,10 @@ describe("GET /api/wakatime/sync - authentication hardening (#1746 #1657)", () =
 
     mocks.supabaseFrom.mockImplementation((table: string) => {
       if (table === "users") {
-        return {
-          select: vi.fn().mockReturnValue({
-            not: vi.fn().mockReturnValue({
-              not: vi.fn().mockResolvedValue({
-                data: [{ id: "user-1", wakatime_api_key_encrypted: "enc", wakatime_api_key_iv: "iv" }],
-                error: null,
-              }),
-            }),
-          }),
-        };
+        return supabaseQueryStub({
+          data: [{ id: "user-1", wakatime_api_key_encrypted: "enc", wakatime_api_key_iv: "iv" }],
+          error: null,
+        });
       }
       return {};
     });

--- a/test/webhook-activity-alerts.test.ts
+++ b/test/webhook-activity-alerts.test.ts
@@ -316,5 +316,8 @@ describe("/api/webhooks/activity-alerts route", () => {
     expect(json.events).toContain("streak.milestone_reached");
     expect(json.events).toContain("goal.completed");
     expect(json.events).toContain("weekly_summary.ready");
-  });
+    // Generous timeout: this is the first import of the route module, and the
+    // cold transform can exceed the 5s default when the full suite runs in
+    // parallel. The assertions themselves are instant.
+  }, 30_000);
 });

--- a/test/weekly-digest-cron-auth.test.ts
+++ b/test/weekly-digest-cron-auth.test.ts
@@ -27,6 +27,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/api/cron/weekly-digest/route";
+import { supabaseQueryStub } from "./supabase-query-stub";
 
 // ─── hoisted mocks ──────────────────────────────────────────────────────────
 
@@ -51,10 +52,9 @@ function makeRequest(authHeader?: string): Request {
 
 /** Configure Supabase to return the given opted-in users. */
 function stubUsers(users: Array<{ github_login: string; email: string }>) {
-  const notChain = vi.fn().mockResolvedValue({ data: users, error: null });
-  const eqChain  = vi.fn().mockReturnValue({ not: notChain });
-  const selChain = vi.fn().mockReturnValue({ eq: eqChain });
-  mocks.supabaseFrom.mockReturnValue({ select: selChain });
+  mocks.supabaseFrom.mockReturnValue(
+    supabaseQueryStub({ data: users, error: null })
+  );
 }
 
 /** Configure Supabase to return no opted-in users. */
@@ -156,12 +156,12 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.sentCount).toBe(2);
+    expect(body.emailsSent).toBe(2);
     // One POST to Resend for each user
     expect(mocks.resendFetch).toHaveBeenCalledTimes(2);
   });
 
-  it("counts sent emails even when RESEND_API_KEY is absent (no network call made)", async () => {
+  it("reports users as skippedUnconfigured when RESEND_API_KEY is absent", async () => {
     vi.stubEnv("CRON_SECRET", "s3cr3t");
     vi.stubEnv("RESEND_API_KEY", "");
     stubUsers([{ github_login: "charlie", email: "charlie@example.com" }]);
@@ -170,9 +170,11 @@ describe("GET /api/cron/weekly-digest — authentication hardening (#1745)", () 
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    // sentCount still increments so the response reflects how many users were
-    // eligible, but no external call is made
-    expect(body.sentCount).toBe(1);
+    // Nothing was sent and nothing failed — a self-hosted deployment using an
+    // external mailer is not an error, but the outcome still has to be visible.
+    expect(body.skippedUnconfigured).toBe(1);
+    expect(body.emailsSent).toBe(0);
+    expect(body.emailsFailed).toBe(0);
     expect(mocks.resendFetch).not.toHaveBeenCalled();
   });
 

--- a/test/weekly-digest.test.ts
+++ b/test/weekly-digest.test.ts
@@ -10,11 +10,12 @@
  *     • cooldown / duplicate-send prevention
  *     • partial failure handling (one bad user does not stop the batch)
  *     • metrics fetched only when GITHUB_TOKEN is configured
- *     • response shape: sentCount / failedCount / skippedCount / errors
+ *     • response shape: emailsSent / emailsFailed / skippedCount / errors
  *     • opted-in filter delegated to the DB query
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { supabaseQueryStub } from "./supabase-query-stub";
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -63,10 +64,9 @@ function stubCronUsers(
     last_digest_sent_at?: string | null;
   }>
 ) {
-  const notChain = vi.fn().mockResolvedValue({ data: users, error: null });
-  const eqChain = vi.fn().mockReturnValue({ not: notChain });
-  const selChain = vi.fn().mockReturnValue({ eq: eqChain });
-  mocks.supabaseFrom.mockReturnValue({ select: selChain });
+  mocks.supabaseFrom.mockReturnValue(
+    supabaseQueryStub({ data: users, error: null })
+  );
 }
 
 /** Configure supabase unsubscribe update to succeed. */
@@ -465,15 +465,15 @@ describe("GET /api/cron/weekly-digest — new behaviours", () => {
 
   // ── Response shape ──────────────────────────────────────────────────────────
 
-  it("response includes sentCount, failedCount, skippedCount, errors", async () => {
+  it("response includes emailsSent, emailsFailed, skippedCount, errors", async () => {
     stubCronUsers([{ github_login: "alice", email: "alice@example.com" }]);
     vi.stubEnv("GITHUB_TOKEN", "gh-token");
     const { GET } = await import("@/app/api/cron/weekly-digest/route");
     const res = await GET(makeCronRequest("Bearer secret"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toHaveProperty("sentCount");
-    expect(body).toHaveProperty("failedCount");
+    expect(body).toHaveProperty("emailsSent");
+    expect(body).toHaveProperty("emailsFailed");
     expect(body).toHaveProperty("skippedCount");
     expect(body).toHaveProperty("errors");
   });
@@ -497,7 +497,7 @@ describe("GET /api/cron/weekly-digest — new behaviours", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.skippedCount).toBe(1);
-    expect(body.sentCount).toBe(0);
+    expect(body.emailsSent).toBe(0);
     expect(mocks.fetchGlobal).not.toHaveBeenCalled();
   });
 
@@ -564,7 +564,7 @@ describe("GET /api/cron/weekly-digest — new behaviours", () => {
     const res = await GET(makeCronRequest("Bearer secret"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.sentCount).toBeGreaterThanOrEqual(1);
+    expect(body.emailsSent).toBeGreaterThanOrEqual(1);
     expect(mocks.fetchGlobal).toHaveBeenCalledOnce();
   });
 
@@ -589,8 +589,8 @@ describe("GET /api/cron/weekly-digest — new behaviours", () => {
     const res = await GET(makeCronRequest("Bearer secret"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.failedCount).toBe(1);
-    expect(body.sentCount).toBeGreaterThanOrEqual(2);
+    expect(body.emailsFailed).toBe(1);
+    expect(body.emailsSent).toBeGreaterThanOrEqual(2);
     expect(body.errors).toHaveLength(1);
     expect(mocks.fetchGlobal).toHaveBeenCalledTimes(3);
   });
@@ -632,7 +632,7 @@ describe("GET /api/cron/weekly-digest — new behaviours", () => {
     const res = await GET(makeCronRequest("Bearer secret"));
     const body = await res.json();
     expect(body.skippedCount).toBe(1);
-    expect(body.sentCount).toBe(1);
+    expect(body.emailsSent).toBe(1);
     expect(mocks.fetchGlobal).toHaveBeenCalledTimes(1);
   });
 

--- a/test/weekly-summary-combined.test.ts
+++ b/test/weekly-summary-combined.test.ts
@@ -1,5 +1,5 @@
 import "./setup";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { getServerSession } from "next-auth";
 import { resolveAppUser } from "@/lib/resolve-user";
@@ -46,6 +46,16 @@ describe("GET /api/metrics/weekly-summary?accountId=combined", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockReset();
+
+    // The fixtures below are pinned to the week of Monday 2026-06-15, and the
+    // route buckets commits into "this week" / "last week" relative to now.
+    // Without a fixed clock this suite passes only during that one week.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2026-06-17T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("successfully fetches and merges weekly summaries across all linked accounts", async () => {


### PR DESCRIPTION
## **User description**
The unit suite has been failing on `main` since #3354 removed the `pnpm test || echo "tests pass"` that swallowed the exit code — **83 failures across 22 files**. The `Continuous Integration Security & Audit Suite` check has been red on every commit since 2026-08-06.

Working through them turned up six real defects, not just stale assertions.

## Product bugs

| Where | What was wrong |
| --- | --- |
| `api/user/settings` PATCH | `clearLeaderboardCache` was **imported and never called**. A user who opted out of the leaderboard stayed listed for up to an hour; one who opted in stayed missing for the same window. The #1779 fix had been dropped in a later refactor. |
| `api/user/settings` PATCH | `cacheDelete` likewise imported and never called. GET caches its payload for 5 minutes, so saved settings did not appear until the entry expired. |
| `api/user/settings` PATCH | `preferred_locale` was written straight to the database unvalidated, then used to select a message bundle on every later render. `isValidLocale` was imported but only applied to the response cookie. |
| `api/user/settings` PATCH | The result of the update was discarded, so a failed write still returned `200` with a body implying success. |
| `ProfileQrModal` | The download handler looked for an `svg` inside the QR container, but the component renders `QRCodeCanvas` — a `canvas`. The lookup always returned null, so **"Download QR Code" did nothing**. It now reads the canvas directly, which also removes the SVG-serialise → Blob → Image round-trip. |
| `ShortcutsModal` | The component returns `null` until a `mounted` flag flips, so the focus effect ran while the close button did not exist and never re-ran. Opening the dialog **left focus outside it** — a keyboard user tabbed through the page behind the modal. `mounted` is now a dependency of that effect. |

## Test repairs

Most of the remaining failures described behaviour that had deliberately changed. Those were updated to the current contract rather than reverting the code:

- `getClientIp` and `getBadgeClientIp` were hardened to ignore spoofable forwarding headers unless a trusted proxy is declared. Rewritten to pin behaviour per `TRUSTED_PROXY` mode, and to assert explicitly that `x-forwarded-for` is ignored — the property that actually matters.
- A `429` from GitHub is a rate limit even when `x-ratelimit-remaining > 0`, because secondary limits do not spend the primary quota.
- `github-accounts` GET degrades to an empty list instead of `401`/`500`.
- `fetchUserSettings` degrades through three progressively smaller column sets so a self-hosted deployment on an older migration still works.
- weekly-digest reports `emailsSent` / `emailsFailed`, not `sentCount` / `failedCount`.

## Test infrastructure

Four of these suites broke for the same structural reason, so the fixes are structural too:

- **`test/supabase-query-stub.ts`** (new) — a chainable, thenable query-builder stub. Mocks written as literal nestings (`select: () => ({ not: () => result })`) encode the exact call chain a route used on the day they were written, which is why several suites broke with `.range is not a function` when the digest and sync routes gained pagination.
- The Anthropic SDK mock wrapped an **arrow function**, which has no `[[Construct]]` slot, so `new Anthropic()` threw `is not a constructor` — 16 tests in one file.
- `user-settings-api` now mocks the settings cache. Left real, the first test to run populated a module-level store and every later test was served that payload instead of hitting the mocked database.
- `weekly-summary-combined` pins the clock. Its fixtures are anchored to the week of Monday 2026-06-15, so the suite could only pass during that one week.
- One route-import test gets a 30s timeout; a cold module transform can exceed the 5s default when all 161 files run in parallel.

Also counts `skipped_unconfigured` in the weekly-digest response — a deployment with no `RESEND_API_KEY` previously incremented no counter at all, so the outcome vanished from the response entirely.

## Verification

- `pnpm test`: **161 files, 2376 tests, all passing** (was 83 failing / 2274 passing)
- `pnpm run type-check`: clean
- `pnpm run build`: green

Stacked on #3498 only by branch order; the two touch disjoint files and can merge in either order.


___

## **CodeAnt-AI Description**
Fix hidden product bugs, close security gaps, and restore reliable CI behavior

### What Changed
- Settings updates now reject unsupported locales, report database write failures, refresh cached settings, and immediately reflect leaderboard visibility changes.
- QR code downloads now produce a PNG, and the shortcuts dialog places keyboard focus inside the modal.
- Rebuild tokens are accepted only through a request header, while generated links reject unsafe URL schemes.
- Rate-limit identity detection trusts forwarding headers only from configured proxies, and lock tokens use unpredictable identifiers.
- Weekly digest results distinguish sent, failed, cooldown-skipped, and unconfigured users.
- Room and repository errors now appear as in-app notifications instead of browser alerts; open SSE connections receive updates in every tab.
- Dependency updates address reported advisories, CI workflows use restricted permissions, containers include a working health check, and repaired tests cover the corrected behavior.

### Impact
`✅ Settings appear immediately after saving`
`✅ Secrets stay out of URLs and logs`
`✅ Fewer broken QR downloads and modal keyboard traps`
`✅ Vulnerable dependencies removed`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
