### PR TITLE
fix: restore prior body overflow when ProfileQrModal unmounts

### DIFF
--- a/src/components/ProfileQrModal.tsx
+++ b/src/components/ProfileQrModal.tsx
@@ -52,11 +52,14 @@ export function ProfileQrModal({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [onClose]);
 
-  // Prevent background scroll while modal is open
+  // Prevent background scroll while modal is open. Restore the previous
+  // inline overflow instead of hardcoding "" so we don't clobber a value
+  // that was already set before this modal mounted.
   useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
-      document.body.style.overflow = "";
+      document.body.style.overflow = previousOverflow;
     };
   }, []);
 

--- a/test/components/ProfileQrModal.test.tsx
+++ b/test/components/ProfileQrModal.test.tsx
@@ -49,7 +49,9 @@ describe("ProfileQrModal", () => {
   it("calls onClose when the close button is clicked", () => {
     render(<ProfileQrModal {...defaultProps} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Close QR code modal/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Close QR code modal/i })
+    );
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -78,16 +80,16 @@ describe("ProfileQrModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("locks body scroll while mounted and releases it on unmount", () => {
+  it("locks body scroll while mounted and restores the previous overflow on unmount", () => {
+    document.body.style.overflow = "scroll";
+
     const { unmount } = render(<ProfileQrModal {...defaultProps} />);
 
     expect(document.body.style.overflow).toBe("hidden");
 
     unmount();
 
-    // Cleanup clears the inline style rather than writing a keyword, so the
-    // stylesheet takes over again.
-    expect(document.body.style.overflow).toBe("");
+    expect(document.body.style.overflow).toBe("scroll");
   });
 
   it("downloads the QR code as a PNG named after the user", () => {


### PR DESCRIPTION
## **User description**
## Summary
- Follow-up from #3362: `ProfileQrModal` currently restores `document.body.style.overflow` to `""` on unmount, which clobbers any inline overflow that was set before the modal opened.
- Capture the previous value and restore it, matching the pattern already used in `RepoAnalyticsSheet`.

## Test plan
- [x] `pnpm exec vitest run test/components/ProfileQrModal.test.tsx`
- [ ] Open the profile QR modal, close it, and confirm background scroll returns to whatever it was before (including if another overlay had already locked it)


___

## **CodeAnt-AI Description**
Restore the page’s previous scroll setting after closing the profile QR modal

### What Changed
- The modal still prevents background scrolling while open
- Closing or unmounting the modal now restores the scroll setting that was active before it opened, instead of clearing it
- Tests verify that an existing overflow setting is preserved

### Impact
`✅ Preserved background scroll behavior with stacked overlays`
`✅ Fewer unexpected page scroll changes after closing the modal`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
